### PR TITLE
reword CrateDB licensing documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -214,17 +214,19 @@ All rights reserved
 Licensed to Crate.IO GmbH (referred to in this notice as "Crate") under one or
 more contributor license agreements.
 
-This directory contains proprietary enterprise modules. These modules (which in
-turn provide enterprise features) are not licensed under any Open Source
+This directory contains proprietary enterprise modules.  These modules (which
+in turn provide Enterprise Features) are not licensed under any Open Source
 license.
 
-To enable or use any of the enterprise features, Crate must have given you
-permission to enable and use the Enterprise Edition of CrateDB and you must
-have a valid Enterprise or Subscription Agreement with Crate. If you enable or
-use features that are part of the Enterprise Edition, you represent and warrant
-that you have a valid Enterprise or Subscription Agreement with Crate. Your use
-of features of the Enterprise Edition is governed by the terms and conditions
-of your Enterprise or Subscription Agreement with Crate.
+Unauthorized copying of these files, via any medium is strictly prohibited.
+
+To use any of these files, Crate.io must have given you permission to enable
+and use such Enterprise Features and you must have a valid Enterprise or
+Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+Features, you represent and warrant that you have a valid Enterprise or
+Subscription Agreement with Crate.io.  Your use of the Enterprise Features if
+governed by the terms and conditions of your Enterprise or Subscription
+Agreement with Crate.io.
 
 
 ================================================================================

--- a/NOTICE
+++ b/NOTICE
@@ -10,18 +10,19 @@ Different parts of CrateDB are available under different licences.
 Unless otherwise indicated, the CrateDB source code is licensed under the
 Apache License, Version 2.0.
 
-Crate bundles proprietary enterprise modules with CrateDB. These modules (which
-in turn provide enterprise features) are not licensed under any version of the
-Apache License. These modules are indicated in the LICENSE file along with
+Crate bundles proprietary enterprise modules with CrateDB.  These modules
+(which in turn provide Enterprise Features) are not licensed under any Open
+Source license.  These modules are indicated in the LICENSE file along with
 information about their licensing.
 
-Third-party components bundled with the CrateDB source code are indicated in the
-LICENSE file along with their respective licenses. Any additional mandatory
-notices pertaining to those dependencies will be reproduced in this file.
+Third-party components bundled with the CrateDB source code are indicated in
+the LICENSE file along with their respective licenses.  Any additional
+mandatory notices pertaining to those dependencies will be reproduced in this
+file.
 
 Crate provides pre-built releases for convenience, also known as convenience
-releases. Building CrateDB from source pulls in a number of additional
-third-party dependencies. Hence, convenience releases will contain a mix of
+releases.  Building CrateDB from source pulls in a number of additional
+third-party dependencies.  Hence, convenience releases will contain a mix of
 CrateDB source code and third-party build-time dependencies not listed in the
 LICENSE file or in this file.
 

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -39,10 +39,6 @@
 #    - host1:4300
 #    - host2:4300
 
-# Enterprise features: CrateDB ships by default with all enterprise features
-# enabled. Get in touch with us to get a license: https://crate.io/enterprise/
-#license.enterprise: true
-
 
 ################################# Full Settings ##############################
 
@@ -57,17 +53,20 @@
 
 ############################# Enterprise Features ############################
 
-# Setting this to `false` disables the Enterprise Edition of CrateDB.
+# CrateDB ships by default with all Enterprise Features enabled. See
+# <https://crate.io/docs/crate/reference/en/latest/enterprise/index.html> for
+# more information.
+
+# Setting this to `false` disables the Enterprise Features.
 #license.enterprise: true
 
-# To enable or use any of the enterprise features, Crate.io must have given
-# you permission to enable and use the Enterprise Edition of CrateDB (see
-# https://crate.io/enterprise/) and you must have a valid Enterprise or
-# Subscription Agreement with Crate.io. If you enable or use features that are
-# part of the Enterprise Edition, you represent and warrant that you have a
-# valid Enterprise or Subscription Agreement with Crate.io. Your use of
-# features of the Enterprise Edition is governed by the terms and conditions
-# of your Enterprise or Subscription Agreement with Crate.io.
+# To use any of these features, Crate.io must have given you permission to
+# enable and use such Enterprise Features and you must have a valid Enterprise
+# or Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+# Features, you represent and warrant that you have a valid Enterprise or
+# Subscription Agreement with Crate.io.  Your use of the Enterprise Features if
+# governed by the terms and conditions of your Enterprise or Subscription
+# Agreement with Crate.io.
 
 #/////////////////////////// JMX Monitoring Plugin ///////////////////////////
 

--- a/blackbox/docs/enterprise/index.rst
+++ b/blackbox/docs/enterprise/index.rst
@@ -4,31 +4,17 @@
 Enterprise Features
 ===================
 
-CrateDB provides an `Enterprise Edition`_. The source code remains open, but if
-you want to use one of the enterprise features in production you need to
-purchase a `enterprise license`_.
+.. rubric:: Table of Contents
 
-The `Enterprise Edition`_ is enabled by default, the
-:ref:`license.enterprise <conf-node-enterprise-license>` config being true, for
-a period of 30 days that will allow users to evaluate the enterprise features.
+.. contents::
+   :local:
 
-Upon the expiration of the 30 days trial period you will have to request an
-enterprise license by `contacting our sales department`_.
-Setting a new license is achieved using the :ref:`SET LICENSE <ref-set-license>`
-statement.
+Feature List
+============
 
-Alternatively, users seeking to use the community edition can do so at any
-point by disabling the enterprise license using the
-:ref:`license.enterprise <conf-node-enterprise-license>` config.
-
-.. WARNING::
-
-  CrateDB will continue to run after the license expires but only the
-  :ref:`SET LICENSE <ref-set-license>` statement and the read only system information
-  statements (against the ``sys`` and ``information_schema`` schemas) will be
-  allowed.
-
-Current features:
+When you first download CrateDB, the :ref:`license.enterprise
+<conf-node-enterprise-license>` setting is set to ``true`` and the following
+enterprise features are enabled:
 
 - :ref:`administration_user_management`: manage multiple database users
 - :ref:`administration-privileges`: configure user privileges
@@ -45,12 +31,35 @@ Current features:
 - `The CrateDB admin UI`_: `shards browser`_, `monitoring overview`_,
   `privileges browser`_
 
-.. _enterprise edition: https://crate.io/enterprise-edition/
-.. _enterprise license: https://crate.io/enterprise-edition/
-.. _MQTT: http://mqtt.org/
+Trial
+=====
+
+You may evaluate CrateDB during a 30-day trial period, after which you must
+`request an enterprise license`_ and configure CrateDB using the :ref:`SET
+LICENSE <ref-set-license>` statement.
+
+.. NOTE::
+
+    When the trial period ends, CrateDB functionality will be limited to
+    executing the following statements:
+
+    - :ref:`SET LICENSE <ref-set-license>`
+
+    - :ref:`SELECT <sql_reference_select>` (:ref:`information_schema
+      <information_schema>` and :ref:`sys <system-information>` schemas only)
+
+If you wish to continue using CrateDB without an enterprise license after the
+trial period ends you must set :ref:`license.enterprise
+<conf-node-enterprise-license>` to ``false``. This activates the `community
+edition`_ of CrateDB and restores all functionality except for the enterprise
+features.
+
+.. _community Edition: https://crate.io/products/cratedb-editions/
+.. _enterprise license: https://crate.io/products/cratedb-editions/
 .. _HyperLogLog++: https://research.google.com/pubs/pub40671.html
-.. _shards browser: https://crate.io/docs/clients/admin-ui/en/latest/shards.html#shards
 .. _monitoring overview: https://crate.io/docs/clients/admin-ui/en/latest/monitoring.html
+.. _MQTT: http://mqtt.org/
 .. _privileges browser: https://crate.io/docs/clients/admin-ui/en/latest/privileges.html
+.. _request an enterprise license: https://crate.io/pricing/#contactsales
+.. _shards browser: https://crate.io/docs/clients/admin-ui/en/latest/shards.html#shards
 .. _The CrateDB admin UI: https://crate.io/docs/clients/admin-ui/en/latest/index.html
-.. _contacting our sales department: https://crate.io/pricing/#contactsales

--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -6,14 +6,16 @@ All rights reserved
 Licensed to Crate.IO GmbH (referred to in this notice as "Crate") under one or
 more contributor license agreements.
 
-This directory contains proprietary enterprise modules. These modules (which in
-turn provide enterprise features) are not licensed under any Open Source
+This directory contains proprietary enterprise modules.  These modules (which
+in turn provide Enterprise Features) are not licensed under any Open Source
 license.
 
-To enable or use any of the enterprise features, Crate must have given you
-permission to enable and use the Enterprise Edition of CrateDB and you must
-have a valid Enterprise or Subscription Agreement with Crate. If you enable or
-use features that are part of the Enterprise Edition, you represent and warrant
-that you have a valid Enterprise or Subscription Agreement with Crate. Your use
-of features of the Enterprise Edition is governed by the terms and conditions
-of your Enterprise or Subscription Agreement with Crate.
+Unauthorized copying of these files, via any medium is strictly prohibited.
+
+To use any of these files, Crate.io must have given you permission to enable
+and use such Enterprise Features and you must have a valid Enterprise or
+Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+Features, you represent and warrant that you have a valid Enterprise or
+Subscription Agreement with Crate.io.  Your use of the Enterprise Features if
+governed by the terms and conditions of your Enterprise or Subscription
+Agreement with Crate.io.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

"CrateDB Enterprise Edition" is now called "CrateDB", and the old "CrateDB" is now called "CrateDB Community Edition". this changeset reflects that

list of changes:

- minor formatting fixes for `LICENSE` and `NOTICE`
- replace "To enable or use any of the enterprise features" section in `LICENSE` with standard text from the source file boilerplates ([example](https://github.com/crate/crate/blob/master/enterprise/jmx-monitoring/src/main/java/io/crate/beans/CircuitBreakers.java))
- update "Enterprise Features" doc page
- update `crate.yml` to match

I do not believe any other changes are needed. enterprise features in the docs are already flagged with an admonition saying "Foo is an [enterprise feature]." with a link through to the "Enterprise Features" page. this remains accurate and useful

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
