### PR TITLE
Added example of using double quotes for nested table parameters

### DIFF
--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -237,6 +237,12 @@ The optional WITH clause can specify parameters for tables.
 :table_parameter:
   Specifies an optional parameter for the table.
 
+.. NOTE::
+
+   Some parameters are nested, and therefore need to be wrapped in double quotes in order to be set:
+   ``WITH ("allocation.max_retries" = 5)``.
+   Nested parameters are those that contain a ``.`` between parameter names, e.g. ``write.wait_for_active_shards``.
+
 Available parameters are:
 
 .. _number_of_replicas:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Updated documentation to mention that certain table parameters (when creating a table) require double quotes, because they are nested. Example included.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
