### PR TITLE
add note about file URIs on Windows

### DIFF
--- a/blackbox/docs/general/dml.rst
+++ b/blackbox/docs/general/dml.rst
@@ -444,6 +444,11 @@ An example import from a file URI::
     cr> delete from quotes;
     DELETE OK, 3 rows affected (... sec)
 
+.. NOTE::
+
+    If you are using Microsoft Windows, you must include the drive letter in
+    the file URI. Consult the `Windows documentation`_ for more information.
+
 If all files inside a directory should be imported a ``*`` wildcard has to be
 used::
 
@@ -563,5 +568,6 @@ exported::
 
 For further details see :ref:`copy_to`.
 
-.. _PCRE: http://www.pcre.org/
 .. _`crate-python`: https://pypi.python.org/pypi/crate/
+.. _PCRE: http://www.pcre.org/
+.. _Windows documentation: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats

--- a/blackbox/docs/sql/statements/copy-from.rst
+++ b/blackbox/docs/sql/statements/copy-from.rst
@@ -90,6 +90,11 @@ URI
 A string literal or array of string literals containing URIs. Each URI must be
 formatted according to the `URI Scheme`_.
 
+.. NOTE::
+
+    If you are using Microsoft Windows, you must include the drive letter in
+    the file URI. Consult the `Windows documentation`_ for more information.
+
 In case the URI scheme is missing the value is assumed to be a file path and
 will be converted to a ``file://`` URI implicitly.
 
@@ -340,7 +345,8 @@ inserted records.
 .. _`AWS Java Documentation`: http://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingAcctOrUserCredJava.html
 .. _`RFC2396`: http://www.ietf.org/rfc/rfc2396.txt
 .. _`URI Scheme`: https://en.wikipedia.org/wiki/URI_scheme
-.. _GeoJSON: http://geojson.org/
-.. _WKT: http://en.wikipedia.org/wiki/Well-known_text
-.. _URL: http://docs.oracle.com/javase/8/docs/api/java/net/URL.html
 .. _`URL encoded`: https://en.wikipedia.org/wiki/Percent-encoding
+.. _GeoJSON: http://geojson.org/
+.. _URL: http://docs.oracle.com/javase/8/docs/api/java/net/URL.html
+.. _Windows documentation: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+.. _WKT: http://en.wikipedia.org/wiki/Well-known_text


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

added two admonitions to the docs that let Windows users know driver letters should be included in the `file:///` URIs

alphabetical order fixed in footer links

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
