### PR TITLE
Improve error messages on licensing errors

### DIFF
--- a/licensing/src/main/java/io/crate/license/EnterpriseLicense.java
+++ b/licensing/src/main/java/io/crate/license/EnterpriseLicense.java
@@ -45,6 +45,8 @@ final class EnterpriseLicense {
             return out.toByteArray();
         } catch (IOException ex) {
             throw new IllegalStateException(ex);
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("The CrateDB distribution is missing its public key", e);
         }
     }
 }

--- a/licensing/src/main/java/io/crate/license/LicenseKey.java
+++ b/licensing/src/main/java/io/crate/license/LicenseKey.java
@@ -90,16 +90,25 @@ public class LicenseKey extends AbstractNamedDiffable<MetaData.Custom> implement
 
     public static DecodedLicense decodeLicense(LicenseKey licenseKey) {
         byte[] keyBytes = Base64.getDecoder().decode(licenseKey.licenseKey());
-        ByteBuffer byteBuffer = ByteBuffer.wrap(keyBytes);
-        LicenseType licenseType = LicenseType.of(byteBuffer.getInt());
-        int version = byteBuffer.getInt();
-        int contentLength = byteBuffer.getInt();
+        LicenseType licenseType;
+        ByteBuffer byteBuffer;
+        int version;
+        int contentLength;
+        try {
+            byteBuffer = ByteBuffer.wrap(keyBytes);
+            licenseType = LicenseType.of(byteBuffer.getInt());
+            version = byteBuffer.getInt();
+            contentLength = byteBuffer.getInt();
+        } catch (InvalidLicenseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidLicenseException("The provided license key has an invalid format", e);
+        }
         if (contentLength > MAX_LICENSE_CONTENT_LENGTH) {
             throw new InvalidLicenseException("The provided license key exceeds the maximum length of " + MAX_LICENSE_CONTENT_LENGTH);
         }
         byte[] contentBytes = new byte[contentLength];
         byteBuffer.get(contentBytes);
-
         return new DecodedLicense(licenseType, version, contentBytes);
     }
 

--- a/licensing/src/main/java/io/crate/license/LicenseService.java
+++ b/licensing/src/main/java/io/crate/license/LicenseService.java
@@ -175,17 +175,16 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
     }
 
     private static byte[] decryptLicenseContent(LicenseType type, byte[] encryptedContent) {
-        byte[] decryptedContent = null;
         switch (type) {
             case TRIAL:
-                decryptedContent = TrialLicense.decrypt(encryptedContent);
-                break;
+                return TrialLicense.decrypt(encryptedContent);
+
             case ENTERPRISE:
-                decryptedContent = EnterpriseLicense.decrypt(encryptedContent);
-                break;
+                return EnterpriseLicense.decrypt(encryptedContent);
+
             default:
+                throw new AssertionError("Invalid license type: " + type);
         }
-        return decryptedContent;
     }
 
     @Override

--- a/licensing/src/main/java/io/crate/license/exception/InvalidLicenseException.java
+++ b/licensing/src/main/java/io/crate/license/exception/InvalidLicenseException.java
@@ -27,4 +27,8 @@ public class InvalidLicenseException extends LicenseException {
     public InvalidLicenseException(String message) {
         super(message);
     }
+
+    public InvalidLicenseException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/licensing/src/test/java/io/crate/license/LicenseKeyTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseKeyTest.java
@@ -66,6 +66,13 @@ public class LicenseKeyTest extends CrateUnitTest {
     }
 
     @Test
+    public void testDecodeErrorOnFirstReadIntResultsInMeaningfulError() {
+        LicenseKey licenseKey = new LicenseKey("foo");
+        expectedException.expectMessage("The provided license key has an invalid format");
+        LicenseKey.decodeLicense(licenseKey);
+    }
+
+    @Test
     public void testLicenceKeyToXContent() throws IOException {
         LicenseKey licenseKey = createLicenseKey();
         XContentBuilder builder = XContentFactory.jsonBuilder();


### PR DESCRIPTION
See commit messages



 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed