### PR TITLE
Extend range of expressions supported in the CASE operand

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -41,6 +41,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support to use any expression in the operand of a ``CASE`` clause.
+
 - Buffer the file output of ``COPY TO`` operations to improve performance by not
   writing to disk on every row.
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -238,7 +238,7 @@ primaryExpression
     | EXTRACT '(' stringLiteralOrIdentifier FROM expr ')'                            #extract
     | CAST '(' expr AS dataType ')'                                                  #cast
     | TRY_CAST '(' expr AS dataType ')'                                              #cast
-    | CASE valueExpression whenClause+ (ELSE elseExpr=expr)? END                     #simpleCase
+    | CASE operand=expr whenClause+ (ELSE elseExpr=expr)? END                        #simpleCase
     | CASE whenClause+ (ELSE elseExpr=expr)? END                                     #searchedCase
     | IF '('condition=expr ',' trueValue=expr (',' falseValue=expr)? ')'             #ifCase
     | ARRAY subqueryExpression                                                       #arraySubquery

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1471,7 +1471,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitSimpleCase(SqlBaseParser.SimpleCaseContext context) {
         return new SimpleCaseExpression(
-            (Expression) visit(context.valueExpression()),
+            (Expression) visit(context.operand),
             visitCollection(context.whenClause(), WhenClause.class),
             visitOptionalContext(context.elseExpr, Expression.class));
     }

--- a/sql/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -23,9 +23,9 @@
 package io.crate.expression.scalar.conditional;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.expression.symbol.Literal;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -86,6 +86,13 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("The number of arguments is incorrect");
         assertEvaluate("nullif(1, 2, 3)", null);
+    }
+
+    @Test
+    public void testOperatorCanBeUsedWithinOperandOfCaseExpression() {
+        assertEvaluate("CASE name ~ 'A.*' OR name = 'Trillian' WHEN true THEN 'YES' ELSE 'NO' END",
+            "YES",
+            Literal.of("Arthur"), Literal.of("Arthur"));
     }
 
     @Test


### PR DESCRIPTION
Previously we didn't support operands like `OR` or `~` in `CASE
operand`. This extends the support to allow all kind of expressions to
improve compatibility with postgres.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed