### PR TITLE
Filter out temporary indices from DB catalog

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -141,7 +141,8 @@ public class InformationSchemaIterables implements ClusterStateListener {
     private static Stream<TableInfo> tablesStream(Schemas schemas) {
         return sequentialStream(schemas)
             .flatMap(s -> sequentialStream(s.getTables()))
-            .filter(i -> !IndexParts.isPartitioned(i.ident().indexNameOrAlias()));
+            .filter(i -> !(IndexParts.isPartitioned(i.ident().indexNameOrAlias()) ||
+                           IndexParts.isDangling(i.ident().indexNameOrAlias())));
     }
 
     private static <T> Stream<T> sequentialStream(Iterable<T> iterable) {

--- a/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocations.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocations.java
@@ -22,6 +22,7 @@
 
 package io.crate.expression.reference.sys.shard;
 
+import io.crate.metadata.IndexParts;
 import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
@@ -68,6 +69,7 @@ public class SysAllocations implements Iterable<SysAllocation> {
         final RoutingAllocation allocation = new RoutingAllocation(
             allocationDeciders, routingNodes, state, clusterInfo, System.nanoTime());
         return allocation.routingTable().allShards().stream()
+            .filter(shardRouting -> !IndexParts.isDangling(shardRouting.getIndexName()))
             .map(shardRouting -> {
                 return new SysAllocation(
                     TransportClusterAllocationExplainAction.explainShard(

--- a/sql/src/main/java/io/crate/metadata/IndexParts.java
+++ b/sql/src/main/java/io/crate/metadata/IndexParts.java
@@ -177,6 +177,12 @@ public class IndexParts {
         return ((diff == 0 && idx1 == 0) || diff == 1) && idx2 + PARTITIONED_TABLE_PART.length() < indexName.length();
     }
 
+    public static boolean isDangling(String indexName) {
+        return indexName.startsWith(".") &&
+               !indexName.startsWith(PARTITIONED_TABLE_PART) &&
+               !BlobIndex.isBlobIndex(indexName);
+    }
+
     private static void assertPartitionPrefix(String prefix) {
         if (!PARTITIONED_KEY_WORD.equals(prefix)) {
             throw new IllegalArgumentException("Invalid partition prefix: " + prefix);

--- a/sql/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class DanglingIndicesIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testDanglingIndicesAreFilteredOutFromDBCatalog() throws Exception {
+        execute("create table doc.t1 (id int) clustered into 3 shards with (number_of_replicas=0)");
+        execute("create table doc.t2 (id int) partitioned by(id) clustered into 3 shards with (number_of_replicas=0)");
+        execute("insert into doc.t2 values (1), (2)");
+
+        execute("refresh table doc.t2");
+        execute("create blob table blobs clustered into 3 shards with (number_of_replicas=0)");
+
+        final String dangling1 = ".shrink.t1";
+        final String dangling2 = ".shrinked..partitioned.t2.ident";
+        final String dangling3 = ".blob.blob_blobs";
+
+        createIndex(dangling1, dangling2, dangling3);
+
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        assertThat(clusterService.state().metaData().hasIndex(dangling1), is(true));
+        assertThat(clusterService.state().metaData().hasIndex(dangling2), is(true));
+        assertThat(clusterService.state().metaData().hasIndex(dangling3), is(true));
+
+        execute("select id, table_name, state from sys.shards where table_name = 't1'");
+        assertThat(response.rowCount(), is(3L));
+
+        execute("select * from sys.health where table_name = 't1'");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select * from sys.allocations where table_name = 't1'");
+        assertThat(response.rowCount(), is(3L));
+
+        execute("select * from information_schema.tables where table_name = 't1'");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select * from information_schema.tables where table_schema = 'blob'");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select schema_name, table_name, values from information_schema.table_partitions " +
+                "where table_name = 't2'");
+        assertThat(response.rowCount(), is(2L));
+    }
+}

--- a/sql/src/test/java/io/crate/metadata/IndexPartsTest.java
+++ b/sql/src/test/java/io/crate/metadata/IndexPartsTest.java
@@ -69,6 +69,18 @@ public class IndexPartsTest {
         assertThat(new IndexParts(schemaTable).getPartitionIdent(), is(""));
         assertThat(new IndexParts(partitionedTable).getPartitionIdent(), is(ident));;
         assertThat(new IndexParts(schemaPartitionedTable).getPartitionIdent(), is(ident));
+
+        assertThat(IndexParts.isDangling(table), is(false));
+        assertThat(IndexParts.isDangling(schemaTable), is(false));
+        assertThat(IndexParts.isDangling(partitionedTable), is(false));
+        assertThat(IndexParts.isDangling(schemaPartitionedTable), is(false));
+        assertThat(IndexParts.isDangling("schema..partitioned."), is(false));
+        assertThat(IndexParts.isDangling("schema.partitioned."), is(false));
+        assertThat(IndexParts.isDangling("schema..partitioned.t"), is(false));
+        assertThat(IndexParts.isDangling(".shrinked.t"), is(true));
+        assertThat(IndexParts.isDangling(".shrinked.schema.t"), is(true));
+        assertThat(IndexParts.isDangling(".shrinked.partitioned.t.ident"), is(true));
+        assertThat(IndexParts.isDangling(".shrinked.schema..partitioned.t.ident"), is(true));
     }
 
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As we may have leftover temp indexes during an incomplete operation (e.g. shrink),
we want to make sure that the db catalog is still functional and that these indexes
are hidden from the user. 

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
