### PR TITLE
Prepare 3.1.4 release

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.1.4.rst
+++ b/blackbox/docs/appendices/release-notes/3.1.4.rst
@@ -1,0 +1,56 @@
+.. _version_3.1.4:
+
+=============
+Version 3.1.4
+=============
+
+Released on 2018/12/19.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.1.4.
+
+    We recommend that you upgrade to the latest 3.0 release before moving to
+    3.1.4.
+
+    If you want to perform a `rolling upgrade`_, your current CrateDB version
+    number must be at least :ref:`version_3.1.1`. Any upgrade from a version
+    prior to this will require a `full restart upgrade`_.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.1 and must be recreated before moving to 3.1.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+
+Fixes
+-----
+
+- ``array_unique`` and ``array_difference`` now work for nested arrays and
+  arrays with objects which contain arrays.
+
+- Fixed an issue that could cause some types of statements to remain listed
+  within ``sys.jobs`` if their execution stopped with a failure.
+
+- Fixed an issue which caused ``EXPLAIN`` statements to use a wrong ``routing``
+  entries representation on versions >= 3.1.0.

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.1.4
     3.1.3
     3.1.2
     3.1.1

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -44,11 +44,3 @@ Changes
 Fixes
 =====
 
-- ``array_unique`` and ``array_difference`` now work for nested arrays and
-  arrays with objects which contain arrays.
-
-- Fixed an issue that could cause some type of statements to remain listed
-  within ``sys.jobs`` if their execution stopped with a failure.
-
-- Fixed an issue which caused ``EXPLAIN`` statements to use a wrong ``routing``
-  entries representation on versions >= 3.1.0.

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -40,7 +40,7 @@ public class Version {
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 
-    public static final boolean SNAPSHOT = true;
+    public static final boolean SNAPSHOT = false;
     public static final Version CURRENT = new Version(3010499, SNAPSHOT, org.elasticsearch.Version.CURRENT);
 
     static {


### PR DESCRIPTION
I will bump the version to 3.1.5-snapshot after this has been merged and the tag created.