### PR TITLE
Tests: validate extended ascii chars in generated schemas are not allowed

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -756,9 +756,19 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         while (true) {
             String schemaName = RandomStrings.randomAsciiLettersOfLengthBetween(random, 1, 20).toLowerCase();
             if (!Schemas.READ_ONLY_SCHEMAS.contains(schemaName) &&
-                !Identifiers.isKeyWord(schemaName)) {
+                !Identifiers.isKeyWord(schemaName) &&
+                !containsExtendedAsciiChars(schemaName)) {
                 return schemaName;
             }
         }
+    }
+
+    private boolean containsExtendedAsciiChars(String value) {
+        for (char c : value.toCharArray()) {
+            if ((short) c > 127) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
We noticed on the azure-pipelines platform that extended ascii chars are sometimes generated.

As was not able to reproduce this, we'll now guard against characters that might collide with UTF-8 (ie. extended ascii chars)

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
