### PR TITLE
Fix window functions evalution output ordering

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
@@ -259,7 +259,7 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
         }
 
         for (Object[] outgoingCells : cellsForCurrentFrame) {
-            resultsForCurrentFrame.push(outgoingCells);
+            resultsForCurrentFrame.add(outgoingCells);
         }
 
         windowForCurrentRow.clear();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When peer rows are involved while evaluating window functions, the output cells where added in the reverse order. 


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
