### PR TITLE
Allow reads on table functions even if license is expired

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -45,6 +45,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented queries on table functions from working if the
+  cluster contains an expired license.
+
 - Casts to nested arrays are now properly supported.
 
 - The type of parameter placeholders in sub-queries in the FROM clause of a

--- a/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
@@ -225,6 +225,12 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
     }
 
     @Test
+    public void testQueryOnTableFunctionIsAllowedIfLicenseIsExpired() {
+        ExecutionPlan plan = e.plan("select null as \"user\", current_schema as \"schema\"");
+        assertThat(plan, instanceOf(Collect.class));
+    }
+
+    @Test
     public void testSetSessionStatementIsAllowedIfLicenseIsExpired() {
         // postgres clients send set session statements initially on connecting, we want to allow them to.
         Plan plan = e.plan("set session whatever = 'x'");


### PR DESCRIPTION
`crash` invokes queries like `select null as \"user\", current_schema as
\"schema\"` on startup. These failed with `License expired`, causing
crash to exit.

This fixes the check to allow such queries so that crash can be used to
enter a valid license.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed