### PR TITLE
Upgrade crate-jdbc to 2.5.0 (JDK 11 compatible).

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -19,7 +19,7 @@ jacksondatabind=2.0.1
 jacksondataformatcsv=2.5.1
 
 # Crate JDBC
-crate_jdbc=2.4.0
+crate_jdbc=2.5.0
 
 # ES deps
 elasticsearch=6.5.1


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Use crate-jdbc version 2.5.0 which introduces full JDK 11 compatibility.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
