### PR TITLE
Delete possible existing tmp indices from previous shrink operation

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import com.google.common.collect.ImmutableMap;
 import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
+import io.crate.execution.ddl.tables.AlterTableOperation;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -31,6 +32,7 @@ import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -720,6 +722,31 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0][0], is(1));
         execute("select id from quotes");
         assertThat(response.rowCount(), is(2L));
+    }
+
+    @Test
+    public void testAlterShardsTableEnsureLeftoverIndicesAreRemoved() throws Exception {
+        execute("create table quotes (id integer, quote string, date timestamp) " +
+                "clustered into 3 shards");
+        ensureYellow();
+
+        final String targetIndexName = AlterTableOperation.SHRINK_PREFIX + "quotes";
+        final String backupIndexName = AlterTableOperation.BACKUP_PREFIX + "quotes";
+
+        client().admin().indices().prepareCreate(targetIndexName).execute().actionGet();
+        client().admin().indices().prepareCreate(backupIndexName).execute().actionGet();
+
+        execute("alter table quotes set (\"blocks.write\"=?)", $(true));
+        execute("alter table quotes set (number_of_shards=?)", $(1));
+
+        execute("select number_of_shards from information_schema.tables where table_name = 'quotes'");
+        assertThat(response.rows()[0][0], is(1));
+
+        IndicesExistsResponse indicesExistsResponse = cluster().client().admin()
+            .indices().prepareExists(new String[]{targetIndexName, backupIndexName})
+            .execute().actionGet();
+
+        assertThat(indicesExistsResponse.isExists(), Matchers.is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Before the actual shrink operation, remove any possible remaining indices from a previous shrinking operation

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
