### PR TITLE
Allow casts from geo_shape to object

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,9 @@ Breaking Changes
 Changes
 =======
 
+- ``geo_shape`` columns can now be casted to ``object`` with ``cast`` in
+  addition to ``try_cast``.
+
 - Added a ``ALTER CLUSTER GC DANGLING ARTIFACTS`` statement that can be used to
   clean up internal structures that weren't properly cleaned up due to cluster
   failures during operations which create such temporary artifacts.

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -150,6 +150,7 @@ public final class DataTypes {
         .put(TIMESTAMP.id(), ImmutableSet.of(DOUBLE, LONG, STRING))
         .put(UNDEFINED.id(), ImmutableSet.of()) // actually convertible to every type, see NullType
         .put(GEO_POINT.id(), ImmutableSet.of(new ArrayType(DOUBLE)))
+        .put(GEO_SHAPE.id(), ImmutableSet.of(OBJECT))
         .put(OBJECT.id(), ImmutableSet.of(GEO_SHAPE))
         .put(ArrayType.ID, ImmutableSet.of()) // convertability handled in ArrayType
         .put(SetType.ID, ImmutableSet.of()) // convertability handled in SetType

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -56,6 +56,14 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void testCastGeoShapeToObject() {
+        Map<String, Object> shape = new HashMap<>();
+        shape.put("type", "LineString");
+        shape.put("coordinates", new Double[][] {new Double[] { 0d, 0d}, new Double[] {2d, 0d} });
+        assertEvaluate("geoshape::object", shape, () -> shape);
+    }
+
+    @Test
     public void testDoubleColonOperatorCast() {
         assertEvaluate("10.4::string", "10.4");
         assertEvaluate("[1, 2, 0]::array(boolean)", new Boolean[]{true, true, false});


### PR DESCRIPTION
`try_cast` already worked, we should allow `cast` as well to have the
proper symmetry of the functions.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed