### PR TITLE
simplify requirements.txt and document docs dir in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -202,6 +202,63 @@
    limitations under the License.
 
 
+===============================================================================
+
+For the `blackbox/docs` directory:
+
+The source files for the documentation are licensed under the Apache License
+Version 2.0. These source files are used by the project maintainers to build
+online documentation for end-users:
+
+  <https://crate.io/docs/crate/reference/en/latest/>
+
+If you want to make contributions to the documentation, it may be necessary for
+you to build the documentation yourself by following the instructions in the
+`DEVELOP.rst` file. If you do this, a number of third-party software components
+are necessary.
+
+We do not ship the source code for these optional third-party software
+components or their dependencies, so we cannot make any guarantees about the
+licensing status of these components.
+
+However, for convenience, the documentation build system explicitly references
+the following software components (grouped by license):
+
+PSF License:
+
+ - Python 3 <https://docs.python.org/3/license.html>
+
+MIT License:
+
+ - pip <https://pypi.org/project/pip/>
+ - setuptools <https://pypi.org/project/setuptools/>
+ - sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>
+ - tqdm <https://pypi.org/project/tqdm/>
+
+BSD License:
+
+ - alabaster <https://pypi.org/project/alabaster/>
+ - sphinx <https://pypi.org/project/Sphinx/>
+
+Apache License 2.0:
+
+ - sphinx-csv-filter <https://pypi.org/project/sphinx-csv-filter/>
+ - crash <https://pypi.org/project/crash/>
+ - crate <https://pypi.org/project/crate/>
+ - crate-docs-theme <https://pypi.org/project/crate-docs-theme/>
+
+Zope Public License:
+
+ - zope.testrunner <https://pypi.org/project/zope.testrunner/>
+
+GNU Lesser General Public License:
+
+ - psycopg2-binary <https://pypi.org/project/psycopg2-binary/>
+
+Please note that each of these components may specify its own dependencies and
+those dependencies may be licensed differently.
+
+
 ================================================================================
 
 For the `enterprise` directory:

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -8,8 +8,6 @@ tqdm==4.24.0
 sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
-zope.exceptions==4.1.0
-zope.interface==4.4.2
 zope.testrunner==4.7.0
 
 # packages for local dev


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- `requirements.txt`
  - eliminates redundant and unnecessary configuration (these packages are pulled in as dependencies for us) 

- LICENSE
  - documents the state of licensing for the `blackbox/docs` directory

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
