### PR TITLE
Fix parameter type detection for nested relations

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -45,6 +45,11 @@ Changes
 Fixes
 =====
 
+- The type of parameter placeholders in sub-queries in the FROM clause of a
+  query can now be resolved to support postgresql clients relying on the
+  ``ParameterDescription`` message.
+  This enables queries like ``select * from (select $1::int + $2) t``
+
 - Fixed error readability of certain ``ALTER TABLE`` operations.
 
 - Fixed sql parser to not allow repeated ``PARTITION BY`` or ``CLUSTERED BY |

--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -76,4 +76,18 @@ public final class AnalyzedInsertStatement implements AnalyzedStatement {
         }
         onDuplicateKeyAssignments.values().forEach(consumer);
     }
+
+    @Nullable
+    public List<List<Symbol>> rows() {
+        return rows;
+    }
+
+    @Nullable
+    public AnalyzedStatement subRelation() {
+        return subRelation;
+    }
+
+    public Map<Reference, Symbol> onDuplicateKeyAssignments() {
+        return onDuplicateKeyAssignments;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
@@ -39,6 +39,13 @@ public interface AnalyzedStatement {
      */
     boolean isWriteOperation();
 
+    /**
+     * Calls the consumer for all top-level symbols within the statement.
+     * Implementations must not traverse into sub-relations.
+     *
+     * Use {@link Relations#traverseDeepSymbols(AnalyzedStatement, Consumer)}
+     * For a variant that traverses into sub-relations.
+     */
     default void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 

--- a/sql/src/main/java/io/crate/analyze/Relations.java
+++ b/sql/src/main/java/io/crate/analyze/Relations.java
@@ -25,8 +25,15 @@ package io.crate.analyze;
 import com.google.common.collect.Lists;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.AnalyzedView;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.OrderedLimitedRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.RelationNormalizer;
+import io.crate.analyze.relations.TableFunctionRelation;
+import io.crate.analyze.relations.TableRelation;
+import io.crate.analyze.relations.UnionSelect;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
@@ -38,8 +45,9 @@ import io.crate.sql.tree.QualifiedName;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
-class Relations {
+public class Relations {
 
     static Collection<? extends Path> namesFromOutputs(List<Symbol> outputs) {
         return Lists.transform(outputs, Symbols::pathFromSymbol);
@@ -90,5 +98,122 @@ class Relations {
             newRelation.setQualifiedName(relation.getQualifiedName());
         }
         return newRelation;
+    }
+
+    /**
+     * Calls the consumer on all symbols of the given statement.
+     * Traverses into all sub-relations
+     */
+    public static void traverseDeepSymbols(AnalyzedStatement stmt, Consumer<? super Symbol> consumer) {
+        TraverseDeepSymbolsStatements.traverse(stmt, consumer);
+    }
+
+    private static class TraverseDeepSymbolsStatements extends AnalyzedStatementVisitor<Consumer<? super Symbol>, Void> {
+
+        private static final TraverseDeepSymbolsStatements INSTANCE = new TraverseDeepSymbolsStatements();
+
+        static void traverse(AnalyzedStatement stmt, Consumer<? super Symbol> consumer) {
+            INSTANCE.process(stmt, consumer);
+        }
+
+        @Override
+        public Void visitInsert(AnalyzedInsertStatement insert, Consumer<? super Symbol> consumer) {
+            List<List<Symbol>> rows = insert.rows();
+            if (rows != null) {
+                for (List<Symbol> row : rows) {
+                    row.forEach(consumer);
+                }
+            }
+            AnalyzedStatement subRelation = insert.subRelation();
+            if (subRelation != null) {
+                traverseDeepSymbols(subRelation, consumer);
+            }
+            insert.onDuplicateKeyAssignments().values().forEach(consumer);
+            return null;
+        }
+
+        @Override
+        public Void visitSelectStatement(QueriedRelation relation, Consumer<? super Symbol> consumer) {
+            TraverseDeepSymbolsRelations.traverse(relation, consumer);
+            return null;
+        }
+
+        @Override
+        protected Void visitAnalyzedStatement(AnalyzedStatement analyzedStatement, Consumer<? super Symbol> consumer) {
+            analyzedStatement.visitSymbols(consumer);
+            return null;
+        }
+    }
+
+    private static class TraverseDeepSymbolsRelations extends AnalyzedRelationVisitor<Consumer<? super Symbol>, Void> {
+
+        private static final TraverseDeepSymbolsRelations INSTANCE = new TraverseDeepSymbolsRelations();
+
+        static void traverse(AnalyzedRelation relation, Consumer<? super Symbol> consumer) {
+            INSTANCE.process(relation, consumer);
+        }
+
+        @Override
+        public Void visitQueriedTable(QueriedTable<?> queriedTable, Consumer<? super Symbol> consumer) {
+            queriedTable.visitSymbols(consumer);
+            process(queriedTable.tableRelation(), consumer);
+            return null;
+        }
+
+        @Override
+        public Void visitMultiSourceSelect(MultiSourceSelect multiSourceSelect, Consumer<? super Symbol> consumer) {
+            multiSourceSelect.visitSymbols(consumer);
+            for (AnalyzedRelation relation : multiSourceSelect.sources().values()) {
+                process(relation, consumer);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitUnionSelect(UnionSelect unionSelect, Consumer<? super Symbol> consumer) {
+            unionSelect.visitSymbols(consumer);
+            process(unionSelect.left(), consumer);
+            process(unionSelect.right(), consumer);
+            return null;
+        }
+
+        @Override
+        public Void visitTableRelation(TableRelation tableRelation, Consumer<? super Symbol> consumer) {
+            return null;
+        }
+
+        @Override
+        public Void visitDocTableRelation(DocTableRelation relation, Consumer<? super Symbol> consumer) {
+            return null;
+        }
+
+        @Override
+        public Void visitTableFunctionRelation(TableFunctionRelation tableFunctionRelation, Consumer<? super Symbol> consumer) {
+            for (Symbol argument : tableFunctionRelation.function().arguments()) {
+                consumer.accept(argument);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitQueriedSelectRelation(QueriedSelectRelation relation, Consumer<? super Symbol> consumer) {
+            relation.visitSymbols(consumer);
+            process(relation.subRelation(), consumer);
+            return null;
+        }
+
+        @Override
+        public Void visitOrderedLimitedRelation(OrderedLimitedRelation relation, Consumer<? super Symbol> consumer) {
+            relation.visitSymbols(consumer);
+            process(relation.childRelation(), consumer);
+            return null;
+        }
+
+        @Override
+        public Void visitView(AnalyzedView analyzedView, Consumer<? super Symbol> consumer) {
+            analyzedView.visitSymbols(consumer);
+            process(analyzedView.relation(), consumer);
+            return null;
+        }
     }
 }

--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -24,6 +24,7 @@ package io.crate.action.sql;
 
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.Relations;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.symbol.Literal;
@@ -43,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -217,6 +219,52 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
 
         assertThat(parameterTypes, is(new DataType[]{DataTypes.STRING, DataTypes.STRING}));
+    }
+
+    @Test
+    public void testTypesCanBeResolvedIfParametersAreInSubRelation() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+
+        AnalyzedStatement stmt = e.analyzer.unboundAnalyze(
+            SqlParser.createStatement("select * from (select $1::int + $2) t"),
+            SessionContext.systemSessionContext(),
+            ParamTypeHints.EMPTY
+        );
+        DataType[] parameterTypes = new Session.ParameterTypeExtractor().getParameterTypes(
+            consumer -> Relations.traverseDeepSymbols(stmt, consumer));
+        assertThat(parameterTypes, arrayContaining(is(DataTypes.INTEGER), is(DataTypes.INTEGER)));
+    }
+
+    @Test
+    public void testTypesCanBeResolvedIfParametersAreInSubRelationOfInsertStatement() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (x int)")
+            .build();
+
+        AnalyzedStatement stmt = e.analyzer.unboundAnalyze(
+            SqlParser.createStatement("insert into t (x) (select * from (select $1::int + $2) t)"),
+            SessionContext.systemSessionContext(),
+            ParamTypeHints.EMPTY
+        );
+        DataType[] parameterTypes = new Session.ParameterTypeExtractor().getParameterTypes(
+            consumer -> Relations.traverseDeepSymbols(stmt, consumer));
+        assertThat(parameterTypes, arrayContaining(is(DataTypes.INTEGER), is(DataTypes.INTEGER)));
+    }
+
+    @Test
+    public void testTypesCanBeResolvedIfParametersAreInSubQueryInDeleteStatement() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (x int)")
+            .build();
+
+        AnalyzedStatement stmt = e.analyzer.unboundAnalyze(
+            SqlParser.createStatement("delete from t where x = (select $1::long)"),
+            SessionContext.systemSessionContext(),
+            ParamTypeHints.EMPTY
+        );
+        DataType[] parameterTypes = new Session.ParameterTypeExtractor().getParameterTypes(
+            consumer -> Relations.traverseDeepSymbols(stmt, consumer));
+        assertThat(parameterTypes, arrayContaining(is(DataTypes.LONG)));
     }
 
     @Test


### PR DESCRIPTION
The ``ParameterDescription`` message didn't contain the types for
parameter placeholders inside sub-relations. That caused errors with
postgres clients relying on that information.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed