### PR TITLE
Use buffered output streams on file writers

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -41,6 +41,8 @@ Breaking Changes
 Changes
 =======
 
+- Buffer the file output of ``COPY TO`` operations to improve performance by not
+  writing to disk on every row.
 
 Fixes
 =====

--- a/sql/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.export;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -203,6 +204,13 @@ public class FileWriterCountCollector implements Collector<Row, long[], Iterable
         return Collections.emptySet();
     }
 
+    @VisibleForTesting
+    static XContentBuilder createJsonBuilder(OutputStream outputStream) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder(outputStream);
+        builder.generator().configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false);
+        return builder;
+    }
+
     interface RowWriter {
 
         void write(Row row);
@@ -223,7 +231,7 @@ public class FileWriterCountCollector implements Collector<Row, long[], Iterable
             this.outputStream = outputStream;
             this.collectExpressions = collectExpressions;
             this.overwrites = overwrites;
-            builder = XContentFactory.jsonBuilder(outputStream);
+            builder = createJsonBuilder(outputStream);
         }
 
         @Override
@@ -288,7 +296,7 @@ public class FileWriterCountCollector implements Collector<Row, long[], Iterable
             this.outputStream = outputStream;
             this.collectExpressions = collectExpressions;
             this.inputs = inputs;
-            builder = XContentFactory.jsonBuilder(outputStream);
+            builder = createJsonBuilder(outputStream);
         }
 
         public void write(Row row) {

--- a/sql/src/main/java/io/crate/execution/engine/export/OutputFile.java
+++ b/sql/src/main/java/io/crate/execution/engine/export/OutputFile.java
@@ -25,6 +25,8 @@ package io.crate.execution.engine.export;
 import com.google.common.base.Preconditions;
 import io.crate.execution.dsl.projection.WriterProjection;
 
+import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -38,7 +40,7 @@ public class OutputFile extends Output {
     private final boolean overwrite;
     private final boolean compression;
 
-    public OutputFile(URI uri, WriterProjection.CompressionType compressionType) {
+    public OutputFile(URI uri, @Nullable WriterProjection.CompressionType compressionType) {
         Preconditions.checkArgument(uri.getHost() == null);
         this.path = uri.getPath();
         compression = compressionType != null;
@@ -60,6 +62,6 @@ public class OutputFile extends Output {
         if (compression) {
             os = new GZIPOutputStream(os);
         }
-        return os;
+        return new BufferedOutputStream(os);
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.export;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.crate.metadata.ColumnIdent;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.Test;
+
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+
+public class FileWriterCountCollectorTest extends CrateUnitTest {
+
+    @Test
+    public void testToNestedStringObjectMap() {
+        Map<ColumnIdent, Object> columnIdentMap = new HashMap<>();
+        columnIdentMap.put(new ColumnIdent("some", Arrays.asList("nested", "column")), "foo");
+        Map<String, Object> convertedMap = FileWriterCountCollector.toNestedStringObjectMap(columnIdentMap);
+
+        Map someMap = (Map) convertedMap.get("some");
+        Map nestedMap = (Map) someMap.get("nested");
+        assertThat(nestedMap.get("column"), is("foo"));
+    }
+
+    @Test
+    public void testJsonBuilderDoesNotPassFlushToStream() throws Exception {
+        Path file = createTempFile("out", "json");
+        try (OutputStream os = new FileOutputStream(file.toFile())) {
+            XContentBuilder xContentBuilder = FileWriterCountCollector.createJsonBuilder(os);
+            assertThat(xContentBuilder.generator().isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM),
+                is(false));
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
@@ -27,7 +27,6 @@ import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.execution.dsl.projection.WriterProjection;
-import io.crate.metadata.ColumnIdent;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.RowGenerator;
 import io.crate.testing.TestingHelpers;
@@ -38,10 +37,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
@@ -49,7 +46,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.crate.data.SentinelRow.SENTINEL;
-import static org.hamcrest.core.Is.is;
 
 public class FileWriterProjectorTest extends CrateUnitTest {
 
@@ -62,17 +58,6 @@ public class FileWriterProjectorTest extends CrateUnitTest {
         IntStream.range(0, 5)
             .mapToObj(i -> String.format(Locale.ENGLISH, "input line %02d", i))
             .collect(Collectors.toList())), SENTINEL);
-
-    @Test
-    public void testToNestedStringObjectMap() throws Exception {
-        Map<ColumnIdent, Object> columnIdentMap = new HashMap<>();
-        columnIdentMap.put(new ColumnIdent("some", Arrays.asList("nested", "column")), "foo");
-        Map<String, Object> convertedMap = FileWriterCountCollector.toNestedStringObjectMap(columnIdentMap);
-
-        Map someMap = (Map) convertedMap.get("some");
-        Map nestedMap = (Map) someMap.get("nested");
-        assertThat(nestedMap.get("column"), is("foo"));
-    }
 
     @Test
     public void testWriteRawToFile() throws Exception {

--- a/sql/src/test/java/io/crate/execution/engine/export/OutputFileTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/export/OutputFileTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.export;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class OutputFileTest extends CrateUnitTest {
+
+    @Test
+    public void testIsBufferedOutputStream() throws Exception {
+        Path file = createTempFile("out", "json");
+        OutputFile outputFile = new OutputFile(file.toUri(), null);
+        try (OutputStream os = outputFile.acquireOutputStream()) {
+            assertThat(os, instanceOf(BufferedOutputStream.class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This will improve performance by not writing to disk on every row.
Relates https://github.com/crate/crate/issues/8034.

Do not merge yet, requires https://github.com/crate/elasticsearch/pull/156 to be merged first.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
