### PR TITLE
Update templates first before updating mapping of the index

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -106,6 +106,9 @@ Changes
 Fixes
 =====
 
+- Fixed a race condition that could allow the creation of partitions with a
+  different schema than other partitions within the same partitioned table.
+
 - Changed the ``user`` hdfs repository parameter to ``security.principal`` as that is
   the parameter used by the underlying repository-hdfs plugin.
 

--- a/sql/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl;
+
+import io.crate.Constants;
+import io.crate.analyze.AddColumnAnalyzedStatement;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
+import static io.crate.metadata.PartitionName.templateName;
+
+public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testTemplateMappingUpdateFailsIfTypeIsDifferent() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                "create table t (p int) partitioned by (p)"
+            ).build();
+
+        ClusterState currentState = clusterService.state();
+        AddColumnAnalyzedStatement addXLong = e.analyze("alter table t add column x long");
+        AddColumnAnalyzedStatement addXString = e.analyze("alter table t add column x string");
+        String templateName = templateName("doc", "t");
+        IndexTemplateMetaData template = currentState.metaData().templates().get(templateName);
+        ClusterState stateWithXLong = ClusterState.builder(currentState)
+            .metaData(MetaData.builder(currentState.metaData())
+                .put(IndexTemplateMetaData.builder(templateName)
+                    .patterns(template.patterns())
+                    .putMapping(
+                        Constants.DEFAULT_MAPPING_TYPE,
+                        Strings.toString(JsonXContent.contentBuilder().map(addXLong.analyzedTableElements().toMapping()))))
+                .build()
+            ).build();
+
+        expectedException.expect(IllegalArgumentException.class);
+        TransportSchemaUpdateAction.updateTemplate(
+            NamedXContentRegistry.EMPTY,
+            stateWithXLong,
+            templateName,
+            addXString.analyzedTableElements().toMapping()
+        );
+    }
+}


### PR DESCRIPTION
The mapping updates for partitioned table had a race condition that
allowed the types of the partitions to go out of sync. The reason for
that was that we updated the index mapping first and relied on its
validation logic. The template was simply replaced if the former
succeeded:

    Create index for partition1 with x=string
    Update template -> success
    Create index for partition2 with x=long
    Update template -> no verification but blind overwrite -> success
    Data in _raw:
      {x=foo0}
      {x=10}
    Mapping according to template: x = long

This changes the logic to update the template first with type
verification.

`testConcurrentPartitionCreationWithColumnCreationTypeMissMatch` was
flaky because of this.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed