### PR TITLE
Adapt deprecated Loggers.getLogger usages

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobContainer.java
+++ b/blob/src/main/java/io/crate/blob/BlobContainer.java
@@ -24,7 +24,7 @@ package io.crate.blob;
 import io.crate.blob.exceptions.DigestNotFoundException;
 import io.crate.common.Hex;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -43,7 +43,7 @@ import java.util.concurrent.Semaphore;
 
 public class BlobContainer {
 
-    private static final Logger logger = Loggers.getLogger(BlobContainer.class);
+    private static final Logger logger = LogManager.getLogger(BlobContainer.class);
     private static final String[] SUB_DIRS = new String[256];
 
     public static final byte[] PREFIXES = new byte[256];

--- a/blob/src/main/java/io/crate/blob/DigestBlob.java
+++ b/blob/src/main/java/io/crate/blob/DigestBlob.java
@@ -29,7 +29,7 @@ import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
 import java.io.Closeable;
@@ -63,7 +63,7 @@ public class DigestBlob implements Closeable {
     private MessageDigest md;
     private long chunks;
     private CountDownLatch headCatchedUpLatch;
-    private static final Logger logger = Loggers.getLogger(DigestBlob.class);
+    private static final Logger logger = LogManager.getLogger(DigestBlob.class);
 
     public DigestBlob(BlobContainer container, String digest, UUID transferId) {
         this.digest = digest;

--- a/blob/src/main/java/io/crate/blob/RemoteDigestBlob.java
+++ b/blob/src/main/java/io/crate/blob/RemoteDigestBlob.java
@@ -25,7 +25,7 @@ import io.crate.common.Hex;
 import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
 import java.util.UUID;
@@ -75,7 +75,7 @@ public class RemoteDigestBlob {
     }
 
 
-    private static final Logger logger = Loggers.getLogger(RemoteDigestBlob.class);
+    private static final Logger logger = LogManager.getLogger(RemoteDigestBlob.class);
 
     private final String digest;
     private final Client client;

--- a/blob/src/main/java/io/crate/blob/transfer/PutHeadChunkRunnable.java
+++ b/blob/src/main/java/io/crate/blob/transfer/PutHeadChunkRunnable.java
@@ -26,7 +26,7 @@ import io.crate.blob.DigestBlob;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
@@ -55,7 +55,7 @@ public class PutHeadChunkRunnable implements Runnable {
     private final UUID transferId;
     private WatchKey watchKey;
     private WatchService watcher;
-    private static final Logger logger = Loggers.getLogger(PutHeadChunkRunnable.class);
+    private static final Logger logger = LogManager.getLogger(PutHeadChunkRunnable.class);
 
     public PutHeadChunkRunnable(DigestBlob digestBlob, long bytesToSend,
                                 TransportService transportService,

--- a/blob/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
+++ b/blob/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
@@ -57,7 +57,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
 import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
@@ -85,7 +85,7 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private static final String EXPIRES_VALUE = "Thu, 31 Dec 2037 23:59:59 GMT";
     private static final String BLOBS_ENDPOINT = "/_blobs";
     public static final Pattern BLOBS_PATTERN = Pattern.compile(String.format(Locale.ENGLISH, "^%s/([^_/][^/]*)/([0-9a-f]{40})$", BLOBS_ENDPOINT));
-    private static final Logger LOGGER = Loggers.getLogger(HttpBlobHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpBlobHandler.class);
 
     private static final Pattern CONTENT_RANGE_PATTERN = Pattern.compile("^bytes=(\\d+)-(\\d*)$");
 

--- a/blob/src/test/java/io/crate/blob/v2/BlobIndexTest.java
+++ b/blob/src/test/java/io/crate/blob/v2/BlobIndexTest.java
@@ -23,7 +23,7 @@
 package io.crate.blob.v2;
 
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -37,7 +37,7 @@ public class BlobIndexTest {
     @Test
     public void testRetrieveBlobRootDirDoesNotThrowNPE() throws Exception {
         Path root = Paths.get("/");
-        Logger logger = Loggers.getLogger(BlobIndexTest.class);
+        Logger logger = LogManager.getLogger(BlobIndexTest.class);
 
         assertThat(BlobIndex.retrieveBlobRootDir(root, "dummy", logger), Matchers.nullValue());
     }

--- a/core/src/main/java/io/crate/monitor/SysInfo.java
+++ b/core/src/main/java/io/crate/monitor/SysInfo.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -108,7 +108,7 @@ public class SysInfo {
         return version;
     }
 
-    private static final Logger LOGGER = Loggers.getLogger(SysInfo.class);
+    private static final Logger LOGGER = LogManager.getLogger(SysInfo.class);
 
 
     private static final SysInfo INSTANCE = new SysInfo.Builder()

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
 
 public final class DataTypes {
 
-    private static final Logger logger = Loggers.getLogger(DataTypes.class);
+    private static final Logger logger = LogManager.getLogger(DataTypes.class);
 
     /**
      * If you add types here make sure to update the SizeEstimatorFactory in the SQL module.

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
@@ -27,7 +27,7 @@ import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Locale;
 
@@ -35,7 +35,7 @@ import java.util.Locale;
 @Sharable
 public class MqttNettyHandler extends ChannelInboundHandlerAdapter {
 
-    private final Logger LOGGER = Loggers.getLogger(MqttNettyHandler.class);
+    private final Logger LOGGER = LogManager.getLogger(MqttNettyHandler.class);
     private final MqttProcessor processor;
 
     MqttNettyHandler(MqttProcessor processor) {

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
@@ -54,7 +54,7 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -82,7 +82,7 @@ import java.util.function.Predicate;
  */
 public class MqttIngestService implements IngestRuleListener {
 
-    private static final Logger LOGGER = Loggers.getLogger(MqttIngestService.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttIngestService.class);
     public static final String SOURCE_IDENT = "mqtt";
     private static final Map<QualifiedName, Integer> MQTT_FIELDS_ORDER = ImmutableMap.of(new QualifiedName("client_id"), 0,
         new QualifiedName("packet_id"), 1,

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/protocol/MqttProcessor.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/protocol/MqttProcessor.java
@@ -30,7 +30,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Locale;
 import java.util.UUID;
@@ -41,7 +41,7 @@ import java.util.function.BiConsumer;
  */
 public class MqttProcessor {
 
-    private static final Logger LOGGER = Loggers.getLogger(MqttProcessor.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttProcessor.class);
 
     private final MqttIngestService ingestService;
 

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/Client.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/Client.java
@@ -30,7 +30,7 @@ import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Throwables;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class Client implements AutoCloseable {
 
-    private static final Logger LOGGER = Loggers.getLogger(Client.class);
+    private static final Logger LOGGER = LogManager.getLogger(Client.class);
 
     private final String host;
     private final int port;

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/operations/MqttIntegrationTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/operations/MqttIntegrationTest.java
@@ -23,7 +23,7 @@ import io.crate.mqtt.netty.Client;
 import io.crate.mqtt.netty.Netty4MqttServerTransport;
 import io.crate.settings.SharedSettings;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -35,7 +35,7 @@ import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_PORT_SETTING;
 
 public abstract class MqttIntegrationTest extends SQLTransportIntegrationTest {
 
-    private static final Logger LOGGER = Loggers.getLogger(MqttIntegrationTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttIntegrationTest.class);
     private static final String PORT_RANGE = "11883-11983";
     private int port;
 

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -41,7 +41,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -60,7 +60,7 @@ import static io.netty.buffer.Unpooled.copiedBuffer;
 
 public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object> {
 
-    private static final Logger LOGGER = Loggers.getLogger(HttpAuthUpstreamHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpAuthUpstreamHandler.class);
     @VisibleForTesting
     static final String WWW_AUTHENTICATE_REALM_MESSAGE = "Basic realm=\"Please provide credentials " +
                                                          "(password maybe empty if trust authentication " +

--- a/http/src/main/java/io/crate/protocols/http/CrateNettyHttpServerTransport.java
+++ b/http/src/main/java/io/crate/protocols/http/CrateNettyHttpServerTransport.java
@@ -27,7 +27,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -109,7 +109,7 @@ public class CrateNettyHttpServerTransport extends Netty4HttpServerTransport {
 
     private static class CrateDispatcher implements HttpServerTransport.Dispatcher {
 
-        private static final Logger LOG = Loggers.getLogger(CrateDispatcher.class);
+        private static final Logger LOG = LogManager.getLogger(CrateDispatcher.class);
 
         private final Path sitePath;
         private final Dispatcher fallbackDispatcher;

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -57,7 +57,7 @@ import io.crate.types.DataType;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -105,7 +105,7 @@ import java.util.function.Function;
 public class Session implements AutoCloseable {
 
     // Logger name should be SQLOperations here
-    private static final Logger LOGGER = Loggers.getLogger(SQLOperations.class);
+    private static final Logger LOGGER = LogManager.getLogger(SQLOperations.class);
 
     // Parser can't handle empty statement but postgres requires support for it.
     // This rewrite is done so that bind/describe calls on an empty statement will work as well

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -37,7 +37,7 @@ import io.crate.sql.tree.CreateSnapshot;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -54,7 +54,7 @@ import static io.crate.analyze.SnapshotSettings.SETTINGS;
 
 class CreateSnapshotAnalyzer {
 
-    private static final Logger LOGGER = Loggers.getLogger(CreateSnapshotAnalyzer.class);
+    private static final Logger LOGGER = LogManager.getLogger(CreateSnapshotAnalyzer.class);
     private final RepositoryService repositoryService;
     private final Schemas schemas;
 

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -36,7 +36,7 @@ import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.SetStatement;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +48,7 @@ import java.util.Set;
 
 class SetStatementAnalyzer {
 
-    private static final Logger logger = Loggers.getLogger(SetStatementAnalyzer.class);
+    private static final Logger logger = LogManager.getLogger(SetStatementAnalyzer.class);
 
     public static AnalyzedStatement analyze(SetStatement node) {
 

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -25,7 +25,7 @@ import io.crate.execution.dsl.phases.ExecutionPhase;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.atomic.AtomicLong;
@@ -45,7 +45,7 @@ public class RamAccountingContext implements RamAccounting {
     private volatile boolean closed = false;
     private volatile boolean tripped = false;
 
-    private static final Logger logger = Loggers.getLogger(RamAccountingContext.class);
+    private static final Logger logger = LogManager.getLogger(RamAccountingContext.class);
 
     public static RamAccountingContext forExecutionPhase(CircuitBreaker breaker, ExecutionPhase executionPhase) {
         String ramAccountingContextId = executionPhase.name() + ": " + executionPhase.phaseId();

--- a/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -31,7 +31,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.EngineException;
@@ -56,7 +56,7 @@ import java.util.function.Predicate;
 
 public class SQLExceptions {
 
-    private static final Logger LOGGER = Loggers.getLogger(SQLExceptions.class);
+    private static final Logger LOGGER = LogManager.getLogger(SQLExceptions.class);
 
     private static final Predicate<Throwable> EXCEPTIONS_TO_UNWRAP = throwable ->
         throwable instanceof TransportException ||

--- a/sql/src/main/java/io/crate/execution/ddl/RepositoryService.java
+++ b/sql/src/main/java/io/crate/execution/ddl/RepositoryService.java
@@ -40,7 +40,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.CreationException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.repositories.RepositoryException;
 
 import javax.annotation.Nullable;
@@ -49,7 +49,7 @@ import java.util.concurrent.CompletableFuture;
 @Singleton
 public class RepositoryService {
 
-    private static final Logger LOGGER = Loggers.getLogger(RepositoryService.class);
+    private static final Logger LOGGER = LogManager.getLogger(RepositoryService.class);
 
     private final ClusterService clusterService;
     private final TransportDeleteRepositoryAction deleteRepositoryAction;

--- a/sql/src/main/java/io/crate/execution/ddl/SnapshotRestoreDDLDispatcher.java
+++ b/sql/src/main/java/io/crate/execution/ddl/SnapshotRestoreDDLDispatcher.java
@@ -47,7 +47,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
@@ -65,7 +65,7 @@ import static io.crate.analyze.SnapshotSettings.WAIT_FOR_COMPLETION;
 @Singleton
 public class SnapshotRestoreDDLDispatcher {
 
-    private static final Logger LOGGER = Loggers.getLogger(SnapshotRestoreDDLDispatcher.class);
+    private static final Logger LOGGER = LogManager.getLogger(SnapshotRestoreDDLDispatcher.class);
     private final TransportActionProvider transportActionProvider;
     private final String[] ALL_TEMPLATES = new String[]{"_all"};
 

--- a/sql/src/main/java/io/crate/execution/ddl/tables/DropTableTask.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/DropTableTask.java
@@ -31,7 +31,7 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.node.ddl.DropTablePlan;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.index.IndexNotFoundException;
 
 import static io.crate.data.SentinelRow.SENTINEL;
@@ -41,7 +41,7 @@ public class DropTableTask {
     private static final Row ROW_ZERO = new Row1(0L);
     private static final Row ROW_ONE = new Row1(1L);
 
-    private static final Logger LOGGER = Loggers.getLogger(DropTableTask.class);
+    private static final Logger LOGGER = LogManager.getLogger(DropTableTask.class);
 
     private final DocTableInfo tableInfo;
     private final TransportDropTableAction transportDropTableAction;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -29,6 +29,7 @@ import io.crate.exceptions.SQLExceptions;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
@@ -45,7 +46,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.Collections;
@@ -58,7 +58,7 @@ public class TableCreator {
 
     private static final Long SUCCESS_RESULT = 1L;
 
-    protected static final Logger logger = Loggers.getLogger(TableCreator.class);
+    protected static final Logger logger = LogManager.getLogger(TableCreator.class);
 
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -46,7 +46,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.DocumentMissingException;
@@ -72,7 +72,7 @@ import static io.crate.data.SentinelRow.SENTINEL;
 
 public class LegacyUpsertByIdTask {
 
-    private static final Logger LOGGER = Loggers.getLogger(UpdateById.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdateById.class);
     private static final BackoffPolicy BACK_OFF_POLICY = LimitedExponentialBackoff.limitedExponential(1000);
 
     private final ClusterService clusterService;

--- a/sql/src/main/java/io/crate/execution/dsl/phases/NodeOperation.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/NodeOperation.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class NodeOperation implements Streamable {
 
-    private static final Logger LOGGER = Loggers.getLogger(NodeOperation.class);
+    private static final Logger LOGGER = LogManager.getLogger(NodeOperation.class);
 
     public static final int NO_DOWNSTREAM = Integer.MAX_VALUE;
 

--- a/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -30,7 +30,7 @@ import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class InterceptingRowConsumer implements RowConsumer {
 
-    private static final Logger LOGGER = Loggers.getLogger(InterceptingRowConsumer.class);
+    private static final Logger LOGGER = LogManager.getLogger(InterceptingRowConsumer.class);
 
     private final AtomicInteger consumerInvokedAndJobInitialized = new AtomicInteger(2);
     private final UUID jobId;

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -46,7 +46,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocSysColumns;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
@@ -64,7 +64,7 @@ import java.util.function.Supplier;
 
 public class LuceneShardCollectorProvider extends ShardCollectorProvider {
 
-    private static final Logger LOGGER = Loggers.getLogger(LuceneShardCollectorProvider.class);
+    private static final Logger LOGGER = LogManager.getLogger(LuceneShardCollectorProvider.class);
 
     private final Supplier<String> localNodeId;
     private final LuceneQueryBuilder luceneQueryBuilder;

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
@@ -38,7 +38,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopFieldCollector;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.lucene.MinimumScoreCollector;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -51,7 +51,7 @@ import java.util.function.Function;
 
 public class LuceneOrderedDocCollector extends OrderedDocCollector {
 
-    private static final Logger LOGGER = Loggers.getLogger(LuceneOrderedDocCollector.class);
+    private static final Logger LOGGER = LogManager.getLogger(LuceneOrderedDocCollector.class);
 
     private final Query query;
     private final Float minScore;

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -42,7 +42,7 @@ import io.crate.execution.jobs.transport.TransportJobAction;
 import io.crate.types.DataTypes;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -51,7 +51,7 @@ import java.util.concurrent.Executor;
 
 public class RemoteCollector {
 
-    private static final Logger LOGGER = Loggers.getLogger(RemoteCollector.class);
+    private static final Logger LOGGER = LogManager.getLogger(RemoteCollector.class);
     private static final int RECEIVER_PHASE_ID = 1;
 
     private final UUID jobId;

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollector.java
@@ -32,7 +32,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -56,7 +56,7 @@ import java.util.function.Function;
  */
 public class ShardStateAwareRemoteCollector {
 
-    private static final Logger LOGGER = Loggers.getLogger(ShardStateAwareRemoteCollector.class);
+    private static final Logger LOGGER = LogManager.getLogger(ShardStateAwareRemoteCollector.class);
     private static final TimeValue STATE_OBSERVER_WAIT_FOR_CHANGE_TIMEOUT = new TimeValue(60000);
 
     private final String localNodeId;

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -32,7 +32,7 @@ import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.expression.InputRow;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,7 +61,7 @@ import static io.crate.exceptions.Exceptions.rethrowUnchecked;
 
 public class FileReadingIterator implements BatchIterator<Row> {
 
-    private static final Logger LOGGER = Loggers.getLogger(FileReadingIterator.class);
+    private static final Logger LOGGER = LogManager.getLogger(FileReadingIterator.class);
     private static final int MAX_SOCKET_TIMEOUT_RETRIES = 5;
     private final Map<String, FileInputFactory> fileInputFactories;
     private final Boolean shared;

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/S3FileInput.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/S3FileInput.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.crate.external.S3ClientHelper;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,7 +39,7 @@ import java.util.function.Predicate;
 public class S3FileInput implements FileInput {
 
     private AmazonS3 client; // to prevent early GC during getObjectContent() in getStream()
-    private static final Logger logger = Loggers.getLogger(S3FileInput.class);
+    private static final Logger logger = LogManager.getLogger(S3FileInput.class);
 
     final S3ClientHelper clientBuilder;
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/FilteredLogSink.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/FilteredLogSink.java
@@ -23,9 +23,9 @@
 package io.crate.execution.engine.collect.stats;
 
 import io.crate.expression.ExpressionsInput;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.Message;
-import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import java.util.Iterator;
@@ -37,7 +37,7 @@ public final class FilteredLogSink<T> implements LogSink<T> {
      * This logger name is documented in the docs for the {@link JobsLogService#STATS_JOBS_LOG_PERSIST_FILTER} setting.
      * Take care when changing the name.
      */
-    private static final Logger STATEMENT_LOGGER = Loggers.getLogger("StatementLog");
+    private static final Logger STATEMENT_LOGGER = LogManager.getLogger("StatementLog");
     private final ExpressionsInput<T, Boolean> memoryFilter;
     private final ExpressionsInput<T, Boolean> persistFilter;
     private final Function<T, Message> createLogMessage;

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
@@ -27,7 +27,7 @@ import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.SizeEstimator;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Locale;
 import java.util.Queue;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RamAccountingQueue<T> extends ForwardingQueue<T> {
 
-    private static final Logger LOGGER = Loggers.getLogger(RamAccountingQueue.class);
+    private static final Logger LOGGER = LogManager.getLogger(RamAccountingQueue.class);
 
     private final Queue<T> delegate;
     private RamAccountingContext context;

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
@@ -38,7 +38,7 @@ import io.crate.expression.InputRow;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -49,7 +49,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class FetchBatchAccumulator implements BatchAccumulator<Row, Iterator<? extends Row>> {
 
-    private static final Logger LOGGER = Loggers.getLogger(FetchBatchAccumulator.class);
+    private static final Logger LOGGER = LogManager.getLogger(FetchBatchAccumulator.class);
 
     private final FetchOperation fetchOperation;
     private final FetchProjectorContext context;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/BulkShardCreationLimiter.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/BulkShardCreationLimiter.java
@@ -26,7 +26,7 @@ import io.crate.analyze.NumberOfReplicas;
 import io.crate.execution.dml.ShardRequest;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.function.Predicate;
@@ -39,7 +39,7 @@ public class BulkShardCreationLimiter<TReq extends ShardRequest<TReq, TItem>, TI
      * <p>wait_for_active_shards</p> timeout of 30sec. Value was wisely chosen after some brave testing.
      */
     static final int MAX_NEW_SHARDS_PER_NODE = 10;
-    private static final Logger LOGGER = Loggers.getLogger(BulkShardCreationLimiter.class);
+    private static final Logger LOGGER = LogManager.getLogger(BulkShardCreationLimiter.class);
 
     private final int numDataNodes;
     private final int numberOfAllShards;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.index.IndexNotFoundException;
 
 import javax.annotation.Nullable;
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
 public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
     implements BiConsumer<ShardedRequests<TReq, TItem>, Row> {
 
-    private static final Logger LOGGER = Loggers.getLogger(GroupRowsByShard.class);
+    private static final Logger LOGGER = LogManager.getLogger(GroupRowsByShard.class);
 
     private final RowShardResolver rowShardResolver;
     private final List<? extends CollectExpression<Row, ?>> expressions;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -42,7 +42,7 @@ import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -147,7 +147,7 @@ public class IndexWriterProjector implements Projector {
         private final Input<Map<String, Object>> sourceInput;
         private final String[] includes;
         private final String[] excludes;
-        private static final Logger logger = Loggers.getLogger(MapInput.class);
+        private static final Logger logger = LogManager.getLogger(MapInput.class);
         private int lastSourceSize;
 
         private MapInput(Input<Map<String, Object>> sourceInput, String[] includes, String[] excludes) {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -56,7 +56,7 @@ import static io.crate.execution.jobs.NodeJobsCounter.MAX_NODE_CONCURRENT_OPERAT
 public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
     implements Function<BatchIterator<Row>, CompletableFuture<? extends Iterable<? extends Row>>> {
 
-    private static final Logger LOGGER = Loggers.getLogger(ShardDMLExecutor.class);
+    private static final Logger LOGGER = LogManager.getLogger(ShardDMLExecutor.class);
 
     private static final BackoffPolicy BACKOFF_POLICY = LimitedExponentialBackoff.limitedExponential(1000);
     public static final int DEFAULT_BULK_SIZE = 10_000;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -43,7 +43,7 @@ import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAc
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -73,7 +73,7 @@ public class ShardingUpsertExecutor
         Setting.Property.NodeScope, Setting.Property.Dynamic), DataTypes.STRING);
 
     private static final BackoffPolicy BACKOFF_POLICY = LimitedExponentialBackoff.limitedExponential(1000);
-    private static final Logger LOGGER = Loggers.getLogger(ShardingUpsertExecutor.class);
+    private static final Logger LOGGER = LogManager.getLogger(ShardingUpsertExecutor.class);
 
     private final GroupRowsByShard<ShardUpsertRequest, ShardUpsertRequest.Item> grouper;
     private final NodeJobsCounter nodeJobsCounter;

--- a/sql/src/main/java/io/crate/execution/jobs/SharedShardContext.java
+++ b/sql/src/main/java/io/crate/execution/jobs/SharedShardContext.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
@@ -41,7 +41,7 @@ import java.util.function.UnaryOperator;
 @NotThreadSafe
 public class SharedShardContext {
 
-    private static final Logger LOGGER = Loggers.getLogger(SharedShardContext.class);
+    private static final Logger LOGGER = LogManager.getLogger(SharedShardContext.class);
 
     private final IndicesService indicesService;
     private final ShardId shardId;

--- a/sql/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -31,7 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportService;
@@ -51,7 +51,7 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
     private final TransportService transportService;
 
     private final TransportKillJobsNodeAction killJobsNodeAction;
-    private static final Logger LOGGER = Loggers.getLogger(NodeDisconnectJobMonitorService.class);
+    private static final Logger LOGGER = LogManager.getLogger(NodeDisconnectJobMonitorService.class);
 
     @Inject
     public NodeDisconnectJobMonitorService(Settings settings,

--- a/sql/src/main/java/io/crate/execution/support/NodeActionRequestHandler.java
+++ b/sql/src/main/java/io/crate/execution/support/NodeActionRequestHandler.java
@@ -24,7 +24,7 @@ package io.crate.execution.support;
 
 import io.crate.exceptions.SQLExceptions;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
@@ -36,7 +36,7 @@ public final class NodeActionRequestHandler<TRequest extends TransportRequest, T
     implements TransportRequestHandler<TRequest> {
 
     private final NodeAction<TRequest, TResponse> nodeAction;
-    private static final Logger LOGGER = Loggers.getLogger(NodeActionRequestHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(NodeActionRequestHandler.class);
 
     public NodeActionRequestHandler(NodeAction<TRequest, TResponse> nodeAction) {
         this.nodeAction = nodeAction;

--- a/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -41,7 +41,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.scalar.arithmetic.MapFunction;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ import java.util.Map;
  */
 public class EvaluatingNormalizer {
 
-    private static final Logger logger = Loggers.getLogger(EvaluatingNormalizer.class);
+    private static final Logger logger = LogManager.getLogger(EvaluatingNormalizer.class);
     private final Functions functions;
     private final RowGranularity granularity;
     private final ReferenceResolver<? extends Input<?>> referenceResolver;

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
@@ -26,7 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.fs.FsService;
@@ -36,7 +36,7 @@ import java.io.IOException;
 
 abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
 
-    private static final Logger LOGGER = Loggers.getLogger(DiskWatermarkNodesSysCheck.class);
+    private static final Logger LOGGER = LogManager.getLogger(DiskWatermarkNodesSysCheck.class);
 
     private final FsService fsService;
     final DiskThresholdSettings diskThresholdSettings;

--- a/sql/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
@@ -36,7 +36,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
@@ -65,7 +65,7 @@ import static io.crate.expression.reference.sys.node.Ports.portFromAddress;
 @Singleton
 public class NodeStatsContextFieldResolver {
 
-    private static final Logger LOGGER = Loggers.getLogger(NodeStatsContextFieldResolver.class);
+    private static final Logger LOGGER = LogManager.getLogger(NodeStatsContextFieldResolver.class);
     private final Supplier<DiscoveryNode> localNode;
     private final Supplier<TransportAddress> boundHttpAddress;
     private final Supplier<HttpStats> httpStatsSupplier;

--- a/sql/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/sql/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -38,7 +38,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.unit.TimeValue;
 
 import javax.script.ScriptException;
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 @Singleton
 public class UserDefinedFunctionService {
 
-    private static final Logger LOGGER = Loggers.getLogger(UserDefinedFunctionService.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserDefinedFunctionService.class);
 
     private final ClusterService clusterService;
     private final Functions functions;

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -77,7 +77,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.cache.IndexCache;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -105,7 +105,7 @@ import static io.crate.metadata.DocReferences.inverseSourceLookup;
 @Singleton
 public class LuceneQueryBuilder {
 
-    private static final Logger LOGGER = Loggers.getLogger(LuceneQueryBuilder.class);
+    private static final Logger LOGGER = LogManager.getLogger(LuceneQueryBuilder.class);
     private static final Visitor VISITOR = new Visitor();
     private final Functions functions;
     private final EvaluatingNormalizer normalizer;

--- a/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -68,7 +68,7 @@ public class FulltextAnalyzerResolver {
     // used for saving the creation statement
     public static final String SQL_STATEMENT_KEY = "_sql_stmt";
 
-    private static final Logger logger = Loggers.getLogger(FulltextAnalyzerResolver.class);
+    private static final Logger logger = LogManager.getLogger(FulltextAnalyzerResolver.class);
 
 
     public enum CustomType {

--- a/sql/src/main/java/io/crate/metadata/PartitionInfos.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionInfos.java
@@ -34,7 +34,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -45,7 +45,7 @@ import java.util.stream.StreamSupport;
 public class PartitionInfos implements Iterable<PartitionInfo> {
 
     private final ClusterService clusterService;
-    private static final Logger LOGGER = Loggers.getLogger(PartitionInfos.class);
+    private static final Logger LOGGER = LogManager.getLogger(PartitionInfos.class);
 
     public PartitionInfos(ClusterService clusterService) {
         this.clusterService = clusterService;

--- a/sql/src/main/java/io/crate/metadata/RoutineInfos.java
+++ b/sql/src/main/java/io/crate/metadata/RoutineInfos.java
@@ -25,7 +25,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -37,7 +37,7 @@ import static java.util.Collections.emptyIterator;
 
 public class RoutineInfos implements Iterable<RoutineInfo> {
 
-    private static final Logger logger = Loggers.getLogger(RoutineInfos.class);
+    private static final Logger logger = LogManager.getLogger(RoutineInfos.class);
     private final UserDefinedFunctionsMetaData functionsMetaData;
     private FulltextAnalyzerResolver ftResolver;
 

--- a/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
@@ -37,7 +37,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
@@ -48,7 +48,7 @@ import java.util.Map;
 
 public class InternalBlobTableInfoFactory implements BlobTableInfoFactory {
 
-    private static final Logger LOGGER = Loggers.getLogger(InternalBlobTableInfoFactory.class);
+    private static final Logger LOGGER = LogManager.getLogger(InternalBlobTableInfoFactory.class);
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Environment environment;
     private final Path globalBlobPath;

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -36,7 +36,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 
@@ -57,7 +57,7 @@ class DocTableInfoBuilder {
     private final MetaData metaData;
     private String[] concreteIndices;
     private String[] concreteOpenIndices;
-    private static final Logger logger = Loggers.getLogger(DocTableInfoBuilder.class);
+    private static final Logger logger = LogManager.getLogger(DocTableInfoBuilder.class);
 
     DocTableInfoBuilder(Functions functions,
                         RelationName ident,

--- a/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
@@ -39,7 +39,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.index.Index;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ import static io.crate.execution.engine.collect.NestableCollectExpression.consta
 
 public class ShardReferenceResolver implements ReferenceResolver<NestableInput<?>> {
 
-    private static final Logger LOGGER = Loggers.getLogger(ShardReferenceResolver.class);
+    private static final Logger LOGGER = LogManager.getLogger(ShardReferenceResolver.class);
     private static final StaticTableReferenceResolver<ShardRowContext> SHARD_REFERENCE_RESOLVER_DELEGATE =
         new StaticTableReferenceResolver<>(SysShardsTableInfo.expressions());
     private static final ReferenceResolver<NestableInput<?>> EMPTY_RESOLVER =

--- a/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -41,7 +41,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
 
@@ -194,7 +194,7 @@ public class TableHealthService extends AbstractComponent {
 
     private static class HealthResultReceiver implements ResultReceiver {
 
-        private static final Logger LOGGER = Loggers.getLogger(TableHealthService.HealthResultReceiver.class);
+        private static final Logger LOGGER = LogManager.getLogger(TableHealthService.HealthResultReceiver.class);
 
         private final CompletableFuture<Map<TablePartitionIdent, ShardsInfo>> result;
         private final Map<TablePartitionIdent, ShardsInfo> tables = new HashMap<>();

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -77,13 +77,13 @@ import io.crate.planner.statement.SetSessionPlan;
 import io.crate.profile.ProfilingContext;
 import io.crate.profile.Timer;
 import io.crate.sql.tree.Expression;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
@@ -98,7 +98,7 @@ import java.util.function.BooleanSupplier;
 @Singleton
 public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
-    private static final Logger LOGGER = Loggers.getLogger(Planner.class);
+    private static final Logger LOGGER = LogManager.getLogger(Planner.class);
 
     private final ClusterService clusterService;
     private final Functions functions;

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -40,7 +40,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -116,7 +116,7 @@ public class TableStatsService extends AbstractComponent implements Runnable {
 
     static class TableStatsResultReceiver extends BaseResultReceiver {
 
-        private static final Logger LOGGER = Loggers.getLogger(TableStatsResultReceiver.class);
+        private static final Logger LOGGER = LogManager.getLogger(TableStatsResultReceiver.class);
 
         private final Consumer<ObjectObjectMap<RelationName, TableStats.Stats>> tableStatsConsumer;
         private ObjectObjectMap<RelationName, TableStats.Stats> newStats = new ObjectObjectHashMap<>();

--- a/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
@@ -34,7 +34,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Expression;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +43,7 @@ import static io.crate.data.SentinelRow.SENTINEL;
 
 public class SetSessionPlan implements Plan {
 
-    private static final Logger LOGGER = Loggers.getLogger(SetSessionPlan.class);
+    private static final Logger LOGGER = LogManager.getLogger(SetSessionPlan.class);
 
     private final Map<String, List<Expression>> settings;
 

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionProperties.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionProperties.java
@@ -24,7 +24,7 @@ package io.crate.protocols.postgres;
 
 import io.crate.auth.Protocol;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -34,7 +34,7 @@ import java.security.cert.Certificate;
 
 public class ConnectionProperties {
 
-    private static final Logger LOGGER = Loggers.getLogger(ConnectionProperties.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConnectionProperties.class);
 
     private final InetAddress address;
     private final Protocol protocol;

--- a/sql/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -33,7 +33,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -57,7 +57,7 @@ import java.util.SortedSet;
  */
 public class Messages {
 
-    private static final Logger LOGGER = Loggers.getLogger(Messages.class);
+    private static final Logger LOGGER = LogManager.getLogger(Messages.class);
 
     private static final byte[] SEVERITY_FATAL = "FATAL".getBytes(StandardCharsets.UTF_8);
     private static final byte[] SEVERITY_ERROR = "ERROR".getBytes(StandardCharsets.UTF_8);

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -45,7 +45,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.ssl.SslContext;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -177,7 +177,7 @@ import static io.crate.protocols.postgres.PostgresWireProtocol.State.STARTUP_HEA
 
 class PostgresWireProtocol {
 
-    private static final Logger LOGGER = Loggers.getLogger(PostgresWireProtocol.class);
+    private static final Logger LOGGER = LogManager.getLogger(PostgresWireProtocol.class);
     private static final String PASSWORD_AUTH_NAME = "password";
 
     final MessageDecoder decoder;

--- a/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -45,7 +45,7 @@ import java.util.function.Predicate;
 
 public class RetryOnFailureResultReceiver implements ResultReceiver {
 
-    private static final Logger LOGGER = Loggers.getLogger(RetryOnFailureResultReceiver.class);
+    private static final Logger LOGGER = LogManager.getLogger(RetryOnFailureResultReceiver.class);
 
     private final ClusterService clusterService;
     private final ClusterState initialState;

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -50,7 +50,7 @@ import io.crate.types.DataType;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -60,7 +60,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class SimplePortal extends AbstractPortal {
 
-    private static final Logger LOGGER = Loggers.getLogger(SimplePortal.class);
+    private static final Logger LOGGER = LogManager.getLogger(SimplePortal.class);
 
     private List<Object> params;
     private String query;

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -24,7 +24,7 @@ package io.crate.protocols.postgres.types;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets;
 public abstract class PGType {
 
     static final int INT32_BYTE_SIZE = Integer.SIZE / 8;
-    private static final Logger LOGGER = Loggers.getLogger(PGType.class);
+    private static final Logger LOGGER = LogManager.getLogger(PGType.class);
 
     private final int oid;
     private final int typeLen;

--- a/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -55,7 +55,7 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.logging.Loggers;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -84,7 +84,7 @@ import static java.util.Collections.singletonList;
 
 public class SqlHttpHandler extends SimpleChannelInboundHandler<HttpPipelinedRequest> {
 
-    private static final Logger LOGGER = Loggers.getLogger(SqlHttpHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(SqlHttpHandler.class);
     private static final String REQUEST_HEADER_USER = "User";
     private static final String REQUEST_HEADER_SCHEMA = "Default-Schema";
     private static final int DEFAULT_SOFT_LIMIT = 10_000;


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed