### PR TITLE
Update `renaming tables` documentation related to close/open removement.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,9 @@ Breaking Changes
 Changes
 =======
 
+- Improved resiliency of the ``ALTER TABLE RENAME`` operation by making it an
+  atomic operation.
+
 - Added support for executing aggregations as ``window functions`` with an
   empty OVER clause as the window definition.
 

--- a/blackbox/docs/general/ddl/alter-table.rst
+++ b/blackbox/docs/general/ddl/alter-table.rst
@@ -101,13 +101,7 @@ A table can be renamed by using ``ALTER TABLE`` with the ``RENAME TO`` clause::
      cr> alter table my_table rename to my_new_table;
      ALTER OK, -1 rows affected (... sec)
 
-During the rename operation the table will be closed, and all operations on the
-table will fail until the rename operation is completed.
-
-.. Warning::
-
-    Do not run multiple concurrent rename operations on the same table. The rename
-    operation is not atomic.
+During the rename operation the shards of the table become temporarily unavailable.
 
 .. _ddl_reroute_shards:
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Tables won't be closed/open during rename operations anymore, reflect
that also in the documentation. Also due to that, rename tables are
an atomic operation, add a CHANGES entry about that.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
