### PR TITLE
Don't require shippable for mergify to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - status-success=ci/jenkins/pr_tests
       - status-success=crate.crate
-      - status-success=Shippable
       - 'status-success=LGTM analysis: Java'
       - 'status-success=LGTM analysis: Python'
     name: default


### PR DESCRIPTION
We're going to remove it in favor of a Jenkins slave running on the new
AWS ARM instances.

Shippable is currently broken due to what seems to be a JDK issue in the
image.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed