### PR TITLE
Remove the logger argument from CumulativePageBucketReceiver

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -184,7 +184,6 @@ public class RemoteCollector {
             pagingIterator = PassThroughPagingIterator.oneShot();
         }
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
-            LOGGER,
             localNode,
             RECEIVER_PHASE_ID,
             executor,

--- a/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -31,6 +31,7 @@ import io.crate.execution.engine.distribution.merge.BatchPagingIterator;
 import io.crate.execution.engine.distribution.merge.KeyIterable;
 import io.crate.execution.engine.distribution.merge.PagingIterator;
 import io.netty.util.collection.IntObjectHashMap;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
@@ -55,6 +56,8 @@ import static io.crate.concurrent.CompletableFutures.failedFuture;
  */
 public class CumulativePageBucketReceiver implements PageBucketReceiver {
 
+    private static final Logger LOGGER = LogManager.getLogger(CumulativePageBucketReceiver.class);
+
     private final Object lock = new Object();
     private final String nodeName;
     private final boolean traceEnabled;
@@ -70,22 +73,19 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
     private final RowConsumer consumer;
     private final PagingIterator<Integer, Row> pagingIterator;
     private final BatchIterator<Row> batchPagingIterator;
-    private final Logger logger;
     private final CompletableFuture<?> processingFuture = new CompletableFuture<>();
 
     private Throwable lastThrowable = null;
     private volatile CompletableFuture<List<KeyIterable<Integer, Row>>> currentPage = new CompletableFuture<>();
     private volatile boolean receivingFirstPage = true;
 
-    public CumulativePageBucketReceiver(Logger logger,
-                                        String nodeName,
+    public CumulativePageBucketReceiver(String nodeName,
                                         int phaseId,
                                         Executor executor,
                                         Streamer<?>[] streamers,
                                         RowConsumer rowConsumer,
                                         PagingIterator<Integer, Row> pagingIterator,
                                         int numBuckets) {
-        this.logger = logger;
         this.nodeName = nodeName;
         this.phaseId = phaseId;
         this.executor = executor;
@@ -117,7 +117,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
                 }
             }
         );
-        traceEnabled = logger.isTraceEnabled();
+        traceEnabled = LOGGER.isTraceEnabled();
     }
 
     @Override
@@ -266,7 +266,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
 
     private void traceLog(String msg, int bucketIdx) {
         if (traceEnabled) {
-            logger.trace("{} phaseId={} bucket={}", msg, phaseId, bucketIdx);
+            LOGGER.trace("{} phaseId={} bucket={}", msg, phaseId, bucketIdx);
         }
     }
 

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -81,13 +81,12 @@ import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.expression.InputFactory;
 import io.crate.expression.RowFilter;
 import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Routing;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.StreamerVisitor;
 import io.crate.types.DataTypes;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -120,7 +119,6 @@ import static io.crate.execution.dsl.projection.Projections.shardProjections;
 public class JobSetup extends AbstractComponent {
 
     private final MapSideDataCollectOperation collectOperation;
-    private final Logger distResultRXTaskLogger;
     private final ClusterService clusterService;
     private final CountOperation countOperation;
     private final CrateCircuitBreakerService circuitBreakerService;
@@ -147,7 +145,6 @@ public class JobSetup extends AbstractComponent {
                     ShardCollectSource shardCollectSource,
                     BigArrays bigArrays) {
         super(settings);
-        distResultRXTaskLogger = LogManager.getLogger(DistResultRXTask.class);
         this.collectOperation = collectOperation;
         this.clusterService = clusterService;
         this.countOperation = countOperation;
@@ -666,7 +663,6 @@ public class JobSetup extends AbstractComponent {
             PageBucketReceiver pageBucketReceiver;
             if (collector == null) {
                 pageBucketReceiver = new CumulativePageBucketReceiver(
-                    distResultRXTaskLogger,
                     nodeName(),
                     phase.phaseId(),
                     searchTp,
@@ -899,7 +895,6 @@ public class JobSetup extends AbstractComponent {
             }
 
             PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
-                distResultRXTaskLogger,
                 nodeName(),
                 mergePhase.phaseId(),
                 searchTp,

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -157,7 +157,6 @@ public class DistributingConsumerTest extends CrateUnitTest {
 
     private DistResultRXTask createPageDownstreamContext(Streamer<?>[] streamers, TestingRowConsumer collectingConsumer) {
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
-            Loggers.getLogger(DistResultRXTask.class),
             "n1",
             1,
             executorService,

--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -41,7 +41,6 @@ import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.logging.Loggers;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -71,7 +70,6 @@ public class DistResultRXTaskTest extends CrateUnitTest {
                                                       int numBuckets) {
 
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
-            Loggers.getLogger(DistResultRXTask.class),
             "n1",
             1,
             MoreExecutors.directExecutor(),

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -137,7 +137,6 @@ public class RootTaskTest extends CrateUnitTest {
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
 
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
-            Loggers.getLogger(DistResultRXTask.class),
             "n1",
             2,
             MoreExecutors.directExecutor(),


### PR DESCRIPTION
Due to the logger changes with ES 6.5 we no longer need to pass the
parents logger instance around to have the node name within the log
messages.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed