### PR TITLE
Add oid mapping for text and text array

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -40,6 +40,9 @@ Breaking Changes
 Changes
 =======
 
+- Improved the compatibility with postgres clients that use the ``text`` type
+  for parameter encoding.
+
 -  Upgraded the Admin UI to 1.11.2 which includes the following changes:
 
    Changed the license information (ident) to be taken from the

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -81,6 +81,8 @@ public class PGTypes {
 
     private static final IntObjectMap<DataType> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();
     private static final Set<PGType> TYPES;
+    private static final int TEXT_OID = 25;
+    private static final int TEXT_ARRAY_OID = 1009;
 
     static {
         for (Map.Entry<DataType, PGType> e : CRATE_TO_PG_TYPES.entrySet()) {
@@ -91,9 +93,10 @@ public class PGTypes {
             }
         }
         PG_TYPES_TO_CRATE_TYPE.put(0, DataTypes.UNDEFINED);
+        PG_TYPES_TO_CRATE_TYPE.put(TEXT_OID, DataTypes.STRING);
+        PG_TYPES_TO_CRATE_TYPE.put(TEXT_ARRAY_OID, new ArrayType(DataTypes.STRING));
         TYPES = new HashSet<>(CRATE_TO_PG_TYPES.values()); // some pgTypes are used multiple times, de-dup them
     }
-
 
     public static Iterable<PGType> pgTypes() {
         return TYPES;

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -74,6 +74,12 @@ public class PGTypesTest extends CrateUnitTest {
             instanceOf(io.crate.types.ArrayType.class));
     }
 
+    @Test
+    public void testTextOidIsMappedToString() {
+        assertThat(PGTypes.fromOID(25), is(DataTypes.STRING));
+        assertThat(PGTypes.fromOID(1009), is(new ArrayType(DataTypes.STRING)));
+    }
+
     private static class Entry {
         final DataType type;
         final Object value;


### PR DESCRIPTION
Clients that try to encode parameters using the text type got a failure:

    Can't map PGType with oid=25 to Crate type
    Can't map PGType with oid=1009 to Crate type





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed