### PR TITLE
Replace usages of RAMDirectory

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -35,8 +35,9 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,10 +50,11 @@ public class LuceneBatchIteratorTest extends CrateUnitTest {
     private List<LongColumnReference> columnRefs;
     private IndexSearcher indexSearcher;
     private ArrayList<Object[]> expectedResult;
+    private IndexWriter iw;
 
     @Before
     public void prepareSearcher() throws Exception {
-        IndexWriter iw = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        iw = new IndexWriter(new MMapDirectory(createTempDir()), new IndexWriterConfig(new StandardAnalyzer()));
         String columnName = "x";
         expectedResult = new ArrayList<>(20);
         for (long i = 0; i < 20; i++) {
@@ -65,6 +67,11 @@ public class LuceneBatchIteratorTest extends CrateUnitTest {
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
         LongColumnReference columnReference = new LongColumnReference(columnName);
         columnRefs = Collections.singletonList(columnReference);
+    }
+
+    @After
+    public void tearDownIndexWriter() throws Exception {
+        iw.close();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -72,6 +72,7 @@ public class LuceneBatchIteratorTest extends CrateUnitTest {
     @After
     public void tearDownIndexWriter() throws Exception {
         iw.close();
+        iw.getDirectory().close();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -97,6 +97,7 @@ public class LuceneOrderedDocCollectorTest extends CrateUnitTest {
     @After
     public void tearDownIndexWriter() throws Exception {
         iw.close();
+        iw.getDirectory().close();
     }
 
     private Directory createLuceneIndex() throws IOException {

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -125,7 +125,9 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
     @After
     public void tearDownIndexWriters() throws Exception {
         iw1.close();
+        iw1.getDirectory().close();
         iw2.close();
+        iw2.getDirectory().close();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -52,11 +52,12 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.shard.ShardId;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,11 +87,13 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
     private List<Object[]> expectedResult;
     private boolean[] reverseFlags = new boolean[]{true};
     private Boolean[] nullsFirst = new Boolean[]{null};
+    private IndexWriter iw1;
+    private IndexWriter iw2;
 
     @Before
     public void prepareSearchers() throws Exception {
-        IndexWriter iw1 = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
-        IndexWriter iw2 = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        iw1 = new IndexWriter(new MMapDirectory(createTempDir()), new IndexWriterConfig(new StandardAnalyzer()));
+        iw2 = new IndexWriter(new MMapDirectory(createTempDir()), new IndexWriterConfig(new StandardAnalyzer()));
 
         expectedResult = LongStream.range(0, 20)
             .mapToObj(i -> new Object[]{i})
@@ -117,6 +120,12 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
             reverseFlags,
             nullsFirst
         );
+    }
+
+    @After
+    public void tearDownIndexWriters() throws Exception {
+        iw1.close();
+        iw2.close();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
@@ -28,7 +28,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
@@ -48,7 +48,7 @@ public abstract class DocLevelExpressionsTest extends ESSingleNodeTestCase {
         Settings settings = Settings.builder().put("index.fielddata.cache", "none").build();
         IndexService indexService = createIndex("test", settings);
         ifd = indexService.fieldData();
-        writer = new IndexWriter(new RAMDirectory(),
+        writer = new IndexWriter(new MMapDirectory(createTempDir()),
             new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(new LogByteSizeMergePolicy()));
 
         insertValues(writer);

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -50,7 +50,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterModule;
@@ -101,6 +101,7 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -228,7 +229,7 @@ public final class QueryTester implements AutoCloseable {
             );
             indexFieldDataService = indexService.fieldData();
             IndexWriterConfig conf = new IndexWriterConfig(new StandardAnalyzer());
-            writer = new IndexWriter(new RAMDirectory(), conf);
+            writer = new IndexWriter(new MMapDirectory(Files.createTempDirectory(tempDir, "lucene-idx")), conf);
             tableName = new QualifiedName(table.ident().name());
             docTableRelation = new DocTableRelation(table);
             expressions = new SqlExpressions(


### PR DESCRIPTION
RAMDirectory is deprecated and it is recommended to use MMapDirectory
instead.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed