### PR TITLE
Log possible dangling indices at node startup

### DIFF
--- a/sql/src/main/java/io/crate/metadata/DanglingArtifactsService.java
+++ b/sql/src/main/java/io/crate/metadata/DanglingArtifactsService.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Singleton
+public class DanglingArtifactsService extends AbstractLifecycleComponent implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(DanglingArtifactsService.class);
+
+    private final ClusterService clusterService;
+    private final List<Pattern> danglingPatterns;
+
+    @Inject
+    public DanglingArtifactsService(Settings settings,
+                                    ClusterService clusterService) {
+        super(settings);
+        this.clusterService = clusterService;
+        this.danglingPatterns = IndexParts.DANGLING_INDICES_PREFIX_PATTERNS
+            .stream()
+            .map(Pattern::compile)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected void doStart() {
+        clusterService.addListener(this);
+    }
+
+    @Override
+    protected void doStop() {
+        clusterService.removeListener(this);
+    }
+
+    @Override
+    protected void doClose() {}
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (logger.isInfoEnabled() && event.isNewCluster()) {
+            for (ObjectCursor<String> key : event.state().metaData().indices().keys()) {
+                for (Pattern pattern : danglingPatterns) {
+                    if (pattern.matcher(key.value).matches()) {
+                        logger.info("Dangling artifacts exist in the cluster. Use 'alter cluster gc dangling artifacts;' to remove them");
+                        doStop();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/plugin/SQLModule.java
+++ b/sql/src/main/java/io/crate/plugin/SQLModule.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SQLOperations;
 import io.crate.execution.ddl.DDLStatementDispatcher;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.ingestion.IngestionService;
+import io.crate.metadata.DanglingArtifactsService;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.planner.Planner;
 import io.crate.planner.TableStats;
@@ -50,5 +51,6 @@ public class SQLModule extends AbstractModule {
         bind(SslContextProvider.class).asEagerSingleton();
         bind(RestSQLAction.class).asEagerSingleton();
         bind(IngestionService.class).asEagerSingleton();
+        bind(DanglingArtifactsService.class).asEagerSingleton();
     }
 }

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -47,6 +47,7 @@ import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import io.crate.ingestion.IngestionModules;
 import io.crate.ingestion.IngestionService;
 import io.crate.lucene.ArrayMapperService;
+import io.crate.metadata.DanglingArtifactsService;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.MetaDataBlobModule;
@@ -179,7 +180,8 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             TasksService.class,
             Schemas.class,
             ArrayMapperService.class,
-            IngestionService.class);
+            IngestionService.class,
+            DanglingArtifactsService.class);
 
         if (ingestionModules != null) {
             serviceClasses.addAll(ingestionModules.getServiceClasses());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Some operations in CrateDB might temporarily create temporary structures to complete the operation.
If during such an operation the cluster starts failing this temporary structures might not be cleaned up correctly.

This change is to log this information at node startup and advise the user how to clean up.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed