### PR TITLE
Fix xContent representation of routing entires.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -43,3 +43,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue which caused ``EXPLAIN`` statements to use a wrong ``routing``
+  entries representation on versions >= 3.1.0.

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -32,10 +32,11 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -100,6 +101,33 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
             }
             assertNotNull(map);
             assertThat(map.size(), greaterThan(0));
+        }
+    }
+
+    @Test
+    public void testPrinterToXContent() {
+        for (String statement : EXPLAIN_TEST_STATEMENTS) {
+            LogicalPlan plan = e.logicalPlan(statement);
+            Map<String, Object> map = null;
+            try {
+                map = ExplainLogicalPlan.explainMap(
+                    plan,
+                    e.getPlannerContext(clusterService.state()),
+                    new ProjectionBuilder(getFunctions()));
+            } catch (Exception e) {
+                fail("statement not printable: " + statement);
+            }
+
+            String json = null;
+            try {
+                XContentBuilder xContentBuilder = JsonXContent.contentBuilder();
+                xContentBuilder.value(map);
+                json = xContentBuilder.bytes().utf8ToString();
+            } catch (Exception e) {
+                fail("printed plan cannot be converted to xContent: " + statement);
+            }
+
+            assertNotNull(json);
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The XContentBuilder uses the generic toString() method on unknown
custom classes which results in a wrong representation of the routing
locations as hppc classes (primitive collection) are used.

Relates 740bcc9d038f37d1d0b21f73242cf637925db79f.
Backport of d14807d99435b4419c64809c1e17af9589b251a8.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
