### PR TITLE
Fix replace(string) documentation header

### DIFF
--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -271,7 +271,7 @@ Computes the MD5 checksum of the given string.
 See :ref:`sha1 <sha1>` for an example.
 
 ``replace(text, from, to)``
-===========================
+---------------------------
 
 Replaces all occurrences of ``from`` in ``text`` with ``to``.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Header level of the replace documentation section was not correct.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
