### PR TITLE
Optimize no-op check in UserManagerService

### DIFF
--- a/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
@@ -200,11 +200,18 @@ public class UserManagerService implements UserManager, ClusterStateListener {
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (!event.metaDataChanged()) {
-            return;
+        MetaData prevMetaData = event.previousState().metaData();
+        MetaData newMetaData = event.state().metaData();
+
+        UsersMetaData prevUsers = prevMetaData.custom(UsersMetaData.TYPE);
+        UsersMetaData newUsers = newMetaData.custom(UsersMetaData.TYPE);
+
+        UsersPrivilegesMetaData prevUsersPrivileges = prevMetaData.custom(UsersPrivilegesMetaData.TYPE);
+        UsersPrivilegesMetaData newUsersPrivileges = newMetaData.custom(UsersPrivilegesMetaData.TYPE);
+
+        if (prevUsers != newUsers || prevUsersPrivileges != newUsersPrivileges) {
+            users = getUsers(newUsers, newUsersPrivileges);
         }
-        MetaData metaData = event.state().metaData();
-        users = getUsers(metaData.custom(UsersMetaData.TYPE), metaData.custom(UsersPrivilegesMetaData.TYPE));
     }
 
 


### PR DESCRIPTION
The MetaData can change more often than the users/privileges within it,
so we can check the latter to avoid re-building the `User` instances.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed