### PR TITLE
Move relation normalization into the planner

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -108,7 +108,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     private final Functions functions;
     private final Schemas schemas;
-    private final RelationNormalizer relationNormalizer;
     private final SymbolPrinter symbolPrinter;
 
     private static final List<Relation> EMPTY_ROW_TABLE_RELATION = ImmutableList.of(
@@ -117,15 +116,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     @Inject
     public RelationAnalyzer(Functions functions, Schemas schemas) {
-        relationNormalizer = new RelationNormalizer(functions);
         this.functions = functions;
         this.symbolPrinter = new SymbolPrinter(functions);
         this.schemas = schemas;
     }
 
     public AnalyzedRelation analyze(Node node, StatementAnalysisContext statementContext) {
-        AnalyzedRelation relation = process(node, statementContext);
-        return relationNormalizer.normalize(relation, statementContext.transactionContext());
+        return process(node, statementContext);
     }
 
     public AnalyzedRelation analyzeUnbound(Query query,

--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -30,8 +30,12 @@ import io.crate.analyze.SetAnalyzedStatement;
 import io.crate.analyze.SetLicenseAnalyzedStatement;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.AnalyzedView;
+import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.OrderedLimitedRelation;
 import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.relations.TableFunctionRelation;
+import io.crate.analyze.relations.TableRelation;
 import io.crate.analyze.relations.UnionSelect;
 import io.crate.expression.tablefunctions.EmptyRowTableFunction;
 import io.crate.metadata.information.InformationSchemaInfo;
@@ -119,6 +123,26 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
         public Boolean visitQueriedTable(QueriedTable<?> queriedTable, Void context) {
             TableInfo tableInfo = queriedTable.tableRelation().tableInfo();
             return isSysSchema(tableInfo.ident().schema()) || isEmptyRowTable(tableInfo);
+        }
+
+        @Override
+        public Boolean visitTableRelation(TableRelation tableRelation, Void context) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitDocTableRelation(DocTableRelation relation, Void context) {
+            return false;
+        }
+
+        @Override
+        public Boolean visitTableFunctionRelation(TableFunctionRelation tableFunctionRelation, Void context) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitView(AnalyzedView analyzedView, Void context) {
+            return process(analyzedView.relation(), context);
         }
     }
 }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -113,11 +113,13 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    Functions functions,
                    TableStats tableStats,
                    LicenseService licenseService) {
-        this.clusterService = clusterService;
-        this.functions = functions;
-        this.logicalPlanner = new LogicalPlanner(functions, tableStats);
-        this.isStatementExecutionAllowed = new IsStatementExecutionAllowed(licenseService::hasValidLicense);
-        initAwarenessAttributes(settings);
+        this(
+            settings,
+            clusterService,
+            functions,
+            tableStats,
+            licenseService::hasValidLicense
+        );
     }
 
     @VisibleForTesting

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -65,7 +65,8 @@ public class SelectStatementPlanner {
         }
 
         private LogicalPlan invokeLogicalPlanner(QueriedRelation relation, Context context) {
-            LogicalPlan logicalPlan = logicalPlanner.plan(relation, context.plannerContext, context.subqueryPlanner, FetchMode.MAYBE_CLEAR);
+            LogicalPlan logicalPlan = logicalPlanner.normalizeAndPlan(
+                relation, context.plannerContext, context.subqueryPlanner, FetchMode.MAYBE_CLEAR);
             if (logicalPlan == null) {
                 throw new UnsupportedOperationException("Cannot create plan for: " + relation);
             }

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -381,7 +381,8 @@ public final class CopyStatementPlanner {
             statement.outputNames(),
             outputFormat);
 
-        LogicalPlan logicalPlan = logicalPlanner.plan(statement.subQueryRelation(), context, subqueryPlanner, FetchMode.NEVER_CLEAR);
+        LogicalPlan logicalPlan = logicalPlanner.normalizeAndPlan(
+            statement.subQueryRelation(), context, subqueryPlanner, FetchMode.NEVER_CLEAR);
         if (logicalPlan == null) {
             return null;
         }

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -22,12 +22,14 @@
 
 package io.crate.analyze;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.hamcrest.Matchers;
@@ -66,7 +68,10 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private <T extends AnalyzedStatement> T analyze(String statement) {
-        return sqlExecutor.analyze(statement);
+        //noinspection unchecked
+        return (T) sqlExecutor.normalize(
+            sqlExecutor.analyze(statement),
+            new TransactionContext(SessionContext.systemSessionContext()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
@@ -49,7 +49,7 @@ public class SelectFromViewAnalyzerTest extends CrateDummyClusterServiceUnitTest
 
     @Test
     public void testSelectFromViewIsResolvedToViewQueryDefinition() {
-        QueriedSelectRelation query = e.analyze("select * from doc.v1");
+        QueriedSelectRelation query = e.normalize("select * from doc.v1");
         assertThat(query.outputs(), Matchers.contains(isField("name"), isField("count(*)")));
         assertThat(query.groupBy(), Matchers.empty());
         assertThat(query.subRelation(), instanceOf(AnalyzedView.class));

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ColumnUnknownException;
@@ -55,6 +56,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -128,11 +130,17 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     private QueriedRelation analyze(String statement) {
-        return sqlExecutor.analyze(statement);
+        return sqlExecutor.normalize(
+            sqlExecutor.analyze(statement),
+            new TransactionContext(SessionContext.systemSessionContext())
+        );
     }
 
     private QueriedRelation analyze(String statement, Object[] arguments) {
-        return (QueriedRelation) sqlExecutor.analyze(statement, arguments);
+        return sqlExecutor.normalize(
+                sqlExecutor.analyze(statement, arguments),
+                new TransactionContext(SessionContext.systemSessionContext())
+            );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -90,7 +90,7 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testMatchPredicateWithSingleRowSubselect() throws Exception {
-        QueriedRelation relation = e.analyze(
+        QueriedRelation relation = e.normalize(
             "select * from users where match(shape 1.2, (select shape from users limit 1))");
         assertThat(relation.where().query(),
             isSQL("MATCH((shape 1.2), SelectSymbol{geo_shape_array}) USING intersects"));

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -22,9 +22,11 @@
 
 package io.crate.analyze;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.AmbiguousColumnAliasException;
+import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -53,7 +55,9 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private <T extends QueriedRelation> T analyze(String stmt) {
-        return (T) executor.analyze(stmt);
+        return (T) executor.normalize(
+            executor.analyze(stmt),
+            new TransactionContext(SessionContext.systemSessionContext()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -142,7 +142,10 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private WhereClause analyzeSelect(String stmt, Object... args) {
-        QueriedRelation rel = e.analyze(stmt, args);
+        QueriedRelation rel = e.normalize(
+            e.analyze(stmt, args),
+            new TransactionContext(SessionContext.systemSessionContext())
+        );
         if (rel instanceof QueriedTable && ((QueriedTable) rel).tableRelation() instanceof DocTableRelation) {
             DocTableRelation docTableRelation = (DocTableRelation) ((QueriedTable) rel).tableRelation();
             WhereClauseOptimizer.DetailedQuery detailedQuery = WhereClauseOptimizer.optimize(

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -61,13 +61,13 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t1 (x int, y int, z as x + y)")
             .addTable("create table t2 (obj object as (a int, c as obj['a'] + 3), b as obj['a'] + 1)")
             .build();
-        QueriedRelation relation = e.analyze("select x, y, z from t1");
+        QueriedRelation relation = e.normalize("select x, y, z from t1");
         t1 = (DocTableInfo) ((QueriedTable) relation).tableRelation().tableInfo();
         x = (Reference) relation.outputs().get(0);
         y = (Reference) relation.outputs().get(1);
         z = (Reference) relation.outputs().get(2);
 
-        relation = e.analyze("select obj, b from t2");
+        relation = e.normalize("select obj, b from t2");
         t2 = (DocTableInfo) ((QueriedTable) relation).tableRelation().tableInfo();
         obj = (Reference) relation.outputs().get(0);
         b = (Reference) relation.outputs().get(1);

--- a/sql/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
@@ -39,11 +39,10 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
     public void testSplitPointsCreationWithFunctionInAggregation() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
 
-        QueriedRelation relation = e.analyze("select sum(coalesce(x, 0::integer)) + 10 from t1");
+        QueriedRelation relation = e.normalize("select sum(coalesce(x, 0::integer)) + 10 from t1");
 
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
 
-        //noinspection unchecked
         assertThat(splitPoints.toCollect(), contains(isFunction("coalesce")));
         assertThat(splitPoints.aggregates(), contains(isFunction("sum")));
     }
@@ -52,13 +51,11 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
     public void testSplitPointsCreationSelectItemAggregationsAreAlwaysAdded() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
 
-        QueriedRelation relation = e.analyze("select sum(coalesce(x, 0::integer)), sum(coalesce(x, 0::integer)) + 10 from t1");
+        QueriedRelation relation = e.normalize("select sum(coalesce(x, 0::integer)), sum(coalesce(x, 0::integer)) + 10 from t1");
 
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
 
-        //noinspection unchecked
         assertThat(splitPoints.toCollect(), contains(isFunction("coalesce")));
-        //noinspection unchecked
         assertThat(splitPoints.aggregates(), contains(isFunction("sum")));
     }
 
@@ -66,7 +63,7 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testScalarIsNotCollectedEarly() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
-        QueriedRelation relation = e.analyze("select x + 1 from t1 group by x");
+        QueriedRelation relation = e.normalize("select x + 1 from t1 group by x");
 
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
         assertThat(splitPoints.toCollect(), contains(isReference("x")));
@@ -78,7 +75,7 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table t1 (x int, xs array(integer))")
             .build();
-        QueriedRelation relation = e.analyze("select unnest(xs), x from t1");
+        QueriedRelation relation = e.normalize("select unnest(xs), x from t1");
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
         assertThat(splitPoints.toCollect(), contains(isReference("xs"), isReference("x")));
         assertThat(splitPoints.tableFunctions(), contains(isFunction("unnest")));
@@ -89,7 +86,7 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table t1 (x int)")
             .build();
-        QueriedRelation relation = e.analyze("select max(x), generate_series(0, max(x)) from t1");
+        QueriedRelation relation = e.normalize("select max(x), generate_series(0, max(x)) from t1");
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
         assertThat(splitPoints.toCollect(), contains(isReference("x")));
         assertThat(splitPoints.aggregates(), contains(isFunction("max")));

--- a/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -66,7 +66,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
     }
 
     private WhereClauseOptimizer.DetailedQuery optimize(String statement) {
-        QueriedTable queriedTable = e.analyze(statement);
+        QueriedTable queriedTable = e.normalize(statement);
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
             e.functions(),
             RowGranularity.CLUSTER,

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -103,7 +103,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNestedLoop_TablesAreSwitchedIfLeftIsSmallerThanRight() {
         txnCtx.sessionContext().setHashJoinEnabled(false);
-        MultiSourceSelect mss = e.analyze("select * from users, locations where users.id = locations.id");
+        MultiSourceSelect mss = e.normalize("select * from users, locations where users.id = locations.id");
 
         TableStats tableStats = new TableStats();
         ObjectObjectHashMap<RelationName, TableStats.Stats> rowCountByTable = new ObjectObjectHashMap<>();
@@ -126,8 +126,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     public void testNestedLoop_TablesAreNotSwitchedIfLeftHasAPushedDownOrderBy() {
         txnCtx.sessionContext().setHashJoinEnabled(false);
         // we use a subselect to simulate the pushed-down order by
-        MultiSourceSelect mss = e.analyze("select users.id from (select id from users order by id) users, " +
-                                          "locations where users.id = locations.id");
+        MultiSourceSelect mss = e.normalize("select users.id from (select id from users order by id) users, " +
+                                            "locations where users.id = locations.id");
 
         TableStats tableStats = new TableStats();
         ObjectObjectHashMap<RelationName, TableStats.Stats> rowCountByTable = new ObjectObjectHashMap<>();
@@ -149,9 +149,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testHashJoin_TableOrderInLogicalAndExecutionPlan() {
-        MultiSourceSelect mss = e.analyze("select users.name, locations.id " +
-                                          "from users " +
-                                          "join locations on users.id = locations.id");
+        MultiSourceSelect mss = e.normalize("select users.name, locations.id " +
+                                            "from users " +
+                                            "join locations on users.id = locations.id");
 
         TableStats tableStats = new TableStats();
         ObjectObjectHashMap<RelationName, TableStats.Stats> rowCountByTable = new ObjectObjectHashMap<>();
@@ -172,9 +172,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testHashJoin_TablesSwitchWhenRightBiggerThanLeft() {
-        MultiSourceSelect mss = e.analyze("select users.name, locations.id " +
-                                          "from users " +
-                                          "join locations on users.id = locations.id");
+        MultiSourceSelect mss = e.normalize("select users.name, locations.id " +
+                                            "from users " +
+                                            "join locations on users.id = locations.id");
 
         TableStats tableStats = new TableStats();
         ObjectObjectHashMap<RelationName, TableStats.Stats> rowCountByTable = new ObjectObjectHashMap<>();
@@ -196,9 +196,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMultipleHashJoins() {
-        MultiSourceSelect mss = e.analyze("select * " +
-                                          "from t1 inner join t2 on t1.a = t2.b " +
-                                          "inner join t3 on t3.c = t2.b");
+        MultiSourceSelect mss = e.normalize("select * " +
+                                            "from t1 inner join t2 on t1.a = t2.b " +
+                                            "inner join t3 on t3.c = t2.b");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
         assertThat(operator, instanceOf(HashJoin.class));
@@ -213,9 +213,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMixedHashJoinNestedLoop() {
-        MultiSourceSelect mss = e.analyze("select * " +
-                                          "from t1 inner join t2 on t1.a = t2.b " +
-                                          "left join t3 on t3.c = t2.b");
+        MultiSourceSelect mss = e.normalize("select * " +
+                                            "from t1 inner join t2 on t1.a = t2.b " +
+                                            "left join t3 on t3.c = t2.b");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
         assertThat(operator, instanceOf(NestedLoopJoin.class));
@@ -230,7 +230,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBlockNestedLoopWhenTableSizeUnknownAndOneExecutionNode() {
-        MultiSourceSelect mss = e.analyze("select * from t1, t4");
+        MultiSourceSelect mss = e.normalize("select * from t1, t4");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
         assertThat(operator, instanceOf(NestedLoopJoin.class));
@@ -254,7 +254,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .setTableStats(tableStats)
             .build();
 
-        MultiSourceSelect mss = e.analyze("select * from t1, t4");
+        MultiSourceSelect mss = e.normalize("select * from t1, t4");
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(NestedLoopJoin.class));
@@ -282,7 +282,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addDocTable(T3.T4_INFO)
             .setTableStats(tableStats)
             .build();
-        MultiSourceSelect mss = e.analyze("select * from t4, t1");
+        MultiSourceSelect mss = e.normalize("select * from t4, t1");
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(NestedLoopJoin.class));
@@ -310,7 +310,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addDocTable(T3.T4_INFO)
             .setTableStats(tableStats)
             .build();
-        MultiSourceSelect mss = e.analyze("select * from t1, t4 order by t1.x");
+        MultiSourceSelect mss = e.normalize("select * from t1, t4 order by t1.x");
 
         LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -301,12 +301,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                    SQLExecutor sqlExecutor,
                                    ClusterService clusterService,
                                    TableStats tableStats) {
-        QueriedRelation relation = sqlExecutor.analyze(statement);
         PlannerContext context = sqlExecutor.getPlannerContext(clusterService.state());
+        QueriedRelation relation = sqlExecutor.analyze(statement);
         LogicalPlanner logicalPlanner = new LogicalPlanner(getFunctions(), tableStats);
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
 
-        return logicalPlanner.plan(relation, context, subqueryPlanner, FetchMode.MAYBE_CLEAR);
+        return logicalPlanner.normalizeAndPlan(relation, context, subqueryPlanner, FetchMode.MAYBE_CLEAR);
     }
 
     public static Matcher<LogicalPlan> isPlan(Functions functions, String expectedPlan) {


### PR DESCRIPTION
This moves the normalization step into the planner so that we hold onto
the original statements structure a bit longer. Doing the normalization
early in the analyzer prevents us from re-creating the formatted SQL
statement. This is because the normalization changes the statement
structure:

For example:

    SELECT u1.name FROM users u1, users u2

Becomes

    SELECT u1.name FROM
      (SELECT name FROM users) u1,
      (SELECT 1 FROM users) u2

If we formatted the SQL statement based on this and re-analysed it we
would add another relation layer.

See also https://github.com/crate/crate/pull/7933
The SQLPrinter had workarounds in place for this issue, but fixing the
workarounds broke other things.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed