### PR TITLE
Move distinct handling into the planner

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -250,7 +250,7 @@ class CopyAnalyzer {
                 expressionAnalysisContext,
                 analysis.transactionContext())
             );
-        QueriedTable<DocTableRelation> subRelation = new QueriedTable<>(tableRelation, querySpec);
+        QueriedTable<DocTableRelation> subRelation = new QueriedTable<>(false, tableRelation, querySpec);
         return new CopyToAnalyzedStatement(
             subRelation, settings, uri, compressionType, outputFormat, outputNames, columnsDefined, overwrites);
     }

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -51,6 +51,7 @@ public class MultiSourceSelect implements QueriedRelation {
     private final Map<QualifiedName, AnalyzedRelation> sources;
     private final Fields fields;
     private final List<JoinPair> joinPairs;
+    private final boolean isDistinct;
     private QualifiedName qualifiedName;
     private QuerySpec querySpec;
 
@@ -112,6 +113,7 @@ public class MultiSourceSelect implements QueriedRelation {
         }).collect(Collectors.toList());
 
         return new MultiSourceSelect(
+            mss.isDistinct,
             mss.qualifiedName,
             newSources,
             mss.fields(),
@@ -130,10 +132,12 @@ public class MultiSourceSelect implements QueriedRelation {
         return f;
     }
 
-    public MultiSourceSelect(Map<QualifiedName, AnalyzedRelation> sources,
+    public MultiSourceSelect(boolean isDistinct,
+                             Map<QualifiedName, AnalyzedRelation> sources,
                              Collection<? extends Path> outputNames,
                              QuerySpec querySpec,
                              List<JoinPair> joinPairs) {
+        this.isDistinct = isDistinct;
         assert sources.size() > 1 : "MultiSourceSelect requires at least 2 relations";
         this.qualifiedName = generateName(sources.keySet());
         this.sources = sources;
@@ -159,11 +163,13 @@ public class MultiSourceSelect implements QueriedRelation {
         return new QualifiedName(sb.toString());
     }
 
-    private MultiSourceSelect(QualifiedName relName,
+    private MultiSourceSelect(boolean isDistinct,
+                              QualifiedName relName,
                               Map<QualifiedName, AnalyzedRelation> sources,
                               Collection<Field> fields,
                               QuerySpec querySpec,
                               List<JoinPair> joinPairs) {
+        this.isDistinct = isDistinct;
         this.qualifiedName = relName;
         this.sources = sources;
         this.joinPairs = joinPairs;
@@ -213,6 +219,11 @@ public class MultiSourceSelect implements QueriedRelation {
     @Override
     public QuerySpec querySpec() {
         return querySpec;
+    }
+
+    @Override
+    public boolean isDistinct() {
+        return isDistinct;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -41,9 +41,14 @@ public class QueriedSelectRelation implements QueriedRelation {
 
     private final Fields fields;
     private final QuerySpec querySpec;
+    private final boolean isDistinct;
     private final QueriedRelation subRelation;
 
-    public QueriedSelectRelation(QueriedRelation subRelation, Collection<? extends Path> outputNames, QuerySpec querySpec) {
+    public QueriedSelectRelation(boolean isDistinct,
+                                 QueriedRelation subRelation,
+                                 Collection<? extends Path> outputNames,
+                                 QuerySpec querySpec) {
+        this.isDistinct = isDistinct;
         this.subRelation = subRelation;
         this.querySpec = querySpec;
         this.fields = new Fields(outputNames.size());
@@ -60,6 +65,11 @@ public class QueriedSelectRelation implements QueriedRelation {
     @Override
     public QuerySpec querySpec() {
         return querySpec;
+    }
+
+    @Override
+    public boolean isDistinct() {
+        return isDistinct;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -38,11 +38,16 @@ import java.util.List;
 
 public final class QueriedTable<TR extends AbstractTableRelation> implements QueriedRelation {
 
+    private final boolean isDistinct;
     private final TR tableRelation;
     private final QuerySpec querySpec;
     private final Fields fields;
 
-    public QueriedTable(TR tableRelation, Collection<? extends Path> outputNames, QuerySpec querySpec) {
+    public QueriedTable(boolean isDistinct,
+                        TR tableRelation,
+                        Collection<? extends Path> outputNames,
+                        QuerySpec querySpec) {
+        this.isDistinct = isDistinct;
         this.tableRelation = tableRelation;
         this.querySpec = querySpec;
         this.fields = new Fields(outputNames.size());
@@ -52,12 +57,17 @@ public final class QueriedTable<TR extends AbstractTableRelation> implements Que
         }
     }
 
-    public QueriedTable(TR tableRelation, QuerySpec querySpec) {
-        this(tableRelation, Relations.namesFromOutputs(querySpec.outputs()), querySpec);
+    public QueriedTable(boolean isDistinct, TR tableRelation, QuerySpec querySpec) {
+        this(isDistinct, tableRelation, Relations.namesFromOutputs(querySpec.outputs()), querySpec);
     }
 
     public QuerySpec querySpec() {
         return querySpec;
+    }
+
+    @Override
+    public boolean isDistinct() {
+        return isDistinct;
     }
 
     public TR tableRelation() {

--- a/sql/src/main/java/io/crate/analyze/Relations.java
+++ b/sql/src/main/java/io/crate/analyze/Relations.java
@@ -68,10 +68,17 @@ class Relations {
                 functions, RowGranularity.CLUSTER, null, tableRelation);
 
             newRelation = new QueriedTable<>(
-                tableRelation, querySpec.copyAndReplace(s -> evalNormalizer.normalize(s, transactionContext)));
+                false,
+                tableRelation,
+                querySpec.copyAndReplace(s -> evalNormalizer.normalize(s, transactionContext)));
         } else {
+            QueriedRelation queriedRelation = (QueriedRelation) relation;
             newRelation = new QueriedSelectRelation(
-                ((QueriedRelation) relation), namesFromOutputs(querySpec.outputs()), querySpec);
+                queriedRelation.isDistinct(),
+                queriedRelation,
+                namesFromOutputs(querySpec.outputs()),
+                querySpec
+            );
             newRelation = (QueriedRelation) normalizer.normalize(newRelation, transactionContext);
         }
         if (newRelation.where().hasQuery() && newRelation.getQualifiedName().equals(relation.getQualifiedName())) {

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -73,6 +73,11 @@ public final class AnalyzedView implements QueriedRelation {
     }
 
     @Override
+    public boolean isDistinct() {
+        return false;
+    }
+
+    @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitView(this, context);
     }

--- a/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
@@ -157,6 +157,11 @@ public class OrderedLimitedRelation implements QueriedRelation {
         return false;
     }
 
+    @Override
+    public boolean isDistinct() {
+        return false;
+    }
+
     public OrderedLimitedRelation map(QueriedRelation newChild, Function<? super Symbol,? extends Symbol> mapper) {
         OrderBy orderBy = orderBy();
         Symbol limit = limit();

--- a/sql/src/main/java/io/crate/analyze/relations/QueriedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QueriedRelation.java
@@ -140,4 +140,6 @@ public interface QueriedRelation extends AnalyzedRelation, AnalyzedStatement {
     default boolean isUnboundPlanningSupported() {
         return true;
     }
+
+    boolean isDistinct();
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -78,6 +78,7 @@ public final class RelationNormalizer {
                 return relation;
             }
             return new QueriedSelectRelation(
+                relation.isDistinct(),
                 normalizedSubRelation,
                 transform(relation.fields(), Field::path),
                 relation.querySpec().copyAndReplace(FieldReplacer.bind(f -> {
@@ -106,6 +107,7 @@ public final class RelationNormalizer {
                 functions, RowGranularity.CLUSTER, null, tableRelation);
 
             QueriedTable<? extends AbstractTableRelation<?>> table = new QueriedTable<>(
+                queriedTable.isDistinct(),
                 tableRelation,
                 transform(queriedTable.fields(), Field::path),
                 queriedTable.querySpec().copyAndReplace(s -> evalNormalizer.normalize(s, tnxCtx))

--- a/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -97,6 +97,11 @@ public class UnionSelect implements QueriedRelation {
     }
 
     @Override
+    public boolean isDistinct() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "US{" + left.getQualifiedName().toString() + ',' + right.getQualifiedName().toString() + '}';
     }

--- a/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
+++ b/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
@@ -141,6 +141,7 @@ final class SemiJoins {
         // normalize is done to rewrite  SELECT * from t1, t2 to SELECT * from (select ... t1) t1, (select ... t2) t2
         // because planner logic expects QueriedRelation in the sources
         MultiSourceSelect mss = new MultiSourceSelect(
+            rel.isDistinct(),
             sources,
             transform(rel.fields(), Field::path),
             newTopQS,

--- a/sql/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/sql/src/main/java/io/crate/planner/operators/Distinct.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.expression.symbol.Symbol;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+
+public final class Distinct {
+
+    public static LogicalPlan.Builder create(LogicalPlan.Builder source, boolean distinct, List<Symbol> outputs) {
+        if (!distinct) {
+            return source;
+        }
+        return (tableStats, usedBeforeNextFetch) -> {
+            LogicalPlan sourcePlan = source.build(tableStats, extractColumns(outputs));
+            return new GroupHashAggregate(sourcePlan, outputs, Collections.emptyList());
+        };
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -67,7 +67,7 @@ public class GroupHashAggregate extends OneInputPlan {
         };
     }
 
-    private GroupHashAggregate(LogicalPlan source, List<Symbol> groupKeys, List<Function> aggregates) {
+    GroupHashAggregate(LogicalPlan source, List<Symbol> groupKeys, List<Function> aggregates) {
         super(source, Lists2.concat(groupKeys, aggregates));
         GroupByConsumer.validateGroupBySymbols(groupKeys);
         this.groupKeys = groupKeys;

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -194,23 +194,27 @@ public class LogicalPlanner {
         return FetchOrEval.create(
             Limit.create(
                 Order.create(
-                    ProjectSet.create(
-                        Filter.create(
-                            groupByOrAggregate(
-                                collectAndFilter(
-                                    relation,
-                                    splitPoints.toCollect(),
-                                    relation.where(),
-                                    subqueryPlanner,
-                                    fetchMode,
-                                    functions,
-                                    txnCtx
-                                ),
-                                relation.groupBy(),
-                                splitPoints.aggregates()),
-                            relation.having()
+                    Distinct.create(
+                        ProjectSet.create(
+                            Filter.create(
+                                groupByOrAggregate(
+                                    collectAndFilter(
+                                        relation,
+                                        splitPoints.toCollect(),
+                                        relation.where(),
+                                        subqueryPlanner,
+                                        fetchMode,
+                                        functions,
+                                        txnCtx
+                                    ),
+                                    relation.groupBy(),
+                                    splitPoints.aggregates()),
+                                relation.having()
+                            ),
+                            splitPoints.tableFunctions()
                         ),
-                        splitPoints.tableFunctions()
+                        relation.isDistinct(),
+                        relation.outputs()
                     ),
                     relation.orderBy()
                 ),

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -29,6 +29,7 @@ import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.format.SymbolFormatter;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -36,7 +37,10 @@ import io.crate.planner.PositionalOrderBy;
 
 import javax.annotation.Nullable;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
 class Order extends OneInputPlan {
 
@@ -80,6 +84,7 @@ class Order extends OneInputPlan {
             executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
         }
         InputColumns.SourceSymbols ctx = new InputColumns.SourceSymbols(source.outputs());
+        ensureOrderByColumnsArePresentInOutputs(source.outputs(), orderBy.orderBySymbols());
         OrderedTopNProjection topNProjection = new OrderedTopNProjection(
             Limit.limitAndOffset(limit, offset),
             0,
@@ -97,6 +102,17 @@ class Order extends OneInputPlan {
             positionalOrderBy
         );
         return executionPlan;
+    }
+
+    private static void ensureOrderByColumnsArePresentInOutputs(List<Symbol> outputs, List<Symbol> orderBySymbols) {
+        Set<Symbol> columnsInOutputs = extractColumns(outputs);
+        for (Symbol columnInOrderBy : extractColumns(orderBySymbols)) {
+            if (!columnsInOutputs.contains(columnInOrderBy)) {
+                throw new UnsupportedOperationException(SymbolFormatter.format(
+                    "Cannot order by \"%s\", as the column does not appear in the outputs of the underlying relation",
+                    columnInOrderBy));
+            }
+        }
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
@@ -51,19 +51,18 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     public void testVisitShowTablesSchema() throws Exception {
         QueriedRelation relation = analyze("show tables in QNAME");
 
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE ((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
 
         relation = analyze("show tables");
-
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE ((information_schema.tables.table_type = 'BASE TABLE') " +
             "AND (NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
     }
 
@@ -71,21 +70,20 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     public void testVisitShowTablesLike() throws Exception {
         QueriedRelation relation = analyze("show tables in QNAME like 'likePattern'");
 
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
             "AND (information_schema.tables.table_name LIKE 'likePattern')) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
 
         relation = analyze("show tables like '%'");
-
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND " +
             "(NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
             "AND (information_schema.tables.table_name LIKE '%')) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
     }
 
@@ -93,22 +91,20 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     public void testVisitShowTablesWhere() throws Exception {
         QueriedRelation relation =
             analyze("show tables in QNAME where table_name = 'foo' or table_name like '%bar%'");
-
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
             "AND ((information_schema.tables.table_name = 'foo') OR (information_schema.tables.table_name LIKE '%bar%'))) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
 
         relation = analyze("show tables where table_name like '%'");
-
+        assertThat(relation.isDistinct(), is(true));
         assertThat(relation.querySpec(), isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') " +
             "AND (NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
             "AND (information_schema.tables.table_name LIKE '%')) " +
-            "GROUP BY information_schema.tables.table_name " +
             "ORDER BY information_schema.tables.table_name"));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -128,4 +128,12 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
                                                      "3| 2\n" +
                                                      "3| 3\n"));
     }
+
+    @Test
+    public void testDistinctIsAppliedAfterTableFunctions() {
+        execute("select distinct generate_series(1, 2), col1 from unnest([1, 1]) order by 1 asc");
+        assertThat(printedTable(response.rows()),
+            is("1| 1\n" +
+               "2| 1\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -293,8 +293,8 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(leftPlan.collectPhase().projections().get(1), instanceOf(GroupProjection.class));
         assertThat(leftPlan.collectPhase().projections().get(1).requiredGranularity(), is(RowGranularity.NODE));
         Collect rightPlan = (Collect) nl.right();
-        assertThat(rightPlan.collectPhase().projections().size(), is(2));
         assertThat(rightPlan.collectPhase().projections(), contains(
+            instanceOf(GroupProjection.class),
             instanceOf(GroupProjection.class),
             instanceOf(GroupProjection.class)
         ));

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -363,6 +363,15 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 sb.append("]\n");
                 plan = boundary.source;
             }
+            if (plan instanceof GroupHashAggregate) {
+                GroupHashAggregate groupHashAggregate = (GroupHashAggregate) plan;
+                startLine("GroupBy[");
+                addSymbolsList(groupHashAggregate.groupKeys);
+                sb.append(" | ");
+                addSymbolsList(groupHashAggregate.aggregates);
+                sb.append("]\n");
+                plan = groupHashAggregate.source;
+            }
             if (plan instanceof MultiPhase) {
                 MultiPhase multiPhase = (MultiPhase) plan;
                 startLine("MultiPhase[\n");

--- a/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+
+public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUnitTest  {
+
+    private SQLExecutor e;
+
+    @Before
+    public void createExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table users (id int, department_id int, name string)")
+            .addTable("create table departments (id int, name string)")
+            .build();
+    }
+
+    @Test
+    public void testOrderByCanContainScalarThatIsNotInDistinctOutputs() {
+        LogicalPlan logicalPlan = e.logicalPlan(
+            "select distinct id from users order by id + 10");
+        assertThat(logicalPlan, isPlan(e.functions(),
+            "RootBoundary[id]\n" +
+            "FetchOrEval[id]\n" +
+            "OrderBy[(id + 10) ASC]\n" +
+            "GroupBy[id | ]\n" +
+            "Collect[doc.users | [id, (id + 10)] | All]\n"));
+    }
+
+    @Test
+    public void testDistinctOnLiteralResultsInGroupByOnLiteral() {
+        LogicalPlan plan = e.logicalPlan("select distinct [1, 2, 3] from users");
+        assertThat(plan, isPlan(e.functions(),
+            "RootBoundary[[1, 2, 3]]\n" +
+            "GroupBy[[1, 2, 3] | ]\n" +
+            "Collect[doc.users | [[1, 2, 3]] | All]\n"));
+    }
+
+    @Test
+    public void testOrderByOnColumnNotPresentInDistinctOutputsIsNotAllowed() {
+        expectedException.expectMessage("Cannot order by \"id\"");
+        e.plan("select distinct name from users order by id");
+    }
+
+    @Test
+    public void testDistinctMixedWithTableFunctionInOutput() {
+        LogicalPlan plan = e.logicalPlan("select distinct generate_series(1, 2), col1 from unnest([1, 1])");
+        assertThat(plan, isPlan(e.functions(),
+            "RootBoundary[generate_series(1, 2), col1]\n" +
+            "GroupBy[generate_series(1, 2), col1 | ]\n" +
+            "ProjectSet[generate_series(1, 2) | col1]\n" +
+            "Collect[.unnest | [col1] | All]\n"));
+    }
+
+    @Test
+    public void testDistinctOnJoinWithGroupByAddsAnotherGroupByOperator() {
+        LogicalPlan logicalPlan = e.logicalPlan(
+            "select distinct count(users.id) from users " +
+            "inner join departments on users.department_id = departments.id " +
+            "group by departments.name"
+        );
+        assertThat(logicalPlan, isPlan(e.functions(),
+            "RootBoundary[count(id)]\n" +
+            "GroupBy[count(id) | ]\n" +
+            "GroupBy[name | count(id)]\n" +
+            "HashJoin[\n" +
+            "    Boundary[department_id, id]\n" +
+            "    Boundary[department_id, id]\n" +
+            "    Collect[doc.users | [department_id, id] | All]\n" +
+            "    --- INNER ---\n" +
+            "    Boundary[name, id]\n" +
+            "    Boundary[name, id]\n" +
+            "    Collect[doc.departments | [name, id] | All]\n" +
+            "]\n"));
+    }
+
+    @Test
+    public void testDistinctOnJoinWithoutGroupByAddsGroupByOperator() {
+        LogicalPlan logicalPlan = e.logicalPlan(
+            "select distinct departments.name from users " +
+            "inner join departments on users.department_id = departments.id " +
+            "order by departments.name");
+        assertThat(logicalPlan, isPlan(e.functions(),
+            "RootBoundary[name]\n" +
+            "OrderBy[name ASC]\n" +
+            "GroupBy[name | ]\n" +
+            "HashJoin[\n" +
+            "    Boundary[department_id]\n" +
+            "    Boundary[department_id]\n" +
+            "    Collect[doc.users | [department_id] | All]\n" +
+            "    --- INNER ---\n" +
+            "    Boundary[id, name]\n" +
+            "    Boundary[id, name]\n" +
+            "    Collect[doc.departments | [id, name] | All]\n" +
+            "]\n"));
+    }
+}


### PR DESCRIPTION
This moves the analysed statement structure closer to the parser AST and
as a side effect allows us to properly execute statement with `DISTINCT`
and table functions in the select list.
Before these statements raised an error that table functions must appear
in the GROUP BY clause.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed