### PR TITLE
Remove the DirectFallbackExecutor

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -28,6 +28,7 @@ import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
+import io.crate.execution.support.ThreadPools;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.apache.logging.log4j.LogManager;
@@ -82,7 +83,7 @@ class InterceptingRowConsumer implements RowConsumer {
         }
         if (failure == null) {
             assert iterator != null : "iterator must be present";
-            executor.execute(() -> consumer.accept(iterator, null));
+            ThreadPools.forceExecute(executor, () -> consumer.accept(iterator, null));
         } else {
             transportKillJobsNodeAction.broadcast(
                 new KillJobsRequest(Collections.singletonList(jobId)), new ActionListener<Long>() {

--- a/sql/src/main/java/io/crate/execution/engine/PhasesTaskFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/PhasesTaskFactory.java
@@ -27,7 +27,6 @@ import io.crate.execution.jobs.JobSetup;
 import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.jobs.transport.TransportJobAction;
-import io.crate.execution.support.ThreadPools;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -63,7 +62,7 @@ public final class PhasesTaskFactory {
         this.indicesService = indicesService;
         this.jobAction = jobAction;
         this.killJobsNodeAction = killJobsNodeAction;
-        this.searchExecutor = ThreadPools.withDirectExecutionFallback(threadPool.executor(ThreadPool.Names.SEARCH));
+        this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
     }
 
     public JobLauncher create(UUID jobId, List<NodeOperationTree> nodeOperationTreeList) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -52,19 +52,18 @@ import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.execution.jobs.SharedShardContext;
 import io.crate.execution.jobs.SharedShardContexts;
-import io.crate.execution.support.ThreadPools;
 import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.reference.StaticTableReferenceResolver;
 import io.crate.expression.reference.sys.shard.ShardRowContext;
 import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.MapBackedRefResolver;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
 import io.crate.metadata.sys.SysShardsTableInfo;
@@ -177,7 +176,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
         this.remoteCollectorFactory = remoteCollectorFactory;
         ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.executor(ThreadPool.Names.SEARCH);
         this.availableThreads = numIdleThreads(executor, EsExecutors.numberOfProcessors(settings));
-        this.executor = ThreadPools.withDirectExecutionFallback(executor);
+        this.executor = executor;
         this.inputFactory = new InputFactory(functions);
         this.shardCollectorProviderFactory = new ShardCollectorProviderFactory(
             clusterService,


### PR DESCRIPTION
This removes the DirectFallbackExecutor in favour of a `forceExecute`
method. It was difficult to reason about an isolated component. (Should
it handle the RejectedExecutionException or not?)

It is also fragile, if at some point it would receive a different
executor the component itself would break.

In the other cases where the DirectFallbackExecutor was used we already
make use of `CompletableFutures.supplyAsync` which is safe (but it fails
instead of running in the caller thread).





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed