### PR TITLE
Use random PSQL port for blackbox tests

### DIFF
--- a/blackbox/docs/src/doc_tests/tests.py
+++ b/blackbox/docs/src/doc_tests/tests.py
@@ -435,6 +435,7 @@ def create_doctest_suite():
             'license.enterprise': 'true',
             'lang.js.enabled': 'true',
             'es.api.enabled': 'true',
+            'psql.port': GLOBAL_PORT_POOL.get(),
         }
     )
     tests = []

--- a/blackbox/hdfs/src/tests.py
+++ b/blackbox/hdfs/src/tests.py
@@ -185,6 +185,9 @@ def test_suite():
         crate_home=crate_path(),
         port=CRATE_HTTP_PORT,
         transport_port=CRATE_TRANSPORT_PORT,
+        settings={
+            'psql.port': GLOBAL_PORT_POOL.get(),
+        }
     )
     hadoop_layer = HadoopLayer()
     layer = HadoopAndCrateLayer(crate_layer, hadoop_layer)

--- a/blackbox/monitoring/src/tests.py
+++ b/blackbox/monitoring/src/tests.py
@@ -262,7 +262,8 @@ def test_suite():
             "CRATE_JAVA_OPTS": JMX_OPTS.format(JMX_PORT)
         },
         settings={
-            'license.enterprise': True
+            'license.enterprise': True,
+            'psql.port': GLOBAL_PORT_POOL.get(),
         }
     )
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Use random PSQL port for blackbox tests to avoid any port binding issues.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
