### PR TITLE
Make sure errors are propagated to the RowConsumer (sys.jobs leaks)

### DIFF
--- a/sql/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -46,11 +46,11 @@ public final class CreateViewPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier dependencies,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
 
         User owner = createViewStmt.owner();
         CreateViewRequest request = new CreateViewRequest(

--- a/sql/src/main/java/io/crate/planner/DropViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/DropViewPlan.java
@@ -48,11 +48,11 @@ public class DropViewPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier dependencies,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         DropViewRequest request = new DropViewRequest(dropViewStmt.views(), dropViewStmt.ifExists());
         Function<DropViewResponse, Row> responseToRow = resp -> {
             if (dropViewStmt.ifExists() || resp.missing().isEmpty()) {

--- a/sql/src/main/java/io/crate/planner/GCDangingArtifactsPlan.java
+++ b/sql/src/main/java/io/crate/planner/GCDangingArtifactsPlan.java
@@ -39,12 +39,11 @@ public final class GCDangingArtifactsPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier dependencies,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
-
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         OneRowActionListener<AcknowledgedResponse> listener =
             new OneRowActionListener<>(consumer, r -> r.isAcknowledged() ? new Row1(1L) : new Row1(0L));
 

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -68,15 +68,15 @@ public class MultiPhasePlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
-        MultiPhaseExecutor.execute(dependencies, executor, plannerContext, params)
+    public void executeOrFail(DependencyCarrier dependencyCarrier,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
+        MultiPhaseExecutor.execute(dependencies, dependencyCarrier, plannerContext, params)
             .whenComplete((subQueryValues, failure) -> {
                 if (failure == null) {
-                    rootPlan.execute(executor, plannerContext, consumer, params, subQueryValues);
+                    rootPlan.execute(dependencyCarrier, plannerContext, consumer, params, subQueryValues);
                 } else {
                     consumer.accept(null, failure);
                 }

--- a/sql/src/main/java/io/crate/planner/NoopPlan.java
+++ b/sql/src/main/java/io/crate/planner/NoopPlan.java
@@ -44,11 +44,11 @@ public final class NoopPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencyCarrier,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         consumer.accept(InMemoryBatchIterator.empty(SENTINEL), null);
     }
 }

--- a/sql/src/main/java/io/crate/planner/SwapTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/SwapTablePlan.java
@@ -55,11 +55,11 @@ public class SwapTablePlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier dependencies,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         boolean dropSource = Objects.requireNonNull(DataTypes.BOOLEAN.value(SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
             dependencies.functions(),

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -143,11 +143,11 @@ public final class UpdatePlanner {
         }
 
         @Override
-        public void execute(DependencyCarrier executor,
-                            PlannerContext plannerContext,
-                            RowConsumer consumer,
-                            Row params,
-                            SubQueryResults subQueryResults) {
+        public void executeOrFail(DependencyCarrier executor,
+                                  PlannerContext plannerContext,
+                                  RowConsumer consumer,
+                                  Row params,
+                                  SubQueryResults subQueryResults) throws Exception {
             ExecutionPlan executionPlan = createExecutionPlan.create(plannerContext, params, subQueryResults);
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId());
 

--- a/sql/src/main/java/io/crate/planner/node/dcl/GenericDCLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dcl/GenericDCLPlan.java
@@ -46,11 +46,11 @@ public class GenericDCLPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         executor.dclAction().apply(statement, params)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
@@ -50,11 +50,11 @@ public class CreateAnalyzerPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         CreateAnalyzerTask task = new CreateAnalyzerTask(
             this, executor.transportActionProvider().transportClusterUpdateSettingsAction());
         task.execute(consumer);

--- a/sql/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
@@ -50,11 +50,11 @@ public final class DeleteAllPartitions implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         DeleteAllPartitionsTask task = new DeleteAllPartitionsTask(
             this, executor.transportActionProvider().transportDeleteIndexAction());
         task.execute(consumer);

--- a/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
@@ -66,16 +66,16 @@ public class DeletePartitions implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         ArrayList<String> indexNames = getIndices(
-            plannerContext.transactionContext(), executor.functions(), params, subQueryResults);
+            plannerContext.transactionContext(), dependencies.functions(), params, subQueryResults);
         DeleteIndexRequest request = new DeleteIndexRequest(indexNames.toArray(new String[0]));
         request.indicesOptions(IndicesOptions.lenientExpandOpen());
-        executor.transportActionProvider().transportDeleteIndexAction()
+        dependencies.transportActionProvider().transportDeleteIndexAction()
             .execute(request, new OneRowActionListener<>(consumer, r -> Row1.ROW_COUNT_UNKNOWN));
     }
 

--- a/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -54,12 +54,12 @@ public class DropTablePlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
-        DropTableTask task = new DropTableTask(this, executor.transportDropTableAction());
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
+        DropTableTask task = new DropTableTask(this, dependencies.transportDropTableAction());
         task.execute(consumer);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
@@ -68,13 +68,13 @@ public class ESClusterUpdateSettingsPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         ESClusterUpdateSettingsTask task = new ESClusterUpdateSettingsTask(
-            this, executor.transportActionProvider().transportClusterUpdateSettingsAction());
+            this, dependencies.transportActionProvider().transportClusterUpdateSettingsAction());
         task.execute(consumer, params);
     }
 

--- a/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
@@ -45,11 +45,11 @@ public class GenericDDLPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         executor.ddlAction().apply(statement, params, plannerContext.transactionContext())
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }

--- a/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
@@ -58,11 +58,11 @@ public class DeleteById implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         DeleteByIdTask task = new DeleteByIdTask(
             plannerContext.jobId(),
             executor.clusterService(),

--- a/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
@@ -176,11 +176,11 @@ public class LegacyUpsertById implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerCtx,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerCtx,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
         LegacyUpsertByIdTask task = new LegacyUpsertByIdTask(
             plannerCtx.transactionContext(),
             plannerCtx.jobId(),

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -68,17 +68,17 @@ public final class UpdateById implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerCtx,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         UpdateByIdTask task = new UpdateByIdTask(
-            plannerCtx.jobId(),
-            plannerCtx.transactionContext(),
-            executor.clusterService(),
-            executor.functions(),
-            executor.transportActionProvider().transportShardUpsertAction(),
+            plannerContext.jobId(),
+            plannerContext.transactionContext(),
+            dependencies.clusterService(),
+            dependencies.functions(),
+            dependencies.transportActionProvider().transportShardUpsertAction(),
             this
         );
         task.execute(consumer, params, subQueryResults);

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -93,11 +93,11 @@ public class ExplainPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier dependencies,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         if (context != null) {
             assert subPlan instanceof LogicalPlan : "subPlan must be a LogicalPlan";
             LogicalPlan plan = (LogicalPlan) subPlan;

--- a/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -75,15 +75,16 @@ public class KillPlan implements Plan {
         return StatementType.MANAGEMENT;
     }
 
+
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         execute(
-            executor.transportActionProvider().transportKillAllNodeAction(),
-            executor.transportActionProvider().transportKillJobsNodeAction(),
+            dependencies.transportActionProvider().transportKillAllNodeAction(),
+            dependencies.transportActionProvider().transportKillJobsNodeAction(),
             consumer
         );
     }

--- a/sql/src/main/java/io/crate/planner/node/management/ShowCreateTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ShowCreateTablePlan.java
@@ -50,11 +50,11 @@ public class ShowCreateTablePlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         Row1 row;
         try {
             CreateTable createTable = MetaDataToASTNodeResolver.resolveCreateTable(statement.tableInfo());

--- a/sql/src/main/java/io/crate/planner/node/management/ShowSessionParameterPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ShowSessionParameterPlan.java
@@ -56,22 +56,17 @@ public class ShowSessionParameterPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         SessionContext sessionContext = plannerContext.transactionContext().sessionContext();
         BatchIterator<Row> batchIterator;
-        try {
-            if (statement.showAll()) {
-                batchIterator = iteratorForAllParameters(sessionContext);
-            } else {
-                batchIterator = iteratorForSingleParameter(statement.parameterName(), sessionContext);
-            }
-        } catch (Throwable t) {
-            consumer.accept(null, t);
-            return;
+        if (statement.showAll()) {
+            batchIterator = iteratorForAllParameters(sessionContext);
+        } else {
+            batchIterator = iteratorForSingleParameter(statement.parameterName(), sessionContext);
         }
         consumer.accept(batchIterator, null);
     }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -228,11 +228,11 @@ public interface LogicalPlan extends Plan {
     long estimatedRowSize();
 
     @Override
-    default void execute(DependencyCarrier executor,
-                         PlannerContext plannerContext,
-                         RowConsumer consumer,
-                         Row params,
-                         SubQueryResults subQueryResults) {
+    default void executeOrFail(DependencyCarrier executor,
+                               PlannerContext plannerContext,
+                               RowConsumer consumer,
+                               Row params,
+                               SubQueryResults subQueryResults) throws Exception {
         LogicalPlanner.execute(this, executor, plannerContext, consumer, params, subQueryResults, false);
     }
 

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -116,11 +116,11 @@ public final class CopyStatementPlanner {
         }
 
         @Override
-        public void execute(DependencyCarrier executor,
-                            PlannerContext plannerContext,
-                            RowConsumer consumer,
-                            Row params,
-                            SubQueryResults subQueryResults) {
+        public void executeOrFail(DependencyCarrier executor,
+                                  PlannerContext plannerContext,
+                                  RowConsumer consumer,
+                                  Row params,
+                                  SubQueryResults subQueryResults) {
             ExecutionPlan executionPlan = planCopyToExecution(
                 copyTo, plannerContext, logicalPlanner, subqueryPlanner, executor.projectionBuilder(), params);
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId());
@@ -144,11 +144,11 @@ public final class CopyStatementPlanner {
         }
 
         @Override
-        public void execute(DependencyCarrier executor,
-                            PlannerContext plannerContext,
-                            RowConsumer consumer,
-                            Row params,
-                            SubQueryResults subQueryResults) {
+        public void executeOrFail(DependencyCarrier executor,
+                                  PlannerContext plannerContext,
+                                  RowConsumer consumer,
+                                  Row params,
+                                  SubQueryResults subQueryResults) {
             ExecutionPlan plan = planCopyFromExecution(executor.clusterService().state().nodes(), copyFrom, plannerContext);
             NodeOperationTree nodeOpTree = NodeOperationTreeGenerator.fromPlan(plan, executor.localNodeId());
             executor.phasesTaskFactory()

--- a/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -121,11 +121,11 @@ public final class DeletePlanner {
         }
 
         @Override
-        public void execute(DependencyCarrier executor,
-                            PlannerContext plannerContext,
-                            RowConsumer consumer,
-                            Row params,
-                            SubQueryResults subQueryResults) {
+        public void executeOrFail(DependencyCarrier executor,
+            PlannerContext plannerContext,
+            RowConsumer consumer,
+            Row params,
+            SubQueryResults subQueryResults) {
 
             WhereClause where = detailedQuery.toBoundWhereClause(
                 table.tableInfo(),

--- a/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
@@ -47,12 +47,12 @@ public class SetLicensePlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
         LicenseKey metaData = new LicenseKey(stmt.licenseKey());
-        executor.licenseService().registerLicense(metaData, new OneRowActionListener<>(consumer, response -> new Row1(1L)));
+        dependencies.licenseService().registerLicense(metaData, new OneRowActionListener<>(consumer, response -> new Row1(1L)));
     }
 }

--- a/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
@@ -57,11 +57,11 @@ public class SetSessionPlan implements Plan {
     }
 
     @Override
-    public void execute(DependencyCarrier executor,
-                        PlannerContext plannerContext,
-                        RowConsumer consumer,
-                        Row params,
-                        SubQueryResults subQueryResults) {
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
         SessionContext sessionContext = plannerContext.transactionContext().sessionContext();
         for (Map.Entry<String, List<Expression>> entry : settings.entrySet()) {
             SessionSetting<?> sessionSetting = SessionSettingRegistry.SETTINGS.get(entry.getKey());

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -226,17 +226,13 @@ public class SimplePortal extends AbstractPortal {
             maxRows,
             new JobsLogsUpdateListener(jobId, jobsLogs)
         );
-        try {
-            plan.execute(
-                dependencyCarrier,
-                plannerContext,
-                consumer,
-                rowParams,
-                SubQueryResults.EMPTY
-            );
-        } catch (Exception e) {
-            consumer.accept(null, e);
-        }
+        plan.execute(
+            dependencyCarrier,
+            plannerContext,
+            consumer,
+            rowParams,
+            SubQueryResults.EMPTY
+        );
         synced = true;
         return resultReceiver.completionFuture();
     }

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
@@ -555,13 +556,15 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             )));
     }
 
-    private void execute(Plan plan, Row params) {
+    private List<Object[]> execute(Plan plan, Row params) throws Exception {
+        TestingRowConsumer consumer = new TestingRowConsumer();
         plan.execute(
             mock(DependencyCarrier.class),
             e.getPlannerContext(clusterService.state()),
-            new TestingRowConsumer(),
+            consumer,
             params,
             SubQueryResults.EMPTY
         );
+        return consumer.getResult();
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -61,11 +61,11 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
             }
 
             @Override
-            public void execute(DependencyCarrier executor,
-                                PlannerContext plannerContext,
-                                RowConsumer consumer,
-                                Row params,
-                                SubQueryResults subQueryResults) {
+            public void executeOrFail(DependencyCarrier executor,
+                                      PlannerContext plannerContext,
+                                      RowConsumer consumer,
+                                      Row params,
+                                      SubQueryResults subQueryResults) {
                 lastParams.set(params);
             }
         };


### PR DESCRIPTION
This ensures that errors raised in the execute implementations of Plans
are always forwarded to the RowConsumer so that the listeners on the
RowConsumers future are triggered. Otherwise statements would remain
stuck in sys.jobs

This is a follow up to be5e329bca3b65577ba0e272bd6f18c5f18c2f09





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed