### PR TITLE
Changed gradle writing folders using outputs.file to outputs.dir

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -431,7 +431,7 @@ task collectEnterpriseModules(
         }
     }
 }
-collectEnterpriseModules.outputs.file ('enterprise')
+collectEnterpriseModules.outputs.dir ('enterprise')
 
 
 task downloadPlugins(
@@ -480,7 +480,7 @@ task downloadPlugins(
     }
 }
 
-downloadPlugins.outputs.file ('plugins')
+downloadPlugins.outputs.dir ('plugins')
 
 
 


### PR DESCRIPTION
Otherwise, it produces the following error:
```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
A problem was found with the configuration of task ':app:collectEnterpriseModules'.
> Cannot write to file '/home/mika/sandbox/crate/crate/app/enterprise' specified for property '$1' as it is a directory.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
A problem was found with the configuration of task ':app:downloadPlugins'.
> Cannot write to file '/home/mika/sandbox/crate/crate/app/plugins' specified for property '$1' as it is a directory.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================
```

I assume this was introduced with the Gradle 5.0 upgrade.