### PR TITLE
Rename `indexName` on RelationName to `indexNameOrAlias`

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
@@ -37,7 +37,7 @@ public abstract class AbstractDropTableAnalyzedStatement<T extends TableInfo> im
     }
 
     public String index() {
-        return tableIdent().indexName();
+        return tableIdent().indexNameOrAlias();
     }
 
     public T table() {

--- a/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
+++ b/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
@@ -120,7 +120,7 @@ public final class RerouteActions {
         ShardedTable shardedTable = statement.tableInfo();
         if (shardedTable instanceof DocTableInfo) {
             DocTableInfo docTableInfo = (DocTableInfo) shardedTable;
-            String indexName = docTableInfo.ident().indexName();
+            String indexName = docTableInfo.ident().indexNameOrAlias();
             PartitionName partitionName = AlterTableAnalyzer.createPartitionName(statement.partitionProperties(),
                 docTableInfo, parameters);
             if (partitionName != null) {

--- a/sql/src/main/java/io/crate/execution/ddl/SnapshotRestoreDDLDispatcher.java
+++ b/sql/src/main/java/io/crate/execution/ddl/SnapshotRestoreDDLDispatcher.java
@@ -189,7 +189,7 @@ public class SnapshotRestoreDDLDispatcher {
             } else if (ignoreUnavailable) {
                 // If ignoreUnavailable is true, it's cheaper to simply return indexName and the partitioned wildcard instead
                 // checking if it's a partitioned table or not
-                resolveIndicesAndTemplatesContext.addIndex(table.tableIdent().indexName());
+                resolveIndicesAndTemplatesContext.addIndex(table.tableIdent().indexNameOrAlias());
                 // For the case its a partitioned table we restore all partitions and the templates
                 String templateName = table.partitionTemplate();
                 resolveIndicesAndTemplatesContext.addIndex(templateName + "*");
@@ -261,7 +261,7 @@ public class SnapshotRestoreDDLDispatcher {
         public static void resolveTableFromSnapshot(RestoreSnapshotAnalyzedStatement.RestoreTableInfo table,
                                                     List<SnapshotInfo> snapshots,
                                                     ResolveIndicesAndTemplatesContext ctx) throws RelationUnknown {
-            String name = table.tableIdent().indexName();
+            String name = table.tableIdent().indexNameOrAlias();
             for (SnapshotInfo snapshot : snapshots) {
                 for (String index : snapshot.indices()) {
                     if (name.equals(index)) {

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -220,8 +220,8 @@ public class AlterTableOperation {
                 }
             }
         } else {
-            results.add(updateMapping(analysis.tableParameter().mappings(), table.ident().indexName()));
-            results.add(updateSettings(analysis.tableParameter(), table.ident().indexName()));
+            results.add(updateMapping(analysis.tableParameter().mappings(), table.ident().indexNameOrAlias()));
+            results.add(updateSettings(analysis.tableParameter(), table.ident().indexNameOrAlias()));
         }
 
         final CompletableFuture<Long> result = new CompletableFuture<>();
@@ -249,8 +249,8 @@ public class AlterTableOperation {
             return renamePartitionedTable(sourceTableInfo, targetRelationName);
         }
 
-        String[] sourceIndices = new String[]{sourceRelationName.indexName()};
-        String[] targetIndices = new String[]{targetRelationName.indexName()};
+        String[] sourceIndices = new String[]{sourceRelationName.indexNameOrAlias()};
+        String[] targetIndices = new String[]{targetRelationName.indexNameOrAlias()};
 
         List<ChainableAction<Long>> actions = new ArrayList<>(3);
 
@@ -402,7 +402,7 @@ public class AlterTableOperation {
             .order(indexTemplateMetaData.order())
             .settings(settings)
             .patterns(indexTemplateMetaData.getPatterns())
-            .alias(new Alias(relationName.indexName()));
+            .alias(new Alias(relationName.indexNameOrAlias()));
         for (ObjectObjectCursor<String, AliasMetaData> container : indexTemplateMetaData.aliases()) {
             Alias alias = new Alias(container.key);
             request.alias(alias);

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -86,7 +86,7 @@ public class TableCreator {
     }
 
     private CreateIndexRequest createIndexRequest(CreateTableAnalyzedStatement statement) {
-        return new CreateIndexRequest(statement.tableIdent().indexName(), settings(statement))
+        return new CreateIndexRequest(statement.tableIdent().indexNameOrAlias(), settings(statement))
             .mapping(Constants.DEFAULT_MAPPING_TYPE, statement.mapping());
     }
 
@@ -101,7 +101,7 @@ public class TableCreator {
             .settings(settings(statement))
             .patterns(Collections.singletonList(statement.templatePrefix()))
             .order(100)
-            .alias(new Alias(statement.tableIdent().indexName()));
+            .alias(new Alias(statement.tableIdent().indexNameOrAlias()));
     }
 
     private void createTable(final CompletableFuture<Long> result, final CreateTableAnalyzedStatement statement) {

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
@@ -76,6 +76,6 @@ public class TransportDropTableAction extends AbstractDDLTransportAction<DropTab
             indicesOptions = IndicesOptions.lenientExpandOpen();
         }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, request.tableIdent().indexName()));
+            indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, request.tableIdent().indexNameOrAlias()));
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -85,6 +85,6 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
     @Override
     protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexName()));
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexNameOrAlias()));
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
@@ -79,7 +79,7 @@ public class TransportRenameTableAction extends AbstractDDLTransportAction<Renam
     protected ClusterBlockException checkBlock(RenameTableRequest request, ClusterState state) {
         try {
             return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-                indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.sourceTableIdent().indexName()));
+                indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.sourceTableIdent().indexNameOrAlias()));
         } catch (IndexNotFoundException e) {
             if (request.isPartitioned() == false) {
                 throw e;

--- a/sql/src/main/java/io/crate/execution/ddl/views/TransportCreateViewAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/views/TransportCreateViewAction.java
@@ -107,7 +107,7 @@ public final class TransportCreateViewAction extends TransportMasterNodeAction<C
     }
 
     private static boolean conflictsWithTable(RelationName viewName, MetaData indexMetaData) {
-        return indexMetaData.hasIndex(viewName.indexName())
+        return indexMetaData.hasIndex(viewName.indexNameOrAlias())
                || indexMetaData.templates().containsKey(PartitionName.templateName(viewName.schema(), viewName.name()));
     }
 

--- a/sql/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
@@ -144,7 +144,7 @@ public class ShardRequestExecutor<Req> {
             List<String> partitionValues = docKey.getPartitionValues(txnCtx, functions, parameters, subQueryResults);
             final String indexName;
             if (partitionValues == null) {
-                indexName = table.ident().indexName();
+                indexName = table.ident().indexNameOrAlias();
             } else {
                 indexName = IndexParts.toIndexName(table.ident(), PartitionName.encodeIdent(partitionValues));
             }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -135,13 +135,13 @@ public class InformationSchemaIterables implements ClusterStateListener {
     private static Stream<ViewInfo> viewsStream(Schemas schemas) {
         return sequentialStream(schemas)
             .flatMap(schema -> sequentialStream(schema.getViews()))
-            .filter(i -> !IndexParts.isPartitioned(i.ident().indexName()));
+            .filter(i -> !IndexParts.isPartitioned(i.ident().indexNameOrAlias()));
     }
 
     private static Stream<TableInfo> tablesStream(Schemas schemas) {
         return sequentialStream(schemas)
             .flatMap(s -> sequentialStream(s.getTables()))
-            .filter(i -> !IndexParts.isPartitioned(i.ident().indexName()));
+            .filter(i -> !IndexParts.isPartitioned(i.ident().indexNameOrAlias()));
     }
 
     private static <T> Stream<T> sequentialStream(Iterable<T> iterable) {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexNameResolver.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexNameResolver.java
@@ -56,7 +56,7 @@ public class IndexNameResolver {
     }
 
     public static Supplier<String> forTable(final RelationName relationName) {
-        return relationName::indexName;
+        return relationName::indexNameOrAlias;
     }
 
     private static Supplier<String> forPartition(RelationName relationName, String partitionIdent) {

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/TableSettingsResolver.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/TableSettingsResolver.java
@@ -41,9 +41,9 @@ public final class TableSettingsResolver {
     }
 
     private static Settings forTable(MetaData metaData, RelationName relationName) {
-        IndexMetaData indexMetaData = metaData.index(relationName.indexName());
+        IndexMetaData indexMetaData = metaData.index(relationName.indexNameOrAlias());
         if (indexMetaData == null) {
-            throw new IndexNotFoundException(relationName.indexName());
+            throw new IndexNotFoundException(relationName.indexNameOrAlias());
         }
         return indexMetaData.getSettings();
     }

--- a/sql/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -84,7 +84,7 @@ public class ShardRowContext {
         if (indexParts.isPartitioned()) {
             partitionIdent = indexParts.getPartitionIdent();
             RelationName relationName = indexParts.toRelationName();
-            aliasName = relationName.indexName();
+            aliasName = relationName.indexNameOrAlias();
             templateName = PartitionName.templateName(relationName.schema(), relationName.name());
         } else {
             partitionIdent = "";

--- a/sql/src/main/java/io/crate/metadata/RelationName.java
+++ b/sql/src/main/java/io/crate/metadata/RelationName.java
@@ -91,7 +91,10 @@ public final class RelationName implements Writeable {
         return Identifiers.quoteIfNeeded(schema) + "." + Identifiers.quoteIfNeeded(name);
     }
 
-    public String indexName() {
+    /**
+     * @return The indexName for non-partitioned tables or the alias name for partitioned tables.
+     */
+    public String indexNameOrAlias() {
         if (schema.equalsIgnoreCase(Schemas.DOC_SCHEMA_NAME)) {
             return name;
         } else if (schema.equalsIgnoreCase(BlobSchemaInfo.NAME)) {

--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -201,7 +201,7 @@ public class Routing implements Writeable {
     public static Routing forTableOnAllNodes(RelationName relationName, DiscoveryNodes nodes) {
         TreeMap<String, Map<String, IntIndexedContainer>> indicesByNode = new TreeMap<>();
         Map<String, IntIndexedContainer> shardsByIndex = Collections.singletonMap(
-            relationName.indexName(),
+            relationName.indexNameOrAlias(),
             IntArrayList.from(IntArrayList.EMPTY_ARRAY)
         );
         for (DiscoveryNode node : nodes) {

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -83,7 +83,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
                          @Nullable Version versionCreated,
                          @Nullable Version versionUpgraded,
                          boolean closed) {
-        assert ident.indexName().equals(index) : "RelationName indexName must match index";
+        assert ident.indexNameOrAlias().equals(index) : "RelationName indexName must match index";
         this.ident = ident;
         this.index = index;
         this.numberOfShards = numberOfShards;

--- a/sql/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -87,7 +87,7 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         RelationName relationName = request.tableIdent();
         String partitionIndexName = request.partitionIndexName();
         MetaData metaData = currentState.metaData();
-        String indexToResolve = partitionIndexName != null ? partitionIndexName : relationName.indexName();
+        String indexToResolve = partitionIndexName != null ? partitionIndexName : relationName.indexNameOrAlias();
         PartitionName partitionName = partitionIndexName != null ? PartitionName.fromIndexOrTemplate(partitionIndexName) : null;
         String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
             currentState, IndicesOptions.lenientExpandOpen(), indexToResolve);

--- a/sql/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
@@ -54,7 +54,7 @@ public class DropTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
     protected ClusterState execute(ClusterState currentState, DropTableRequest request) throws Exception {
         RelationName relationName = request.tableIdent();
         final Set<Index> concreteIndices = new HashSet<>(Arrays.asList(indexNameExpressionResolver.concreteIndices(
-            currentState, IndicesOptions.lenientExpandOpen(), relationName.indexName())));
+            currentState, IndicesOptions.lenientExpandOpen(), relationName.indexNameOrAlias())));
         currentState = deleteIndexService.deleteIndices(currentState, concreteIndices);
 
         if (request.isPartitioned()) {

--- a/sql/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -99,17 +99,17 @@ public class RenameTableClusterStateExecutor extends DDLClusterStateTaskExecutor
 
         try {
             Index[] sourceIndices = indexNameExpressionResolver.concreteIndices(currentState, STRICT_INDICES_OPTIONS,
-                sourceRelationName.indexName());
+                sourceRelationName.indexNameOrAlias());
             validateAllIndicesAreClosed(currentState, sourceRelationName, sourceIndices, isPartitioned);
 
             String[] targetIndices;
             if (isPartitioned) {
                 targetIndices = buildNewPartitionIndexNames(sourceIndices, targetRelationName);
                 // change the alias for all partitions
-                currentState = changeAliases(currentState, sourceIndices, sourceRelationName.indexName(),
-                    targetRelationName.indexName());
+                currentState = changeAliases(currentState, sourceIndices, sourceRelationName.indexNameOrAlias(),
+                    targetRelationName.indexNameOrAlias());
             } else {
-                targetIndices = new String[]{targetRelationName.indexName()};
+                targetIndices = new String[]{targetRelationName.indexNameOrAlias()};
             }
 
             MetaData metaData = currentState.getMetaData();
@@ -203,7 +203,7 @@ public class RenameTableClusterStateExecutor extends DDLClusterStateTaskExecutor
             .settings(sourceTemplateMetaData.settings())
             .patterns(Collections.singletonList(targetTemplatePrefix))
             .putMapping(Constants.DEFAULT_MAPPING_TYPE, sourceTemplateMetaData.mappings().get(Constants.DEFAULT_MAPPING_TYPE))
-            .putAlias(AliasMetaData.builder(targetIdent.indexName()));
+            .putAlias(AliasMetaData.builder(targetIdent.indexNameOrAlias()));
         IndexTemplateMetaData newTemplate = templateBuilder.build();
 
         mdBuilder.removeTemplate(sourceTemplateMetaData.getName()).put(newTemplate);

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -74,18 +74,18 @@ class DocTableInfoBuilder {
         DocIndexMetaData docIndexMetaData;
         String templateName = PartitionName.templateName(ident.schema(), ident.name());
         if (metaData.getTemplates().containsKey(templateName)) {
-            docIndexMetaData = buildDocIndexMetaDataFromTemplate(ident.indexName(), templateName);
+            docIndexMetaData = buildDocIndexMetaDataFromTemplate(ident.indexNameOrAlias(), templateName);
             // We need all concrete indices, regardless of their state, for operations such as reopening.
             concreteIndices = indexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.lenientExpandOpen(), ident.indexName());
+                state, IndicesOptions.lenientExpandOpen(), ident.indexNameOrAlias());
             // We need all concrete open indices, as closed indices must not appear in the routing.
             concreteOpenIndices = indexNameExpressionResolver.concreteIndexNames(
                 state, IndicesOptions.fromOptions(true, true, true,
-                    false, IndicesOptions.strictExpandOpenAndForbidClosed()), ident.indexName());
+                    false, IndicesOptions.strictExpandOpenAndForbidClosed()), ident.indexNameOrAlias());
         } else {
             try {
                 concreteIndices = indexNameExpressionResolver.concreteIndexNames(
-                    state, IndicesOptions.strictExpandOpen(), ident.indexName());
+                    state, IndicesOptions.strictExpandOpen(), ident.indexNameOrAlias());
                 concreteOpenIndices = concreteIndices;
                 if (concreteIndices.length == 0) {
                     // no matching index found
@@ -153,7 +153,7 @@ class DocTableInfoBuilder {
                         partitions.add(partitionName);
                     } catch (IllegalArgumentException e) {
                         // ignore
-                        logger.warn(String.format(Locale.ENGLISH, "Cannot build partition %s of index %s", indexName, ident.indexName()));
+                        logger.warn(String.format(Locale.ENGLISH, "Cannot build partition %s of index %s", indexName, ident.indexNameOrAlias()));
                     }
                 }
             }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -400,7 +400,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                     onDuplicateKeyAssignments = analysis.onDuplicateKeyAssignments().get(i);
                 }
                 legacyUpsertById.add(
-                    tableInfo.ident().indexName(),
+                    tableInfo.ident().indexNameOrAlias(),
                     analysis.ids().get(i),
                     analysis.routingValues().get(i),
                     onDuplicateKeyAssignments,

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -160,7 +160,7 @@ public class Get extends ZeroInputPlan {
             assert partitionValues != null : "values must not be null";
             return IndexParts.toIndexName(relation, PartitionName.encodeIdent(partitionValues));
         } else {
-            return relation.indexName();
+            return relation.indexNameOrAlias();
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/TableDefinitions.java
+++ b/sql/src/test/java/io/crate/analyze/TableDefinitions.java
@@ -233,7 +233,7 @@ public final class TableDefinitions {
     public static TestingBlobTableInfo createBlobTable(RelationName ident) {
         return new TestingBlobTableInfo(
             ident,
-            ident.indexName(),
+            ident.indexNameOrAlias(),
             5,
             "0",
             ImmutableMap.<String, Object>of(),

--- a/sql/src/test/java/io/crate/execution/ddl/RerouteActionsTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/RerouteActionsTest.java
@@ -184,7 +184,7 @@ public class RerouteActionsTest extends CrateDummyClusterServiceUnitTest {
 
         ClusterRerouteRequest request = new ClusterRerouteRequest();
         AllocateReplicaAllocationCommand command = new AllocateReplicaAllocationCommand(
-            userTable.ident().indexName(), 0, "node1");
+            userTable.ident().indexNameOrAlias(), 0, "node1");
         request.add(command);
         assertEquals(request, actualRequest);
     }
@@ -201,7 +201,7 @@ public class RerouteActionsTest extends CrateDummyClusterServiceUnitTest {
 
         ClusterRerouteRequest request = new ClusterRerouteRequest();
         MoveAllocationCommand command = new MoveAllocationCommand(
-            userTable.ident().indexName(), 0, "node1", "node2");
+            userTable.ident().indexNameOrAlias(), 0, "node1", "node2");
         request.add(command);
         assertEquals(request, actualRequest);
     }
@@ -220,7 +220,7 @@ public class RerouteActionsTest extends CrateDummyClusterServiceUnitTest {
 
         ClusterRerouteRequest request = new ClusterRerouteRequest();
         CancelAllocationCommand command = new CancelAllocationCommand(
-            userTable.ident().indexName(), 0, "node1", true);
+            userTable.ident().indexNameOrAlias(), 0, "node1", true);
         request.add(command);
         assertEquals(request, actualRequest);
     }

--- a/sql/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
@@ -72,7 +72,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
         indexUUID = UUIDs.randomBase64UUID();
         IndicesService indicesService = mock(IndicesService.class);
         IndexService indexService = mock(IndexService.class);
-        when(indicesService.indexServiceSafe(new Index(TABLE_IDENT.indexName(), indexUUID))).thenReturn(indexService);
+        when(indicesService.indexServiceSafe(new Index(TABLE_IDENT.indexNameOrAlias(), indexUUID))).thenReturn(indexService);
         indexShard = mock(IndexShard.class);
         when(indexService.getShard(0)).thenReturn(indexShard);
 
@@ -93,7 +93,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testKilledSetWhileProcessingItemsDoesNotThrowExceptionAndMustMarkItemPosition() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), indexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), indexUUID, 0);
         final ShardDeleteRequest request = new ShardDeleteRequest(shardId, UUID.randomUUID());
         request.add(1, new ShardDeleteRequest.Item("1"));
 
@@ -106,7 +106,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testReplicaOperationWillSkipItemsFromMarkedPositionOn() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), indexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), indexUUID, 0);
         final ShardDeleteRequest request = new ShardDeleteRequest(shardId, UUID.randomUUID());
         request.add(1, new ShardDeleteRequest.Item("1"));
         request.skipFromLocation(1);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -143,7 +143,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         IndicesService indicesService = mock(IndicesService.class);
         IndexService indexService = mock(IndexService.class);
-        Index charactersIndex = new Index(TABLE_IDENT.indexName(), charactersIndexUUID);
+        Index charactersIndex = new Index(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID);
         Index partitionIndex = new Index(PARTITION_INDEX, partitionIndexUUID);
 
         when(indicesService.indexServiceSafe(charactersIndex)).thenReturn(indexService);
@@ -175,7 +175,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
@@ -196,7 +196,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
@@ -237,7 +237,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
@@ -258,7 +258,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
-        ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",

--- a/sql/src/test/java/io/crate/metadata/RelationNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/RelationNameTest.java
@@ -34,9 +34,9 @@ public class RelationNameTest extends CrateUnitTest {
     @Test
     public void testIndexName() throws Exception {
         RelationName ti = new RelationName(Schemas.DOC_SCHEMA_NAME, "t");
-        assertThat(ti.indexName(), is("t"));
+        assertThat(ti.indexNameOrAlias(), is("t"));
         ti = new RelationName("s", "t");
-        assertThat(ti.indexName(), is("s.t"));
+        assertThat(ti.indexNameOrAlias(), is("s.t"));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class RelationNameTest extends CrateUnitTest {
     @Test
     public void testFromIndexNameCreatesCorrectBlobRelationName() {
         RelationName relationName = new RelationName("blob", "foobar");
-        String indexName = relationName.indexName();
+        String indexName = relationName.indexNameOrAlias();
         assertThat(BlobIndex.isBlobIndex(indexName), is(true));
         assertThat(RelationName.fromIndexName(indexName), is(relationName));
     }

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -159,7 +159,7 @@ public class TestingTableInfo extends DocTableInfo {
         private static String[] concreteIndices(RelationName ident, ImmutableList<PartitionName> partitionsList) {
             String[] concreteIndices;
             if (partitionsList.isEmpty()) {
-                concreteIndices = new String[]{ident.indexName()};
+                concreteIndices = new String[]{ident.indexNameOrAlias()};
             } else {
                 concreteIndices = Lists.transform(partitionsList, new Function<PartitionName, String>() {
                     @Nullable

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -150,7 +150,7 @@ public final class QueryTester implements AutoCloseable {
 
             DocSchemaInfo docSchema = findDocSchema(sqlExecutor.schemas());
             table = (DocTableInfo) docSchema.getTables().iterator().next();
-            Index index = new Index(table.ident().indexName(), UUIDs.randomBase64UUID());
+            Index index = new Index(table.ident().indexNameOrAlias(), UUIDs.randomBase64UUID());
             queryBuilder = new LuceneQueryBuilder(sqlExecutor.functions());
             Settings nodeSettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, indexVersion)

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -443,7 +443,7 @@ public class SQLExecutor {
             XContentBuilder mappingBuilder = XContentFactory.jsonBuilder().map(analyzedStmt.mapping());
             CompressedXContent mapping = new CompressedXContent(BytesReference.bytes(mappingBuilder));
             Settings settings = analyzedStmt.tableParameter().settings().getByPrefix("index.");
-            AliasMetaData.Builder alias = AliasMetaData.builder(analyzedStmt.tableIdent().indexName());
+            AliasMetaData.Builder alias = AliasMetaData.builder(analyzedStmt.tableIdent().indexNameOrAlias());
             IndexTemplateMetaData.Builder template = IndexTemplateMetaData.builder(analyzedStmt.templateName())
                 .patterns(singletonList(analyzedStmt.templatePrefix()))
                 .order(100)
@@ -486,7 +486,7 @@ public class SQLExecutor {
             ClusterState prevState = clusterService.state();
             RelationName relationName = analyzedStmt.tableIdent();
             IndexMetaData indexMetaData = getIndexMetaData(
-                relationName.indexName(), analyzedStmt, prevState.nodes().getSmallestNonClientNodeVersion())
+                relationName.indexNameOrAlias(), analyzedStmt, prevState.nodes().getSmallestNonClientNodeVersion())
                 .build();
 
             ClusterState state = ClusterState.builder(prevState)


### PR DESCRIPTION
If the `RelationName` refers to a partitioned table it is not actually
the name of an index but the alias name.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed