### PR TITLE
Allow SET SESSION statements on expired license

### DIFF
--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -26,6 +26,7 @@ import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QueriedTable;
+import io.crate.analyze.SetAnalyzedStatement;
 import io.crate.analyze.SetLicenseAnalyzedStatement;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
@@ -58,7 +59,17 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
         if (analyzedStatement instanceof SetLicenseAnalyzedStatement) {
             return true;
         }
+        if (analyzedStatement instanceof SetAnalyzedStatement) {
+            switch (((SetAnalyzedStatement) analyzedStatement).scope()) {
+                case SESSION_TRANSACTION_MODE:
+                case SESSION:
+                case LOCAL:
+                    return true;
 
+                default:
+                    return false;
+            }
+        }
         return (analyzedStatement instanceof QueriedRelation
                 && IS_READ_QUERY_ON_SYSTEM_TABLE.test((QueriedRelation) analyzedStatement));
     }

--- a/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
@@ -27,6 +27,7 @@ import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.statement.SetLicensePlan;
+import io.crate.planner.statement.SetSessionPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
@@ -221,5 +222,12 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
     public void testSetLicenseIsAllowed() {
         Plan plan = e.plan("set license 'XXX'");
         assertThat(plan, instanceOf(SetLicensePlan.class));
+    }
+
+    @Test
+    public void testSetSessionStatementIsAllowedIfLicenseIsExpired() {
+        // postgres clients send set session statements initially on connecting, we want to allow them to.
+        Plan plan = e.plan("set session whatever = 'x'");
+        assertThat(plan, instanceOf(SetSessionPlan.class));
     }
 }


### PR DESCRIPTION
To enable postgres client connections. They invoke some `SET SESSION`
statements when establishing the connection and it should be possible to
use them to invoke `SET LICENSE`.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed