### PR TITLE
Fix an error handling issue that led to sys.jobs leaks

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -132,3 +132,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue that could cause some type of statements to remain listed
+  within ``sys.jobs`` if their execution stopped with a failure.

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -226,13 +226,17 @@ public class SimplePortal extends AbstractPortal {
             maxRows,
             new JobsLogsUpdateListener(jobId, jobsLogs)
         );
-        plan.execute(
-            dependencyCarrier,
-            plannerContext,
-            consumer,
-            rowParams,
-            SubQueryResults.EMPTY
-        );
+        try {
+            plan.execute(
+                dependencyCarrier,
+                plannerContext,
+                consumer,
+                rowParams,
+                SubQueryResults.EMPTY
+            );
+        } catch (Exception e) {
+            consumer.accept(null, e);
+        }
         synced = true;
         return resultReceiver.completionFuture();
     }


### PR DESCRIPTION
Some `plan.execute` implementations raise an error instead of properly
triggering the listener.

This led to a leak of statements in the `sys.jobs` table as the
component responsible for removing the entries wasn't triggered.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed