### PR TITLE
Fix xContent serialization of routing entires.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -120,3 +120,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue which caused ``EXPLAIN`` statements to use a wrong ``routing``
+  entries representation on versions >= 3.1.3.

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -32,11 +32,13 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -101,6 +103,33 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
             }
             assertNotNull(map);
             assertThat(map.size(), greaterThan(0));
+        }
+    }
+
+    @Test
+    public void testPrinterToXContent() {
+        for (String statement : EXPLAIN_TEST_STATEMENTS) {
+            LogicalPlan plan = e.logicalPlan(statement);
+            Map<String, Object> map = null;
+            try {
+                map = ExplainLogicalPlan.explainMap(
+                    plan,
+                    e.getPlannerContext(clusterService.state()),
+                    new ProjectionBuilder(getFunctions()));
+            } catch (Exception e) {
+                fail("statement not printable: " + statement);
+            }
+
+            String json = null;
+            try {
+                XContentBuilder xContentBuilder = JsonXContent.contentBuilder();
+                xContentBuilder.value(map);
+                json = BytesReference.bytes(xContentBuilder).utf8ToString();
+            } catch (Exception e) {
+                fail("printed plan cannot be converted to xContent: " + statement);
+            }
+
+            assertNotNull(json);
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Since ES 6.3.0, the XContentBuilder is more strict and throws an exception
instead of using any objects toString() method, so any hppc object must
be converted upfront.
Also using toString() for the routing location entries (IntArrayList), 
resulted in a wrong representation.

Relates 740bcc9d038f37d1d0b21f73242cf637925db79f.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
