### PR TITLE
Remove the isEmptyRowTable check from IsStatementExecutionAllowed predicate

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 ---
 jobs:
-  - job: LinuxJDK10
+  - job: LinuxJDK11
     pool:
       vmImage: 'Ubuntu 16.04'
     steps:
@@ -13,7 +13,7 @@ jobs:
           gradleWrapperFile: 'gradlew'
           gradleOptions: '-Xmx2048m'
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.10'
+          jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'

--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -37,7 +37,6 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.analyze.relations.UnionSelect;
-import io.crate.expression.tablefunctions.EmptyRowTableFunction;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.table.TableInfo;
@@ -85,10 +84,6 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
                    || InformationSchemaInfo.NAME.equals(schema);
         }
 
-        private static boolean isEmptyRowTable(TableInfo tableInfo) {
-            return tableInfo.ident().equals(EmptyRowTableFunction.TABLE_IDENT);
-        }
-
         @Override
         public boolean test(AnalyzedRelation relation) {
             return process(relation, null);
@@ -122,7 +117,7 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
         @Override
         public Boolean visitQueriedTable(QueriedTable<?> queriedTable, Void context) {
             TableInfo tableInfo = queriedTable.tableRelation().tableInfo();
-            return isSysSchema(tableInfo.ident().schema()) || isEmptyRowTable(tableInfo);
+            return isSysSchema(tableInfo.ident().schema());
         }
 
         @Override


### PR DESCRIPTION
There is a separate `visitTableFunctionRelation`, so the
`isEmptyRowTable` isn't required - it always evaluated to false.


 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed