### PR TITLE
Tests: Make RamBlockSizeCalculatorTest deterministic

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -26,6 +26,7 @@ import io.crate.breaker.RowAccounting;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.BatchIterator;
 import io.crate.data.ListenableBatchIterator;
+import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.data.join.CombinedRow;
@@ -74,7 +75,7 @@ public class HashJoinOperation implements CompletionListenable {
                             getHashBuilderFromSymbols(txnCtx, inputFactory, joinLeftInputs),
                             getHashBuilderFromSymbols(txnCtx, inputFactory, joinRightInputs),
                             rowAccounting,
-                            new RamBlockSizeCalculator(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
+                            new RamBlockSizeCalculator(Paging.PAGE_SIZE, circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
                         ), completionFuture);
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {

--- a/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -29,6 +29,7 @@ import io.crate.concurrent.CompletionListenable;
 import io.crate.data.BatchIterator;
 import io.crate.data.FilteringBatchIterator;
 import io.crate.data.ListenableBatchIterator;
+import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.data.join.CombinedRow;
@@ -155,7 +156,8 @@ public class NestedLoopOperation implements CompletionListenable {
                                                                   long estimatedNumberOfRowsLeft,
                                                                   boolean blockNestedLoop) {
         if (blockNestedLoop) {
-            IntSupplier blockSizeCalculator = new RamBlockSizeCalculator(circuitBreaker, estimatedRowsSizeLeft, estimatedNumberOfRowsLeft);
+            IntSupplier blockSizeCalculator = new RamBlockSizeCalculator(
+                Paging.PAGE_SIZE, circuitBreaker, estimatedRowsSizeLeft, estimatedNumberOfRowsLeft);
             RowAccounting rowAccounting = new RowAccountingWithEstimators(leftSideColumnTypes, ramAccountingContext);
             return JoinBatchIterators.crossJoinBlockNL(left, right, combiner, blockSizeCalculator, rowAccounting);
         } else {


### PR DESCRIPTION
Paging.PAGE_SIZE is mutated in some tests, that could cause the tests in
RamBlockSizeCalculatorTests to fail.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed