### PR TITLE
Add support for casts to nested arrays

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -45,6 +45,8 @@ Changes
 Fixes
 =====
 
+- Casts to nested arrays are now properly supported.
+
 - The type of parameter placeholders in sub-queries in the FROM clause of a
   query can now be resolved to support postgresql clients relying on the
   ``ParameterDescription`` message.

--- a/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -24,7 +24,6 @@ package io.crate.analyze;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.DefaultTraversalVisitor;
-import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.ObjectColumnType;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -32,14 +31,14 @@ import io.crate.types.DataTypes;
 
 import java.util.Locale;
 
-public class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType, Void> {
+public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType, Void> {
 
     private DataTypeAnalyzer() {}
 
     private static final DataTypeAnalyzer INSTANCE = new DataTypeAnalyzer();
 
-    public static DataType convert(Expression expression) {
-        return INSTANCE.process(expression, null);
+    public static DataType convert(ColumnType columnType) {
+        return INSTANCE.process(columnType, null);
     }
 
     @Override
@@ -48,8 +47,7 @@ public class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType, Void> {
         if (typeName == null) {
             return DataTypes.NOT_SUPPORTED;
         } else {
-            typeName = typeName.toLowerCase(Locale.ENGLISH);
-            return DataTypes.ofName(typeName);
+            return DataTypes.ofName(typeName.toLowerCase(Locale.ENGLISH));
         }
     }
 
@@ -63,14 +61,7 @@ public class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType, Void> {
         if (node.type() == ColumnType.Type.SET) {
             throw new UnsupportedOperationException("the SET dataType is currently not supported");
         }
-
-        if (node.innerType().type() != ColumnType.Type.PRIMITIVE) {
-            throw new UnsupportedOperationException("Nesting ARRAY or SET types is not supported");
-        }
-
         DataType innerType = process(node.innerType(), context);
         return new ArrayType(innerType);
     }
-
-
 }

--- a/sql/src/test/java/io/crate/analyze/DataTypeAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DataTypeAnalyzerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Cast;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DataTypeAnalyzerTest {
+
+    @Test
+    public void testCastToNestedArrayExpressionReturnsArrayType() {
+        Cast cast = (Cast) SqlParser.createExpression("xs::array(array(int))");
+        DataType dataType = DataTypeAnalyzer.convert(cast.getType());
+        assertThat(dataType, is(new ArrayType(new ArrayType(DataTypes.INTEGER))));
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -53,10 +53,10 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -2002,5 +2002,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testUsingWindowFunctionInWhereClauseIsNotAllowed() {
         expectedException.expectMessage("Window functions are not allowed in WHERE");
         analyze("select count(*) from t1 where sum(1) OVER() = 1");
+    }
+
+    @Test
+    public void testCastToNestedArrayCanBeUsed() {
+        QueriedRelation relation = analyze("select [[1, 2, 3]]::array(array(int))");
+        assertThat(relation.outputs().get(0).valueType(), is(new ArrayType(new ArrayType(DataTypes.INTEGER))));
     }
 }


### PR DESCRIPTION
That we didn't allow it was an artificial limitation. Casts to nested
arrays might be necessary for use with postgres clients that depend on
the parameter description where we're not able to infer the type
otherwise.



 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed