### PR TITLE
Bump emulated postgresql wire protocol to v10.5

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -40,6 +40,8 @@ Breaking Changes
 Changes
 =======
 
+- Changed PostgreSQL wire interface to emulate version ``10.5``.
+
 -  Added support for CrateDB license management
    enabling users to trial the enterprise features,
    set a production enterprise license or continue

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -41,7 +41,7 @@ which is why clients should generally enable ``autocommit``.
 Server Compatibility and Implementation Status
 ==============================================
 
-CrateDB emulates PostgreSQL server version ``9.5``.
+CrateDB emulates PostgreSQL server version ``10.5``.
 
 Start-Up
 --------

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -353,10 +353,10 @@ either because of the table is empty or by a not matching where clause.
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/head/connect.html#connection-failover
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
 .. _Value Expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html
-.. _pgsql_pg_type: https://www.postgresql.org/docs/9.6/static/catalog-pg-type.html
-.. _pgsql_pg_class: https://www.postgresql.org/docs/9.6/static/catalog-pg-class.html
-.. _pgsql_pg_namespace: https://www.postgresql.org/docs/9.6/static/catalog-pg-namespace.html
-.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/9.6/static/catalog-pg-attrdef.html
-.. _pgsql_pg_attribute: https://www.postgresql.org/docs/9.6/static/catalog-pg-attribute.html
-.. _pgsql_pg_index: https://www.postgresql.org/docs/9.6/static/catalog-pg-index.html
-.. _pgsql_pg_constraint: https://www.postgresql.org/docs/9.6/static/catalog-pg-constraint.html
+.. _pgsql_pg_type: https://www.postgresql.org/docs/10/static/catalog-pg-type.html
+.. _pgsql_pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
+.. _pgsql_pg_namespace: https://www.postgresql.org/docs/10/static/catalog-pg-namespace.html
+.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html
+.. _pgsql_pg_attribute: https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html
+.. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
+.. _pgsql_pg_constraint: https://www.postgresql.org/docs/10/static/catalog-pg-constraint.html

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -64,6 +64,7 @@ public class PgAttributeTable extends StaticTableInfo {
         static final ColumnIdent ATTALIGN = new ColumnIdent("attalign");
         static final ColumnIdent ATTNOTNULL = new ColumnIdent("attnotnull");
         static final ColumnIdent ATTHASDEF = new ColumnIdent("atthasdef");
+        static final ColumnIdent ATTIDENTITY = new ColumnIdent("attidentity");
         static final ColumnIdent ATTISDROPPED = new ColumnIdent("attisdropped");
         static final ColumnIdent ATTISLOCAL = new ColumnIdent("attislocal");
         static final ColumnIdent ATTINHCOUNT = new ColumnIdent("attinhcount");
@@ -90,6 +91,7 @@ public class PgAttributeTable extends StaticTableInfo {
             .put(Columns.ATTALIGN, () -> NestableCollectExpression.constant(null))
             .put(Columns.ATTNOTNULL, () -> NestableCollectExpression.forFunction(c -> !c.info.isNullable()))
             .put(Columns.ATTHASDEF, () -> NestableCollectExpression.constant(false)) // don't support default values
+            .put(Columns.ATTIDENTITY, () -> NestableCollectExpression.constant(""))
             .put(Columns.ATTISDROPPED, () -> NestableCollectExpression.constant(false)) // don't support dropping columns
             .put(Columns.ATTISLOCAL, () -> NestableCollectExpression.constant(true))
             .put(Columns.ATTINHCOUNT, () -> NestableCollectExpression.constant(0))
@@ -116,6 +118,7 @@ public class PgAttributeTable extends StaticTableInfo {
                 .register(Columns.ATTALIGN.name(), DataTypes.STRING, null)
                 .register(Columns.ATTNOTNULL.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.ATTHASDEF.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.ATTIDENTITY.name(), DataTypes.STRING, null)
                 .register(Columns.ATTISDROPPED.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.ATTISLOCAL.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.ATTINHCOUNT.name(), DataTypes.INTEGER, null)

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -61,7 +61,6 @@ public class PgClassTable extends StaticTableInfo {
         static final ColumnIdent RELTUPLES = new ColumnIdent("reltuples");
         static final ColumnIdent RELALLVISIBLE = new ColumnIdent("relallvisible");
         static final ColumnIdent RELTOASTRELID = new ColumnIdent("reltoastrelid");
-        static final ColumnIdent RELTOASTIDXID = new ColumnIdent("reltoastidxid");
         static final ColumnIdent RELHASINDEX = new ColumnIdent("relhasindex");
         static final ColumnIdent RELISSHARED = new ColumnIdent("relisshared");
         static final ColumnIdent RELPERSISTENCE = new ColumnIdent("relpersistence");
@@ -73,11 +72,16 @@ public class PgClassTable extends StaticTableInfo {
         static final ColumnIdent RELHASRULES = new ColumnIdent("relhasrules");
         static final ColumnIdent RELHASTRIGGERS = new ColumnIdent("relhastriggers");
         static final ColumnIdent RELHASSUBCLASS = new ColumnIdent("relhassubclass");
+        static final ColumnIdent RELROWSECURITY = new ColumnIdent("relrowsecurity");
+        static final ColumnIdent RELFORCEROWSECURITY = new ColumnIdent("relforcerowsecurity");
         static final ColumnIdent RELISPOPULATED = new ColumnIdent("relispopulated");
+        static final ColumnIdent RELREPLIDENT = new ColumnIdent("relreplident");
+        static final ColumnIdent RELISPARTITION = new ColumnIdent("relispartition");
         static final ColumnIdent RELFROZENXID = new ColumnIdent("relfrozenxid");
         static final ColumnIdent RELMINMXID = new ColumnIdent("relminmxid");
         static final ColumnIdent RELACL = new ColumnIdent("relacl");
         static final ColumnIdent RELOPTIONS = new ColumnIdent("reloptions");
+        static final ColumnIdent RELPARTBOUND = new ColumnIdent("relpartbound");
     }
 
     private static final String KIND_TABLE = "r";
@@ -100,7 +104,6 @@ public class PgClassTable extends StaticTableInfo {
             .put(Columns.RELTUPLES, () -> NestableCollectExpression.constant(0.0f))
             .put(Columns.RELALLVISIBLE, () -> NestableCollectExpression.constant(0))
             .put(Columns.RELTOASTRELID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELTOASTIDXID, () -> NestableCollectExpression.constant(0))
             .put(Columns.RELHASINDEX, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELISSHARED, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELPERSISTENCE, () -> NestableCollectExpression.constant(PERSISTENCE_PERMANENT))
@@ -113,11 +116,16 @@ public class PgClassTable extends StaticTableInfo {
             .put(Columns.RELHASRULES, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELHASTRIGGERS, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELHASSUBCLASS, () -> NestableCollectExpression.constant(false))
+            .put(Columns.RELROWSECURITY, () -> NestableCollectExpression.constant(false))
+            .put(Columns.RELFORCEROWSECURITY, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELISPOPULATED, () -> NestableCollectExpression.constant(true))
+            .put(Columns.RELREPLIDENT, () -> NestableCollectExpression.constant("p"))
+            .put(Columns.RELISPARTITION, () -> NestableCollectExpression.constant(false))
             .put(Columns.RELFROZENXID, () -> NestableCollectExpression.constant(0))
             .put(Columns.RELMINMXID, () -> NestableCollectExpression.constant(0))
             .put(Columns.RELACL, () -> NestableCollectExpression.constant(null))
             .put(Columns.RELOPTIONS, () -> NestableCollectExpression.constant(null))
+            .put(Columns.RELPARTBOUND, () -> NestableCollectExpression.constant(null))
             .build();
     }
 
@@ -136,8 +144,7 @@ public class PgClassTable extends StaticTableInfo {
                 .register(Columns.RELTUPLES.name(), DataTypes.FLOAT, null)
                 .register(Columns.RELALLVISIBLE.name(), DataTypes.INTEGER, null)
                 .register(Columns.RELTOASTRELID.name(), DataTypes.INTEGER, null)
-                .register(Columns.RELTOASTIDXID.name(), DataTypes.INTEGER, null)
-                .register(Columns.RELHASSUBCLASS.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.RELHASINDEX.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELISSHARED.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELPERSISTENCE.name(), DataTypes.STRING, null)
                 .register(Columns.RELKIND.name(), DataTypes.STRING, null)
@@ -147,12 +154,17 @@ public class PgClassTable extends StaticTableInfo {
                 .register(Columns.RELHASPKEY.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELHASRULES.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELHASTRIGGERS.name(), DataTypes.BOOLEAN, null)
-                .register(Columns.RELHASINDEX.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.RELHASSUBCLASS.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.RELROWSECURITY.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.RELFORCEROWSECURITY.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELISPOPULATED.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.RELREPLIDENT.name(), DataTypes.STRING, null)
+                .register(Columns.RELISPARTITION.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.RELFROZENXID.name(), DataTypes.INTEGER, null)
                 .register(Columns.RELMINMXID.name(), DataTypes.INTEGER, null)
                 .register(Columns.RELACL.name(), DataTypes.OBJECT_ARRAY, null)
-                .register(Columns.RELOPTIONS.name(), DataTypes.STRING_ARRAY, null),
+                .register(Columns.RELOPTIONS.name(), DataTypes.STRING_ARRAY, null)
+                .register(Columns.RELPARTBOUND.name(), DataTypes.OBJECT, null),
             Collections.emptyList());
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -57,6 +57,7 @@ public class PgIndexTable extends StaticTableInfo {
         static final ColumnIdent INDCHECKXMIN = new ColumnIdent("indcheckxmin");
         static final ColumnIdent INDISREADY = new ColumnIdent("indisready");
         static final ColumnIdent INDISLIVE = new ColumnIdent("indislive");
+        static final ColumnIdent INDISREPLIDENT = new ColumnIdent("indisreplident");
         static final ColumnIdent INDKEY = new ColumnIdent("indkey");
         static final ColumnIdent INDCOLLATION = new ColumnIdent("indcollation");
         static final ColumnIdent INDCLASS = new ColumnIdent("indclass");
@@ -79,6 +80,7 @@ public class PgIndexTable extends StaticTableInfo {
             .put(Columns.INDCHECKXMIN, () -> NestableCollectExpression.constant(false))
             .put(Columns.INDISREADY, () -> NestableCollectExpression.constant(true))
             .put(Columns.INDISLIVE, () -> NestableCollectExpression.constant(true))
+            .put(Columns.INDISREPLIDENT, () -> NestableCollectExpression.constant(false))
             .put(Columns.INDKEY, () -> NestableCollectExpression.constant((short) 0))
             .put(Columns.INDCOLLATION, () -> NestableCollectExpression.constant(null))
             .put(Columns.INDCLASS, () -> NestableCollectExpression.constant(null))
@@ -102,6 +104,7 @@ public class PgIndexTable extends StaticTableInfo {
                 .register(Columns.INDCHECKXMIN.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.INDISREADY.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.INDISLIVE.name(), DataTypes.BOOLEAN, null)
+                .register(Columns.INDISREPLIDENT.name(), DataTypes.BOOLEAN, null)
                 .register(Columns.INDKEY.name(), DataTypes.SHORT_ARRAY, null)
                 .register(Columns.INDCOLLATION.name(), DataTypes.INTEGER_ARRAY, null)
                 .register(Columns.INDCLASS.name(), DataTypes.INTEGER_ARRAY, null)

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -423,7 +423,7 @@ class PostgresWireProtocol {
 
     private void sendParamsAndRdyForQuery(Channel channel) {
         Messages.sendParameterStatus(channel, "crate_version", Version.CURRENT.toString());
-        Messages.sendParameterStatus(channel, "server_version", "9.5.0");
+        Messages.sendParameterStatus(channel, "server_version", "10.5");
         Messages.sendParameterStatus(channel, "server_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "client_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "datestyle", "ISO");

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -571,7 +571,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(637, response.rowCount());
+        assertEquals(643, response.rowCount());
     }
 
     @Test
@@ -722,7 +722,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        short max_ordinal = 32;
+        short max_ordinal = 34;
         assertEquals(max_ordinal, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");

--- a/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -46,10 +46,10 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
     public void testPgClassTable() {
         execute("select * from pg_catalog.pg_class where relname in ('t1', 'v1', 'tables', 'nodes') order by relname");
         assertThat(printedTable(response.rows()), is(
-            "-1420189195| NULL| 0| 0| 0| 0| 0| false| false| true| false| false| false| true| false| r| 0| nodes| -458336339| 17| 0| NULL| 0| 0| p| 0| 0| 0| 0.0| 0\n" +
-            "728874843| NULL| 0| 0| 0| 0| 0| false| false| true| false| false| false| true| false| r| 0| t1| -2048275947| 2| 0| NULL| 0| 0| p| 0| 0| 0| 0.0| 0\n" +
-            "-1689918046| NULL| 0| 0| 0| 0| 0| false| false| true| false| false| false| true| false| r| 0| tables| 204690627| 16| 0| NULL| 0| 0| p| 0| 0| 0| 0.0| 0\n" +
-            "845171032| NULL| 0| 0| 0| 0| 0| false| false| false| false| false| false| true| false| v| 0| v1| -2048275947| 1| 0| NULL| 0| 0| p| 0| 0| 0| 0.0| 0\n"));
+            "-1420189195| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| nodes| -458336339| 17| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| 0.0| 0\n" +
+            "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 2| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| 0.0| 0\n" +
+            "-1689918046| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| tables| 204690627| 16| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| 0.0| 0\n" +
+            "845171032| NULL| 0| 0| 0| 0| false| 0| false| false| false| false| false| false| false| true| false| v| 0| v1| -2048275947| 1| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| 0.0| 0\n"));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
     public void testPgAttributeTable() {
         execute("select a.* from pg_catalog.pg_attribute as a join pg_catalog.pg_class as c on a.attrelid = c.oid where c.relname = 't1' order by a.attnum");
         assertThat(printedTable(response.rows()), is(
-            "NULL| NULL| false| -1| 0| NULL| false| 0| false| true| 4| id| 0| false| 1| NULL| 728874843| 0| NULL| 23| -1\n" +
-            "NULL| NULL| false| -1| 0| NULL| false| 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1\n"));
+            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| 4| id| 0| false| 1| NULL| 728874843| 0| NULL| 23| -1\n" +
+            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Bump emulated postgresql wire protocol to v10.5 and also adapt v10.5 relevant changes of the `pg_catalog` tables.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
