### PR TITLE
Add a pg_catalog.pg_description table

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -41,6 +41,9 @@ Breaking Changes
 Changes
 =======
 
+- Added a ``pg_description`` table to the ``pg_catalog`` schema for improved
+  postgresql compatibility.
+
 - Added support for window function ``row_number()``.
 
 - Added support to use any expression in the operand of a ``CASE`` clause.

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -86,6 +86,7 @@ number of replicas.
     | pg_catalog         | pg_class                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_constraint           | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_database             | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_description          | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_index                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_namespace            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
@@ -107,7 +108,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 40 rows in set (... sec)
+    SELECT 41 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -138,6 +138,7 @@ following tables:
  - `pg_attrdef <pgsql_pg_attrdef_>`__
  - `pg_index <pgsql_pg_index_>`__
  - `pg_constraint <pgsql_pg_constraint_>`__
+ - `pg_description`_
 
 
 ``pg_type``
@@ -362,3 +363,4 @@ either because of the table is empty or by a not matching where clause.
 .. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
 .. _pgsql_pg_constraint: https://www.postgresql.org/docs/10/static/catalog-pg-constraint.html
 .. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
+.. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -48,6 +48,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgIndexTable.IDENT.name(), new PgIndexTable())
             .put(PgConstraintTable.IDENT.name(), new PgConstraintTable())
             .put(PgDatabaseTable.NAME.name(), new PgDatabaseTable())
+            .put(PgDescriptionTable.NAME.name(), new PgDescriptionTable())
             .build();
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -83,6 +84,11 @@ public class PgCatalogTableDefinitions {
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relationName().fqn()),
             PgConstraintTable.expressions()
         ));
+
+        tableDefinitions.put(PgDescriptionTable.NAME, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgDescriptionTable.expressions())
+        );
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.types.DataTypes;
+import org.elasticsearch.cluster.ClusterState;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+
+public final class PgDescriptionTable extends StaticTableInfo {
+
+    public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_description");
+
+    static class Columns {
+        private static final ColumnIdent OBJOID = new ColumnIdent("objoid");
+        private static final ColumnIdent CLASSOID = new ColumnIdent("classoid");
+        private static final ColumnIdent OBJSUBID = new ColumnIdent("objsubid");
+        private static final ColumnIdent DESCRIPTION = new ColumnIdent("description");
+    }
+
+    PgDescriptionTable() {
+        super(NAME, new ColumnRegistrar(NAME, RowGranularity.DOC)
+            .register(Columns.OBJOID, DataTypes.INTEGER)
+            .register(Columns.CLASSOID, DataTypes.INTEGER)
+            .register(Columns.OBJSUBID, DataTypes.INTEGER)
+            .register(Columns.DESCRIPTION, DataTypes.STRING),
+            Collections.emptyList()
+        );
+    }
+
+    public static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
+            .put(Columns.OBJOID, () -> constant(null))
+            .put(Columns.CLASSOID, () -> constant(null))
+            .put(Columns.OBJSUBID, () -> constant(null))
+            .put(Columns.DESCRIPTION, () -> constant(null))
+            .build();
+    }
+
+    @Override
+    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause, RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
+        return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
+    }
+
+    @Override
+    public RowGranularity rowGranularity() {
+        return RowGranularity.DOC;
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -57,7 +57,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(34L, response.rowCount());
+        assertEquals(35L, response.rowCount());
 
         assertThat(TestingHelpers.printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
@@ -76,6 +76,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_class| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_constraint| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_database| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_description| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_index| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_namespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
@@ -207,13 +208,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(34L, response.rowCount());
+        assertEquals(35L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(35L, response.rowCount());
+        assertEquals(36L, response.rowCount());
     }
 
     @Test
@@ -589,7 +590,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(660, response.rowCount());
+        assertEquals(664, response.rowCount());
     }
 
     @Test
@@ -806,7 +807,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureYellow();
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(37L, response.rows()[0][0]);
+        assertEquals(38L, response.rows()[0][0]);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
 public class PgCatalogITest extends SQLTransportIntegrationTest {
@@ -82,5 +83,12 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select cn.* from pg_constraint cn, pg_class c where cn.conrelid = c.oid and c.relname = 't1'");
         assertThat(printedTable(response.rows()), is(
             "NULL| false| false| NULL| a| NULL| NULL| s| 0| a| 0| 0| true| NULL| t1_pk| -2048275947| true| NULL| NULL| 728874843| NULL| p| 0| true| -874078436\n"));
+    }
+
+    @Test
+    public void testPgDescriptionTableIsEmpty() {
+        execute("select * from pg_description");
+        assertThat(printedTable(response.rows()), is(""));
+        assertThat(response.cols(), arrayContaining("classoid", "description", "objoid", "objsubid"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -89,7 +89,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(34L, response.rowCount());
+        assertEquals(35L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
The table is always empty as we don't support adding comments to
database objects.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed