### PR TITLE
Remove some ShardUpgradeRequest.Builder overloads

### DIFF
--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -28,7 +28,6 @@ import io.crate.execution.dml.ShardRequest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
-import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -363,37 +362,6 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
         private final Reference[] missingAssignmentsColumns;
         private final UUID jobId;
         private boolean validateGeneratedColumns;
-
-        public Builder(String userName,
-                       String currentSchema,
-                       TimeValue timeout,
-                       DuplicateKeyAction duplicateKeyAction,
-                       boolean continueOnError,
-                       @Nullable String[] assignmentsColumns,
-                       @Nullable Reference[] missingAssignmentsColumns,
-                       UUID jobId) {
-            this(userName,
-                currentSchema,
-                timeout,
-                duplicateKeyAction,
-                continueOnError,
-                assignmentsColumns,
-                missingAssignmentsColumns,
-                jobId,
-                true);
-        }
-
-        public Builder(String userName,
-                       String currentSchema,
-                       DuplicateKeyAction duplicateKeyAction,
-                       boolean continueOnError,
-                       @Nullable String[] assignmentsColumns,
-                       @Nullable Reference[] missingAssignmentsColumns,
-                       UUID jobId,
-                       boolean validateGeneratedColumns) {
-            this(userName, currentSchema, ReplicationRequest.DEFAULT_TIMEOUT, duplicateKeyAction, continueOnError,
-                assignmentsColumns, missingAssignmentsColumns, jobId, validateGeneratedColumns);
-        }
 
         public Builder(String userName,
                        String currentSchema,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -37,9 +37,9 @@ import io.crate.expression.InputRow;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 
@@ -101,7 +101,9 @@ public class ColumnIndexWriterProjector implements Projector {
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
-            jobId);
+            jobId,
+            true
+        );
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory = id -> new ShardUpsertRequest.Item(

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -79,11 +79,11 @@ import io.crate.expression.reference.sys.SysRowUpdater;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataTypes;
 import io.crate.types.StringType;
@@ -449,7 +449,8 @@ public class ProjectionToProjectorVisitor
             false,
             projection.assignmentsColumns(),
             null,
-            context.jobId
+            context.jobId,
+            true
         );
         ShardDMLExecutor<ShardUpsertRequest, ShardUpsertRequest.Item> shardDMLExecutor = new ShardDMLExecutor<>(
             ShardDMLExecutor.DEFAULT_BULK_SIZE,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -35,6 +35,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 
@@ -60,6 +61,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
+            TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             assignmentColumns,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -47,6 +47,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
@@ -179,6 +180,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
+            TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
@@ -200,6 +202,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
+            TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
@@ -241,6 +244,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
+            TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
@@ -262,6 +266,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             "dummyUser",
             "dummySchema",
+            TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,


### PR DESCRIPTION
One overload was only used in tests.
The other provided a default for `validateGeneratedColumns` without any
indication whether it defaults to true or false - so it is better to be
explicit about it at the call-sites.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed