### PR TITLE
Support ECS Task IAM profile credentials on AWS S3 repositories.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -44,3 +44,4 @@ Changes
 Fixes
 =====
 
+- Support ECS Task IAM profile credentials on AWS S3 repositories.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Support ECS Task IAM profile credentials on AWS S3 repositories.

Relates https://github.com/crate/crate/issues/8005.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
