### PR TITLE
WIP: Fix shippable java truststore issue

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -23,8 +23,7 @@ build:
   ci:
     # Solve "trustAnchors parameter must be non-empty" issue
     - sudo dpkg --purge --force-depends ca-certificates-java
-    - sudo apt-get update & sudo apt-get install ca-certificates-java
-    - sudo update-ca-certificates -f
+    - sudo apt-get update & sudo apt-get install ca-certificates-utils
 
     - useradd -m ciuser
     - CIUSER_BUILD_DIR=/home/ciuser/build

--- a/shippable.yml
+++ b/shippable.yml
@@ -22,8 +22,7 @@ env:
 build:
   ci:
     # Solve "trustAnchors parameter must be non-empty" issue
-    - sudo dpkg --purge --force-depends ca-certificates-java
-    - sudo apt-get update & sudo apt-get install ca-certificates-utils
+    - sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
     - useradd -m ciuser
     - CIUSER_BUILD_DIR=/home/ciuser/build

--- a/shippable.yml
+++ b/shippable.yml
@@ -22,6 +22,7 @@ env:
 build:
   ci:
     # Solve "trustAnchors parameter must be non-empty" issue
+    - sudo dpkg --purge --force-depends ca-certificates-java
     - sudo apt-get update & sudo apt-get install ca-certificates-java
     - sudo update-ca-certificates -f
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,6 +21,10 @@ env:
 # to avoid errors in es submodule.
 build:
   ci:
+    # Solve "trustAnchors parameter must be non-empty" issue
+    - sudo apt-get update & sudo apt-get install ca-certificates-java
+    - sudo update-ca-certificates -f
+
     - useradd -m ciuser
     - CIUSER_BUILD_DIR=/home/ciuser/build
     - mv $SHIPPABLE_BUILD_DIR $CIUSER_BUILD_DIR


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fix issue with java truststore on shippable runs:
`Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty`

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
