### PR TITLE
Add support for per-table shard allocation filtering.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for per-table shard allocation filtering.
+
 - Added support for shrinking an existing table or table partition using the
   ``ALTER TABLE SET`` statement.
 

--- a/blackbox/docs/general/ddl/index.rst
+++ b/blackbox/docs/general/ddl/index.rst
@@ -19,6 +19,7 @@ Data Definition
    partitioned-tables
    sharding
    replication
+   shard-allocation
    column-policy
    fulltext-indices
    analyzers

--- a/blackbox/docs/general/ddl/shard-allocation.rst
+++ b/blackbox/docs/general/ddl/shard-allocation.rst
@@ -1,0 +1,58 @@
+.. _ddl_shard_allocation:
+
+============================
+ Shard Allocation Filtering
+============================
+
+Shard allocation filters allows to configure shard and replicas allocation per
+table across generic attributes associated with nodes.
+
+.. NOTE::
+
+   The per-table shard allocation filtering works in conjunction with
+   :ref:`Cluster Level Allocation <conf_routing>`.
+
+It is possible to assign certain attributes to a node, see
+:ref:`conf-node-attributes`.
+
+These attributes can be used with `routing.allocation.*` settings to allocate a
+table to a particular group of nodes.
+
+Settings
+========
+
+The following settings are dynamic, allowing tables to be allocated (when
+defined on table creation) or moved (when defined by altering a table) from one
+set of nodes to another:
+
+:routing.allocation.include.{attribute}:
+   Assign the table to a node whose *{attribute}* has **at least one** of the
+   comma-separated values.
+
+:routing.allocation.require.{attribute}:
+   Assign the table to a node whose *{attribute}* has **all** of the comma-separated
+   values.
+
+:routing.allocation.exclude.{attribute}:
+   Assign the table to a node whose *{attribute}* has **none** of the
+   comma-separated values.
+
+Special Attributes
+==================
+
+Following special attributes are supported:
+
+:_name:
+   Match nodes by node name.
+
+:_host_ip:
+   Match nodes by host IP address (IP associated with hostname).
+
+:_publish_ip:
+   Match nodes by publish IP address.
+
+:_ip:
+   Match either _host_ip or _publish_ip.
+
+:_host:
+   Match nodes by hostname.

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -469,6 +469,27 @@ the shard unallocated.
 :value:
   Number of retries to allocate a shard. Defaults to 5.
 
+``routing.allocation.include.{attribute}``
+------------------------------------------
+
+Assign the table to a node whose ``{attribute}`` has at least one of the
+comma-separated values.
+See :ref:`ddl_shard_allocation` for details.
+
+``routing.allocation.require.{attribute}``
+------------------------------------------
+
+Assign the table to a node whose ``{attribute}`` has all of the comma-separated
+values.
+See :ref:`ddl_shard_allocation` for details.
+
+``routing.allocation.exclude.{attribute}``
+------------------------------------------
+
+Assign the table to a node whose ``{attribute}`` has none of the comma-separated
+values.
+See :ref:`ddl_shard_allocation` for details.
+
 ``warming.enable``
 ------------------
 

--- a/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -98,6 +98,12 @@ public class InformationTablesTableInfo extends InformationTableInfo {
             ImmutableList.of("routing", "allocation", "enable"));
         static final ColumnIdent TABLE_SETTINGS_ROUTING_ALLOCATION_TOTAL_SHARDS_PER_NODE = new ColumnIdent("settings",
             ImmutableList.of("routing", "allocation", "total_shards_per_node"));
+        static final ColumnIdent TABLE_SETTINGS_ROUTING_ALLOCATION_REQUIRE = new ColumnIdent("settings",
+            ImmutableList.of("routing", "allocation", "require"));
+        static final ColumnIdent TABLE_SETTINGS_ROUTING_ALLOCATION_INCLUDE = new ColumnIdent("settings",
+            ImmutableList.of("routing", "allocation", "include"));
+        static final ColumnIdent TABLE_SETTINGS_ROUTING_ALLOCATION_EXCLUDE = new ColumnIdent("settings",
+            ImmutableList.of("routing", "allocation", "exclude"));
         static final ColumnIdent TABLE_SETTINGS_WARMER = new ColumnIdent("settings",
             ImmutableList.of("warmer"));
         static final ColumnIdent TABLE_SETTINGS_WARMER_ENABLED = new ColumnIdent("settings",
@@ -169,6 +175,9 @@ public class InformationTablesTableInfo extends InformationTableInfo {
             .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION, DataTypes.OBJECT)
             .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION_ENABLE, DataTypes.STRING)
             .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION_TOTAL_SHARDS_PER_NODE, DataTypes.INTEGER)
+            .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION_REQUIRE, DataTypes.OBJECT)
+            .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION_INCLUDE, DataTypes.OBJECT)
+            .register(Columns.TABLE_SETTINGS_ROUTING_ALLOCATION_EXCLUDE, DataTypes.OBJECT)
             .register(Columns.TABLE_SETTINGS_WARMER, DataTypes.OBJECT)
             .register(Columns.TABLE_SETTINGS_WARMER_ENABLED, DataTypes.BOOLEAN)
             .register(Columns.TABLE_SETTINGS_WRITE, DataTypes.OBJECT)

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -62,6 +62,7 @@ import java.util.Map;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -1120,5 +1121,19 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateTableAnalyzedStatement stmt = e.analyze("create table t (p int, x int) partitioned by (p) " +
                                                       "with (number_of_routing_shards = 10)");
         assertThat(stmt.tableParameter().settings().get("index.number_of_routing_shards"), is("10"));
+    }
+
+    @Test
+    public void testAlterTableSetDynamicSetting() {
+        AlterTableAnalyzedStatement analysis =
+            e.analyze("alter table users set (\"routing.allocation.exclude.foo\"='bar')");
+        assertThat(analysis.tableParameter().settings().get(INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "foo"), is("bar"));
+    }
+
+    @Test
+    public void testAlterTableResetDynamicSetting() {
+        AlterTableAnalyzedStatement analysis =
+            e.analyze("alter table users reset (\"routing.allocation.exclude.foo\")");
+        assertThat(analysis.tableParameter().settings().get(INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "foo"), nullValue());
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -589,7 +589,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(657, response.rowCount());
+        assertEquals(660, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Shard allocation filters can be set/reset as table parameters on 
`CREATE` and `ALTER` statements.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
