### PR TITLE
Support using functions that require a transaction context in generated columns

### DIFF
--- a/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -24,7 +24,7 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.data.Row;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -79,7 +79,7 @@ public class PreExecutionBenchmark {
             .build();
         selectStatement = SqlParser.createStatement("select name from users");
         selectAnalysis =
-            e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
+            e.analyzer.boundAnalyze(selectStatement, new CoordinatorTxnCtx(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
         plannerContext = e.getPlannerContext(clusterService.state(), new Random(dummySeed));
     }
 
@@ -106,7 +106,7 @@ public class PreExecutionBenchmark {
 
     @Benchmark
     public Analysis measureAnalyzeSimpleSelect() {
-        return e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
+        return e.analyzer.boundAnalyze(selectStatement, new CoordinatorTxnCtx(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
     }
 
     @Benchmark

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -12,6 +12,7 @@ import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.types.DataTypes;
@@ -44,6 +45,7 @@ public class CsvReaderBenchmark {
 
     private String fileUri;
     private InputFactory inputFactory;
+    private TransactionContext txnCtx = TransactionContext.of("dummyUser", "dummySchema");
     File tempFile;
 
     @Setup
@@ -93,7 +95,7 @@ public class CsvReaderBenchmark {
     @Benchmark()
     public void measureFileReadingIteratorForCSV(Blackhole blackhole) {
         Reference raw = createReference("_raw", DataTypes.STRING);
-        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -12,6 +12,7 @@ import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.types.DataTypes;
@@ -44,6 +45,7 @@ public class JsonReaderBenchmark {
 
     private String fileUri;
     private InputFactory inputFactory;
+    private TransactionContext txnCtx = TransactionContext.of("dummyUser", "dummySchema");
     File tempFile;
 
     @Setup
@@ -91,7 +93,8 @@ public class JsonReaderBenchmark {
     @Benchmark()
     public void measureFileReadingIteratorForJson(Blackhole blackhole) {
         Reference raw = createReference("_raw", DataTypes.STRING);
-        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(
+            txnCtx, FileLineReferenceResolver::getImplementation);
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,8 @@ Breaking Changes
 Changes
 =======
 
+- Functions like ``current_schema`` and ``current_user`` which depend on the
+  active session can now be used as generated columns.
 
 - Added the ``replace`` scalar function.
 

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -21,6 +21,7 @@ package io.crate.operation.language;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.ArrayType;
 import io.crate.types.GeoPointType;
@@ -68,7 +69,7 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(Input<Object>[] values) {
+    public Object evaluate(TransactionContext txnCtx, Input<Object>[] values) {
         try {
             return evaluateScriptWithBindings(JavaScriptLanguage.bindScript(script), values);
         } catch (ScriptException e) {
@@ -97,7 +98,7 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
         }
 
         @Override
-        public final Object evaluate(Input<Object>[] values) {
+        public final Object evaluate(TransactionContext txnCtx, Input<Object>[] values) {
             return evaluateScriptWithBindings(bindings, values);
         }
 

--- a/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
@@ -26,7 +26,7 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.tree.CreateIngestRule;
 import io.crate.sql.tree.QualifiedName;
 import org.junit.Test;
@@ -61,7 +61,7 @@ public class MqttAnalyzerTest {
         sessionContext.setSearchPath("custom");
         ParameterContext parameterContext = mock(ParameterContext.class);
         ParamTypeHints paramTypeHints = mock(ParamTypeHints.class);
-        Analysis analysis = new Analysis(new TransactionContext(sessionContext), parameterContext, paramTypeHints);
+        Analysis analysis = new Analysis(new CoordinatorTxnCtx(sessionContext), parameterContext, paramTypeHints);
 
         CreateIngestionRuleAnalysedStatement analyzed = analyzer.analyze(createIngestRule, analysis);
 

--- a/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
+++ b/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
@@ -19,7 +19,6 @@
 package io.crate.scalar.systeminformation;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.auth.user.User;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -27,13 +26,12 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Locale;
 
 public class UserFunction extends Scalar<String, Object> implements FunctionFormatSpec {
 
@@ -58,24 +56,17 @@ public class UserFunction extends Scalar<String, Object> implements FunctionForm
     }
 
     @Override
-    public String evaluate(Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
-        throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "Cannot evaluate %s function", name));
+        return txnCtx.userName();
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext transactionContext) {
-        if (transactionContext == null) {
+    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx) {
+        if (txnCtx == null) {
             return Literal.NULL;
         }
-
-        assert transactionContext.sessionContext() != null : name + " requires a session context";
-        User user = transactionContext.sessionContext().user();
-        String username = null;
-        if (user != null) {
-            username = user.name();
-        }
-        return Literal.of(username);
+        return Literal.of(txnCtx.userName());
     }
 
     @Override

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -29,7 +29,7 @@ import io.crate.exceptions.UnauthorizedException;
 import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.sql.parser.SqlParser;
@@ -126,7 +126,7 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
 
     private void analyze(String stmt, User user) {
         e.analyzer.boundAnalyze(SqlParser.createStatement(stmt),
-            new TransactionContext(new SessionContext(0, Option.NONE, user,
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, user,
                 userManager.getStatementValidator(user, Schemas.DOC_SCHEMA_NAME),
                 userManager.getExceptionValidator(user, Schemas.DOC_SCHEMA_NAME))), ParameterContext.EMPTY);
     }

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -38,8 +38,8 @@ import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
@@ -160,7 +160,7 @@ public class Session implements AutoCloseable {
      *              Use {@link #quickExec(String, ResultReceiver, Row)} to use the regular parser
      */
     public void quickExec(String statement, Function<String, Statement> parse, ResultReceiver resultReceiver, Row params) {
-        TransactionContext txnCtx = new TransactionContext(sessionContext);
+        CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(sessionContext);
         Statement parsedStmt = parse.apply(statement);
         AnalyzedStatement analyzedStatement = analyzer.unboundAnalyze(parsedStmt, sessionContext, ParamTypeHints.EMPTY);
         assert analyzedStatement.isUnboundPlanningSupported()
@@ -217,7 +217,7 @@ public class Session implements AutoCloseable {
                             RoutingProvider routingProvider,
                             RowConsumer consumer,
                             Row params,
-                            TransactionContext txnCtx) {
+                            CoordinatorTxnCtx txnCtx) {
         PlannerContext plannerContext = new PlannerContext(
             planner.currentClusterState(),
             routingProvider,

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -26,8 +26,8 @@ import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.Expression;
@@ -54,7 +54,7 @@ public class AlterUserAnalyzer {
     }
 
 
-    public AlterUserAnalyzedStatement analyze(AlterUser node, ParamTypeHints typeHints, TransactionContext txnContext) {
+    public AlterUserAnalyzedStatement analyze(AlterUser node, ParamTypeHints typeHints, CoordinatorTxnCtx txnContext) {
         ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,

--- a/sql/src/main/java/io/crate/analyze/Analysis.java
+++ b/sql/src/main/java/io/crate/analyze/Analysis.java
@@ -23,20 +23,20 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 
 public class Analysis {
 
     private final ParameterContext parameterContext;
-    private final TransactionContext transactionContext;
+    private final CoordinatorTxnCtx coordinatorTxnCtx;
 
     private final ParamTypeHints paramTypeHints;
     private AnalyzedStatement analyzedStatement;
     private AnalyzedRelation rootRelation;
 
-    public Analysis(TransactionContext transactionContext, ParameterContext parameterContext, ParamTypeHints paramTypeHints) {
+    public Analysis(CoordinatorTxnCtx coordinatorTxnCtx, ParameterContext parameterContext, ParamTypeHints paramTypeHints) {
         this.paramTypeHints = paramTypeHints;
-        this.transactionContext = transactionContext;
+        this.coordinatorTxnCtx = coordinatorTxnCtx;
         this.parameterContext = parameterContext;
     }
 
@@ -60,12 +60,12 @@ public class Analysis {
         return rootRelation;
     }
 
-    public TransactionContext transactionContext() {
-        return transactionContext;
+    public CoordinatorTxnCtx transactionContext() {
+        return coordinatorTxnCtx;
     }
 
     public SessionContext sessionContext() {
-        return transactionContext.sessionContext();
+        return coordinatorTxnCtx.sessionContext();
     }
 
     public ParamTypeHints paramTypeHints() {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -37,7 +37,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.types.ArrayType;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
@@ -244,9 +244,9 @@ public class AnalyzedTableElements {
                              Collection<? extends Reference> existingColumns,
                              Functions functions,
                              ParameterContext parameterContext,
-                             TransactionContext transactionContext) {
+                             CoordinatorTxnCtx coordinatorTxnCtx) {
         expandColumnIdents();
-        validateGeneratedColumns(relationName, existingColumns, functions, parameterContext, transactionContext);
+        validateGeneratedColumns(relationName, existingColumns, functions, parameterContext, coordinatorTxnCtx);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -260,7 +260,7 @@ public class AnalyzedTableElements {
                                           Collection<? extends Reference> existingColumns,
                                           Functions functions,
                                           ParameterContext parameterContext,
-                                          TransactionContext transactionContext) {
+                                          CoordinatorTxnCtx coordinatorTxnCtx) {
         List<Reference> tableReferences = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReference(relationName, columnDefinition, tableReferences);
@@ -269,7 +269,7 @@ public class AnalyzedTableElements {
 
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(tableReferences, relationName);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, transactionContext, parameterContext, tableReferenceResolver, null);
+            functions, coordinatorTxnCtx, parameterContext, tableReferenceResolver, null);
         SymbolPrinter printer = new SymbolPrinter(functions);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         for (AnalyzedColumnDefinition columnDefinition : columns) {

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -32,7 +32,7 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.tree.AlterBlobTable;
 import io.crate.sql.tree.AlterClusterRerouteRetryFailed;
 import io.crate.sql.tree.AlterTable;
@@ -208,10 +208,10 @@ public class Analyzer {
         this.alterUserAnalyzer = new AlterUserAnalyzer(functions);
     }
 
-    public Analysis boundAnalyze(Statement statement, TransactionContext transactionContext, ParameterContext parameterContext) {
-        Analysis analysis = new Analysis(transactionContext, parameterContext, ParamTypeHints.EMPTY);
+    public Analysis boundAnalyze(Statement statement, CoordinatorTxnCtx coordinatorTxnCtx, ParameterContext parameterContext) {
+        Analysis analysis = new Analysis(coordinatorTxnCtx, parameterContext, ParamTypeHints.EMPTY);
         AnalyzedStatement analyzedStatement = analyzedStatement(statement, analysis);
-        transactionContext.sessionContext().ensureStatementAuthorized(analyzedStatement);
+        coordinatorTxnCtx.sessionContext().ensureStatementAuthorized(analyzedStatement);
         analysis.analyzedStatement(analyzedStatement);
         return analysis;
     }

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -39,6 +39,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
@@ -46,7 +47,6 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.Validators;
@@ -281,12 +281,12 @@ class CopyAnalyzer {
                                                  EvaluatingNormalizer normalizer,
                                                  ExpressionAnalyzer expressionAnalyzer,
                                                  ExpressionAnalysisContext expressionAnalysisContext,
-                                                 TransactionContext transactionContext) {
+                                                 CoordinatorTxnCtx coordinatorTxnCtx) {
         // primary key optimization and partition selection from query happens later
         // based on the queriedRelation in the LogicalPlanner
         if (where.isPresent()) {
             Symbol query = normalizer.normalize(
-                expressionAnalyzer.convert(where.get(), expressionAnalysisContext), transactionContext);
+                expressionAnalyzer.convert(where.get(), expressionAnalysisContext), coordinatorTxnCtx);
             return new WhereClause(query, partitions, Collections.emptySet());
         } else {
             return new WhereClause(null, partitions, Collections.emptySet());

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -24,11 +24,11 @@ package io.crate.analyze;
 import io.crate.analyze.expressions.ExpressionToStringVisitor;
 import io.crate.data.Row;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CrateTableOption;
 import io.crate.sql.tree.CreateTable;
@@ -80,11 +80,11 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     public CreateTableAnalyzedStatement analyze(CreateTable createTable,
                                                 ParameterContext parameterContext,
-                                                TransactionContext transactionContext) {
+                                                CoordinatorTxnCtx coordinatorTxnCtx) {
         CreateTableAnalyzedStatement statement = new CreateTableAnalyzedStatement();
         Row parameters = parameterContext.parameters();
         RelationName relationName = RelationName
-            .of(createTable.name().getName(), transactionContext.sessionContext().searchPath().currentSchema());
+            .of(createTable.name().getName(), coordinatorTxnCtx.sessionContext().searchPath().currentSchema());
         statement.table(relationName, createTable.ifNotExists(), schemas);
 
         // apply default in case it is not specified in the genericProperties,
@@ -105,7 +105,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
             Collections.emptyList(),
             functions,
             parameterContext,
-            transactionContext);
+            coordinatorTxnCtx);
 
         // update table settings
         statement.tableParameter().settingsBuilder().put(tableElements.settings());

--- a/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
@@ -26,8 +26,8 @@ import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.Expression;
@@ -54,7 +54,7 @@ public class CreateUserAnalyzer {
         this.functions = functions;
     }
 
-    public CreateUserAnalyzedStatement analyze(CreateUser node, ParamTypeHints typeHints, TransactionContext txnContext) {
+    public CreateUserAnalyzedStatement analyze(CreateUser node, ParamTypeHints typeHints, CoordinatorTxnCtx txnContext) {
         if (!node.properties().isEmpty()) {
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 functions,

--- a/sql/src/main/java/io/crate/analyze/CreateViewAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateViewAnalyzer.java
@@ -25,7 +25,7 @@ package io.crate.analyze;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.parser.SqlParser;
@@ -40,7 +40,7 @@ public final class CreateViewAnalyzer {
         this.relationAnalyzer = relationAnalyzer;
     }
 
-    public AnalyzedStatement analyze(CreateView createView, TransactionContext txnCtx) {
+    public AnalyzedStatement analyze(CreateView createView, CoordinatorTxnCtx txnCtx) {
         RelationName name = RelationName.of(createView.name(), txnCtx.sessionContext().searchPath().currentSchema());
         name.ensureValidForRelationCreation();
         if (BlobSchemaInfo.NAME.equals(name.schema())) {

--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -32,9 +32,9 @@ import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Delete;
 
@@ -48,7 +48,7 @@ final class DeleteAnalyzer {
         this.relationAnalyzer = relationAnalyzer;
     }
 
-    public AnalyzedDeleteStatement analyze(Delete delete, ParamTypeHints typeHints, TransactionContext txnContext) {
+    public AnalyzedDeleteStatement analyze(Delete delete, ParamTypeHints typeHints, CoordinatorTxnCtx txnContext) {
         StatementAnalysisContext stmtCtx = new StatementAnalysisContext(typeHints, Operation.DELETE, txnContext);
         RelationAnalysisContext relationCtx = stmtCtx.startRelation();
         AnalyzedRelation relation = relationAnalyzer.analyze(delete.getRelation(), stmtCtx);

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -39,11 +39,11 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolFormatter;
 import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Assignment;
@@ -105,7 +105,7 @@ class InsertFromSubQueryAnalyzer {
         this.relationAnalyzer = relationAnalyzer;
     }
 
-    public AnalyzedInsertStatement analyze(InsertFromSubquery insert, ParamTypeHints typeHints, TransactionContext txnCtx) {
+    public AnalyzedInsertStatement analyze(InsertFromSubquery insert, ParamTypeHints typeHints, CoordinatorTxnCtx txnCtx) {
         DocTableInfo targetTable = (DocTableInfo) schemas.resolveTableInfo(insert.table().getName(), Operation.INSERT,
             txnCtx.sessionContext().searchPath());
         DocTableRelation tableRelation = new DocTableRelation(targetTable);
@@ -240,7 +240,7 @@ class InsertFromSubQueryAnalyzer {
                                                        DocTableRelation targetTable,
                                                        List<Reference> targetCols,
                                                        ExpressionAnalyzer exprAnalyzer,
-                                                       TransactionContext txnCtx,
+                                                       CoordinatorTxnCtx txnCtx,
                                                        Function<ParameterExpression, Symbol> paramConverter,
                                                        Insert.DuplicateKeyContext duplicateKeyContext) {
         if (duplicateKeyContext.getAssignments().isEmpty()) {
@@ -279,7 +279,7 @@ class InsertFromSubQueryAnalyzer {
     private Map<Reference, Symbol> processUpdateAssignments(DocTableRelation tableRelation,
                                                             List<Reference> targetColumns,
                                                             java.util.function.Function<ParameterExpression, Symbol> parameterContext,
-                                                            TransactionContext transactionContext,
+                                                            CoordinatorTxnCtx coordinatorTxnCtx,
                                                             FieldProvider fieldProvider,
                                                             Insert.DuplicateKeyContext duplicateKeyContext) {
         if (duplicateKeyContext.getAssignments().isEmpty()) {
@@ -287,9 +287,9 @@ class InsertFromSubQueryAnalyzer {
         }
 
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, transactionContext, parameterContext, fieldProvider, null, Operation.UPDATE);
+            functions, coordinatorTxnCtx, parameterContext, fieldProvider, null, Operation.UPDATE);
 
         return getUpdateAssignments(functions, tableRelation, targetColumns, expressionAnalyzer,
-            transactionContext, parameterContext, duplicateKeyContext);
+            coordinatorTxnCtx, parameterContext, duplicateKeyContext);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -30,9 +30,9 @@ import io.crate.analyze.relations.RelationSplitter;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Path;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
@@ -71,7 +71,7 @@ public class MultiSourceSelect implements QueriedRelation {
      */
     public static MultiSourceSelect createWithPushDown(RelationNormalizer relationNormalizer,
                                                        Functions functions,
-                                                       TransactionContext transactionContext,
+                                                       CoordinatorTxnCtx coordinatorTxnCtx,
                                                        MultiSourceSelect mss,
                                                        QuerySpec querySpec) {
         RelationSplitter splitter = new RelationSplitter(
@@ -85,7 +85,7 @@ public class MultiSourceSelect implements QueriedRelation {
         for (Map.Entry<QualifiedName, AnalyzedRelation> entry : mss.sources.entrySet()) {
             AnalyzedRelation relation = entry.getValue();
             QuerySpec spec = splitter.getSpec(relation);
-            QueriedRelation queriedRelation = Relations.applyQSToRelation(relationNormalizer, functions, transactionContext, relation, spec);
+            QueriedRelation queriedRelation = Relations.applyQSToRelation(relationNormalizer, functions, coordinatorTxnCtx, relation, spec);
             Function<Field, Field> convertField = f -> mapFieldToNewRelation(f, relation, queriedRelation);
             querySpec = querySpec.copyAndReplace(FieldReplacer.bind(convertField));
             entry.setValue(queriedRelation);

--- a/sql/src/main/java/io/crate/analyze/Relations.java
+++ b/sql/src/main/java/io/crate/analyze/Relations.java
@@ -30,10 +30,10 @@ import io.crate.analyze.relations.RelationNormalizer;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Path;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.QualifiedName;
 
 import java.util.Collection;
@@ -58,7 +58,7 @@ class Relations {
      */
     static QueriedRelation applyQSToRelation(RelationNormalizer normalizer,
                                              Functions functions,
-                                             TransactionContext transactionContext,
+                                             CoordinatorTxnCtx coordinatorTxnCtx,
                                              AnalyzedRelation relation,
                                              QuerySpec querySpec) {
         QueriedRelation newRelation;
@@ -70,7 +70,7 @@ class Relations {
             newRelation = new QueriedTable<>(
                 false,
                 tableRelation,
-                querySpec.copyAndReplace(s -> evalNormalizer.normalize(s, transactionContext)));
+                querySpec.copyAndReplace(s -> evalNormalizer.normalize(s, coordinatorTxnCtx)));
         } else {
             QueriedRelation queriedRelation = (QueriedRelation) relation;
             newRelation = new QueriedSelectRelation(
@@ -79,7 +79,7 @@ class Relations {
                 namesFromOutputs(querySpec.outputs()),
                 querySpec
             );
-            newRelation = (QueriedRelation) normalizer.normalize(newRelation, transactionContext);
+            newRelation = (QueriedRelation) normalizer.normalize(newRelation, coordinatorTxnCtx);
         }
         if (newRelation.where().hasQuery() && newRelation.getQualifiedName().equals(relation.getQualifiedName())) {
             // This relation will be represented as a subquery and needs a proper QualifiedName.

--- a/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -31,6 +31,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataType;
@@ -49,16 +50,17 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
 
     private final SubQueryResults subQueryResults;
 
-    private SymbolEvaluator(Functions functions, SubQueryResults subQueryResults) {
-        super(functions);
+    private SymbolEvaluator(TransactionContext txnCtx, Functions functions, SubQueryResults subQueryResults) {
+        super(txnCtx, functions);
         this.subQueryResults = subQueryResults;
     }
 
-    public static Object evaluate(Functions functions,
+    public static Object evaluate(TransactionContext txnCtx,
+                                  Functions functions,
                                   Symbol symbol,
                                   Row params,
                                   SubQueryResults subQueryValues) {
-        SymbolEvaluator symbolEval = new SymbolEvaluator(functions, subQueryValues);
+        SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, functions, subQueryValues);
         return symbolEval.process(symbol, params).value();
     }
 

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -25,7 +25,7 @@ package io.crate.analyze;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.Explain;
@@ -73,8 +73,8 @@ class UnboundAnalyzer {
     }
 
     public AnalyzedStatement analyze(Statement statement, SessionContext sessionContext, ParamTypeHints paramTypeHints) {
-        TransactionContext transactionContext = new TransactionContext(sessionContext);
-        return dispatcher.process(statement, new Analysis(transactionContext, ParameterContext.EMPTY, paramTypeHints));
+        CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
+        return dispatcher.process(statement, new Analysis(coordinatorTxnCtx, ParameterContext.EMPTY, paramTypeHints));
     }
 
     private static class UnboundDispatcher extends AstVisitor<AnalyzedStatement, Analysis> {
@@ -147,11 +147,11 @@ class UnboundAnalyzer {
 
         @Override
         protected AnalyzedStatement visitShowColumns(ShowColumns node, Analysis context) {
-            TransactionContext transactionContext = context.transactionContext();
+            CoordinatorTxnCtx coordinatorTxnCtx = context.transactionContext();
             Query query = showStatementAnalyzer.rewriteShowColumns(node,
-                transactionContext.sessionContext().searchPath().currentSchema());
+                coordinatorTxnCtx.sessionContext().searchPath().currentSchema());
             return (QueriedRelation) relationAnalyzer.analyzeUnbound(
-                query, transactionContext, context.parameterContext().typeHints());
+                query, coordinatorTxnCtx, context.parameterContext().typeHints());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -35,10 +35,10 @@ import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Assignment;
@@ -72,7 +72,7 @@ public final class UpdateAnalyzer {
         this.relationAnalyzer = relationAnalyzer;
     }
 
-    public AnalyzedUpdateStatement analyze(Update update, ParamTypeHints typeHints, TransactionContext txnCtx) {
+    public AnalyzedUpdateStatement analyze(Update update, ParamTypeHints typeHints, CoordinatorTxnCtx txnCtx) {
         /* UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`
          *               ^^^^^^^^^^^^^^^^^^       ^^^^^^
          *               assignments               whereClause
@@ -117,7 +117,7 @@ public final class UpdateAnalyzer {
 
     private HashMap<Reference, Symbol> getAssignments(List<Assignment> assignments,
                                                       ParamTypeHints typeHints,
-                                                      TransactionContext txnCtx,
+                                                      CoordinatorTxnCtx txnCtx,
                                                       AbstractTableRelation table,
                                                       EvaluatingNormalizer normalizer,
                                                       SubqueryAnalyzer subqueryAnalyzer,

--- a/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
@@ -27,8 +27,8 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolFormatter;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.Insert;
@@ -90,12 +90,12 @@ public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
     }
 
     ValuesAwareExpressionAnalyzer(Functions functions,
-                                  TransactionContext transactionContext,
+                                  CoordinatorTxnCtx coordinatorTxnCtx,
                                   Function<ParameterExpression, Symbol> convertParamFunction,
                                   FieldProvider fieldProvider,
                                   ValuesResolver valuesResolver,
                                   Insert.DuplicateKeyContext.Type duplicateKeyType) {
-        super(functions, transactionContext, convertParamFunction, fieldProvider, null);
+        super(functions, coordinatorTxnCtx, convertParamFunction, fieldProvider, null);
         this.valuesResolver = valuesResolver;
         this.duplicateKeyType = duplicateKeyType;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -23,7 +23,7 @@ package io.crate.analyze.relations;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.ParameterExpression;
 
@@ -34,20 +34,20 @@ import java.util.function.Function;
 public class StatementAnalysisContext {
 
     private final Operation currentOperation;
-    private final TransactionContext transactionContext;
+    private final CoordinatorTxnCtx coordinatorTxnCtx;
     private final Function<ParameterExpression, Symbol> convertParamFunction;
     private final List<RelationAnalysisContext> lastRelationContextQueue = new ArrayList<>();
 
     public StatementAnalysisContext(Function<ParameterExpression, Symbol> convertParamFunction,
                                     Operation currentOperation,
-                                    TransactionContext transactionContext) {
+                                    CoordinatorTxnCtx coordinatorTxnCtx) {
         this.convertParamFunction = convertParamFunction;
         this.currentOperation = currentOperation;
-        this.transactionContext = transactionContext;
+        this.coordinatorTxnCtx = coordinatorTxnCtx;
     }
 
-    public TransactionContext transactionContext() {
-        return transactionContext;
+    public CoordinatorTxnCtx transactionContext() {
+        return coordinatorTxnCtx;
     }
 
     Operation currentOperation() {
@@ -84,7 +84,7 @@ public class StatementAnalysisContext {
     }
 
     public SessionContext sessionContext() {
-        return transactionContext.sessionContext();
+        return coordinatorTxnCtx.sessionContext();
     }
 
     public Function<ParameterExpression,Symbol> convertParamFunction() {

--- a/sql/src/main/java/io/crate/analyze/where/DocKeys.java
+++ b/sql/src/main/java/io/crate/analyze/where/DocKeys.java
@@ -27,6 +27,7 @@ import io.crate.analyze.Id;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.planner.ExplainLeaf;
 import io.crate.planner.operators.SubQueryResults;
@@ -58,17 +59,17 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
             key = docKeys.get(pos);
         }
 
-        public String getId(Functions functions, Row params, SubQueryResults subQueryResults) {
+        public String getId(TransactionContext txnCtx, Functions functions, Row params, SubQueryResults subQueryResults) {
             return idFunction.apply(
                 Lists.transform(
                     key.subList(0, width),
-                    s -> DataTypes.STRING.value(SymbolEvaluator.evaluate(functions, s, params, subQueryResults))
+                    s -> DataTypes.STRING.value(SymbolEvaluator.evaluate(txnCtx, functions, s, params, subQueryResults))
                 ));
         }
 
-        public Optional<Long> version(Functions functions, Row params, SubQueryResults subQueryResults) {
+        public Optional<Long> version(TransactionContext txnCtx, Functions functions, Row params, SubQueryResults subQueryResults) {
             if (withVersions && key.get(width) != null) {
-                Object val = SymbolEvaluator.evaluate(functions, key.get(width), params, subQueryResults);
+                Object val = SymbolEvaluator.evaluate(txnCtx, functions, key.get(width), params, subQueryResults);
                 return Optional.of(LongType.INSTANCE.value(val));
             }
             return Optional.empty();
@@ -78,21 +79,21 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
             return key;
         }
 
-        public List<String> getPartitionValues(Functions functions, Row params, SubQueryResults subQueryResults) {
+        public List<String> getPartitionValues(TransactionContext txnCtx, Functions functions, Row params, SubQueryResults subQueryResults) {
             if (partitionIdx == null || partitionIdx.isEmpty()) {
                 return Collections.emptyList();
             }
             return Lists.transform(
                 partitionIdx,
-                pIdx -> DataTypes.STRING.value(SymbolEvaluator.evaluate(functions, key.get(pIdx), params, subQueryResults)));
+                pIdx -> DataTypes.STRING.value(SymbolEvaluator.evaluate(txnCtx, functions, key.get(pIdx), params, subQueryResults)));
 
         }
 
-        public String getRouting(Functions functions, Row params, SubQueryResults subQueryResults) {
+        public String getRouting(TransactionContext txnCtx, Functions functions, Row params, SubQueryResults subQueryResults) {
             if (clusteredByIdx >= 0) {
-                return SymbolEvaluator.evaluate(functions, key.get(clusteredByIdx), params, subQueryResults).toString();
+                return SymbolEvaluator.evaluate(txnCtx, functions, key.get(clusteredByIdx), params, subQueryResults).toString();
             }
-            return getId(functions, params, subQueryResults);
+            return getId(txnCtx, functions, params, subQueryResults);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -39,7 +39,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -72,8 +72,8 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext transactionContext) {
-        return extractMatches(columns, symbol, false, transactionContext);
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
+        return extractMatches(columns, symbol, false, coordinatorTxnCtx);
     }
 
     /**
@@ -100,15 +100,15 @@ public class EqualityExtractor {
     @Nullable
     public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns,
                                                   Symbol symbol,
-                                                  @Nullable TransactionContext transactionContext) {
-        return extractMatches(columns, symbol, true, transactionContext);
+                                                  @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
+        return extractMatches(columns, symbol, true, coordinatorTxnCtx);
     }
 
     @Nullable
     private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns,
                                               Symbol symbol,
                                               boolean exact,
-                                              @Nullable TransactionContext transactionContext) {
+                                              @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
             new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
         Symbol proxiedTree = ProxyInjectingVisitor.INSTANCE.process(symbol, context);
@@ -131,7 +131,7 @@ public class EqualityExtractor {
                     anyNull = true;
                 }
             }
-            Symbol normalized = normalizer.normalize(proxiedTree, transactionContext);
+            Symbol normalized = normalizer.normalize(proxiedTree, coordinatorTxnCtx);
             if (normalized == Literal.BOOLEAN_TRUE) {
                 if (anyNull) {
                     return null;

--- a/sql/src/main/java/io/crate/execution/dml/delete/DeleteByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/DeleteByIdTask.java
@@ -26,6 +26,7 @@ import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dml.ShardRequestExecutor;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.planner.node.dml.DeleteById;
 import io.crate.planner.operators.SubQueryResults;
@@ -43,6 +44,7 @@ public class DeleteByIdTask {
 
     public DeleteByIdTask(UUID jobId,
                           ClusterService clusterService,
+                          TransactionContext txnCtx,
                           Functions functions,
                           TransportShardDeleteAction deleteAction,
                           DeleteById deleteById) {
@@ -51,6 +53,7 @@ public class DeleteByIdTask {
         DeleteRequests deleteRequests = new DeleteRequests(jobId, requestTimeout);
         executor = new ShardRequestExecutor<>(
             clusterService,
+            txnCtx,
             functions,
             deleteById.table(),
             deleteRequests,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/CheckConstraints.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/CheckConstraints.java
@@ -27,6 +27,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 
@@ -39,8 +40,11 @@ public final class CheckConstraints<T, E extends CollectExpression<T, ?>> {
     private final List<E> expressions;
     private final List<ColumnIdent> notNullColumns;
 
-    public CheckConstraints(InputFactory inputFactory, ReferenceResolver<E> refResolver, DocTableInfo table) {
-        InputFactory.Context<E> ctx = inputFactory.ctxForRefs(refResolver);
+    public CheckConstraints(TransactionContext txnCtx,
+                            InputFactory inputFactory,
+                            ReferenceResolver<E> refResolver,
+                            DocTableInfo table) {
+        InputFactory.Context<E> ctx = inputFactory.ctxForRefs(txnCtx, refResolver);
         notNullColumns = new ArrayList<>(table.notNullColumns());
         for (int i = 0; i < notNullColumns.size(); i++) {
             Reference notNullRef = table.getReference(notNullColumns.get(i));

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -44,10 +45,10 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
     private final Map<ColumnIdent, Input<?>> generatedCols;
     private final List<CollectExpression<Map<String, Object>, ?>> expressions;
 
-    public GeneratedColsFromRawInsertSource(Functions functions, List<GeneratedReference> generatedColumns) {
+    public GeneratedColsFromRawInsertSource(TransactionContext txnCtx, Functions functions, List<GeneratedReference> generatedColumns) {
         InputFactory inputFactory = new InputFactory(functions);
         InputFactory.Context<CollectExpression<Map<String, Object>, ?>> ctx =
-            inputFactory.ctxForRefs(FromSourceRefResolver.INSTANCE);
+            inputFactory.ctxForRefs(txnCtx, FromSourceRefResolver.INSTANCE);
         this.generatedCols = new HashMap<>(generatedColumns.size());
         for (int i = 0; i < generatedColumns.size(); i++) {
             GeneratedReference ref = generatedColumns.get(i);

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 
@@ -60,12 +61,13 @@ public final class GeneratedColumns<T> {
     }
 
     public GeneratedColumns(InputFactory inputFactory,
+                            TransactionContext txnCtx,
                             Validation validation,
                             ReferenceResolver<CollectExpression<T, ?>> refResolver,
                             Collection<Reference> presentColumns,
                             List<GeneratedReference> allGeneratedColumns) {
         toValidate = validation == Validation.NONE ? Collections.emptyMap() : new HashMap<>();
-        InputFactory.Context<CollectExpression<T, ?>> ctx = inputFactory.ctxForRefs(refResolver);
+        InputFactory.Context<CollectExpression<T, ?>> ctx = inputFactory.ctxForRefs(txnCtx, refResolver);
         toInject = new HashMap<>();
         for (GeneratedReference generatedCol : allGeneratedColumns) {
             if (presentColumns.contains(generatedCol)) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -34,6 +34,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.ValueExtractors;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
@@ -53,7 +54,8 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     private final CheckConstraints<Row, CollectExpression<Row, ?>> checks;
     private final GeneratedColumns<Row> generatedColumns;
 
-    InsertSourceFromCells(Functions functions,
+    InsertSourceFromCells(TransactionContext txnCtx,
+                          Functions functions,
                           DocTableInfo table,
                           GeneratedColumns.Validation validation,
                           List<Reference> targets) {
@@ -65,13 +67,14 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         } else {
             generatedColumns = new GeneratedColumns<>(
                 inputFactory,
+                txnCtx,
                 validation,
                 referenceResolver,
                 targets,
                 table.generatedColumns()
             );
         }
-        checks = new CheckConstraints<>(inputFactory, referenceResolver, table);
+        checks = new CheckConstraints<>(txnCtx, inputFactory, referenceResolver, table);
     }
 
     public void checkConstraints(Object[] values) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -38,7 +39,8 @@ public interface InsertSourceGen {
     BytesReference generateSource(Object[] values) throws IOException;
 
 
-    static InsertSourceGen of(Functions functions,
+    static InsertSourceGen of(TransactionContext txnCtx,
+                              Functions functions,
                               DocTableInfo table,
                               GeneratedColumns.Validation validation,
                               List<Reference> targets) {
@@ -46,9 +48,9 @@ public interface InsertSourceGen {
             if (table.generatedColumns().isEmpty()) {
                 return new FromRawInsertSource();
             } else {
-                return new GeneratedColsFromRawInsertSource(functions, table.generatedColumns());
+                return new GeneratedColsFromRawInsertSource(txnCtx, functions, table.generatedColumns());
             }
         }
-        return new InsertSourceFromCells(functions, table, validation, targets);
+        return new InsertSourceFromCells(txnCtx, functions, table, validation, targets);
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
@@ -56,8 +56,8 @@ public class TableFunctionCollectPhase extends RoutedCollectPhase implements Col
             outputs,
             projections,
             where,
-            DistributionInfo.DEFAULT_BROADCAST,
-            null);
+            DistributionInfo.DEFAULT_BROADCAST
+        );
         this.functionImplementation = functionImplementation;
         this.functionArguments = functionArguments;
     }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -32,10 +32,10 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -240,8 +240,8 @@ public class WriterProjection extends Projection {
                '}';
     }
 
-    public WriterProjection normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
-        Symbol nUri = normalizer.normalize(uri, transactionContext);
+    public WriterProjection normalize(EvaluatingNormalizer normalizer, TransactionContext txnCtx) {
+        Symbol nUri = normalizer.normalize(uri, txnCtx);
         if (uri != nUri) {
             return new WriterProjection(
                 inputs,

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -132,7 +132,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         assert function.arguments().size() <= 1 : "function's number of arguments must be 0 or 1";
 
         if (function.arguments().size() == 1) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
@@ -22,14 +22,15 @@
 package io.crate.execution.engine.collect;
 
 import io.crate.analyze.OrderBy;
-import io.crate.lucene.FieldTypeLookup;
-import io.crate.metadata.Functions;
-import io.crate.metadata.Reference;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.OrderByCollectorExpression;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
 import io.crate.types.DataType;
 import io.crate.types.IpType;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -55,7 +56,8 @@ public class DocInputFactory {
         this.referenceResolver = referenceResolver;
     }
 
-    public InputFactory.Context<? extends LuceneCollectorExpression<?>> extractImplementations(RoutedCollectPhase phase) {
+    public InputFactory.Context<? extends LuceneCollectorExpression<?>> extractImplementations(TransactionContext txnCtx,
+                                                                                               RoutedCollectPhase phase) {
         OrderBy orderBy = phase.orderBy();
         ReferenceResolver<? extends LuceneCollectorExpression<?>> refResolver;
         if (orderBy == null) {
@@ -68,7 +70,7 @@ public class DocInputFactory {
                 return referenceResolver.getImplementation(ref);
             };
         }
-        InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = inputFactory.ctxForRefs(refResolver);
+        InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = inputFactory.ctxForRefs(txnCtx, refResolver);
         ctx.add(phase.toCollect());
         return ctx;
     }
@@ -93,7 +95,7 @@ public class DocInputFactory {
         return new OrderByCollectorExpression(ref, orderBy, valueConversion);
     }
 
-    public InputFactory.Context<? extends LuceneCollectorExpression<?>> getCtx() {
-        return inputFactory.ctxForRefs(referenceResolver);
+    public InputFactory.Context<? extends LuceneCollectorExpression<?>> getCtx(TransactionContext txnCtx) {
+        return inputFactory.ctxForRefs(txnCtx, referenceResolver);
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -146,11 +146,11 @@ final class GroupByOptimizedIterator {
             );
             collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
-            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx();
+            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
             docCtx.add(collectPhase.toCollect().stream().filter(s -> !s.equals(keyRef))::iterator);
             IndexOrdinalsFieldData keyIndexFieldData = queryShardContext.getForField(keyFieldType);
 
-            InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations();
+            InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations(collectTask.txnCtx());
             ctxForAggregations.add(groupProjection.values());
 
             List<AggregationContext> aggregations = ctxForAggregations.aggregations();
@@ -168,6 +168,7 @@ final class GroupByOptimizedIterator {
 
             LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
                 collectPhase.where(),
+                collectTask.txnCtx(),
                 indexShard.mapperService(),
                 queryShardContext,
                 sharedShardContext.indexService().cache()

--- a/sql/src/main/java/io/crate/execution/engine/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/MapSideDataCollectOperation.java
@@ -26,6 +26,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.engine.collect.sources.CollectSource;
 import io.crate.execution.engine.collect.sources.CollectSourceResolver;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -49,11 +50,12 @@ public class MapSideDataCollectOperation {
         this.threadPool = threadPool;
     }
 
-    public BatchIterator<Row> createIterator(CollectPhase collectPhase,
+    public BatchIterator<Row> createIterator(TransactionContext txnCtx,
+                                             CollectPhase collectPhase,
                                              boolean requiresScroll,
                                              CollectTask collectTask) {
         CollectSource service = collectSourceResolver.getService(collectPhase);
-        return service.getIterator(collectPhase, collectTask, requiresScroll);
+        return service.getIterator(txnCtx, collectPhase, collectTask, requiresScroll);
     }
 
     public void launch(Runnable runnable, String threadPoolName) throws RejectedExecutionException {

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -147,6 +147,8 @@ public class RemoteCollectorFactory {
         String localNode = clusterService.localNode().getId();
         return remoteNode -> new RemoteCollector(
             jobId,
+            collectTask.txnCtx().userName(),
+            collectTask.txnCtx().currentSchema(),
             localNode,
             remoteNode,
             transportActionProvider.transportJobInitAction(),
@@ -176,8 +178,7 @@ public class RemoteCollectorFactory {
             collectPhase.toCollect(),
             new ArrayList<>(Projections.shardProjections(collectPhase.projections())),
             collectPhase.where(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            null
+            DistributionInfo.DEFAULT_BROADCAST
         );
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
@@ -29,6 +29,7 @@ import io.crate.data.Row;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 
 import javax.annotation.Nullable;
@@ -51,13 +52,14 @@ public class RowShardResolver {
     private String routing;
 
 
-    public RowShardResolver(Functions functions,
+    public RowShardResolver(TransactionContext txnCtx,
+                            Functions functions,
                             List<ColumnIdent> pkColumns,
                             List<? extends Symbol> primaryKeySymbols,
                             @Nullable ColumnIdent clusteredByColumn,
                             @Nullable Symbol routingSymbol) {
         InputFactory inputFactory = new InputFactory(functions);
-        InputFactory.Context<CollectExpression<Row, ?>> context = inputFactory.ctxForInputColumns();
+        InputFactory.Context<CollectExpression<Row, ?>> context = inputFactory.ctxForInputColumns(txnCtx);
         idFunction = Id.compileWithNullValidation(pkColumns, clusteredByColumn);
         if (routingSymbol == null) {
             routingInput = null;

--- a/sql/src/main/java/io/crate/execution/engine/collect/RowsTransformer.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RowsTransformer.java
@@ -35,6 +35,7 @@ import io.crate.expression.InputCondition;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
 import java.util.ArrayList;
@@ -42,14 +43,16 @@ import java.util.Collections;
 
 public final class RowsTransformer {
 
-    public static Iterable<Row> toRowsIterable(InputFactory inputFactory,
+    public static Iterable<Row> toRowsIterable(TransactionContext txnCtx,
+                                               InputFactory inputFactory,
                                                ReferenceResolver<?> referenceResolver,
                                                RoutedCollectPhase collectPhase,
                                                Iterable<?> iterable) {
-        return toRowsIterable(inputFactory, referenceResolver, collectPhase, iterable, true);
+        return toRowsIterable(txnCtx, inputFactory, referenceResolver, collectPhase, iterable, true);
     }
 
-    public static Iterable<Row> toRowsIterable(InputFactory inputFactory,
+    public static Iterable<Row> toRowsIterable(TransactionContext txnCtx,
+                                               InputFactory inputFactory,
                                                ReferenceResolver<?> referenceResolver,
                                                RoutedCollectPhase collectPhase,
                                                Iterable<?> iterable,
@@ -57,7 +60,7 @@ public final class RowsTransformer {
         if (!QueryClause.canMatch(collectPhase.where())) {
             return Collections.emptyList();
         }
-        InputFactory.Context ctx = inputFactory.ctxForRefs(referenceResolver);
+        InputFactory.Context ctx = inputFactory.ctxForRefs(txnCtx, referenceResolver);
         ctx.add(collectPhase.toCollect());
         OrderBy orderBy = collectPhase.orderBy();
         if (orderBy != null) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -117,6 +117,7 @@ public abstract class ShardCollectorProvider {
         return Projectors.wrap(
             Projections.shardProjections(collectPhase.projections()),
             collectPhase.jobId(),
+            collectTask.txnCtx(),
             collectTask.queryPhaseRamAccountingContext(),
             projectorFactory,
             iterator

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -40,9 +40,9 @@ import io.crate.execution.jobs.transport.JobRequest;
 import io.crate.execution.jobs.transport.JobResponse;
 import io.crate.execution.jobs.transport.TransportJobAction;
 import io.crate.types.DataTypes;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -55,6 +55,8 @@ public class RemoteCollector {
     private static final int RECEIVER_PHASE_ID = 1;
 
     private final UUID jobId;
+    private final String userName;
+    private final String currentSchema;
     private final String localNode;
     private final String remoteNode;
     private final Executor executor;
@@ -72,6 +74,8 @@ public class RemoteCollector {
     private boolean collectorKilled = false;
 
     public RemoteCollector(UUID jobId,
+                           String userName,
+                           String currentSchema,
                            String localNode,
                            String remoteNode,
                            TransportJobAction transportJobAction,
@@ -82,6 +86,8 @@ public class RemoteCollector {
                            RowConsumer consumer,
                            RoutedCollectPhase collectPhase) {
         this.jobId = jobId;
+        this.userName = userName;
+        this.currentSchema = currentSchema;
         this.localNode = localNode;
         this.remoteNode = remoteNode;
         this.executor = executor;
@@ -141,7 +147,14 @@ public class RemoteCollector {
             }
             transportJobAction.execute(
                 remoteNode,
-                new JobRequest(jobId, localNode, Collections.singletonList(nodeOperation), enableProfiling),
+                new JobRequest(
+                    jobId,
+                    userName,
+                    currentSchema,
+                    localNode,
+                    Collections.singletonList(nodeOperation),
+                    enableProfiling
+                ),
                 new ActionListener<JobResponse>() {
                     @Override
                     public void onResponse(JobResponse jobResponse) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.collect.count;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.inject.ImplementedBy;
 import org.elasticsearch.index.Index;
 
@@ -33,8 +34,9 @@ import java.util.concurrent.CompletableFuture;
 @ImplementedBy(InternalCountOperation.class)
 public interface CountOperation {
 
-    CompletableFuture<Long> count(Map<String, IntIndexedContainer> indexShardMap,
+    CompletableFuture<Long> count(TransactionContext txnCtx,
+                                  Map<String, IntIndexedContainer> indexShardMap,
                                   Symbol filter) throws IOException, InterruptedException;
 
-    long count(Index index, int shardId, Symbol filter) throws IOException, InterruptedException;
+    long count(TransactionContext txnCtx, Index index, int shardId, Symbol filter) throws IOException, InterruptedException;
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSource.java
@@ -26,8 +26,12 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.engine.collect.CollectTask;
+import io.crate.metadata.TransactionContext;
 
 public interface CollectSource {
 
-    BatchIterator<Row> getIterator(CollectPhase collectPhase, CollectTask collectTask, boolean supportMoveToStart);
+    BatchIterator<Row> getIterator(TransactionContext txnCtx,
+                                   CollectPhase collectPhase,
+                                   CollectTask collectTask,
+                                   boolean supportMoveToStart);
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
@@ -40,6 +40,7 @@ import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.RowGranularity;
@@ -186,7 +187,10 @@ public class CollectSourceResolver {
     private static class VoidCollectSource implements CollectSource {
 
         @Override
-        public BatchIterator<Row> getIterator(CollectPhase collectPhase, CollectTask collectTask, boolean supportMoveToStart) {
+        public BatchIterator<Row> getIterator(TransactionContext txnCtx,
+                                              CollectPhase collectPhase,
+                                              CollectTask collectTask,
+                                              boolean supportMoveToStart) {
             return InMemoryBatchIterator.empty(SentinelRow.SENTINEL);
         }
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSource.java
@@ -40,6 +40,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.reference.sys.node.NodeStatsContext;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.LocalSysColReferenceResolver;
 import io.crate.metadata.RowGranularity;
@@ -73,7 +74,10 @@ public class NodeStatsCollectSource implements CollectSource {
     }
 
     @Override
-    public BatchIterator<Row> getIterator(CollectPhase phase, CollectTask collectTask, boolean supportMoveToStart) {
+    public BatchIterator<Row> getIterator(TransactionContext txnCtx,
+                                          CollectPhase phase,
+                                          CollectTask collectTask,
+                                          boolean supportMoveToStart) {
         RoutedCollectPhase collectPhase = (RoutedCollectPhase) phase;
         if (!QueryClause.canMatch(collectPhase.where())) {
             return InMemoryBatchIterator.empty(SentinelRow.SENTINEL);
@@ -85,7 +89,7 @@ public class NodeStatsCollectSource implements CollectSource {
         if (nodes.isEmpty()) {
             return InMemoryBatchIterator.empty(SentinelRow.SENTINEL);
         }
-        return NodeStats.newInstance(nodeStatsAction, collectPhase, nodes, inputFactory);
+        return NodeStats.newInstance(nodeStatsAction, collectPhase, nodes, txnCtx, inputFactory);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ProjectorSetupCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ProjectorSetupCollectSource.java
@@ -27,6 +27,7 @@ import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.engine.collect.CollectTask;
 import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.execution.engine.pipeline.Projectors;
+import io.crate.metadata.TransactionContext;
 
 public class ProjectorSetupCollectSource implements CollectSource {
 
@@ -39,13 +40,17 @@ public class ProjectorSetupCollectSource implements CollectSource {
     }
 
     @Override
-    public BatchIterator<Row> getIterator(CollectPhase collectPhase, CollectTask collectTask, boolean supportMoveToStart) {
+    public BatchIterator<Row> getIterator(TransactionContext txnCtx,
+                                          CollectPhase collectPhase,
+                                          CollectTask collectTask,
+                                          boolean supportMoveToStart) {
         return Projectors.wrap(
             collectPhase.projections(),
             collectPhase.jobId(),
+            collectTask.txnCtx(),
             collectTask.queryPhaseRamAccountingContext(),
             projectorFactory,
-            sourceDelegate.getIterator(collectPhase, collectTask, supportMoveToStart)
+            sourceDelegate.getIterator(txnCtx, collectPhase, collectTask, supportMoveToStart)
         );
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/SingleRowSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/SingleRowSource.java
@@ -34,6 +34,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.InputRow;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.metadata.ClusterReferenceResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import org.elasticsearch.common.inject.Inject;
@@ -52,7 +53,10 @@ public class SingleRowSource implements CollectSource {
     }
 
     @Override
-    public BatchIterator<Row> getIterator(CollectPhase phase, CollectTask collectTask, boolean supportMoveToStart) {
+    public BatchIterator<Row> getIterator(TransactionContext txnCtx,
+                                          CollectPhase phase,
+                                          CollectTask collectTask,
+                                          boolean supportMoveToStart) {
         RoutedCollectPhase collectPhase = (RoutedCollectPhase) phase;
         collectPhase = collectPhase.normalize(clusterNormalizer, null);
 
@@ -63,7 +67,7 @@ public class SingleRowSource implements CollectSource {
             : "whereClause must have been normalized to a value, but is: " + collectPhase.where();
 
         InputFactory inputFactory = new InputFactory(functions);
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(collectPhase.toCollect());
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx, collectPhase.toCollect());
 
         return InMemoryBatchIterator.of(new InputRow(ctx.topLevelInputs()), SentinelRow.SENTINEL);
     }

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
@@ -36,9 +36,10 @@ import io.crate.data.Row;
 import io.crate.data.UnsafeArrayRow;
 import io.crate.expression.InputRow;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -58,7 +59,8 @@ public class FetchBatchAccumulator implements BatchAccumulator<Row, Iterator<? e
     private final InputRow outputRow;
     private final ArrayList<Object[]> inputValues = new ArrayList<>();
 
-    public FetchBatchAccumulator(FetchOperation fetchOperation,
+    public FetchBatchAccumulator(TransactionContext txnCtx,
+                                 FetchOperation fetchOperation,
                                  Functions functions,
                                  List<Symbol> outputSymbols,
                                  FetchProjectorContext fetchProjectorContext,
@@ -67,7 +69,7 @@ public class FetchBatchAccumulator implements BatchAccumulator<Row, Iterator<? e
         this.context = fetchProjectorContext;
         this.fetchSize = fetchSize;
 
-        FetchRowInputSymbolVisitor rowInputSymbolVisitor = new FetchRowInputSymbolVisitor(functions);
+        FetchRowInputSymbolVisitor rowInputSymbolVisitor = new FetchRowInputSymbolVisitor(txnCtx, functions);
         this.collectRowContext = new FetchRowInputSymbolVisitor.Context(fetchProjectorContext.tableToFetchSource);
 
         List<Input<?>> inputs = new ArrayList<>(outputSymbols.size());

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
@@ -22,28 +22,32 @@
 
 package io.crate.execution.engine.fetch;
 
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.AsyncOperationBatchIterator;
 import io.crate.data.BatchIterator;
 import io.crate.data.Projector;
 import io.crate.data.Row;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 
 import java.util.List;
 
 public class FetchProjector implements Projector {
 
+    private final TransactionContext txnCtx;
     private final FetchOperation fetchOperation;
     private final Functions functions;
     private final List<Symbol> outputSymbols;
     private final FetchProjectorContext fetchProjectorContext;
     private final int fetchSize;
 
-    public FetchProjector(FetchOperation fetchOperation,
+    public FetchProjector(TransactionContext txnCtx,
+                          FetchOperation fetchOperation,
                           Functions functions,
                           List<Symbol> outputSymbols,
                           FetchProjectorContext fetchProjectorContext,
                           int fetchSize) {
+        this.txnCtx = txnCtx;
         this.fetchOperation = fetchOperation;
         this.functions = functions;
         this.outputSymbols = outputSymbols;
@@ -56,6 +60,7 @@ public class FetchProjector implements Projector {
         return new AsyncOperationBatchIterator<>(
             batchIterator,
             new FetchBatchAccumulator(
+                txnCtx,
                 fetchOperation,
                 functions,
                 outputSymbols,

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchRowInputSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchRowInputSymbolVisitor.java
@@ -28,6 +28,7 @@ import io.crate.expression.BaseImplementationSymbolVisitor;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.InputColumn;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -185,8 +186,8 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
         }
     }
 
-    public FetchRowInputSymbolVisitor(Functions functions) {
-        super(functions);
+    public FetchRowInputSymbolVisitor(TransactionContext txnCtx, Functions functions) {
+        super(txnCtx, functions);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
@@ -27,6 +27,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.projection.SourceIndexWriterReturnSummaryProjection;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 
 import java.util.Collections;
@@ -52,10 +53,11 @@ public class UpsertResultContext {
         };
     }
 
-    public static UpsertResultContext forReturnSummary(SourceIndexWriterReturnSummaryProjection projection,
+    public static UpsertResultContext forReturnSummary(TransactionContext txnCtx,
+                                                       SourceIndexWriterReturnSummaryProjection projection,
                                                        DiscoveryNode discoveryNode,
                                                        InputFactory inputFactory) {
-        InputFactory.Context<CollectExpression<Row, ?>> ctxSourceInfo = inputFactory.ctxForInputColumns();
+        InputFactory.Context<CollectExpression<Row, ?>> ctxSourceInfo = inputFactory.ctxForInputColumns(txnCtx);
         //noinspection unchecked
         Input<String> sourceUriInput = (Input<String>) ctxSourceInfo.add(projection.sourceUri());
         //noinspection unchecked

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -32,6 +32,7 @@ import io.crate.data.join.CombinedRow;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
 import java.util.List;
@@ -53,6 +54,7 @@ public class HashJoinOperation implements CompletionListenable {
                              List<Symbol> joinLeftInputs,
                              List<Symbol> joinRightInputs,
                              RowAccounting rowAccounting,
+                             TransactionContext txnCtx,
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
                              long estimatedRowSizeForLeft,
@@ -69,8 +71,8 @@ public class HashJoinOperation implements CompletionListenable {
                             rightBatchIterator.join(),
                             numRightCols,
                             joinPredicate,
-                            getHashBuilderFromSymbols(inputFactory, joinLeftInputs),
-                            getHashBuilderFromSymbols(inputFactory, joinRightInputs),
+                            getHashBuilderFromSymbols(txnCtx, inputFactory, joinLeftInputs),
+                            getHashBuilderFromSymbols(txnCtx, inputFactory, joinRightInputs),
                             rowAccounting,
                             new RamBlockSizeCalculator(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
                         ), completionFuture);
@@ -97,8 +99,10 @@ public class HashJoinOperation implements CompletionListenable {
         return JoinOperations.getBatchConsumer(rightBatchIterator, true);
     }
 
-    private static Function<Row, Integer> getHashBuilderFromSymbols(InputFactory inputFactory, List<Symbol> inputs) {
-        InputFactory.Context<? extends CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(inputs);
+    private static Function<Row, Integer> getHashBuilderFromSymbols(TransactionContext txnCtx,
+                                                                    InputFactory inputFactory,
+                                                                    List<Symbol> inputs) {
+        InputFactory.Context<? extends CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx, inputs);
         Object[] values = new Object[ctx.topLevelInputs().size()];
 
         return row -> {

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
@@ -27,6 +27,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
 import javax.annotation.Nullable;
@@ -78,21 +79,23 @@ public class ProjectingRowConsumer implements RowConsumer {
     public static RowConsumer create(RowConsumer lastConsumer,
                                      Collection<? extends Projection> projections,
                                      UUID jobId,
+                                     TransactionContext txnCtx,
                                      RamAccountingContext ramAccountingContext,
                                      ProjectorFactory projectorFactory) {
         if (projections.isEmpty()) {
             return lastConsumer;
         }
-        return new ProjectingRowConsumer(lastConsumer, projections, jobId, ramAccountingContext, projectorFactory);
+        return new ProjectingRowConsumer(lastConsumer, projections, jobId, txnCtx, ramAccountingContext, projectorFactory);
     }
 
     private ProjectingRowConsumer(RowConsumer consumer,
                                   Collection<? extends Projection> projections,
                                   UUID jobId,
+                                  TransactionContext txnCtx,
                                   RamAccountingContext ramAccountingContext,
                                   ProjectorFactory projectorFactory) {
         this.consumer = consumer;
-        this.projectors = new Projectors(projections, jobId, ramAccountingContext, projectorFactory);
+        this.projectors = new Projectors(projections, jobId, txnCtx, ramAccountingContext, projectorFactory);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
@@ -25,13 +25,17 @@ package io.crate.execution.engine.pipeline;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Projector;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.RowGranularity;
 
 import java.util.UUID;
 
 public interface ProjectorFactory {
 
-    Projector create(Projection projection, RamAccountingContext ramAccountingContext, UUID jobId);
+    Projector create(Projection projection,
+                     TransactionContext txnCtx,
+                     RamAccountingContext ramAccountingContext,
+                     UUID jobId);
 
     RowGranularity supportedGranularity();
 }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
@@ -28,6 +28,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.metadata.TransactionContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,6 +46,7 @@ public final class Projectors {
 
     public Projectors(Collection<? extends Projection> projections,
                       UUID jobId,
+                      TransactionContext txnCtx,
                       RamAccountingContext ramAccountingContext,
                       ProjectorFactory projectorFactory) {
         boolean independentScroll = false;
@@ -53,7 +55,7 @@ public final class Projectors {
             if (projection.requiredGranularity().ordinal() > projectorFactory.supportedGranularity().ordinal()) {
                 continue;
             }
-            Projector projector = projectorFactory.create(projection, ramAccountingContext, jobId);
+            Projector projector = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId);
             projectors.add(projector);
             independentScroll = independentScroll || projector.providesIndependentScroll();
         }
@@ -66,6 +68,7 @@ public final class Projectors {
      */
     public static BatchIterator<Row> wrap(Collection<? extends Projection> projections,
                                           UUID jobId,
+                                          TransactionContext txnCtx,
                                           RamAccountingContext ramAccountingContext,
                                           ProjectorFactory projectorFactory,
                                           BatchIterator<Row> source) {
@@ -74,7 +77,7 @@ public final class Projectors {
             if (projection.requiredGranularity().ordinal() > projectorFactory.supportedGranularity().ordinal()) {
                 continue;
             }
-            result = projectorFactory.create(projection, ramAccountingContext, jobId).apply(result);
+            result = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId).apply(result);
         }
         return result;
     }

--- a/sql/src/main/java/io/crate/execution/engine/sort/LuceneSortGenerator.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/LuceneSortGenerator.java
@@ -23,9 +23,10 @@
 package io.crate.execution.engine.sort;
 
 import io.crate.analyze.OrderBy;
-import io.crate.lucene.FieldTypeLookup;
 import io.crate.execution.engine.collect.DocInputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.metadata.TransactionContext;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 
@@ -34,7 +35,8 @@ import javax.annotation.Nullable;
 public class LuceneSortGenerator {
 
     @Nullable
-    public static Sort generateLuceneSort(CollectorContext context,
+    public static Sort generateLuceneSort(TransactionContext txnCtx,
+                                          CollectorContext context,
                                           OrderBy orderBy,
                                           DocInputFactory docInputFactory,
                                           FieldTypeLookup fieldTypeLookup) {
@@ -44,6 +46,7 @@ public class LuceneSortGenerator {
         SortSymbolVisitor sortSymbolVisitor = new SortSymbolVisitor(docInputFactory, fieldTypeLookup);
         SortField[] sortFields = sortSymbolVisitor.generateSortFields(
             orderBy.orderBySymbols(),
+            txnCtx,
             context,
             orderBy.reverseFlags(),
             orderBy.nullsFirst()

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -81,6 +81,7 @@ import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.expression.InputFactory;
 import io.crate.expression.RowFilter;
 import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Routing;
 import io.crate.planner.distribution.DistributionType;
@@ -172,11 +173,15 @@ public class JobSetup extends AbstractComponent {
         );
     }
 
-    public List<CompletableFuture<StreamBucket>> prepareOnRemote(Collection<? extends NodeOperation> nodeOperations,
+    public List<CompletableFuture<StreamBucket>> prepareOnRemote(String userName,
+                                                                 String currentSchema,
+                                                                 Collection<? extends NodeOperation> nodeOperations,
                                                                  RootTask.Builder contextBuilder,
                                                                  SharedShardContexts sharedShardContexts) {
         Context context = new Context(
             clusterService.localNode().getId(),
+            userName,
+            currentSchema,
             contextBuilder,
             logger,
             distributingConsumerFactory,
@@ -193,12 +198,16 @@ public class JobSetup extends AbstractComponent {
         return context.directResponseFutures;
     }
 
-    public List<CompletableFuture<StreamBucket>> prepareOnHandler(Collection<? extends NodeOperation> nodeOperations,
+    public List<CompletableFuture<StreamBucket>> prepareOnHandler(String userName,
+                                                                  String currentSchema,
+                                                                  Collection<? extends NodeOperation> nodeOperations,
                                                                   RootTask.Builder taskBuilder,
                                                                   List<Tuple<ExecutionPhase, RowConsumer>> handlerPhases,
                                                                   SharedShardContexts sharedShardContexts) {
         Context context = new Context(
             clusterService.localNode().getId(),
+            userName,
+            currentSchema,
             taskBuilder,
             logger,
             distributingConsumerFactory,
@@ -429,8 +438,11 @@ public class JobSetup extends AbstractComponent {
         private final RootTask.Builder taskBuilder;
         private final Logger logger;
         private final List<ExecutionPhase> leafs = new ArrayList<>();
+        private TransactionContext transactionContext;
 
         Context(String localNodeId,
+                String userName,
+                String currentSchema,
                 RootTask.Builder taskBuilder,
                 Logger logger,
                 DistributingConsumerFactory distributingConsumerFactory,
@@ -441,6 +453,7 @@ public class JobSetup extends AbstractComponent {
             this.opCtx = new NodeOperationCtx(localNodeId, nodeOperations);
             this.distributingConsumerFactory = distributingConsumerFactory;
             this.sharedShardContexts = sharedShardContexts;
+            this.transactionContext = TransactionContext.of(userName, currentSchema);
         }
 
         public UUID jobId() {
@@ -492,7 +505,8 @@ public class JobSetup extends AbstractComponent {
         }
 
         /**
-         * The rowReceiver for handlerPhases got passed into {@link #prepareOnHandler(Collection, RootTask.Builder, List, SharedShardContexts)}
+         * The rowReceiver for handlerPhases got passed into
+         * {@link #prepareOnHandler(String, String, Collection, RootTask.Builder, List, SharedShardContexts)}
          * and is registered there.
          * <p>
          * Retrieve it
@@ -534,6 +548,10 @@ public class JobSetup extends AbstractComponent {
             handlerConsumersByPhaseId.put(phase.phaseId(), consumer);
             leafs.add(phase);
         }
+
+        public TransactionContext txnCtx() {
+            return transactionContext;
+        }
     }
 
     private class InnerPreparer extends ExecutionPhaseVisitor<Context, Boolean> {
@@ -550,6 +568,7 @@ public class JobSetup extends AbstractComponent {
             RowConsumer consumer = context.getRowConsumer(phase, 0);
             context.registerSubContext(new CountTask(
                 phase,
+                context.transactionContext,
                 countOperation,
                 consumer,
                 indexShardMap
@@ -567,6 +586,7 @@ public class JobSetup extends AbstractComponent {
                 context.getRowConsumer(pkLookupPhase, 0),
                 nodeProjections,
                 pkLookupPhase.jobId(),
+                context.txnCtx(),
                 ramAccountingContext,
                 projectorFactory
             );
@@ -575,6 +595,7 @@ public class JobSetup extends AbstractComponent {
                 pkLookupPhase.phaseId(),
                 pkLookupPhase.name(),
                 ramAccountingContext,
+                context.transactionContext,
                 inputFactory,
                 pkLookupOperation,
                 pkLookupPhase.partitionedByColumns(),
@@ -601,6 +622,7 @@ public class JobSetup extends AbstractComponent {
                     consumer,
                     phase.projections(),
                     phase.jobId(),
+                    context.txnCtx(),
                     ramAccountingContext,
                     projectorFactory
                 );
@@ -617,15 +639,15 @@ public class JobSetup extends AbstractComponent {
                 if (firstProjection instanceof GroupProjection) {
                     GroupProjection groupProjection = (GroupProjection) firstProjection;
 
-                    GroupingProjector groupingProjector =
-                        (GroupingProjector) projectorFactory.create(groupProjection, ramAccountingContext, phase.jobId());
+                    GroupingProjector groupingProjector = (GroupingProjector) projectorFactory.create(
+                        groupProjection, context.txnCtx(), ramAccountingContext, phase.jobId());
                     collector = groupingProjector.getCollector();
                     projections = projections.subList(1, projections.size());
                 } else if (firstProjection instanceof AggregationProjection) {
                     AggregationProjection aggregationProjection = (AggregationProjection) firstProjection;
 
-                    AggregationPipe aggregationPipe =
-                        (AggregationPipe) projectorFactory.create(aggregationProjection, ramAccountingContext, phase.jobId());
+                    AggregationPipe aggregationPipe = (AggregationPipe) projectorFactory.create(
+                        aggregationProjection, context.txnCtx(), ramAccountingContext, phase.jobId());
 
                     collector = aggregationPipe.getCollector();
                     projections = projections.subList(1, projections.size());
@@ -636,6 +658,7 @@ public class JobSetup extends AbstractComponent {
                 consumer,
                 projections,
                 phase.jobId(),
+                context.txnCtx(),
                 ramAccountingContext,
                 projectorFactory
             );
@@ -689,6 +712,7 @@ public class JobSetup extends AbstractComponent {
 
             context.registerSubContext(new CollectTask(
                 phase,
+                context.txnCtx(),
                 collectOperation,
                 ramAccountingContext,
                 consumer,
@@ -703,6 +727,7 @@ public class JobSetup extends AbstractComponent {
             RowConsumer consumer = context.getRowConsumer(phase, Paging.PAGE_SIZE);
             context.registerSubContext(new CollectTask(
                 phase,
+                context.txnCtx(),
                 collectOperation,
                 ramAccountingContext,
                 consumer,
@@ -745,8 +770,8 @@ public class JobSetup extends AbstractComponent {
             RowConsumer lastConsumer = context.getRowConsumer(phase, Paging.PAGE_SIZE);
 
             RowConsumer firstConsumer = ProjectingRowConsumer.create(
-                lastConsumer, phase.projections(), phase.jobId(), ramAccountingContext, projectorFactory);
-            Predicate<Row> joinCondition = RowFilter.create(inputFactory, phase.joinCondition());
+                lastConsumer, phase.projections(), phase.jobId(), context.txnCtx(), ramAccountingContext, projectorFactory);
+            Predicate<Row> joinCondition = RowFilter.create(context.transactionContext, inputFactory, phase.joinCondition());
 
             NestedLoopOperation joinOperation = new NestedLoopOperation(
                 phase.numLeftOutputs(),
@@ -799,8 +824,8 @@ public class JobSetup extends AbstractComponent {
             RowConsumer lastConsumer = context.getRowConsumer(phase, Paging.PAGE_SIZE);
 
             RowConsumer firstConsumer = ProjectingRowConsumer.create(
-                lastConsumer, phase.projections(), phase.jobId(), ramAccountingContext, projectorFactory);
-            Predicate<Row> joinCondition = RowFilter.create(inputFactory, phase.joinCondition());
+                lastConsumer, phase.projections(), phase.jobId(), context.txnCtx(), ramAccountingContext, projectorFactory);
+            Predicate<Row> joinCondition = RowFilter.create(context.transactionContext, inputFactory, phase.joinCondition());
 
             HashJoinOperation joinOperation = new HashJoinOperation(
                 phase.numLeftOutputs(),
@@ -814,6 +839,7 @@ public class JobSetup extends AbstractComponent {
                 //    7 bytes per key for the IntHashObjectHashMap  (should be 4 but the map pre-allocates more)
                 //    7 bytes perv value (pointer from the map to the list) (should be 4 but the map pre-allocates more)
                 new RowAccountingWithEstimators(phase.leftOutputTypes(), ramAccountingContext, 110),
+                context.transactionContext,
                 inputFactory,
                 breaker(),
                 phase.estimatedRowSizeForLeft(),
@@ -866,6 +892,7 @@ public class JobSetup extends AbstractComponent {
                     rowConsumer,
                     mergePhase.projections(),
                     mergePhase.jobId(),
+                    ctx.txnCtx(),
                     ramAccountingContext,
                     projectorFactory
                 );

--- a/sql/src/main/java/io/crate/execution/jobs/transport/JobRequest.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/JobRequest.java
@@ -35,6 +35,8 @@ import java.util.UUID;
 public class JobRequest extends TransportRequest {
 
     private UUID jobId;
+    private String userName;
+    private String currentSchema;
     private String coordinatorNodeId;
     private Collection<? extends NodeOperation> nodeOperations;
     private boolean enableProfiling;
@@ -43,10 +45,14 @@ public class JobRequest extends TransportRequest {
     }
 
     public JobRequest(UUID jobId,
+                      String userName,
+                      String currentSchema,
                       String coordinatorNodeId,
                       Collection<? extends NodeOperation> nodeOperations,
                       boolean enableProfiling) {
         this.jobId = jobId;
+        this.userName = userName;
+        this.currentSchema = currentSchema;
         this.coordinatorNodeId = coordinatorNodeId;
         this.nodeOperations = nodeOperations;
         this.enableProfiling = enableProfiling;
@@ -68,6 +74,14 @@ public class JobRequest extends TransportRequest {
         return enableProfiling;
     }
 
+    public String userName() {
+        return userName;
+    }
+
+    public String currentSchema() {
+        return currentSchema;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -82,6 +96,9 @@ public class JobRequest extends TransportRequest {
         }
         this.nodeOperations = nodeOperations;
         enableProfiling = in.readBoolean();
+
+        userName = in.readString();
+        currentSchema = in.readString();
     }
 
     @Override
@@ -98,5 +115,7 @@ public class JobRequest extends TransportRequest {
         }
 
         out.writeBoolean(enableProfiling);
+        out.writeString(userName);
+        out.writeString(currentSchema);
     }
 }

--- a/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -88,7 +88,12 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
         SharedShardContexts sharedShardContexts = maybeInstrumentProfiler(request.enableProfiling(), contextBuilder);
 
         List<CompletableFuture<StreamBucket>> directResponseFutures = jobSetup.prepareOnRemote(
-            request.nodeOperations(), contextBuilder, sharedShardContexts);
+            request.userName(),
+            request.currentSchema(),
+            request.nodeOperations(),
+            contextBuilder,
+            sharedShardContexts
+        );
 
         try {
             RootTask context = tasksService.createTask(contextBuilder);

--- a/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.format.SymbolFormatter;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 
@@ -41,9 +42,11 @@ import java.util.Locale;
 
 public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?>> {
 
+    private final TransactionContext txnCtx;
     protected final Functions functions;
 
-    public BaseImplementationSymbolVisitor(Functions functions) {
+    public BaseImplementationSymbolVisitor(TransactionContext txnCtx, Functions functions) {
+        this.txnCtx = txnCtx;
         this.functions = functions;
     }
 
@@ -59,7 +62,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
             for (Symbol argument : function.arguments()) {
                 argumentInputs[i++] = process(argument, context);
             }
-            return new FunctionExpression<>(scalarImpl, argumentInputs);
+            return new FunctionExpression<>(txnCtx, scalarImpl, argumentInputs);
         } else {
             throw new UnsupportedFeatureException(
                 String.format(

--- a/sql/src/main/java/io/crate/expression/FunctionExpression.java
+++ b/sql/src/main/java/io/crate/expression/FunctionExpression.java
@@ -23,6 +23,7 @@
 package io.crate.expression;
 
 import io.crate.data.Input;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
 import java.util.Arrays;
@@ -31,15 +32,17 @@ public final class FunctionExpression<ReturnType, InputType> implements Input<Re
 
     private final Input<InputType>[] arguments;
     private final Scalar<ReturnType, InputType> scalar;
+    private final TransactionContext txnCtx;
 
-    public FunctionExpression(Scalar<ReturnType, InputType> scalar, Input<InputType>[] arguments) {
+    public FunctionExpression(TransactionContext txnCtx, Scalar<ReturnType, InputType> scalar, Input<InputType>[] arguments) {
+        this.txnCtx = txnCtx;
         this.scalar = scalar;
         this.arguments = arguments;
     }
 
     @Override
     public ReturnType value() {
-        return scalar.evaluate(arguments);
+        return scalar.evaluate(txnCtx, arguments);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/RowFilter.java
+++ b/sql/src/main/java/io/crate/expression/RowFilter.java
@@ -22,10 +22,11 @@
 
 package io.crate.expression;
 
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -36,15 +37,15 @@ public class RowFilter implements Predicate<Row> {
     private final Input<Boolean> filterCondition;
     private final List<CollectExpression<Row, ?>> expressions;
 
-    public static Predicate<Row> create(InputFactory inputFactory, @Nullable Symbol filterSymbol) {
+    public static Predicate<Row> create(TransactionContext txnCtx, InputFactory inputFactory, @Nullable Symbol filterSymbol) {
         if (filterSymbol == null) {
             return i -> true;
         }
-        return new RowFilter(inputFactory, filterSymbol);
+        return new RowFilter(txnCtx, inputFactory, filterSymbol);
     }
 
-    private RowFilter(InputFactory inputFactory, Symbol filterSymbol) {
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns();
+    private RowFilter(TransactionContext txnCtx, InputFactory inputFactory, Symbol filterSymbol) {
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         //noinspection unchecked
         filterCondition = (Input) ctx.add(filterSymbol);
         expressions = ctx.expressions();

--- a/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -23,7 +23,10 @@
 package io.crate.expression.eval;
 
 import io.crate.analyze.relations.FieldResolver;
+import io.crate.data.Input;
 import io.crate.expression.NestableInput;
+import io.crate.expression.reference.ReferenceResolver;
+import io.crate.expression.scalar.arithmetic.MapFunction;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.FunctionCopyVisitor;
@@ -32,16 +35,13 @@ import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.SymbolFormatter;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
-import io.crate.expression.reference.ReferenceResolver;
-import io.crate.expression.scalar.arithmetic.MapFunction;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -156,10 +156,10 @@ public class EvaluatingNormalizer {
         }
     }
 
-    public Symbol normalize(@Nullable Symbol symbol, @Nullable TransactionContext transactionContext) {
+    public Symbol normalize(@Nullable Symbol symbol, @Nullable TransactionContext txnCtx) {
         if (symbol == null) {
             return null;
         }
-        return visitor.process(symbol, transactionContext);
+        return visitor.process(symbol, txnCtx);
     }
 }

--- a/sql/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -48,7 +48,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         assert function != null : "function must not be null";
         assert function.arguments().size() == 2 : "number of args must be 2";
 
@@ -56,7 +56,7 @@ public class AndOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left instanceof Input && right instanceof Input) {
-            return Literal.of(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
         }
 
         /**
@@ -90,7 +90,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Boolean evaluate(Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd arguments must not be null";

--- a/sql/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -28,6 +28,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
@@ -54,7 +55,7 @@ public final class CmpOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd argument must not be null";

--- a/sql/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -29,6 +29,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
@@ -60,7 +61,7 @@ public final class EqOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "number of args must be 2";
         Object left = args[0].value();
         if (left == null) {
@@ -87,7 +88,7 @@ public final class EqOperator extends Operator<Object> {
         }
 
         @Override
-        public Boolean evaluate(Input[] args) {
+        public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
             Object[] left = (Object[]) args[0].value();
             if (left == null) {
                 return null;
@@ -115,7 +116,7 @@ public final class EqOperator extends Operator<Object> {
 
         @Override
         @SafeVarargs
-        public final Boolean evaluate(Input<Object>... args) {
+        public final Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
             Object left = args[0].value();
             Object right = args[1].value();
             if (left == null || right == null) {

--- a/sql/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
@@ -65,7 +66,7 @@ public class LikeOperator extends Operator<String> {
     }
 
     @Override
-    public Boolean evaluate(Input<String>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
 
@@ -154,7 +155,7 @@ public class LikeOperator extends Operator<String> {
 
         @SafeVarargs
         @Override
-        public final Boolean evaluate(Input<String>... args) {
+        public final Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
             String value = args[0].value();
             if (value == null) {
                 return null;

--- a/sql/src/main/java/io/crate/expression/operator/Operator.java
+++ b/sql/src/main/java/io/crate/expression/operator/Operator.java
@@ -29,8 +29,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.OperatorFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -48,7 +48,7 @@ public abstract class Operator<I> extends Scalar<Boolean, I> implements Operator
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         // all operators evaluates to NULL if one argument is NULL
         // let's handle this here to prevent unnecessary collect operations
         for (Symbol symbol : function.arguments()) {
@@ -56,7 +56,7 @@ public abstract class Operator<I> extends Scalar<Boolean, I> implements Operator
                 return Literal.NULL;
             }
         }
-        return super.normalizeSymbol(function, transactionContext);
+        return super.normalizeSymbol(function, txnCtx);
     }
 
     private static boolean isNull(Symbol symbol) {

--- a/sql/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.operator;
 
+import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
@@ -45,7 +45,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         assert function != null : "function must not be null";
         assert function.arguments().size() == 2  : "number of args must be 2";
 
@@ -53,7 +53,7 @@ public class OrOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left.symbolType().isValueSymbol() && right.symbolType().isValueSymbol()) {
-            return Literal.of(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
         }
 
         /*
@@ -91,7 +91,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Boolean evaluate(Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd argument must not be null";

--- a/sql/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
 import java.util.regex.Pattern;
@@ -39,7 +40,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
 
 
     @Override
-    public Boolean evaluate(Input<String>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
         assert args.length == 2 : "invalid number of arguments";
         String source = args[0].value();
         if (source == null) {

--- a/sql/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
@@ -43,7 +44,7 @@ public class RegexpMatchOperator extends Operator<String> {
 
 
     @Override
-    public Boolean evaluate(Input<String>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
         assert args.length == 2 : "invalid number of arguments";
         String source = args[0].value();
         if (source == null) {

--- a/sql/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -29,6 +29,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
@@ -92,7 +93,7 @@ public final class AnyLikeOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
         Object value = args[0].value();
         Object collectionReference = args[1].value();
 

--- a/sql/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -27,6 +27,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
@@ -89,7 +90,7 @@ public final class AnyOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null : "1st argument must not be null";

--- a/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -22,19 +22,19 @@
 package io.crate.expression.predicate;
 
 import com.google.common.base.Preconditions;
+import io.crate.data.Input;
 import io.crate.expression.symbol.FuncArg;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
-import io.crate.data.Input;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -67,7 +67,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         assert symbol != null : "function must not be null";
         assert symbol.arguments().size() == 1 : "function's number of arguments must be 1";
 
@@ -81,7 +81,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
     }
 
     @Override
-    public Boolean evaluate(Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 1 : "number of args must be 1";
         return args[0] == null || args[0].value() == null;
     }

--- a/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -21,15 +21,15 @@
 
 package io.crate.expression.predicate;
 
+import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.OperatorFormatSpec;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -52,7 +52,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         assert symbol != null : "function must not be null";
         assert symbol.arguments().size() == 1 : "function's number of arguments must be 1";
 
@@ -73,7 +73,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
     }
 
     @Override
-    public Boolean evaluate(Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
         assert args.length == 1 : "number of args must be 1";
         Boolean value = args[0].value();
         return value != null ? !value : null;

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -24,11 +24,12 @@ package io.crate.expression.scalar;
 import com.google.common.base.Preconditions;
 import io.crate.data.Input;
 import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -65,7 +66,7 @@ class ArrayCatFunction extends Scalar<Object[], Object> {
     }
 
     @Override
-    public Object[] evaluate(Input[] args) {
+    public Object[] evaluate(TransactionContext txnCtx, Input[] args) {
         DataType innerType = ((ArrayType) this.info().returnType()).innerType();
         List<Object> resultList = new ArrayList<>();
 

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -24,15 +24,16 @@ package io.crate.expression.scalar;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import io.crate.data.Input;
 import io.crate.expression.symbol.FuncArg;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -98,7 +99,7 @@ class ArrayDifferenceFunction extends Scalar<Object[], Object> {
     }
 
     @Override
-    public Object[] evaluate(Input[] args) {
+    public Object[] evaluate(TransactionContext txnCtx, Input[] args) {
         Object[] originalArray = (Object[]) args[0].value();
         if (originalArray == null) {
             return null;

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
 class ArrayLowerFunction extends Scalar<Integer, Object[]> {
@@ -45,7 +46,7 @@ class ArrayLowerFunction extends Scalar<Integer, Object[]> {
     }
 
     @Override
-    public Integer evaluate(Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
         Object[] array = (Object[]) args[0].value();
         Object dimension1Indexed = args[1].value();
         if (array == null || array.length == 0 || dimension1Indexed == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -28,6 +28,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
@@ -69,7 +70,7 @@ class ArrayUniqueFunction extends Scalar<Object[], Object> {
     }
 
     @Override
-    public Object[] evaluate(Input[] args) {
+    public Object[] evaluate(TransactionContext txnCtx, Input[] args) {
         Set<Object> uniqueSet = new LinkedHashSet<>();
         for (Input array : args) {
             assert array != null : "inputs must never be null";

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
 public class ArrayUpperFunction extends Scalar<Integer, Object[]> {
@@ -47,7 +48,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object[]> {
     }
 
     @Override
-    public Integer evaluate(Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
         Object[] array = (Object[]) args[0].value();
         Object dimension1Indexed = args[1].value();
         if (array == null || array.length == 0 || dimension1Indexed == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -52,7 +53,7 @@ public class CollectionAverageFunction extends Scalar<Double, Set<Number>> {
     }
 
     @Override
-    public Double evaluate(Input<Set<Number>>... args) {
+    public Double evaluate(TransactionContext txnCtx, Input<Set<Number>>... args) {
         // NOTE: always returning double ignoring the input type, maybe better implement type safe
         Set<Number> arg0Value = args[0].value();
         if (arg0Value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -23,12 +23,13 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -52,7 +53,7 @@ public class CollectionCountFunction extends Scalar<Long, Collection<DataType>> 
     }
 
     @Override
-    public Long evaluate(Input<Collection<DataType>>... args) {
+    public Long evaluate(TransactionContext txnCtx, Input<Collection<DataType>>... args) {
         // TODO: eliminate Integer.MAX_VALUE limitation of Set.size()
         Collection<DataType> arg0Value = args[0].value();
         if (arg0Value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -30,8 +30,8 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
@@ -60,7 +60,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         if (anyNonLiterals(function.arguments())) {
             return function;
         }
@@ -69,7 +69,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             inputs[i] = ((Input) function.arguments().get(i));
         }
         //noinspection unchecked
-        return Literal.of(functionInfo.returnType(), evaluate(inputs));
+        return Literal.of(functionInfo.returnType(), evaluate(txnCtx, inputs));
     }
 
     private static class StringConcatFunction extends ConcatFunction {
@@ -79,7 +79,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         }
 
         @Override
-        public String evaluate(Input[] args) {
+        public String evaluate(TransactionContext txnCtx, Input[] args) {
             String firstArg = (String) args[0].value();
             String secondArg = (String) args[1].value();
             if (firstArg == null) {
@@ -102,7 +102,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         }
 
         @Override
-        public String evaluate(Input[] args) {
+        public String evaluate(TransactionContext txnCtx, Input[] args) {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < args.length; i++) {
                 Input input = args[i];

--- a/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -26,6 +26,7 @@ import io.crate.Constants;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
@@ -42,7 +43,7 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
     }
 
     @Override
-    public String evaluate(Input[] args) {
+    public String evaluate(TransactionContext txnCtx, Input[] args) {
         return Constants.DB_NAME;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -69,7 +70,7 @@ public class DateFormatFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         String format;
         Input<?> timezoneLiteral = null;
         if (args.length == 1) {

--- a/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -28,8 +28,8 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TimestampType;
@@ -117,7 +117,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         assert symbol.arguments().size() > 1 && symbol.arguments().size() < 4 : "Invalid number of arguments";
 
         if (anyNonLiterals(symbol.arguments())) {
@@ -138,12 +138,12 @@ public class DateTruncFunction extends Scalar<Long, Object> {
 
         return Literal.of(
             DataTypes.TIMESTAMP,
-            evaluate(new Input[]{interval, timezone, tsSymbol})
+            evaluate(txnCtx, new Input[]{interval, timezone, tsSymbol})
         );
     }
 
     @Override
-    public final Long evaluate(Input[] args) {
+    public final Long evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length > 1 && args.length < 4 : "Invalid number of arguments";
         Object value;
         String timeZone = TimeZoneParser.DEFAULT_TZ_LITERAL.value();

--- a/sql/src/main/java/io/crate/expression/scalar/DoubleScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DoubleScalar.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
 import java.util.function.DoubleUnaryOperator;
@@ -51,7 +52,7 @@ public final class DoubleScalar extends Scalar<Double, Number> {
 
     @SafeVarargs
     @Override
-    public final Double evaluate(Input<Number>... args) {
+    public final Double evaluate(TransactionContext txnCtx, Input<Number>... args) {
         assert args.length == 1 : "DoubleScalar expects exactly 1 argument, got: " + args.length;
         Number value = args[0].value();
         if (value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.sql.tree.Extract;
 import io.crate.types.DataType;
@@ -114,7 +115,7 @@ public class ExtractFunctions {
         public abstract Number evaluate(long value);
 
         @Override
-        public Number evaluate(Input... args) {
+        public Number evaluate(TransactionContext txnCtx, Input... args) {
             assert args.length == 1 : "extract only takes one argument";
             Object value = args[0].value();
             if (value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -27,6 +27,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.types.DataType;
@@ -53,7 +54,7 @@ public class FormatFunction extends Scalar<String, Object> {
 
     @SafeVarargs
     @Override
-    public final String evaluate(Input<Object>... args) {
+    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length > 1 : "number of args must be > 1";
         Object arg0Value = args[0].value();
         assert arg0Value != null : "1st argument must not be null";

--- a/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
@@ -53,7 +54,7 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
     }
 
     @Override
-    public Boolean evaluate(Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
         assert args.length == 1 : "ignore3vl expects exactly 1 argument, got: " + args.length;
         Boolean value = args[0].value();
         if (value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -26,6 +26,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
@@ -55,7 +56,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     }
 
     @Override
-    public Object evaluate(Input[] args) {
+    public Object evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "invalid number of arguments";
         return evaluate(args[0].value(), args[1].value());
     }

--- a/sql/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -27,6 +27,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
@@ -68,7 +69,7 @@ public class SubscriptObjectFunction extends Scalar<Object, Map> {
     }
 
     @Override
-    public Object evaluate(Input[] args) {
+    public Object evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "invalid number of arguments";
         return evaluate(args[0].value(), args[1].value());
     }

--- a/sql/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -27,6 +27,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
@@ -56,7 +57,7 @@ public class SubstrFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(Input[] args) {
+    public String evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 || args.length == 3 : "number of arguments must be 2 or 3";
         String val = (String) args[0].value();
         if (val == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
 
@@ -49,7 +50,7 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
 
     @SafeVarargs
     @Override
-    public final R evaluate(Input<T>... args) {
+    public final R evaluate(TransactionContext txnCtx, Input<T>... args) {
         assert args.length == 3 : "TripleScalar expects exactly 3 arguments, got: " + args.length;
         T value1 = args[0].value();
         if (value1 == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 
@@ -54,7 +55,7 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
 
     @SafeVarargs
     @Override
-    public final R evaluate(Input<T>... args) {
+    public final R evaluate(TransactionContext txnCtx, Input<T>... args) {
         assert args.length == 1 : "UnaryScalar expects exactly 1 argument, got: " + args.length;
         T value = args[0].value();
         if (value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -22,16 +22,17 @@
 package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.expression.symbol.FuncArg;
 import io.crate.data.Input;
-import io.crate.metadata.functions.params.FuncParams;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.FuncArg;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 
 import javax.annotation.Nullable;
@@ -58,7 +59,7 @@ public class AbsFunction extends Scalar<Number, Number> {
     }
 
     @Override
-    public Number evaluate(Input<Number>... args) {
+    public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
         assert args.length == 1 : "number of args must be 1";
         Number value = args[0].value();
         if (value != null) {

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -22,15 +22,16 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.symbol.FuncArg;
 import io.crate.data.Input;
-import io.crate.metadata.functions.params.FuncParams;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.FuncArg;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 
@@ -71,7 +72,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
 
     @SafeVarargs
     @Override
-    public final Object evaluate(Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
         Object[] values = new Object[args.length];
         for (int i = 0; i < values.length; i++) {
             values[i] = args[i].value();

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.arithmetic;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 
@@ -51,7 +52,7 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
 
 
     @Override
-    public T evaluate(Input<T>[] args) {
+    public T evaluate(TransactionContext txnCtx, Input<T>[] args) {
         T arg0Value = type.value(args[0].value());
         T arg1Value = type.value(args[1].value());
 

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -23,8 +23,9 @@ package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -61,7 +62,7 @@ public abstract class CeilFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Long evaluate(Input[] args) {
+        public Long evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;
@@ -78,7 +79,7 @@ public abstract class CeilFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Integer evaluate(Input[] args) {
+        public Integer evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -23,8 +23,9 @@ package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -61,7 +62,7 @@ public abstract class FloorFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Long evaluate(Input[] args) {
+        public Long evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;
@@ -78,7 +79,7 @@ public abstract class FloorFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Integer evaluate(Input[] args) {
+        public Integer evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -23,10 +23,11 @@ package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableSet;
 import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -96,7 +97,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         }
 
         @Override
-        public Number evaluate(Input<Number>... args) {
+        public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
             assert args.length == 2 : "number of args must be 2";
             Number value1 = args[0].value();
             Number value2 = args[1].value();
@@ -130,7 +131,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         }
 
         @Override
-        public Number evaluate(Input<Number>... args) {
+        public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
             assert args.length == 1  : "number of args must be 1";
             Number value = args[0].value();
             if (value == null) {

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -29,6 +29,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
@@ -81,7 +82,7 @@ public class MapFunction extends Scalar<Object, Object> {
 
     @SafeVarargs
     @Override
-    public final Object evaluate(Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
         Map<String, Object> m = new HashMap<>(args.length / 2, 1.0f);
         for (int i = 0; i < args.length - 1; i += 2) {
             m.put((String) args[i].value(), args[i + 1].value());

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -22,14 +22,14 @@
 package io.crate.expression.scalar.arithmetic;
 
 
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         /* There is no evaluation here, so the function is executed
            per row. Else every row would contain the same random value*/
         assert symbol.arguments().size() == 0 : "function's number of arguments must be 0";
@@ -64,7 +64,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Double evaluate(Input[] args) {
+    public Double evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 0 : "number of args must be 0";
         return this.random.nextDouble();
     }

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -23,8 +23,9 @@ package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -61,7 +62,7 @@ public abstract class RoundFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Integer evaluate(Input[] args) {
+        public Integer evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;
@@ -77,7 +78,7 @@ public abstract class RoundFunction extends SingleArgumentArithmeticFunction {
         }
 
         @Override
-        public Long evaluate(Input[] args) {
+        public Long evaluate(TransactionContext txnCtx, Input[] args) {
             Object value = args[0].value();
             if (value == null) {
                 return null;

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -22,15 +22,16 @@
 package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.base.Preconditions;
-import io.crate.expression.symbol.FuncArg;
 import io.crate.data.Input;
-import io.crate.metadata.functions.params.FuncParams;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.FuncArg;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -63,7 +64,7 @@ public abstract class SquareRootFunction extends Scalar<Number, Number> {
         }
 
         @Override
-        public Double evaluate(Input[] args) {
+        public Double evaluate(TransactionContext txnCtx, Input[] args) {
             Number value = (Number) args[0].value();
             if (value == null) {
                 return null;

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -22,21 +22,21 @@
 
 package io.crate.expression.scalar.cast;
 
+import io.crate.data.Input;
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
-import io.crate.data.Input;
-import io.crate.exceptions.ConversionException;
 import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -62,7 +62,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
 
     @SafeVarargs
     @Override
-    public final Object evaluate(Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 1 : "Number of arguments must be 1";
         Object value = args[0].value();
         try {
@@ -78,7 +78,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         assert symbol.arguments().size() == 1 : "Number of arguments must be 1";
         Symbol argument = symbol.arguments().get(0);
         if (argument.symbolType().isValueSymbol()) {

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -23,8 +23,9 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 
 public class CoalesceFunction extends ConditionalFunction {
     public static final String NAME = "coalesce";
@@ -34,7 +35,7 @@ public class CoalesceFunction extends ConditionalFunction {
     }
 
     @Override
-    public Object evaluate(Input... args) {
+    public Object evaluate(TransactionContext txnCtx, Input... args) {
         for (Input input : args) {
             Object value = input.value();
             if (value != null) {

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 
 import java.util.Comparator;
 
@@ -34,7 +35,7 @@ abstract class ConditionalCompareFunction extends ConditionalFunction implements
     }
 
     @Override
-    public Object evaluate(Input... args) {
+    public Object evaluate(TransactionContext txnCtx, Input... args) {
         assert args != null : "args must not be null";
         assert args.length > 0 : "number of args must be > 1";
 

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -23,14 +23,15 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 
 import java.util.List;
@@ -70,7 +71,7 @@ public class IfFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(Input... args) {
+    public Object evaluate(TransactionContext txnCtx, Input... args) {
         Boolean condition = (Boolean) args[0].value();
         if (condition != null && condition) {
             return args[1].value();

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -23,12 +23,13 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public class NullIfFunction extends ConditionalFunction {
     }
 
     @Override
-    public Object evaluate(Input... args) {
+    public Object evaluate(TransactionContext txnCtx, Input... args) {
         Object arg0Value = args[0].value();
         return arg0Value != null && arg0Value.equals(args[1].value()) ? null : arg0Value;
     }

--- a/sql/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -21,20 +21,20 @@
 
 package io.crate.expression.scalar.geo;
 
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolFormatter;
-import io.crate.data.Input;
 import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -75,7 +75,7 @@ public class DistanceFunction extends Scalar<Double, Object> {
     }
 
     @Override
-    public Double evaluate(Input[] args) {
+    public Double evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "number of args must be 2";
         return evaluate(args[0], args[1]);
     }
@@ -113,7 +113,7 @@ public class DistanceFunction extends Scalar<Double, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         Symbol arg1 = symbol.arguments().get(0);
         Symbol arg2 = symbol.arguments().get(1);
         DataType arg1Type = arg1.valueType();

--- a/sql/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -24,16 +24,16 @@ package io.crate.expression.scalar.geo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.locationtech.spatial4j.shape.Shape;
@@ -75,7 +75,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Boolean evaluate(Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 2 : "Invalid number of Arguments";
         Object left = args[0].value();
         if (left == null) {
@@ -96,7 +96,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
         int numLiterals = 0;
@@ -117,7 +117,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
         }
 
         if (numLiterals == 2) {
-            return Literal.of(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
         }
 
         if (literalConverted) {

--- a/sql/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -31,8 +31,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.locationtech.spatial4j.context.SpatialContext;
@@ -85,7 +85,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Boolean evaluate(Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "number of args must be 2";
         return evaluate(args[0], args[1]);
     }
@@ -133,7 +133,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
 

--- a/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -22,15 +22,15 @@
 
 package io.crate.expression.scalar.postgres;
 
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         assert symbol.arguments().size() == 0 : "function's number of arguments must be 0";
         return Literal.of(-1);
     }
@@ -61,7 +61,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     }
 
     @Override
-    public Integer evaluate(Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 0 : "number of args must be 0";
         return -1;
     }

--- a/sql/src/main/java/io/crate/expression/scalar/regex/MatchesFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/regex/MatchesFunction.java
@@ -31,8 +31,8 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
@@ -78,7 +78,7 @@ public class MatchesFunction extends Scalar<String[], Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         final int size = symbol.arguments().size();
         assert size == 2 || size == 3 : "function's number of arguments must be 2 or 3";
 
@@ -101,7 +101,7 @@ public class MatchesFunction extends Scalar<String[], Object> {
         if (size == 3) {
             args[2] = (Input) symbol.arguments().get(2);
         }
-        return Literal.of(evaluate(args), ARRAY_STRING_TYPE);
+        return Literal.of(evaluate(txnCtx, args), ARRAY_STRING_TYPE);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class MatchesFunction extends Scalar<String[], Object> {
     }
 
     @Override
-    public String[] evaluate(Input[] args) {
+    public String[] evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 || args.length == 3 : "number of args must be 2 or 3";
         String val = (String) args[0].value();
         String pattern = (String) args[1].value();

--- a/sql/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -31,8 +31,8 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
@@ -74,7 +74,7 @@ public class RegexpReplaceFunction extends Scalar<String, Object> implements Fun
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         List<Symbol> arguments = function.arguments();
         final int size = arguments.size();
         assert size == 3 || size == 4 : "function's number of arguments must be 3 or 4";
@@ -122,7 +122,7 @@ public class RegexpReplaceFunction extends Scalar<String, Object> implements Fun
     }
 
     @Override
-    public String evaluate(Input[] args) {
+    public String evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 3 || args.length == 4 : "number of args must be 3 or 4";
         String val = (String) args[0].value();
         String pattern = (String) args[1].value();

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -31,8 +31,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -59,18 +59,17 @@ public class CurrentSchemaFunction extends Scalar<String, Object> implements Fun
     }
 
     @Override
-    public String evaluate(Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
-        throw new UnsupportedOperationException("Cannot evaluate CURRENT_SCHEMA function.");
+        return txnCtx.currentSchema();
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext transactionContext) {
-        if (transactionContext == null) {
+    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx) {
+        if (txnCtx == null) {
             return Literal.NULL;
         }
-        assert transactionContext.sessionContext() != null : "CURRENT_SCHEMA requires a session context";
-        return Literal.of(transactionContext.sessionContext().searchPath().currentSchema());
+        return Literal.of(txnCtx.currentSchema());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
@@ -40,7 +41,7 @@ public class PgGetExpr extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         return null;
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -23,19 +23,18 @@ package io.crate.expression.scalar.timestamp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.math.LongMath;
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
-import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.joda.time.DateTimeUtils;
 
 import java.math.RoundingMode;
 import java.util.Collections;
@@ -58,8 +57,8 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
 
 
     @Override
-    public Long evaluate(Input<Integer>... args) {
-        long millis = DateTimeUtils.currentTimeMillis();
+    public Long evaluate(TransactionContext txnCtx, Input<Integer>... args) {
+        long millis = txnCtx.currentTimeMillis();
         Integer precision = 3;
         if (args.length == 1) {
             precision = args[0].value();
@@ -97,9 +96,9 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         // use evaluatedFunctions map to make sure multiple occurrences of current_timestamp within a query result in the same result
-        return eval(function, transactionContext.currentTimeMillis());
+        return eval(function, txnCtx.currentTimeMillis());
     }
 
     private Symbol eval(Function function, long currentTimeMillis) {

--- a/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -30,6 +30,7 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -67,7 +68,7 @@ public class EmptyRowTableFunction {
         }
 
         @Override
-        public Object evaluate(Input[] args) {
+        public Object evaluate(TransactionContext txnCtx, Input[] args) {
             return new CollectionBucket(Collections.singletonList(new Object[0]));
         }
 

--- a/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -33,6 +33,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -139,7 +140,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
     }
 
     @Override
-    public Bucket evaluate(Input<T>... args) {
+    public Bucket evaluate(TransactionContext txnCtx, Input<T>... args) {
         T startInclusive = args[0].value();
         T stopInclusive = args[1].value();
         T step = args.length == 3 ? args[2].value() : defaultStep;

--- a/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -33,6 +33,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -78,13 +79,15 @@ public class UnnestFunction {
         }
 
         /**
+         *
+         * @param txnCtx
          * @param arguments collection of array-literals
          *                  e.g. [ [1, 2], [Marvin, Trillian] ]
          * @return Bucket containing the unnested rows.
          * [ [1, Marvin], [2, Trillian] ]
          */
         @Override
-        public Bucket evaluate(Input[] arguments) {
+        public Bucket evaluate(TransactionContext txnCtx, Input[] arguments) {
             final List<Object[]> values = extractValues(arguments);
             final int numCols = arguments.length;
             final int numRows = maxLength(values);

--- a/sql/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/sql/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import io.crate.action.sql.SessionContext;
+import org.joda.time.DateTimeUtils;
+
+import java.util.Objects;
+
+/**
+ * TransactionContext is a context that is used to keep state which is valid during a transaction.
+ *
+ * In Crate a transaction is always bound to the lifecycle of a single query/statement execution as there is no
+ * transaction support.
+ */
+public final class CoordinatorTxnCtx implements TransactionContext {
+
+    private final SessionContext sessionContext;
+    private Long currentTimeMillis = null;
+
+    public static CoordinatorTxnCtx systemTransactionContext() {
+        return new CoordinatorTxnCtx(SessionContext.systemSessionContext());
+    }
+
+    public CoordinatorTxnCtx(SessionContext sessionContext) {
+        this.sessionContext = Objects.requireNonNull(sessionContext);
+    }
+
+    /**
+     * @return current timestamp in ms. Subsequent calls will always return the same value. (Not thread-safe)
+     */
+    @Override
+    public long currentTimeMillis() {
+        if (currentTimeMillis == null) {
+            // no synchronization because StmtCtx is mostly used during single-threaded analysis phase
+            currentTimeMillis = DateTimeUtils.currentTimeMillis();
+        }
+        return currentTimeMillis;
+    }
+
+    @Override
+    public String userName() {
+        return sessionContext.user().name();
+    }
+
+    @Override
+    public String currentSchema() {
+        return sessionContext.searchPath().currentSchema();
+    }
+
+    public SessionContext sessionContext() {
+        return sessionContext;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -40,11 +40,11 @@ public interface FunctionImplementation {
      * Normalize a symbol into a simplified form.
      * This may return the symbol as is if it cannot be normalized.
      *
-     * @param transactionContext context which is shared across normalizeSymbol calls during a statement-lifecycle.
+     * @param txnCtx context which is shared across normalizeSymbol calls during a statement-lifecycle.
      *                This will only be present if normalizeSymbol is called on the handler node.
      *                normalizeSymbol calls during execution won't receive a StmtCtx
      */
-    default Symbol normalizeSymbol(Function function, @Nullable TransactionContext transactionContext) {
+    default Symbol normalizeSymbol(Function function, @Nullable TransactionContext txnCtx) {
         return function;
     }
 }

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -21,11 +21,11 @@
 
 package io.crate.metadata;
 
+import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.OperatorFormatSpec;
-import io.crate.data.Input;
 
 import java.util.Collection;
 import java.util.List;
@@ -59,7 +59,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     /**
      * Evaluate the function using the provided arguments
      */
-    public abstract ReturnType evaluate(Input<InputType>... args);
+    public abstract ReturnType evaluate(TransactionContext txnCtx, Input<InputType>... args);
 
     /**
      * Called to return a "optimized" version of a scalar implementation.
@@ -68,7 +68,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      * (or rather, a subset of a single query if executed distributed).
      *
      * @param arguments arguments in symbol form. If any symbols are literals, any arguments passed to
-     *                  {@link #evaluate(Input[])} will have the same value as those literals.
+     *                  {@link #evaluate(TransactionContext, Input[])} will have the same value as those literals.
      *                  (Within the scope of a single operation)
      */
     public Scalar<ReturnType, InputType> compile(List<Symbol> arguments) {
@@ -76,9 +76,9 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         try {
-            return evaluateIfLiterals(this, symbol);
+            return evaluateIfLiterals(this, txnCtx, symbol);
         } catch (Throwable t) {
             return symbol;
         }
@@ -97,7 +97,9 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      * This method will evaluate the function using the given scalar if all arguments are literals.
      * Otherwise it will return the function as is or NULL in case it contains a null literal
      */
-    protected static <ReturnType, InputType> Symbol evaluateIfLiterals(Scalar<ReturnType, InputType> scalar, Function function) {
+    protected static <ReturnType, InputType> Symbol evaluateIfLiterals(Scalar<ReturnType, InputType> scalar,
+                                                                       TransactionContext txnCtx,
+                                                                       Function function) {
         List<Symbol> arguments = function.arguments();
         for (Symbol argument : arguments) {
             if (!(argument instanceof Input)) {
@@ -111,7 +113,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             idx++;
         }
         //noinspection unchecked
-        return Literal.of(function.info().returnType(), scalar.evaluate(inputs));
+        return Literal.of(function.info().returnType(), scalar.evaluate(txnCtx, inputs));
     }
 
     private static class OperatorScalar<R, I> extends Scalar<R, I> implements OperatorFormatSpec {
@@ -129,8 +131,8 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
         }
 
         @Override
-        public R evaluate(Input<I>... args) {
-            return func.evaluate(args);
+        public R evaluate(TransactionContext txnCtx, Input<I>... args) {
+            return func.evaluate(txnCtx, args);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -38,6 +38,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
 import io.crate.core.collections.Maps;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
@@ -47,7 +48,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.parser.SqlParser;
@@ -540,7 +540,7 @@ public class DocIndexMetaData {
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, TransactionContext.systemTransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            functions, CoordinatorTxnCtx.systemTransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
         ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;

--- a/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
@@ -26,8 +26,8 @@ import io.crate.data.Bucket;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.table.TableInfo;
 
 /**
@@ -36,7 +36,7 @@ import io.crate.metadata.table.TableInfo;
 public abstract class TableFunctionImplementation<T> extends Scalar<Bucket, T> {
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
         // Never normalize table functions;
         // The RelationAnalyzer expects a function symbol and can't deal with Literals
         return function;

--- a/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
@@ -30,7 +30,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
 import org.elasticsearch.cluster.ClusterState;
@@ -64,7 +64,7 @@ public class InternalViewInfoFactory implements ViewInfoFactory {
         List<Reference> columns;
         try {
             AnalyzedRelation relation = analyzerProvider.get()
-                .analyze(parsedStmt, TransactionContext.systemTransactionContext(), ParameterContext.EMPTY);
+                .analyze(parsedStmt, CoordinatorTxnCtx.systemTransactionContext(), ParameterContext.EMPTY);
             final List<Reference> collectedColumns = new ArrayList<>(relation.fields().size());
             relation.fields()
                 .forEach(field -> collectedColumns.add(

--- a/sql/src/main/java/io/crate/planner/PlannerContext.java
+++ b/sql/src/main/java/io/crate/planner/PlannerContext.java
@@ -29,7 +29,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.table.TableInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -49,14 +49,14 @@ public class PlannerContext {
             context.routingProvider,
             UUID.randomUUID(),
             context.functions,
-            context.transactionContext,
+            context.coordinatorTxnCtx,
             softLimit,
             fetchSize
         );
     }
 
     private final UUID jobId;
-    private final TransactionContext transactionContext;
+    private final CoordinatorTxnCtx coordinatorTxnCtx;
     private final int softLimit;
     private final int fetchSize;
     private final RoutingBuilder routingBuilder;
@@ -70,7 +70,7 @@ public class PlannerContext {
                           RoutingProvider routingProvider,
                           UUID jobId,
                           Functions functions,
-                          TransactionContext transactionContext,
+                          CoordinatorTxnCtx coordinatorTxnCtx,
                           int softLimit,
                           int fetchSize) {
         this.routingProvider = routingProvider;
@@ -78,7 +78,7 @@ public class PlannerContext {
         this.routingBuilder = new RoutingBuilder(clusterState, routingProvider);
         this.clusterState = clusterState;
         this.jobId = jobId;
-        this.transactionContext = transactionContext;
+        this.coordinatorTxnCtx = coordinatorTxnCtx;
         this.softLimit = softLimit;
         this.fetchSize = fetchSize;
         this.handlerNode = clusterState.getNodes().getLocalNodeId();
@@ -92,8 +92,8 @@ public class PlannerContext {
         return fetchSize;
     }
 
-    public TransactionContext transactionContext() {
-        return transactionContext;
+    public CoordinatorTxnCtx transactionContext() {
+        return coordinatorTxnCtx;
     }
 
     public void applySoftLimit(QuerySpec querySpec) {

--- a/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.SubQueryAndParamBinder;
@@ -108,7 +108,7 @@ public final class WhereClauseOptimizer {
                                               Functions functions,
                                               Row params,
                                               SubQueryResults subQueryResults,
-                                              TransactionContext txnCtx) {
+                                              CoordinatorTxnCtx txnCtx) {
             if (docKeys != null) {
                 throw new IllegalStateException(getClass().getSimpleName()
                                                 + " must not be converted to a WhereClause if docKeys are present");
@@ -143,7 +143,7 @@ public final class WhereClauseOptimizer {
     public static DetailedQuery optimize(EvaluatingNormalizer normalizer,
                                          Symbol query,
                                          DocTableInfo table,
-                                         TransactionContext txnCtx) {
+                                         CoordinatorTxnCtx txnCtx) {
         Symbol queryGenColsProcessed = GeneratedColumnExpander.maybeExpand(
             query,
             table.generatedColumns(),

--- a/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
+++ b/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
@@ -44,10 +44,10 @@ import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
@@ -93,7 +93,7 @@ final class SemiJoins {
      * @return the rewritten relation or null if a rewrite wasn't possible.
      */
     @Nullable
-    QueriedRelation tryRewrite(QueriedRelation rel, TransactionContext transactionCtx) {
+    QueriedRelation tryRewrite(QueriedRelation rel, CoordinatorTxnCtx transactionCtx) {
         WhereClause where = rel.where();
         if (!where.hasQuery()) {
             return null;

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -153,7 +153,7 @@ public final class UpdatePlanner {
 
             executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), singletonList(nodeOpTree))
-                .execute(consumer);
+                .execute(consumer, plannerContext.transactionContext());
         }
 
         @Override
@@ -168,7 +168,7 @@ public final class UpdatePlanner {
             }
             return executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), nodeOpTreeList)
-                .executeBulk();
+                .executeBulk(plannerContext.transactionContext());
         }
     }
 
@@ -224,8 +224,7 @@ public final class UpdatePlanner {
             newArrayList(idReference),
             singletonList(updateProjection),
             where.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            plannerCtx.transactionContext().sessionContext().user()
+            DistributionInfo.DEFAULT_BROADCAST
         );
         Collect collect = new Collect(collectPhase, TopN.NO_LIMIT, 0, 1, 1, null);
         return Merge.ensureOnHandler(collect, plannerCtx, singletonList(MergeCountProjection.INSTANCE));

--- a/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
@@ -50,7 +50,7 @@ public class GenericDDLPlan implements Plan {
                         RowConsumer consumer,
                         Row params,
                         SubQueryResults subQueryResults) {
-        executor.ddlAction().apply(statement, params)
+        executor.ddlAction().apply(statement, params, plannerContext.transactionContext())
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
@@ -66,6 +66,7 @@ public class DeleteById implements Plan {
         DeleteByIdTask task = new DeleteByIdTask(
             plannerContext.jobId(),
             executor.clusterService(),
+            plannerContext.transactionContext(),
             executor.functions(),
             executor.transportActionProvider().transportShardDeleteAction(),
             this
@@ -81,6 +82,7 @@ public class DeleteById implements Plan {
         DeleteByIdTask task = new DeleteByIdTask(
             plannerContext.jobId(),
             executor.clusterService(),
+            plannerContext.transactionContext(),
             executor.functions(),
             executor.transportActionProvider().transportShardDeleteAction(),
             this

--- a/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
@@ -182,6 +182,7 @@ public class LegacyUpsertById implements Plan {
                         Row params,
                         SubQueryResults subQueryResults) {
         LegacyUpsertByIdTask task = new LegacyUpsertByIdTask(
+            plannerCtx.transactionContext(),
             plannerCtx.jobId(),
             this,
             executor.clusterService(),
@@ -199,6 +200,7 @@ public class LegacyUpsertById implements Plan {
                                                      List<Row> bulkParams,
                                                      SubQueryResults subQueryResults) {
         LegacyUpsertByIdTask task = new LegacyUpsertByIdTask(
+            plannerContext.transactionContext(),
             plannerContext.jobId(),
             this,
             executor.clusterService(),

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -75,6 +75,7 @@ public final class UpdateById implements Plan {
                         SubQueryResults subQueryResults) {
         UpdateByIdTask task = new UpdateByIdTask(
             plannerCtx.jobId(),
+            plannerCtx.transactionContext(),
             executor.clusterService(),
             executor.functions(),
             executor.transportActionProvider().transportShardUpsertAction(),
@@ -90,6 +91,7 @@ public final class UpdateById implements Plan {
                                                      SubQueryResults subQueryResults) {
         UpdateByIdTask task = new UpdateByIdTask(
             plannerContext.jobId(),
+            plannerContext.transactionContext(),
             executor.clusterService(),
             executor.functions(),
             executor.transportActionProvider().transportShardUpsertAction(),

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -93,7 +93,7 @@ public class ExplainPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
+    public void execute(DependencyCarrier dependencies,
                         PlannerContext plannerContext,
                         RowConsumer consumer,
                         Row params,
@@ -113,12 +113,19 @@ public class ExplainPlan implements Plan {
                 timer.start();
 
                 NodeOperationTree operationTree = LogicalPlanner.getNodeOperationTree(
-                    plan, executor, plannerContext, params, subQueryResults);
+                    plan, dependencies, plannerContext, params, subQueryResults);
 
                 resultReceiver.completionFuture()
-                    .whenComplete(createResultConsumer(executor, consumer, jobId, timer, operationTree));
+                    .whenComplete(createResultConsumer(dependencies, consumer, jobId, timer, operationTree));
 
-                LogicalPlanner.executeNodeOpTree(executor, jobId, noopRowConsumer, true, operationTree);
+                LogicalPlanner.executeNodeOpTree(
+                    dependencies,
+                    plannerContext.transactionContext(),
+                    jobId,
+                    noopRowConsumer,
+                    true,
+                    operationTree
+                );
             } else {
                 consumer.accept(null,
                     new UnsupportedOperationException("EXPLAIN ANALYZE does not support profiling multi-phase plans, " +
@@ -128,10 +135,10 @@ public class ExplainPlan implements Plan {
             try {
                 Map<String, Object> map;
                 if (subPlan instanceof LogicalPlan) {
-                    map = ExplainLogicalPlan.explainMap((LogicalPlan) subPlan, plannerContext, executor.projectionBuilder());
+                    map = ExplainLogicalPlan.explainMap((LogicalPlan) subPlan, plannerContext, dependencies.projectionBuilder());
                 } else if (subPlan instanceof CopyStatementPlanner.CopyFrom) {
                     ExecutionPlan executionPlan = CopyStatementPlanner.planCopyFromExecution(
-                        executor.clusterService().state().nodes(),
+                        dependencies.clusterService().state().nodes(),
                         ((CopyStatementPlanner.CopyFrom) subPlan).copyFrom,
                         plannerContext
                     );

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -289,7 +289,8 @@ class Collect extends ZeroInputPlan {
                 functionArguments.add(
                     Literal.of(
                         arg.valueType(),
-                        SymbolEvaluator.evaluate(plannerContext.functions(), arg, params, subQueryResults)
+                        SymbolEvaluator.evaluate(
+                            plannerContext.transactionContext(), plannerContext.functions(), arg, params, subQueryResults)
                     )
                 );
             }
@@ -317,8 +318,7 @@ class Collect extends ZeroInputPlan {
             boundOutputs,
             Collections.emptyList(),
             where.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            sessionContext.user()
+            DistributionInfo.DEFAULT_BROADCAST
         );
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -80,14 +80,16 @@ public class Get extends ZeroInputPlan {
         List<Symbol> boundOutputs = Lists2.map(
             outputs, s -> SubQueryAndParamBinder.convert(s, params, subQueryResults));
         for (DocKeys.DocKey docKey : docKeys) {
-            String id = docKey.getId(plannerContext.functions(), params, subQueryResults);
+            String id = docKey.getId(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
             if (id == null) {
                 continue;
             }
-            List<String> partitionValues = docKey.getPartitionValues(plannerContext.functions(), params, subQueryResults);
+            List<String> partitionValues = docKey.getPartitionValues(
+                plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
             String indexName = indexName(docTableInfo, partitionValues);
 
-            String routing = docKey.getRouting(plannerContext.functions(), params, subQueryResults);
+            String routing = docKey.getRouting(
+                plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
             ShardRouting shardRouting;
             try {
                 shardRouting = plannerContext.resolveShard(indexName, id, routing);
@@ -117,7 +119,7 @@ public class Get extends ZeroInputPlan {
                 idsByShard.put(shardRouting.shardId(), pkAndVersions);
             }
             long version = docKey
-                .version(plannerContext.functions(), params, subQueryResults)
+                .version(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults)
                 .orElse(Versions.MATCH_ANY);
             pkAndVersions.add(new PKAndVersion(id, version));
         }

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -33,7 +33,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.TableStats;
 import io.crate.planner.consumer.FetchMode;
@@ -68,13 +68,13 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
     private final WhereClause where;
     private final SubqueryPlanner subqueryPlanner;
     private final Functions functions;
-    private final TransactionContext txnCtx;
+    private final CoordinatorTxnCtx txnCtx;
 
     private JoinPlanBuilder(MultiSourceSelect mss,
                             WhereClause where,
                             SubqueryPlanner subqueryPlanner,
                             Functions functions,
-                            TransactionContext txnCtx) {
+                            CoordinatorTxnCtx txnCtx) {
         this.mss = mss;
         this.where = where;
         this.subqueryPlanner = subqueryPlanner;
@@ -86,7 +86,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                                        WhereClause where,
                                        SubqueryPlanner subqueryPlanner,
                                        Functions functions,
-                                       TransactionContext txnCtx) {
+                                       CoordinatorTxnCtx txnCtx) {
         return new JoinPlanBuilder(mss, where, subqueryPlanner, functions, txnCtx);
     }
 
@@ -242,7 +242,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                                             boolean orderByCanBePushedDown,
                                             QueriedRelation leftRelation,
                                             Functions functions,
-                                            TransactionContext txnCtx) {
+                                            CoordinatorTxnCtx txnCtx) {
         QualifiedName nextName = nextRel.getQualifiedName();
 
         Set<Symbol> usedFromNext = new LinkedHashSet<>();

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -77,9 +77,21 @@ class Limit extends OneInputPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         int limit = firstNonNull(
-            DataTypes.INTEGER.value(evaluate(plannerContext.functions(), this.limit, params, subQueryResults)), NO_LIMIT);
+            DataTypes.INTEGER.value(evaluate(
+                plannerContext.transactionContext(),
+                plannerContext.functions(),
+                this.limit,
+                params,
+                subQueryResults)),
+            NO_LIMIT);
         int offset = firstNonNull(
-            DataTypes.INTEGER.value(evaluate(plannerContext.functions(), this.offset, params, subQueryResults)), 0);
+            DataTypes.INTEGER.value(evaluate(
+                plannerContext.transactionContext(),
+                plannerContext.functions(),
+                this.offset,
+                params,
+                subQueryResults)),
+            0);
 
         ExecutionPlan executionPlan = source.build(
             plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -32,8 +32,8 @@ import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.TransactionContext;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -64,7 +64,7 @@ import static io.crate.planner.operators.Limit.limitAndOffset;
  */
 public class Union extends TwoInputPlan {
 
-    static Builder create(UnionSelect ttr, SubqueryPlanner subqueryPlanner, Functions functions, TransactionContext txnCtx) {
+    static Builder create(UnionSelect ttr, SubqueryPlanner subqueryPlanner, Functions functions, CoordinatorTxnCtx txnCtx) {
         return (tableStats, usedColsByParent) -> {
 
             QueriedRelation left = ttr.left();

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -126,7 +126,7 @@ public final class CopyStatementPlanner {
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId());
             executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), Collections.singletonList(nodeOpTree))
-                .execute(consumer);
+                .execute(consumer, plannerContext.transactionContext());
         }
     }
 
@@ -153,7 +153,7 @@ public final class CopyStatementPlanner {
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(plan, executor.localNodeId());
             executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), Collections.singletonList(nodeOpTree))
-                .execute(consumer);
+                .execute(consumer, plannerContext.transactionContext());
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -146,7 +146,7 @@ public final class DeletePlanner {
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId());
             executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), Collections.singletonList(nodeOpTree))
-                .execute(consumer);
+                .execute(consumer, plannerContext.transactionContext());
         }
 
         @Override
@@ -167,7 +167,7 @@ public final class DeletePlanner {
             }
             return executor.phasesTaskFactory()
                 .create(plannerContext.jobId(), nodeOperationTreeList)
-                .executeBulk();
+                .executeBulk(plannerContext.transactionContext());
         }
     }
 
@@ -187,8 +187,7 @@ public final class DeletePlanner {
             newArrayList(idReference),
             ImmutableList.of(deleteProjection),
             where.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            sessionContext.user()
+            DistributionInfo.DEFAULT_BROADCAST
         );
         Collect collect = new Collect(collectPhase, TopN.NO_LIMIT, 0, 1, 1, null);
         return Merge.ensureOnHandler(collect, context, Collections.singletonList(MergeCountProjection.INSTANCE));

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -39,7 +39,7 @@ import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
@@ -65,7 +65,7 @@ class BatchPortal extends AbstractPortal {
     private final List<List<? extends DataType>> outputTypes = new ArrayList<>();
     private final List<ResultReceiver> resultReceivers = new ArrayList<>();
 
-    private TransactionContext transactionContext;
+    private CoordinatorTxnCtx coordinatorTxnCtx;
 
     BatchPortal(String name,
                 String query,
@@ -115,14 +115,14 @@ class BatchPortal extends AbstractPortal {
                        @Nullable AnalyzedStatement analyzedStatement,
                        List<Object> params,
                        @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
-        transactionContext = new TransactionContext(sessionContext);
+        coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
         queries.add(query);
         batchParams.add(params);
         this.resultFormatCodes.add(resultFormatCodes);
 
         if (analyzedStatement == null) {
             Analysis analysis = portalContext.getAnalyzer().boundAnalyze(
-                statement, transactionContext, new ParameterContext(getArgs(), Collections.emptyList()));
+                statement, coordinatorTxnCtx, new ParameterContext(getArgs(), Collections.emptyList()));
             analyzedStatement = analysis.analyzedStatement();
         }
 
@@ -158,7 +158,7 @@ class BatchPortal extends AbstractPortal {
                 routingProvider,
                 jobId,
                 planner.functions(),
-                transactionContext,
+                coordinatorTxnCtx,
                 0,
                 0
             );

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -35,7 +35,7 @@ import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.symbol.Field;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
@@ -140,11 +140,11 @@ class BulkPortal extends AbstractPortal {
     @Override
     public CompletableFuture<?> sync(Planner planner, JobsLogs jobsLogs) {
         List<Row> bulkParams = Rows.of(bulkArgs);
-        TransactionContext transactionContext = new TransactionContext(sessionContext);
+        CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
 
         if (analyzedStatement == null) {
             Analysis analysis = portalContext.getAnalyzer().boundAnalyze(statement,
-                transactionContext,
+                coordinatorTxnCtx,
                 new ParameterContext(Row.EMPTY, bulkParams));
             analyzedStatement = analysis.analyzedStatement();
         }
@@ -156,7 +156,7 @@ class BulkPortal extends AbstractPortal {
             routingProvider,
             jobId,
             planner.functions(),
-            transactionContext,
+            coordinatorTxnCtx,
             0,
             maxRows
         );

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -38,7 +38,7 @@ import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.symbol.Field;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
@@ -75,7 +75,7 @@ public class SimplePortal extends AbstractPortal {
     private int maxRows = 0;
     private int defaultLimit;
     private Row rowParams;
-    private TransactionContext transactionContext;
+    private CoordinatorTxnCtx coordinatorTxnCtx;
 
     public SimplePortal(String name,
                         Analyzer analyzer,
@@ -143,13 +143,13 @@ public class SimplePortal extends AbstractPortal {
         this.params = params;
         this.rowParams = new RowN(params.toArray());
         this.resultFormatCodes = resultFormatCodes;
-        if (transactionContext == null) {
-            transactionContext = new TransactionContext(sessionContext);
+        if (coordinatorTxnCtx == null) {
+            coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
         }
         if (analyzedStatement == null || analyzedStatement.isUnboundPlanningSupported() == false) {
             Analysis analysis = portalContext.getAnalyzer().boundAnalyze(
                 statement,
-                transactionContext,
+                coordinatorTxnCtx,
                 new ParameterContext(rowParams, Collections.emptyList()));
             analyzedStatement = analysis.analyzedStatement();
         }
@@ -193,7 +193,7 @@ public class SimplePortal extends AbstractPortal {
             routingProvider,
             jobId,
             planner.functions(),
-            transactionContext,
+            coordinatorTxnCtx,
             defaultLimit,
             maxRows
         );
@@ -247,14 +247,14 @@ public class SimplePortal extends AbstractPortal {
         }
         Analysis analysis = portalContext
             .getAnalyzer()
-            .boundAnalyze(statement, transactionContext, new ParameterContext(rowParams, Collections.emptyList()));
+            .boundAnalyze(statement, coordinatorTxnCtx, new ParameterContext(rowParams, Collections.emptyList()));
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         PlannerContext plannerContext = new PlannerContext(
             planner.currentClusterState(),
             routingProvider,
             jobId,
             planner.functions(),
-            transactionContext,
+            coordinatorTxnCtx,
             defaultLimit,
             maxRows
         );

--- a/sql/src/main/java/io/crate/user/UserActions.java
+++ b/sql/src/main/java/io/crate/user/UserActions.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataTypes;
@@ -44,8 +45,9 @@ public final class UserActions {
     @Nullable
     public static SecureHash generateSecureHash(Map<String, Symbol> userStmtProperties,
                                                 Row parameters,
+                                                TransactionContext txnCtx,
                                                 Functions functions) throws GeneralSecurityException, IllegalArgumentException {
-        try (SecureString pw = getUserPasswordProperty(userStmtProperties, parameters, functions)) {
+        try (SecureString pw = getUserPasswordProperty(userStmtProperties, parameters, txnCtx, functions)) {
             if (pw != null) {
                 if (pw.length() == 0) {
                     throw new IllegalArgumentException("Password must not be empty");
@@ -60,12 +62,13 @@ public final class UserActions {
     @Nullable
     static SecureString getUserPasswordProperty(Map<String, Symbol> userStmtProperties,
                                                 Row parameters,
+                                                TransactionContext txnCtx,
                                                 Functions functions) throws IllegalArgumentException {
         final String PASSWORD_PROPERTY = "password";
         for (String key : userStmtProperties.keySet()) {
             if (PASSWORD_PROPERTY.equals(key)) {
                 String value = DataTypes.STRING.value(
-                    SymbolEvaluator.evaluate(functions, userStmtProperties.get(key), parameters, SubQueryResults.EMPTY));
+                    SymbolEvaluator.evaluate(txnCtx, functions, userStmtProperties.get(key), parameters, SubQueryResults.EMPTY));
                 if (value != null) {
                     return new SecureString(value.toCharArray());
                 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -36,7 +36,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.sql.parser.ParsingException;
 import io.crate.sql.parser.SqlParser;
@@ -764,7 +764,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testExplicitSchemaHasPrecedenceOverDefaultSchema() {
         CreateTableAnalyzedStatement statement = (CreateTableAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("create table foo.bar (x string)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "hoschi")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "hoschi")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         // schema from statement must take precedence
@@ -775,7 +775,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testDefaultSchemaIsAddedToTableIdentIfNoEplicitSchemaExistsInTheStatement() {
         CreateTableAnalyzedStatement statement = (CreateTableAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("create table bar (x string)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "hoschi")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "hoschi")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(statement.tableIdent().schema(), is("hoschi"));

--- a/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
@@ -30,7 +30,7 @@ import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.auth.user.User;
 import io.crate.data.Row;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Literal;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -84,7 +84,7 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
         CreateFunctionAnalyzedStatement analysis = (CreateFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("CREATE FUNCTION bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_schema"));
@@ -96,7 +96,7 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
         CreateFunctionAnalyzedStatement analysis = (CreateFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("CREATE FUNCTION my_other_schema.bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_other_schema"));

--- a/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
@@ -30,7 +30,7 @@ import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.auth.user.User;
 import io.crate.data.Row;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -69,7 +69,7 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testDropFunctionWithSessionSetSchema() throws Exception {
         DropFunctionAnalyzedStatement analysis = (DropFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("DROP FUNCTION bar(long, object)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER,s -> {}, t -> {}, "my_schema")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_schema"));
@@ -80,7 +80,7 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testDropFunctionExplicitSchemaSupersedesSessionSchema() throws Exception {
         DropFunctionAnalyzedStatement analysis = (DropFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("DROP FUNCTION my_other_schema.bar(long, object)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, User.CRATE_USER, s -> {}, t -> {}, "my_schema")),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_other_schema"));

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -12,6 +12,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ClusterReferenceResolver;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
@@ -20,7 +21,6 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -42,7 +42,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     private Functions functions;
     private Reference dummyLoadInfo;
 
-    private final TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
+    private final CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(SessionContext.systemSessionContext());
 
     @Before
     public void prepare() throws Exception {
@@ -105,7 +105,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
 
         // the dummy reference load == 0.08 evaluates to true,
         // so the whole query can be normalized to a single boolean literal
-        Symbol query = visitor.normalize(op_or, transactionContext);
+        Symbol query = visitor.normalize(op_or, coordinatorTxnCtx);
         assertThat(query, isLiteral(true));
     }
 
@@ -114,7 +114,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         EvaluatingNormalizer visitor = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, referenceResolver, null);
 
         Function op_or = prepareFunctionTree();
-        Symbol query = visitor.normalize(op_or, transactionContext);
+        Symbol query = visitor.normalize(op_or, coordinatorTxnCtx);
         assertThat(query, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -27,9 +27,9 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.hamcrest.Matchers;
@@ -71,7 +71,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         //noinspection unchecked
         return (T) sqlExecutor.normalize(
             sqlExecutor.analyze(statement),
-            new TransactionContext(SessionContext.systemSessionContext()));
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -32,8 +32,8 @@ import io.crate.auth.user.User;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -281,7 +281,7 @@ public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     private PrivilegesAnalyzedStatement analyzePrivilegesStatement(String statement) {
         return (PrivilegesAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement(statement),
-            new TransactionContext(new SessionContext(0, Option.NONE, GRANTOR_TEST_USER, s -> {}, t -> {})),
+            new CoordinatorTxnCtx(new SessionContext(0, Option.NONE, GRANTOR_TEST_USER, s -> {}, t -> {})),
             ParameterContext.EMPTY
         ).analyzedStatement();
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -56,7 +56,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -132,14 +132,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     private QueriedRelation analyze(String statement) {
         return sqlExecutor.normalize(
             sqlExecutor.analyze(statement),
-            new TransactionContext(SessionContext.systemSessionContext())
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext())
         );
     }
 
     private QueriedRelation analyze(String statement, Object[] arguments) {
         return sqlExecutor.normalize(
                 sqlExecutor.analyze(statement, arguments),
-                new TransactionContext(SessionContext.systemSessionContext())
+                new CoordinatorTxnCtx(SessionContext.systemSessionContext())
             );
     }
 

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -26,7 +26,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.AmbiguousColumnAliasException;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -57,7 +57,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private <T extends QueriedRelation> T analyze(String stmt) {
         return (T) executor.normalize(
             executor.analyze(stmt),
-            new TransactionContext(SessionContext.systemSessionContext()));
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -45,12 +45,12 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.ArrayLiteral;
@@ -92,7 +92,7 @@ import static org.mockito.Mockito.when;
 public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private ImmutableMap<QualifiedName, AnalyzedRelation> dummySources;
-    private TransactionContext transactionContext;
+    private CoordinatorTxnCtx coordinatorTxnCtx;
     private ExpressionAnalysisContext context;
     private ParamTypeHints paramTypeHints;
     private Functions functions;
@@ -104,7 +104,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         paramTypeHints = ParamTypeHints.EMPTY;
         DummyRelation dummyRelation = new DummyRelation("obj.x", "myObj.x", "myObj.x.AbC");
         dummySources = ImmutableMap.of(new QualifiedName("foo"), dummyRelation);
-        transactionContext = TransactionContext.systemTransactionContext();
+        coordinatorTxnCtx = CoordinatorTxnCtx.systemTransactionContext();
         context = new ExpressionAnalysisContext();
         functions = getFunctions();
         executor = SQLExecutor.builder(clusterService)
@@ -121,7 +121,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expectMessage("Unsupported expression current_time");
         SessionContext sessionContext = SessionContext.systemSessionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, transactionContext, paramTypeHints,
+            functions, coordinatorTxnCtx, paramTypeHints,
             new FullQualifiedNameFieldProvider(
                 dummySources,
                 ParentRelations.NO_PARENTS,
@@ -138,7 +138,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), User.CRATE_USER,s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            new TransactionContext(sessionContext),
+            new CoordinatorTxnCtx(sessionContext),
             paramTypeHints,
             new FullQualifiedNameFieldProvider(
                 dummySources,
@@ -181,7 +181,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), User.CRATE_USER, s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            new TransactionContext(sessionContext),
+            new CoordinatorTxnCtx(sessionContext),
             paramTypeHints,
             new FullQualifiedNameFieldProvider(
                 dummySources,
@@ -213,10 +213,10 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new QualifiedName("t2"), tr2
         );
         SessionContext sessionContext = SessionContext.systemSessionContext();
-        TransactionContext transactionContext = new TransactionContext(sessionContext);
+        CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            transactionContext,
+            coordinatorTxnCtx,
             paramTypeHints,
             new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.searchPath().currentSchema()),
             null
@@ -261,19 +261,19 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             Collections.singletonList(Literal.BOOLEAN_FALSE),
             localContext,
             functions,
-            TransactionContext.systemTransactionContext());
+            CoordinatorTxnCtx.systemTransactionContext());
         Symbol fn2 = ExpressionAnalyzer.allocateFunction(
             functionName,
             Collections.singletonList(Literal.BOOLEAN_FALSE),
             localContext,
             functions,
-            TransactionContext.systemTransactionContext());
+            CoordinatorTxnCtx.systemTransactionContext());
         Symbol fn3 = ExpressionAnalyzer.allocateFunction(
             functionName,
             Collections.singletonList(Literal.BOOLEAN_TRUE),
             localContext,
             functions,
-            TransactionContext.systemTransactionContext());
+            CoordinatorTxnCtx.systemTransactionContext());
 
         // different instances
         assertThat(fn1, allOf(

--- a/sql/src/test/java/io/crate/analyze/where/DocKeysTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/DocKeysTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
@@ -36,6 +37,7 @@ import static org.hamcrest.core.Is.is;
 
 public class DocKeysTest extends CrateUnitTest {
 
+
     @Test
     public void testClusteredIsFirstInId() throws Exception {
         // if a the table is clustered and has a pk, the clustering value is put in front in the id computation
@@ -44,8 +46,9 @@ public class DocKeysTest extends CrateUnitTest {
         );
         DocKeys docKeys = new DocKeys(pks, false, 1, null);
         DocKeys.DocKey key = docKeys.getOnlyKey();
-        assertThat(key.getRouting(getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("Ford"));
-        assertThat(key.getId(getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("AgRGb3JkATE="));
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+        assertThat(key.getRouting(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("Ford"));
+        assertThat(key.getId(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("AgRGb3JkATE="));
     }
 
 }

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -27,7 +27,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -46,7 +46,7 @@ import static org.hamcrest.core.Is.is;
 @SuppressWarnings("unchecked")
 public class EqualityExtractorTest extends CrateUnitTest {
 
-    private TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
+    private CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(SessionContext.systemSessionContext());
     private SqlExpressions expressions = new SqlExpressions(ImmutableMap.of(T3.T1, T3.TR_1), T3.TR_1);
     private EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
     private EqualityExtractor ee = new EqualityExtractor(normalizer);
@@ -54,7 +54,7 @@ public class EqualityExtractorTest extends CrateUnitTest {
     private ColumnIdent i = new ColumnIdent("i");
 
     private List<List<Symbol>> analyzeParentX(Symbol query) {
-        return ee.extractParentMatches(ImmutableList.of(x), query, transactionContext);
+        return ee.extractParentMatches(ImmutableList.of(x), query, coordinatorTxnCtx);
     }
 
     private List<List<Symbol>> analyzeExactX(Symbol query) {
@@ -66,7 +66,7 @@ public class EqualityExtractorTest extends CrateUnitTest {
     }
 
     private List<List<Symbol>> analyzeExact(Symbol query, List<ColumnIdent> primaryKeys) {
-        return ee.extractExactMatches(primaryKeys, query, transactionContext);
+        return ee.extractExactMatches(primaryKeys, query, coordinatorTxnCtx);
     }
 
     private Symbol query(String expression) {

--- a/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -25,7 +25,7 @@ package io.crate.analyze.where;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.eval.NullEliminator;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -46,7 +46,7 @@ public class NullEliminatorTest extends CrateUnitTest {
 
     private void assertReplacedAndNormalized(String expression, String expectedString) {
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
-        assertReplaced(expression, expectedString,  s -> normalizer.normalize(s, TransactionContext.systemTransactionContext()));
+        assertReplaced(expression, expectedString,  s -> normalizer.normalize(s, CoordinatorTxnCtx.systemTransactionContext()));
     }
 
     private void assertReplaced(String expression, String expectedString, Function<Symbol, Symbol> postProcessor) {

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -34,10 +34,10 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.any.AnyLikeOperator;
 import io.crate.expression.operator.any.AnyOperators;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.planner.WhereClauseOptimizer;
 import io.crate.planner.operators.SubQueryResults;
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.is;
 @SuppressWarnings("unchecked")
 public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private final TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
+    private final CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(SessionContext.systemSessionContext());
     private SQLExecutor e;
 
     @Before
@@ -144,7 +144,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private WhereClause analyzeSelect(String stmt, Object... args) {
         QueriedRelation rel = e.normalize(
             e.analyze(stmt, args),
-            new TransactionContext(SessionContext.systemSessionContext())
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext())
         );
         if (rel instanceof QueriedTable && ((QueriedTable) rel).tableRelation() instanceof DocTableRelation) {
             DocTableRelation docTableRelation = (DocTableRelation) ((QueriedTable) rel).tableRelation();
@@ -152,14 +152,14 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 new EvaluatingNormalizer(getFunctions(), RowGranularity.CLUSTER, null, docTableRelation),
                 rel.where().queryOrFallback(),
                 docTableRelation.tableInfo(),
-                transactionContext
+                coordinatorTxnCtx
             );
             return detailedQuery.toBoundWhereClause(
                 docTableRelation.tableInfo(),
                 getFunctions(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
-                transactionContext
+                coordinatorTxnCtx
             );
         }
         return rel.where();

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -29,6 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.DocRefResolver;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -54,6 +55,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = query.tableRelation().tableInfo();
         GeneratedColumns<Doc> generatedColumns = new GeneratedColumns<>(
             new InputFactory(e.functions()),
+            CoordinatorTxnCtx.systemTransactionContext(),
             GeneratedColumns.Validation.NONE,
             new DocRefResolver(Collections.emptyList()),
             Collections.emptyList(),

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -58,6 +58,8 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         UUID jobId = UUID.randomUUID();
         Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            "dummyUser",
+            "dummySchema",
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             assignmentColumns,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -177,6 +177,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            "dummyUser",
+            "dummySchema",
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
@@ -196,6 +198,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            "dummyUser",
+            "dummySchema",
             DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
@@ -235,6 +239,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            "dummyUser",
+            "dummySchema",
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
@@ -254,6 +260,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            "dummyUser",
+            "dummySchema",
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,

--- a/sql/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -31,6 +31,8 @@ import io.crate.blob.v2.BlobShard;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.integrationtests.SQLHttpIntegrationTest;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
@@ -56,10 +58,10 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
     private BlobShardCollectorProvider collectorProvider;
 
     private Iterable<Row> getBlobRows(RoutedCollectPhase phase, boolean repeat) throws Exception {
-        Method m = BlobShardCollectorProvider.class.getDeclaredMethod("getBlobRows", RoutedCollectPhase.class, boolean.class);
+        Method m = BlobShardCollectorProvider.class.getDeclaredMethod("getBlobRows", TransactionContext.class, RoutedCollectPhase.class, boolean.class);
         m.setAccessible(true);
         //noinspection unchecked
-        return (Iterable<Row>) m.invoke(collectorProvider, phase, repeat);
+        return (Iterable<Row>) m.invoke(collectorProvider, CoordinatorTxnCtx.systemTransactionContext(), phase, repeat);
     }
 
     @Test
@@ -79,8 +81,7 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
             ImmutableList.of(),
             ImmutableList.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            null
+            DistributionInfo.DEFAULT_BROADCAST
         );
 
         // No read Isolation

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -28,6 +28,7 @@ import io.crate.data.Row;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.jobs.SharedShardContexts;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.testing.TestingRowConsumer;
@@ -66,6 +67,7 @@ public class CollectTaskTest extends RandomizedTest {
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
         collectTask = new CollectTask(
             collectPhase,
+            CoordinatorTxnCtx.systemTransactionContext(),
             mock(MapSideDataCollectOperation.class),
             ramAccountingContext,
             new TestingRowConsumer(),
@@ -107,8 +109,10 @@ public class CollectTaskTest extends RandomizedTest {
         Engine.Searcher mock1 = mock(Engine.Searcher.class);
         MapSideDataCollectOperation collectOperationMock = mock(MapSideDataCollectOperation.class);
 
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         CollectTask jobCtx = new CollectTask(
             collectPhase,
+            txnCtx,
             collectOperationMock,
             ramAccountingContext,
             new TestingRowConsumer(),
@@ -117,7 +121,7 @@ public class CollectTaskTest extends RandomizedTest {
         jobCtx.addSearcher(1, mock1);
 
         BatchIterator<Row> batchIterator = mock(BatchIterator.class);
-        when(collectOperationMock.createIterator(eq(collectPhase), anyBoolean(), eq(jobCtx)))
+        when(collectOperationMock.createIterator(eq(txnCtx), eq(collectPhase), anyBoolean(), eq(jobCtx)))
             .thenReturn(batchIterator);
         jobCtx.prepare();
         jobCtx.start();

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -194,8 +194,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             toCollect,
             ImmutableList.of(),
             whereClause.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            null
+            DistributionInfo.DEFAULT_BROADCAST
         );
     }
 
@@ -245,7 +244,12 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             "remoteNode");
 
         List<CompletableFuture<StreamBucket>> results = jobSetup.prepareOnRemote(
-            ImmutableList.of(nodeOperation), builder, sharedShardContexts);
+            "dummyUser",
+            "dummySchema",
+            ImmutableList.of(nodeOperation),
+            builder,
+            sharedShardContexts
+        );
         RootTask rootTask = tasksService.createTask(builder);
         rootTask.start();
         return results.get(0).get(2, TimeUnit.SECONDS);

--- a/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -28,6 +28,7 @@ import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.execution.engine.collect.sources.FileCollectSource;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
@@ -84,7 +85,8 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
         );
         TestingRowConsumer consumer = new TestingRowConsumer();
         CollectTask collectTask = mock(CollectTask.class);
-        BatchIterator<Row> iterator = fileCollectSource.getIterator(collectNode, collectTask, false);
+        BatchIterator<Row> iterator = fileCollectSource.getIterator(
+            CoordinatorTxnCtx.systemTransactionContext(), collectNode, collectTask, false);
         consumer.accept(iterator, null);
         assertThat(new CollectionBucket(consumer.getResult()), contains(
             isRow("Arthur", 38),

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -30,6 +30,8 @@ import io.crate.execution.engine.collect.stats.TransportNodeStatsAction;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
@@ -66,6 +68,7 @@ public class NodeStatsTest extends CrateUnitTest {
     private RoutedCollectPhase collectPhase;
     private Collection<DiscoveryNode> nodes = new HashSet<>();
     private TransportNodeStatsAction transportNodeStatsAction = mock(TransportNodeStatsAction.class);
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     private Reference idRef;
     private Reference nameRef;
@@ -100,6 +103,7 @@ public class NodeStatsTest extends CrateUnitTest {
             transportNodeStatsAction,
             collectPhase,
             nodes,
+            txnCtx,
             new InputFactory(getFunctions())
         );
         iterator.loadNextBatch();
@@ -119,6 +123,7 @@ public class NodeStatsTest extends CrateUnitTest {
             transportNodeStatsAction,
             collectPhase,
             nodes,
+            txnCtx,
             new InputFactory(getFunctions())
         );
         iterator.loadNextBatch();
@@ -137,6 +142,7 @@ public class NodeStatsTest extends CrateUnitTest {
             transportNodeStatsAction,
             collectPhase,
             nodes,
+            txnCtx,
             new InputFactory(getFunctions())
         );
         iterator.loadNextBatch();
@@ -166,6 +172,7 @@ public class NodeStatsTest extends CrateUnitTest {
             transportNodeStatsAction,
             collectPhase,
             nodes,
+            txnCtx,
             new InputFactory(getFunctions())
         ));
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -87,8 +87,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
             Collections.singletonList(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             WhereClause.MATCH_ALL.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            null
+            DistributionInfo.DEFAULT_BROADCAST
         );
         transportJobAction = mock(TransportJobAction.class);
         TasksService tasksService = new TasksService(
@@ -110,6 +109,8 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         consumer = new TestingRowConsumer();
         remoteCollector = new RemoteCollector(
             jobId,
+            "dummyUser",
+            "dummySchema",
             "localNode",
             "remoteNode",
             transportJobAction,

--- a/sql/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.relations.TableRelation;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.table.TableInfo;
@@ -54,9 +55,10 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
 
         CountOperation countOperation = internalCluster().getDataNodeInstance(CountOperation.class);
         ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         MetaData metaData = clusterService.state().getMetaData();
         Index index = metaData.index(getFqn("t")).getIndex();
-        assertThat(countOperation.count(index, 0, Literal.BOOLEAN_TRUE), is(3L));
+        assertThat(countOperation.count(txnCtx, index, 0, Literal.BOOLEAN_TRUE), is(3L));
 
         Schemas schemas = internalCluster().getInstance(Schemas.class);
         TableInfo tableInfo = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "t"));
@@ -65,6 +67,6 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);
 
         Symbol filter = sqlExpressions.normalize(sqlExpressions.asSymbol("name = 'Marvin'"));
-        assertThat(countOperation.count(index, 0, filter), is(1L));
+        assertThat(countOperation.count(txnCtx, index, 0, filter), is(1L));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -39,9 +39,8 @@ import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.expression.reference.file.SourceLineExpression;
 import io.crate.expression.reference.file.SourceUriFailureExpression;
 import io.crate.external.S3ClientHelper;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.test.integration.CrateUnitTest;
@@ -90,6 +89,7 @@ public class FileReadingCollectorTest extends CrateUnitTest {
     private static File tmpFileEmptyLine;
     private InputFactory inputFactory;
     private Input<String> sourceUriFailureInput;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -119,8 +119,8 @@ public class FileReadingCollectorTest extends CrateUnitTest {
     @Before
     public void prepare() throws Exception {
         Functions functions = new Functions(
-            ImmutableMap.<FunctionIdent, FunctionImplementation>of(),
-            ImmutableMap.<String, FunctionResolver>of()
+            ImmutableMap.of(),
+            ImmutableMap.of()
         );
         inputFactory = new InputFactory(functions);
     }
@@ -279,7 +279,7 @@ public class FileReadingCollectorTest extends CrateUnitTest {
                                                    final S3ObjectInputStream s3InputStream,
                                                    boolean collectSourceUriFailure) {
         InputFactory.Context<LineCollectorExpression<?>> ctx =
-            inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+            inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
         List<Input<?>> inputs = new ArrayList<>(2);
         Reference raw = createReference(SourceLineExpression.COLUMN_NAME, DataTypes.STRING);
         inputs.add(ctx.add(raw));

--- a/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -29,6 +29,8 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.test.integration.CrateUnitTest;
@@ -62,6 +64,7 @@ public class FileReadingIteratorTest extends CrateUnitTest {
     private String JSON_AS_MAP_SECOND_LINE = "{\"id\": 5, \"name\": \"Trillian\", \"details\": {\"age\": 33}}";
     private String CSV_AS_MAP_FIRST_LINE = "{\"name\":\"Arthur\",\"id\":\"4\",\"age\":\"38\"}";
     private String CSV_AS_MAP_SECOND_LINE = "{\"name\":\"Trillian\",\"id\":\"5\",\"age\":\"33\"}";
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void prepare() {
@@ -161,7 +164,7 @@ public class FileReadingIteratorTest extends CrateUnitTest {
     private BatchIterator<Row> createBatchIterator(Collection<String> fileUris, String compression, FileUriCollectPhase.InputFormat format) {
         Reference raw = createReference("_raw", DataTypes.STRING);
         InputFactory.Context<LineCollectorExpression<?>> ctx =
-            inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+            inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         return FileReadingIterator.newInstance(

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
@@ -79,8 +79,7 @@ public class DistributingConsumerFactoryTest extends CrateDummyClusterServiceUni
             ImmutableList.of(),
             ImmutableList.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
-            DistributionInfo.DEFAULT_MODULO,
-            null
+            DistributionInfo.DEFAULT_MODULO
         );
         MergePhase mergePhase = new MergePhase(
             jobId,

--- a/sql/src/test/java/io/crate/execution/engine/fetch/FetchBatchAccumulatorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/fetch/FetchBatchAccumulatorTest.java
@@ -29,13 +29,14 @@ import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
-import io.crate.expression.symbol.FetchReference;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
 import io.crate.data.Row1;
+import io.crate.expression.symbol.FetchReference;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -71,6 +72,7 @@ public class FetchBatchAccumulatorTest {
     @Test
     public void testFetchBatchAccumulatorMultipleFetches() throws Exception {
         FetchBatchAccumulator fetchBatchAccumulator = new FetchBatchAccumulator(
+            CoordinatorTxnCtx.systemTransactionContext(),
             fetchOperation,
             getFunctions(),
             buildOutputSymbols(),

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -81,6 +82,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             new NodeJobsCounter(),
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
+            CoordinatorTxnCtx.systemTransactionContext(),
             internalCluster().getInstance(Functions.class),
             Settings.EMPTY,
             tableSettings,

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -32,6 +32,7 @@ import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -95,6 +96,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
             new NodeJobsCounter(),
             scheduler,
             executor,
+            CoordinatorTxnCtx.systemTransactionContext(),
             TestingHelpers.getFunctions(),
             Settings.EMPTY,
             Settings.EMPTY,

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -30,7 +30,9 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
@@ -47,11 +49,12 @@ public class MapRowUsingInputsTest extends CrateUnitTest {
 
     private List<Input<?>> inputs;
     private List<CollectExpression<Row, ?>> expressions;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void createInputs() throws Exception {
         InputFactory inputFactory = new InputFactory(getFunctions());
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns();
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         inputs = Collections.singletonList(ctx.add(ArithmeticFunctions.of(
             ArithmeticFunctions.Names.ADD,
             new InputColumn(0, DataTypes.LONG),

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -41,6 +41,8 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
@@ -81,6 +83,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
     private Functions functions;
     private ThreadPool threadPool;
     private ProjectorFactory projectorFactory;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
 
     @Before
@@ -144,7 +147,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
         RowConsumer delegateConsumerRequiresScroll = new DummyRowConsumer(true);
 
         RowConsumer projectingConsumer = ProjectingRowConsumer.create(delegateConsumerRequiresScroll,
-            Collections.singletonList(filterProjection), UUID.randomUUID(), RAM_ACCOUNTING_CONTEXT, projectorFactory);
+            Collections.singletonList(filterProjection), UUID.randomUUID(), txnCtx, RAM_ACCOUNTING_CONTEXT, projectorFactory);
 
         assertThat(projectingConsumer.requiresScroll(), is(true));
     }
@@ -157,7 +160,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
         RowConsumer delegateConsumerRequiresScroll = new DummyRowConsumer(true);
 
         RowConsumer projectingConsumer = ProjectingRowConsumer.create(delegateConsumerRequiresScroll,
-            Collections.singletonList(groupProjection), UUID.randomUUID(), RAM_ACCOUNTING_CONTEXT, projectorFactory);
+            Collections.singletonList(groupProjection), UUID.randomUUID(), txnCtx, RAM_ACCOUNTING_CONTEXT, projectorFactory);
 
         assertThat(projectingConsumer.requiresScroll(), is(false));
     }
@@ -169,7 +172,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
         RowConsumer delegateConsumerRequiresScroll = new DummyRowConsumer(false);
 
         RowConsumer projectingConsumer = ProjectingRowConsumer.create(delegateConsumerRequiresScroll,
-            Collections.singletonList(groupProjection), UUID.randomUUID(), RAM_ACCOUNTING_CONTEXT, projectorFactory);
+            Collections.singletonList(groupProjection), UUID.randomUUID(), txnCtx, RAM_ACCOUNTING_CONTEXT, projectorFactory);
 
         assertThat(projectingConsumer.requiresScroll(), is(false));
     }
@@ -189,6 +192,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
             consumer,
             Collections.singletonList(writerProjection),
             UUID.randomUUID(),
+            txnCtx,
             RAM_ACCOUNTING_CONTEXT,
             projectorFactory
         );

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -33,6 +33,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -96,7 +97,9 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
         Projectors projectors = new Projectors(
             Arrays.asList(filterProjection, groupProjection),
             UUID.randomUUID(),
-            RAM_ACCOUNTING_CONTEXT, projectorFactory
+            CoordinatorTxnCtx.systemTransactionContext(),
+            RAM_ACCOUNTING_CONTEXT,
+            projectorFactory
         );
 
         assertThat(projectors.providesIndependentScroll(), is(true));

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -29,6 +29,7 @@ import io.crate.execution.engine.collect.CollectTask;
 import io.crate.execution.engine.collect.MapSideDataCollectOperation;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.engine.distribution.merge.PassThroughPagingIterator;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.profile.ProfilingContext;
@@ -128,6 +129,7 @@ public class RootTaskTest extends CrateUnitTest {
 
         CollectTask collectChildTask = new CollectTask(
             collectPhase,
+            CoordinatorTxnCtx.systemTransactionContext(),
             mock(MapSideDataCollectOperation.class),
             mock(RamAccountingContext.class),
             new TestingRowConsumer(),

--- a/sql/src/test/java/io/crate/execution/jobs/transport/JobRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/transport/JobRequestTest.java
@@ -35,7 +35,7 @@ public class JobRequestTest {
 
     @Test
     public void testJobRequestStreaming() throws Exception {
-        JobRequest r1 = new JobRequest(UUID.randomUUID(), "n1", Collections.emptyList(), true);
+        JobRequest r1 = new JobRequest(UUID.randomUUID(), "dummyUser", "dummySchema", "n1", Collections.emptyList(), true);
 
         BytesStreamOutput out = new BytesStreamOutput();
         r1.writeTo(out);

--- a/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesRootTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesRootTaskTest.java
@@ -65,8 +65,7 @@ public class ExecutionPhasesRootTaskTest {
             ImmutableList.of(),
             ImmutableList.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
-            DistributionInfo.DEFAULT_BROADCAST,
-            null
+            DistributionInfo.DEFAULT_BROADCAST
         );
 
         MergePhase m1 = new MergePhase(

--- a/sql/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/sql/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
@@ -35,13 +36,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
+
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
     private static Symbol normalizeSymbol(String source, String pattern) {
         RegexpMatchCaseInsensitiveOperator op = new RegexpMatchCaseInsensitiveOperator();
         Function function = new Function(
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
+        return op.normalizeSymbol(function, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 
     private Boolean regexpNormalize(String source, String pattern) {
@@ -69,7 +73,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
 
     private Boolean regexpEvaluate(String source, String pattern) {
         RegexpMatchCaseInsensitiveOperator op = new RegexpMatchCaseInsensitiveOperator();
-        return op.evaluate(Literal.of(source), Literal.of(pattern));
+        return op.evaluate(txnCtx, Literal.of(source), Literal.of(pattern));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
+++ b/sql/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
@@ -35,13 +36,17 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class RegexpMatchOperatortest extends CrateUnitTest {
+
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
+
     private static Symbol normalizeSymbol(String source, String pattern) {
         RegexpMatchOperator op = new RegexpMatchOperator();
         Function function = new Function(
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
+        return op.normalizeSymbol(function, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 
     private Boolean regexpNormalize(String source, String pattern) {
@@ -69,7 +74,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
 
     private Boolean regexpEvaluate(String source, String pattern) {
         RegexpMatchOperator op = new RegexpMatchOperator();
-        return op.evaluate(Literal.of(source), Literal.of(pattern));
+        return op.evaluate(txnCtx, Literal.of(source), Literal.of(pattern));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
@@ -23,8 +23,10 @@ package io.crate.expression.operator.any;
 
 import io.crate.expression.operator.input.ObjectInput;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -35,6 +37,8 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 
 public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
 
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
     private Boolean anyEq(Object value, Object arrayExpr) {
         AnyOperator anyOperator = new AnyOperator(
             new FunctionInfo(
@@ -42,7 +46,7 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
                 DataTypes.BOOLEAN),
             cmp -> cmp == 0
         );
-        return anyOperator.evaluate(new ObjectInput(value), new ObjectInput(arrayExpr));
+        return anyOperator.evaluate(txnCtx, new ObjectInput(value), new ObjectInput(arrayExpr));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -21,13 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.data.Input;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.SearchPath;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +41,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     private RandomFunction random;
+    private TransactionContext txnCtx = TransactionContext.of("dummyUser", "dummySchema");
 
     @Before
     public void prepareRandom() {
@@ -52,14 +51,14 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateRandom() {
-        assertThat(random.evaluate(new Input[0]),
+        assertThat(random.evaluate(txnCtx, new Input[0]),
             is(allOf(greaterThanOrEqualTo(0.0), lessThan(1.0))));
     }
 
     @Test
     public void normalizeReference() {
-        Function function = new Function(random.info(), Collections.<Symbol>emptyList());
-        Function normalized = (Function) random.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
+        Function function = new Function(random.info(), Collections.emptyList());
+        Function normalized = (Function) random.normalizeSymbol(function, txnCtx);
         assertThat(normalized, sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -25,9 +25,11 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.testing.SqlExpressions;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -51,12 +53,10 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    public void testEvaluateCurrentSchemaNotSupported() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot evaluate CURRENT_SCHEMA function.");
+    public void testEvaluateCurrentSchema() throws Exception {
         Function function = (Function) sqlExpressions.asSymbol("current_schema()");
         FunctionIdent ident = function.info().ident();
         Scalar impl = (Scalar) functions.getQualified(ident);
-        impl.evaluate();
+        assertThat(impl.evaluate(TransactionContext.of("dummyUser", "dummySchema")), Matchers.is("dummySchema"));
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -28,7 +28,9 @@ import io.crate.data.Bucket;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.sql.tree.QualifiedName;
@@ -44,6 +46,7 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
 
     private SqlExpressions sqlExpressions;
     private Functions functions;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void prepareFunctions() throws Exception {
@@ -57,7 +60,7 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
         TableFunctionImplementation<?> tableFunction = (TableFunctionImplementation) functions.getQualified(ident);
-        return tableFunction.evaluate(function.arguments().stream().map(a -> (Input) a).toArray(Input[]::new));
+        return tableFunction.evaluate(txnCtx, function.arguments().stream().map(a -> (Input) a).toArray(Input[]::new));
     }
 
     protected void assertExecute(String expr, String expected) {

--- a/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -25,6 +25,7 @@ package io.crate.expression.udf;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -77,7 +78,7 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
         }
 
         @Override
-        public Integer evaluate(Input<Integer>[] args) {
+        public Integer evaluate(TransactionContext txnCtx, Input<Integer>[] args) {
             return RESULT;
         }
     }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -52,7 +52,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
@@ -416,7 +416,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     public static class PlanForNode {
         public final Plan plan;
         final String nodeName;
-        final PlannerContext plannerContext;
+        public final PlannerContext plannerContext;
 
         private PlanForNode(Plan plan, String nodeName, PlannerContext plannerContext) {
             this.plan = plan;
@@ -435,19 +435,19 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         ParameterContext parameterContext = new ParameterContext(Row.EMPTY, Collections.<Row>emptyList());
         SessionContext sessionContext = new SessionContext(
             0, Option.NONE, User.CRATE_USER, x -> {}, x -> {}, sqlExecutor.getCurrentSchema());
-        TransactionContext transactionContext = new TransactionContext(sessionContext);
+        CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         PlannerContext plannerContext = new PlannerContext(
             planner.currentClusterState(),
             routingProvider,
             UUID.randomUUID(),
             planner.functions(),
-            transactionContext,
+            coordinatorTxnCtx,
             0,
             0
         );
         Plan plan = planner.plan(
-            analyzer.boundAnalyze(SqlParser.createStatement(stmt), transactionContext, parameterContext).analyzedStatement(),
+            analyzer.boundAnalyze(SqlParser.createStatement(stmt), coordinatorTxnCtx, parameterContext).analyzedStatement(),
             plannerContext);
         return new PlanForNode(plan, nodeName, plannerContext);
     }

--- a/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -33,6 +33,7 @@ import io.crate.expression.udf.UserDefinedFunctionMetaData;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.testing.UseJdbc;
 import io.crate.types.DataType;
@@ -73,7 +74,7 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
         }
 
         @Override
-        public String evaluate(Input<InputType>... args) {
+        public String evaluate(TransactionContext txnCtx, Input<InputType>... args) {
             // dummy-lang functions simple print the type of the only argument
             return "DUMMY EATS " + metaData.argumentTypes().get(0).getName();
         }

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -15,6 +15,7 @@ import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.ParameterContext;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
@@ -22,7 +23,6 @@ import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.view.ViewInfoFactory;
 import io.crate.sql.parser.SqlParser;
@@ -964,7 +964,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
             new NumberOfShards(clusterService)
         );
 
-        Analysis analysis = new Analysis(new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
+        Analysis analysis = new Analysis(new CoordinatorTxnCtx(SessionContext.systemSessionContext()), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
         CreateTableAnalyzedStatement analyzedStatement = analyzer.analyze(
             (CreateTable) statement, analysis.parameterContext(), analysis.transactionContext());
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -31,6 +31,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -67,7 +68,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
                 return new Scalar() {
                     private final FunctionInfo info = new FunctionInfo(new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()), metaData.returnType());
                     @Override
-                    public Object evaluate(Input[] args) {
+                    public Object evaluate(TransactionContext txnCtx, Input[] args) {
                         return null;
                     }
 

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -42,7 +42,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.parser.SqlParser;
@@ -282,10 +282,10 @@ public class TestingTableInfo extends DocTableInfo {
         }
 
         private void initializeGeneratedExpressions(Functions functions, Collection<Reference> columns) {
-            TransactionContext transactionContext = TransactionContext.systemTransactionContext();
+            CoordinatorTxnCtx coordinatorTxnCtx = CoordinatorTxnCtx.systemTransactionContext();
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(columns, ident);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-                functions, transactionContext, null, tableReferenceResolver, null);
+                functions, coordinatorTxnCtx, null, tableReferenceResolver, null);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
                 ExpressionAnalysisContext context = new ExpressionAnalysisContext();

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -31,10 +31,10 @@ import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
@@ -107,6 +107,6 @@ public abstract class AggregationTest extends CrateUnitTest {
             (AggregationFunction) functions.get(null, functionName, arguments, SearchPath.pathWithPGCatalogAndDoc());
         return function.normalizeSymbol(
             new Function(function.info(), arguments),
-            new TransactionContext(SessionContext.systemSessionContext()));
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -28,6 +28,8 @@ import io.crate.data.Row;
 import io.crate.exceptions.VersionInvalidException;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.ddl.DeletePartitions;
 import io.crate.planner.node.dml.DeleteById;
 import io.crate.planner.operators.SubQueryResults;
@@ -49,6 +51,7 @@ import static org.hamcrest.Matchers.is;
 public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void prepare() throws IOException {
@@ -79,7 +82,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan.docKeys().size(), is(2));
         List<String> docKeys = Lists.newArrayList(plan.docKeys())
             .stream()
-            .map(x -> x.getId(e.functions(), Row.EMPTY, SubQueryResults.EMPTY))
+            .map(x -> x.getId(txnCtx, e.functions(), Row.EMPTY, SubQueryResults.EMPTY))
             .collect(Collectors.toList());
 
         assertThat(docKeys, Matchers.containsInAnyOrder("1", "2"));

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -2,7 +2,7 @@ package io.crate.planner;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.node.ddl.ESClusterUpdateSettingsPlan;
 import io.crate.planner.node.management.KillPlan;
 import io.crate.sql.tree.LongLiteral;
@@ -56,7 +56,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             new RoutingProvider(Randomness.get().nextInt(), Collections.emptyList()),
             UUID.randomUUID(),
             e.functions(),
-            new TransactionContext(SessionContext.systemSessionContext()),
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext()),
             0,
             0);
 

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -31,6 +31,8 @@ import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.UpdateProjection;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.planner.consumer.UpdatePlanner;
 import io.crate.planner.node.dml.UpdateById;
@@ -55,6 +57,7 @@ import static org.hamcrest.core.Is.is;
 public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void prepare() throws IOException {
@@ -103,7 +106,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(updateById.assignmentByTargetCol().values(), contains(isLiteral("Vogon lyric fan")));
         assertThat(updateById.docKeys().size(), is(1));
 
-        assertThat(updateById.docKeys().getOnlyKey().getId(e.functions(), Row.EMPTY, SubQueryResults.EMPTY), is("1"));
+        assertThat(updateById.docKeys().getOnlyKey().getId(txnCtx, e.functions(), Row.EMPTY, SubQueryResults.EMPTY), is("1"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
+++ b/sql/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
@@ -24,6 +24,8 @@ package io.crate.planner.node.ddl;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.RowN;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -31,6 +33,8 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class DeletePartitionsTest extends CrateDummyClusterServiceUnitTest {
+
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Test
     public void testIndexNameGeneration() throws Exception {
@@ -41,12 +45,12 @@ public class DeletePartitionsTest extends CrateDummyClusterServiceUnitTest {
 
         Object[] args1 = {"1395874800000"};
         assertThat(
-            plan.getIndices(e.functions(), new RowN(args1), SubQueryResults.EMPTY),
+            plan.getIndices(txnCtx, e.functions(), new RowN(args1), SubQueryResults.EMPTY),
             Matchers.containsInAnyOrder(".partitioned.parted_pks.04732cpp6ks3ed1o60o30c1g"));
 
         Object[] args2 = {"1395961200000"};
         assertThat(
-            plan.getIndices(e.functions(), new RowN(args2), SubQueryResults.EMPTY),
+            plan.getIndices(txnCtx, e.functions(), new RowN(args2), SubQueryResults.EMPTY),
             Matchers.containsInAnyOrder(".partitioned.parted_pks.04732cpp6ksjcc9i60o30c1g"));
     }
 

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -29,10 +29,10 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.NestedLoopPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.TransactionContext;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
@@ -65,7 +65,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     private Functions functions = getFunctions();
     private ProjectionBuilder projectionBuilder = new ProjectionBuilder(functions);
     private PlannerContext plannerCtx;
-    private TransactionContext txnCtx = TransactionContext.systemTransactionContext();
+    private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void setUpExecutor() throws IOException {

--- a/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
+++ b/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
@@ -24,6 +24,7 @@ package io.crate.testing;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
@@ -46,7 +47,7 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
 
     @SafeVarargs
     @Override
-    public final Boolean evaluate(Input<Long>... args) {
+    public final Boolean evaluate(TransactionContext txnCtx, Input<Long>... args) {
         long millis = (args.length > 0) ? args[0].value() : 1000L;
         try {
             Thread.sleep(millis);


### PR DESCRIPTION
Generated column definitions which use scalar functions depending on the
active session like `username STRING GENERATED ALWAYS AS CURRENT_USER`
caused failures on update statements because the generated columns are
computed on the shard and relies on `evaluate`, but these functions
didn't implement `evaluate` but relied on `normalizeSymbol` being
executed on the coordinator node.

This adds a new `FunctionTxnCtx` which is available for `evaluate` of
scalar functions to resolve this issue,

To be able to create the `FunctionTxnCtx` on the shards/collect nodes,
this adds the userName and currentSchema to the `JobRequest` and
`ShardUpsertRequest`. It also removes the `User` from
`RoutedCollectPhase`, since we're able to retrieve it now on
shard/collect.

An alternative approach would have been to inject the generated column
into the assignments of an update statement. But then we would have
required a way to distinguish between generated columns we have to
validate (user supplied) and generated columns that don't require
validation (because we injected them).
That's because we wouldn't have been able to validate columns depending
on `current_user` (no evaluate implementation) or `current_timestamp`
(undeterministic, value changes between coordinator and shard)


- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed