### PR TITLE
Analyzer changes to support shard shrinking

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -53,7 +53,7 @@ public class AlterTableAnalyzer {
         DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(), Operation.ALTER_BLOCKS,
             sessionContext.searchPath());
         PartitionName partitionName = createPartitionName(table.partitionProperties(), docTableInfo, parameters);
-        TableParameterInfo tableParameterInfo = getTableParameterInfo(table, docTableInfo, partitionName);
+        TableParameterInfo tableParameterInfo = getTableParameterInfo(table, partitionName);
         TableParameter tableParameter = getTableParameter(node, parameters, tableParameterInfo);
         maybeRaiseBlockedException(docTableInfo, tableParameter.settings());
         return new AlterTableAnalyzedStatement(docTableInfo, partitionName, tableParameter, table.excludePartitions());
@@ -85,12 +85,9 @@ public class AlterTableAnalyzer {
     }
 
     private static TableParameterInfo getTableParameterInfo(Table table,
-                                                            DocTableInfo tableInfo,
                                                             @Nullable PartitionName partitionName) {
         if (partitionName == null) {
-            return (tableInfo.isPartitioned())
-                ? TableParameterInfo.PARTITIONED_TABLE_PARAMETER_INFO
-                : TableParameterInfo.TABLE_PARAMETER_INFO;
+            return TableParameterInfo.TABLE_ALTER_PARAMETER_INFO;
         }
         assert !table.excludePartitions() : "Alter table ONLY not supported when using a partition";
         return TableParameterInfo.PARTITION_PARAMETER_INFO;

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -91,7 +91,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
         // if it is it will get overwritten afterwards.
         TablePropertiesAnalyzer.analyze(
             statement.tableParameter(),
-            TableParameterInfo.TABLE_PARAMETER_INFO,
+            TableParameterInfo.TABLE_CREATE_PARAMETER_INFO,
             createTable.properties(),
             parameters,
             true

--- a/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
@@ -117,7 +117,7 @@ public class TableParameterInfo {
             .add(NUMBER_OF_REPLICAS)
             .build();
 
-    private static final ImmutableMap<String, Setting> SUPPORTED_SETTINGS_FOR_PARTITIONED_TABLES
+    private static final ImmutableMap<String, Setting> SUPPORTED_SETTINGS_INCL_SHARDS
         = ImmutableMap.<String, Setting>builder()
             .putAll(SUPPORTED_SETTINGS_DEFAULT)
             .put(stripIndexPrefix(NUMBER_OF_SHARDS.getKey()), NUMBER_OF_SHARDS)
@@ -143,12 +143,14 @@ public class TableParameterInfo {
 
     private static final ImmutableMap<String, Setting> EMPTY_MAP = ImmutableMap.of();
 
-    static final TableParameterInfo TABLE_PARAMETER_INFO
+    static final TableParameterInfo TABLE_CREATE_PARAMETER_INFO
         = new TableParameterInfo(SUPPORTED_SETTINGS_DEFAULT, SUPPORTED_MAPPINGS_DEFAULT);
-    public static final TableParameterInfo PARTITIONED_TABLE_PARAMETER_INFO
-        = new TableParameterInfo(SUPPORTED_SETTINGS_FOR_PARTITIONED_TABLES, SUPPORTED_MAPPINGS_DEFAULT);
-    public static final TableParameterInfo PARTITION_PARAMETER_INFO
+    static final TableParameterInfo TABLE_ALTER_PARAMETER_INFO
+        = new TableParameterInfo(SUPPORTED_SETTINGS_INCL_SHARDS, SUPPORTED_MAPPINGS_DEFAULT);
+    public static final TableParameterInfo PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
         = new TableParameterInfo(SUPPORTED_SETTINGS_DEFAULT, EMPTY_MAP);
+    static final TableParameterInfo PARTITION_PARAMETER_INFO
+        = new TableParameterInfo(SUPPORTED_SETTINGS_INCL_SHARDS, EMPTY_MAP);
     static final TableParameterInfo BLOB_TABLE_CREATE_PARAMETER_INFO
         = new TableParameterInfo(SUPPORTED_SETTINGS_FOR_BLOB_CREATION, EMPTY_MAP);
     public static final TableParameterInfo BLOB_TABLE_ALTER_PARAMETER_INFO

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -209,9 +209,12 @@ public class AlterTableOperation {
 
                 if (!analysis.excludePartitions()) {
                     // create new filtered partition table settings
-                    TableParameterInfo partitionParameterInfo = TableParameterInfo.PARTITION_PARAMETER_INFO;
-                    List<String> supportedSettings = partitionParameterInfo.supportedSettings()
-                        .values().stream().map(Setting::getKey).collect(Collectors.toList());
+                    List<String> supportedSettings = TableParameterInfo.PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
+                        .supportedSettings()
+                        .values()
+                        .stream()
+                        .map(Setting::getKey)
+                        .collect(Collectors.toList());
                     // auto_expand_replicas must be explicitly added as it is hidden under NumberOfReplicasSetting
                     supportedSettings.add(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
                     TableParameter parameterWithFilteredSettings = new TableParameter(

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -311,10 +311,28 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     }
 
     @Test
-    public void testAlterTablePartitionWithNumberOfShardsIsInvalid() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid property \"number_of_shards\" passed to [ALTER | CREATE] TABLE statement");
-        e.analyze("alter table parted partition (date=1395874800000) set (number_of_shards=1)");
+    public void testAlterTablePartitionWithNumberOfShards() {
+        AlterTableAnalyzedStatement analysis = e.analyze(
+            "alter table parted partition (date=1395874800000) set (number_of_shards=1)");
+        assertThat(analysis.partitionName().isPresent(), is(true));
+        assertThat(analysis.table().isPartitioned(), is(true));
+        assertEquals("1", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
+    }
+    public void testAlterTablePartitionSetShards() {
+        AlterTableAnalyzedStatement analysis = e.analyze(
+            "alter table parted partition (date=1395874800000) set (number_of_shards=1)");
+        assertThat(analysis.partitionName().isPresent(), is(true));
+        assertThat(analysis.table().isPartitioned(), is(true));
+        assertEquals("1", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
+    }
+
+    @Test
+    public void testAlterTablePartitionResetShards() {
+        AlterTableAnalyzedStatement analysis = e.analyze(
+            "alter table parted partition (date=1395874800000) reset (number_of_shards)");
+        assertThat(analysis.partitionName().isPresent(), is(true));
+        assertThat(analysis.table().isPartitioned(), is(true));
+        assertEquals("5", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add support to analyser module to support:
- ALTER TABLE t SET (number_of_shards = X) where t is a non-partitioned table
- ALTER TABLE t PARTITION (p = 1) SET (number_of_shards = X) where t is a partitioned table

Also ensure bwc for statement:
- ALTER TABLE t SET (number_of_shards = X) where t is a partitioned table

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
