### PR TITLE
Fix a NPE on to-inner-join rewritable outer joins

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,9 @@ Changes
 Fixes
 =====
 
+- Fixed a ``NullPointerException`` that occurs on ``OUTER`` joins which can
+  be rewritten to ``INNER`` joins and uses a function as a select item.
+
 - Fixed a ``NullPointerException`` that could occur using ``array_difference``.
 
 - Fixed a race condition that could lead to stuck queries. One case this could

--- a/sql/src/main/java/io/crate/analyze/Rewriter.java
+++ b/sql/src/main/java/io/crate/analyze/Rewriter.java
@@ -251,7 +251,7 @@ public class Rewriter {
 
             // if the column was only added to the outerSpec outputs because of the whereClause
             // it's possible to not collect it as long is it isn't used somewhere else
-            if (!mssOutputSymbols.contains(input) &&
+            if (!SymbolVisitors.any(symbol -> Objects.equals(input, symbol), mssOutputSymbols) &&
                 !SymbolVisitors.any(symbol -> Objects.equals(input, symbol), joinCondition)) {
                 fieldsToNotCollect.add(input);
             }

--- a/sql/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -28,6 +28,15 @@ public class SymbolVisitors {
 
     private static final AnyPredicateVisitor ANY_VISITOR = new AnyPredicateVisitor();
 
+    public static boolean any(Predicate<? super Symbol> symbolPredicate, Iterable<? extends Symbol> symbols) {
+        for (Symbol symbol : symbols) {
+            if (any(symbolPredicate, symbol)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean any(Predicate<? super Symbol> symbolPredicate, Symbol symbol) {
         return ANY_VISITOR.process(symbol, symbolPredicate);
     }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -569,7 +569,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testOuterJoinToInnerJoinRewrite() throws Exception {
         // disable hash joins otherwise it will be a distributed join and the plan differs
         e.getSessionContext().setHashJoinEnabled(false);
-        QueryThenFetch qtf = e.plan("select u1.text, u2.text " +
+        QueryThenFetch qtf = e.plan("select u1.text, concat(u2.text, '_foo') " +
                                     "from users u1 left join users u2 on u1.id = u2.id " +
                                     "where u2.name = 'Arthur'" +
                                     "and u2.id > 1 ");
@@ -582,6 +582,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         // doesn't contain "name" because whereClause is pushed down,
         // but still contains "id" because it is in the joinCondition
         assertThat(rightCM.collectPhase().toCollect(), contains(isReference("_fetchid"), isReference("id")));
+
+        Collect left = (Collect) nl.left();
+        assertThat(left.collectPhase().toCollect(), contains(isReference("_fetchid"), isReference("id")));
     }
 
     @Test


### PR DESCRIPTION
If a function was used as a select symbol, it was removed by accident
because it was compared directly instead of traversing into the function
tree.

Fixes https://github.com/crate/crate/issues/8103.