### PR TITLE
Add `DROP ANALZER` statement support.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,9 @@ None
 Changes
 =======
 
+- Output the custom analyzer/tokenizer/token_filter/char_filter definition inside
+  the ``information_schema.routines.routine_definition`` column.
+
 - Added support for the ``last_value`` window function as an enterprise
   feature.
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,9 @@ None
 Changes
 =======
 
+- Implemented the ``DROP ANALYZER`` statement to support removal of custom
+  analyzer definitions from the cluster.
+
 - Output the custom analyzer/tokenizer/token_filter/char_filter definition inside
   the ``information_schema.routines.routine_definition`` column.
 

--- a/blackbox/docs/general/ddl/fulltext-indices.rst
+++ b/blackbox/docs/general/ddl/fulltext-indices.rst
@@ -302,3 +302,15 @@ and will override the tokenizer with ``mypattern``.
 
    See the reference documentation of the :ref:`builtin-analyzer` to get
    detailed information on the available analyzers.
+
+
+.. hide: Drop created custom analyzers::
+
+    cr> drop ANALYZER myanalyzer;
+    DROP OK, 1 row affected (... sec)
+    cr> drop ANALYZER myanalyzer_customized;
+    DROP OK, 1 row affected (... sec)
+    cr> drop ANALYZER german_snowball;
+    DROP OK, 1 row affected (... sec)
+    cr> drop ANALYZER e2;
+    DROP OK, 1 row affected (... sec)

--- a/blackbox/docs/sql/statements/drop-analyzer.rst
+++ b/blackbox/docs/sql/statements/drop-analyzer.rst
@@ -1,0 +1,31 @@
+.. _drop-analyzer:
+
+=================
+``DROP ANALYZER``
+=================
+
+Remove a custom analzer.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Synopsis
+========
+
+.. code-block:: sql
+
+    DROP ANALYZER analyzer_ident
+
+Description
+===========
+
+DROP ANALYZER removes a custom created analyzer from the cluster.
+
+
+Parameters
+==========
+
+:analyzer_ident:
+  The name of the analyzer to be removed.

--- a/blackbox/docs/sql/statements/index.rst
+++ b/blackbox/docs/sql/statements/index.rst
@@ -24,6 +24,7 @@ SQL Statements
     deallocate
     delete
     deny
+    drop-analyzer
     drop-function
     drop-ingest-rule
     drop-repository

--- a/blackbox/docs/src/doc_tests/tests.py
+++ b/blackbox/docs/src/doc_tests/tests.py
@@ -386,23 +386,6 @@ def tearDown(test):
             except Exception as e:
                 print('Failed to drop table {}.{}: {}'.format(schema, table, e))
 
-    # at the moment it is not possible to reset custom analyzers, char_filters,
-    # and tokenizers via SQL
-    # that's why we do a PUT request to the ES api
-    reset_custom_analysis = {
-        'persistent': {
-            'crate.analysis.custom.analyzer.*': None,
-            'crate.analysis.custom.char_filter.*': None,
-            'crate.analysis.custom.tokenizer.*': None,
-        }
-    }
-    request = Request('http://' + CRATE_DSN + '/_cluster/settings',
-                      data=json.dumps(reset_custom_analysis).encode('utf-8'),
-                      headers={'Content-Type': 'application/json'},
-                      method='PUT')
-    with urlopen(request) as response:
-        assert response.status == 200
-
 
 docsuite = partial(doctest.DocFileSuite,
                    tearDown=tearDown,

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -82,6 +82,7 @@ statement
     | DROP USER (IF EXISTS)? name=ident                                              #dropUser
     | DROP INGEST RULE (IF EXISTS)? rule_name=ident                                  #dropIngestRule
     | DROP VIEW (IF EXISTS)? names=qnames                                            #dropView
+    | DROP ANALYZER name=ident                                                       #dropAnalyzer
     | GRANT (priviliges=idents | ALL PRIVILEGES?)
         (ON clazz qnames)? TO users=idents                                           #grantPrivilege
     | DENY (priviliges=idents | ALL PRIVILEGES?)

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -77,6 +77,7 @@ import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DoubleLiteral;
+import io.crate.sql.tree.DropAnalyzer;
 import io.crate.sql.tree.DropBlobTable;
 import io.crate.sql.tree.DropFunction;
 import io.crate.sql.tree.DropIngestRule;
@@ -321,6 +322,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getIdentText(context.extendedName),
             visitCollection(context.analyzerElement(), AnalyzerElement.class)
         );
+    }
+
+    @Override
+    public Node visitDropAnalyzer(SqlBaseParser.DropAnalyzerContext ctx) {
+        return new DropAnalyzer(getIdentText(ctx.name));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -389,6 +389,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitDropAnalyzer(DropAnalyzer node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitTokenizer(Tokenizer node, C context) {
         return visitNode(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropAnalyzer.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropAnalyzer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+public class DropAnalyzer extends Statement {
+
+    private final String name;
+
+    public DropAnalyzer(String name) {
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DropAnalyzer that = (DropAnalyzer) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "DropAnalyzer{" +
+               "name=" + name +
+               '}';
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDropAnalyzer(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -556,6 +556,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testDropAnalyzer() {
+        printStatement("drop analyzer my_analyzer");
+    }
+
+    @Test
     public void testCreateUserStmtBuilder() {
         printStatement("create user \"Günter\"");
         printStatement("create user root");

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -87,6 +87,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
+    protected R visitDropAnalyzerStatement(DropAnalyzerStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
+
     protected R visitDDLStatement(DDLStatement analysis, C context) {
         return visitAnalyzedStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -58,6 +58,7 @@ import io.crate.sql.tree.CreateView;
 import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.DenyPrivilege;
+import io.crate.sql.tree.DropAnalyzer;
 import io.crate.sql.tree.DropBlobTable;
 import io.crate.sql.tree.DropFunction;
 import io.crate.sql.tree.DropIngestRule;
@@ -114,6 +115,7 @@ public class Analyzer {
     private final ShowStatementAnalyzer showStatementAnalyzer;
     private final CreateBlobTableAnalyzer createBlobTableAnalyzer;
     private final CreateAnalyzerStatementAnalyzer createAnalyzerStatementAnalyzer;
+    private final DropAnalyzerStatementAnalyzer dropAnalyzerStatementAnalyzer;
     private final DropBlobTableAnalyzer dropBlobTableAnalyzer;
     private final RefreshTableAnalyzer refreshTableAnalyzer;
     private final OptimizeTableAnalyzer optimizeTableAnalyzer;
@@ -191,6 +193,7 @@ public class Analyzer {
         );
         this.createBlobTableAnalyzer = new CreateBlobTableAnalyzer(schemas, numberOfShards);
         this.createAnalyzerStatementAnalyzer = new CreateAnalyzerStatementAnalyzer(fulltextAnalyzerResolver);
+        this.dropAnalyzerStatementAnalyzer = new DropAnalyzerStatementAnalyzer(fulltextAnalyzerResolver);
         this.refreshTableAnalyzer = new RefreshTableAnalyzer(schemas);
         this.optimizeTableAnalyzer = new OptimizeTableAnalyzer(schemas);
         this.alterTableAnalyzer = new AlterTableAnalyzer(schemas);
@@ -318,6 +321,11 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitCreateAnalyzer(CreateAnalyzer node, Analysis context) {
             return createAnalyzerStatementAnalyzer.analyze(node, context);
+        }
+
+        @Override
+        public AnalyzedStatement visitDropAnalyzer(DropAnalyzer node, Analysis context) {
+            return dropAnalyzerStatementAnalyzer.analyze(node.name());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -41,7 +41,10 @@ import org.elasticsearch.common.settings.Settings;
 import java.util.Locale;
 import java.util.Map;
 
-import static io.crate.analyze.CreateAnalyzerAnalyzedStatement.getSettingsKey;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.CHAR_FILTER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 
 
 class CreateAnalyzerStatementAnalyzer
@@ -117,7 +120,7 @@ class CreateAnalyzerStatementAnalyzer
             Settings.Builder builder = Settings.builder();
             for (Map.Entry<String, Expression> tokenizerProperty : properties.properties().entrySet()) {
                 GenericPropertiesConverter.genericPropertyToSetting(builder,
-                    getSettingsKey("index.analysis.tokenizer.%s.%s", name, tokenizerProperty.getKey()),
+                    TOKENIZER.buildSettingChildName(name, tokenizerProperty.getKey()),
                     tokenizerProperty.getValue(),
                     context.analysis.parameterContext().parameters());
             }
@@ -130,7 +133,7 @@ class CreateAnalyzerStatementAnalyzer
     @Override
     public CreateAnalyzerAnalyzedStatement visitGenericProperty(GenericProperty property, Context context) {
         GenericPropertiesConverter.genericPropertyToSetting(context.statement.genericAnalyzerSettingsBuilder(),
-            getSettingsKey("index.analysis.analyzer.%s.%s", context.statement.ident(), property.key()),
+            ANALYZER.buildSettingChildName(context.statement.ident(), property.key()),
             property.value(),
             context.analysis.parameterContext().parameters()
         );
@@ -176,7 +179,7 @@ class CreateAnalyzerStatementAnalyzer
                 Settings.Builder builder = Settings.builder();
                 for (Map.Entry<String, Expression> tokenFilterProperty : properties.properties().entrySet()) {
                     GenericPropertiesConverter.genericPropertyToSetting(builder,
-                        getSettingsKey("index.analysis.filter.%s.%s", name, tokenFilterProperty.getKey()),
+                        TOKEN_FILTER.buildSettingChildName(name, tokenFilterProperty.getKey()),
                         tokenFilterProperty.getValue(),
                         context.analysis.parameterContext().parameters());
                 }
@@ -219,7 +222,7 @@ class CreateAnalyzerStatementAnalyzer
                 Settings.Builder builder = Settings.builder();
                 for (Map.Entry<String, Expression> charFilterProperty : properties.properties().entrySet()) {
                     GenericPropertiesConverter.genericPropertyToSetting(builder,
-                        getSettingsKey("index.analysis.char_filter.%s.%s", name, charFilterProperty.getKey()),
+                        CHAR_FILTER.buildSettingChildName(name, charFilterProperty.getKey()),
                         charFilterProperty.getValue(),
                         context.analysis.parameterContext().parameters());
                 }

--- a/sql/src/main/java/io/crate/analyze/DropAnalyzerStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DropAnalyzerStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import org.elasticsearch.common.settings.Settings;
+
+public class DropAnalyzerStatement extends AbstractDDLAnalyzedStatement {
+
+    private final Settings settings;
+
+    DropAnalyzerStatement(Settings settings) {
+        this.settings = settings;
+    }
+
+    public Settings settingsForRemoval() {
+        return settings;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
+        return analyzedStatementVisitor.visitDropAnalyzerStatement(this, context);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/DropAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropAnalyzerStatementAnalyzer.java
@@ -26,7 +26,10 @@ import io.crate.exceptions.AnalyzerUnknownException;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import org.elasticsearch.common.settings.Settings;
 
-import static io.crate.metadata.settings.AnalyzerSettings.CUSTOM_ANALYSIS_SETTINGS_PREFIX;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.CHAR_FILTER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 
 public class DropAnalyzerStatementAnalyzer {
 
@@ -44,25 +47,25 @@ public class DropAnalyzerStatementAnalyzer {
             throw new AnalyzerUnknownException(analyzerName);
         }
         Settings.Builder builder = Settings.builder();
-        builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "analyzer." + analyzerName);
+        builder.putNull(ANALYZER.buildSettingName(analyzerName));
 
         Settings settings = ftResolver.getCustomAnalyzer(analyzerName);
 
-        String tokenizerName = settings.get("index.analysis.analyzer." + analyzerName + ".tokenizer");
+        String tokenizerName = settings.get(ANALYZER.buildSettingChildName(analyzerName, TOKENIZER.getName()));
         if (tokenizerName != null
             && ftResolver.hasCustomThingy(tokenizerName, FulltextAnalyzerResolver.CustomType.TOKENIZER)) {
-            builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "tokenizer." + tokenizerName);
+            builder.putNull(TOKENIZER.buildSettingName(tokenizerName));
         }
 
-        for (String tokenFilterName : settings.getAsList("index.analysis.analyzer." + analyzerName + ".filter")) {
+        for (String tokenFilterName : settings.getAsList(ANALYZER.buildSettingChildName(analyzerName, TOKEN_FILTER.getName()))) {
             if (ftResolver.hasCustomThingy(tokenFilterName, FulltextAnalyzerResolver.CustomType.TOKEN_FILTER)) {
-                builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "filter." + tokenFilterName);
+                builder.putNull(TOKEN_FILTER.buildSettingName(tokenFilterName));
             }
         }
 
-        for (String charFilterName : settings.getAsList("index.analysis.analyzer." + analyzerName + ".char_filter")) {
+        for (String charFilterName : settings.getAsList(ANALYZER.buildSettingChildName(analyzerName, CHAR_FILTER.getName()))) {
             if (ftResolver.hasCustomThingy(charFilterName, FulltextAnalyzerResolver.CustomType.CHAR_FILTER)) {
-                builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "char_filter." + charFilterName);
+                builder.putNull(CHAR_FILTER.buildSettingName(charFilterName));
             }
         }
 

--- a/sql/src/main/java/io/crate/analyze/DropAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropAnalyzerStatementAnalyzer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.exceptions.AnalyzerUnknownException;
+import io.crate.metadata.FulltextAnalyzerResolver;
+import org.elasticsearch.common.settings.Settings;
+
+import static io.crate.metadata.settings.AnalyzerSettings.CUSTOM_ANALYSIS_SETTINGS_PREFIX;
+
+public class DropAnalyzerStatementAnalyzer {
+
+    private final FulltextAnalyzerResolver ftResolver;
+
+    DropAnalyzerStatementAnalyzer(FulltextAnalyzerResolver ftResolver) {
+        this.ftResolver = ftResolver;
+    }
+
+    public DropAnalyzerStatement analyze(String analyzerName) {
+        if (ftResolver.hasBuiltInAnalyzer(analyzerName)) {
+            throw new IllegalArgumentException("Cannot drop a built-in analyzer");
+        }
+        if (ftResolver.hasCustomAnalyzer(analyzerName) == false) {
+            throw new AnalyzerUnknownException(analyzerName);
+        }
+        Settings.Builder builder = Settings.builder();
+        builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "analyzer." + analyzerName);
+
+        Settings settings = ftResolver.getCustomAnalyzer(analyzerName);
+
+        String tokenizerName = settings.get("index.analysis.analyzer." + analyzerName + ".tokenizer");
+        if (tokenizerName != null
+            && ftResolver.hasCustomThingy(tokenizerName, FulltextAnalyzerResolver.CustomType.TOKENIZER)) {
+            builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "tokenizer." + tokenizerName);
+        }
+
+        for (String tokenFilterName : settings.getAsList("index.analysis.analyzer." + analyzerName + ".filter")) {
+            if (ftResolver.hasCustomThingy(tokenFilterName, FulltextAnalyzerResolver.CustomType.TOKEN_FILTER)) {
+                builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "filter." + tokenFilterName);
+            }
+        }
+
+        for (String charFilterName : settings.getAsList("index.analysis.analyzer." + analyzerName + ".char_filter")) {
+            if (ftResolver.hasCustomThingy(charFilterName, FulltextAnalyzerResolver.CustomType.CHAR_FILTER)) {
+                builder.putNull(CUSTOM_ANALYSIS_SETTINGS_PREFIX + "char_filter." + charFilterName);
+            }
+        }
+
+        return new DropAnalyzerStatement(builder.build());
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
@@ -252,7 +252,7 @@ public class FulltextAnalyzerResolver {
      * @param type
      * @return true if exists, false otherwise
      */
-    private boolean hasCustomThingy(String name, CustomType type) {
+    public boolean hasCustomThingy(String name, CustomType type) {
         return clusterService.state().metaData().persistentSettings().hasValue(
             String.format(Locale.ROOT, "%s%s.%s", AnalyzerSettings.CUSTOM_ANALYSIS_SETTINGS_PREFIX, type.getName(), name));
     }

--- a/sql/src/main/java/io/crate/metadata/RoutineInfo.java
+++ b/sql/src/main/java/io/crate/metadata/RoutineInfo.java
@@ -43,11 +43,11 @@ public class RoutineInfo {
     public RoutineInfo(String name,
                        String type,
                        @Nullable String schema,
-                       @Nullable  String specificName,
+                       @Nullable String specificName,
                        @Nullable String definition,
                        @Nullable String body,
                        @Nullable String dataType,
-                       @Nullable boolean isDeterministic) {
+                       boolean isDeterministic) {
         assert name != null : "name must not be null";
         assert type != null : "type must not be null";
         this.specificName = specificName;
@@ -61,16 +61,11 @@ public class RoutineInfo {
     }
 
     public RoutineInfo(String name, String type) {
-        assert name != null : "name must not be null";
-        assert type != null : "type must not be null";
-        this.name = name;
-        this.type = type;
-        this.specificName = null;
-        this.schema = null;
-        this.body = null;
-        this.dataType = null;
-        this.definition = null;
-        this.isDeterministic = false;
+        this(name, type, null, null, null, null, null, false);
+    }
+
+    public RoutineInfo(String name, String type, @Nullable String definition) {
+        this(name, type, null, null, definition, null, null, false);
     }
 
     @Nonnull

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -40,6 +40,7 @@ import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.DCLStatement;
 import io.crate.analyze.DDLStatement;
 import io.crate.analyze.DeallocateAnalyzedStatement;
+import io.crate.analyze.DropAnalyzerStatement;
 import io.crate.analyze.DropBlobTableAnalyzedStatement;
 import io.crate.analyze.DropTableAnalyzedStatement;
 import io.crate.analyze.DropViewStmt;
@@ -62,7 +63,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.consumer.UpdatePlanner;
 import io.crate.planner.node.dcl.GenericDCLPlan;
-import io.crate.planner.node.ddl.CreateAnalyzerPlan;
+import io.crate.planner.node.ddl.CreateDropAnalyzerPlan;
 import io.crate.planner.node.ddl.DropTablePlan;
 import io.crate.planner.node.ddl.ESClusterUpdateSettingsPlan;
 import io.crate.planner.node.ddl.GenericDDLPlan;
@@ -291,7 +292,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
         } catch (IOException ioe) {
             throw new UnhandledServerException("Could not build analyzer Settings", ioe);
         }
-        return new CreateAnalyzerPlan(analyzerSettings);
+        return new CreateDropAnalyzerPlan(analyzerSettings);
+    }
+
+    @Override
+    protected Plan visitDropAnalyzerStatement(DropAnalyzerStatement analysis, PlannerContext context) {
+        return new CreateDropAnalyzerPlan(analysis.settingsForRemoval());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -55,7 +55,6 @@ import io.crate.analyze.ShowCreateTableAnalyzedStatement;
 import io.crate.analyze.ShowSessionParameterAnalyzedStatement;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ExpiredLicenseException;
-import io.crate.exceptions.UnhandledServerException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.license.LicenseService;
 import io.crate.metadata.Functions;
@@ -89,7 +88,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -286,13 +284,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     protected Plan visitCreateAnalyzerStatement(CreateAnalyzerAnalyzedStatement analysis, PlannerContext context) {
-        Settings analyzerSettings;
-        try {
-            analyzerSettings = analysis.buildSettings();
-        } catch (IOException ioe) {
-            throw new UnhandledServerException("Could not build analyzer Settings", ioe);
-        }
-        return new CreateDropAnalyzerPlan(analyzerSettings);
+        return new CreateDropAnalyzerPlan(analysis.buildSettings());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateDropAnalyzerPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateDropAnalyzerPlan.java
@@ -37,12 +37,12 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.function.Function;
 
-public class CreateAnalyzerPlan implements Plan {
+public class CreateDropAnalyzerPlan implements Plan {
 
     private final Settings analyzerSettings;
     private static final Function<Object, Row> TO_ONE_ROW = o -> new Row1(1L);
 
-    public CreateAnalyzerPlan(Settings analyzerSettings) {
+    public CreateDropAnalyzerPlan(Settings analyzerSettings) {
         this.analyzerSettings = analyzerSettings;
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -63,7 +64,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
         MetaData metaData = MetaData.builder()
                                     .persistentSettings(
                                         Settings.builder()
-                                                .put("crate.analysis.custom.analyzer.ft_search", analyzerSettings)
+                                                .put(ANALYZER.buildSettingName("ft_search"), analyzerSettings)
                                                 .build())
                                     .build();
         ClusterState state =

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -61,6 +61,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.hamcrest.Matchers.hasItem;
@@ -80,7 +81,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             Settings.builder().put("search", "foobar").build()).utf8ToString();
         MetaData metaData = MetaData.builder()
             .persistentSettings(
-                Settings.builder().put("crate.analysis.custom.analyzer.ft_search", analyzerSettings).build())
+                Settings.builder().put(ANALYZER.buildSettingName("ft_search"), analyzerSettings).build())
             .build();
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
             .metaData(metaData)

--- a/sql/src/test/java/io/crate/analyze/DropAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropAnalyzerTest.java
@@ -31,6 +31,10 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.CHAR_FILTER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -41,29 +45,44 @@ public class DropAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void setUpExecutor() throws Exception {
         Settings settings = Settings.builder()
-            .put("crate.analysis.custom.analyzer.a1", "{\"index\":{\"analysis\":{\"analyzer\":{\"a1\":{\"type\":\"custom\",\"tokenizer\":\"lowercase\"}}}}}")
+            .put(ANALYZER.buildSettingName("a1"),
+                Settings.builder()
+                    .put(ANALYZER.buildSettingChildName("a1", "type"), "custom")
+                    .put(ANALYZER.buildSettingChildName("a1", TOKENIZER.getName()), "lowercase")
+                    .build().toString())
 
-            .put("crate.analysis.custom.analyzer.a2",
-                "{\"index\":{\"analysis\":{\"analyzer\":{\"a2\":{" +
-                "\"tokenizer\":\"a2_mypattern\"," +
-                "\"type\":\"custom\"}}}}}")
-            .put("crate.analysis.custom.tokenizer.a2_mypattern",
-                "{\"index\":{\"analysis\":{\"tokenizer\":{\"a2_mypattern\":{\"pattern\":\".*\",\"type\":\"pattern\"}}}}}")
+            .put(ANALYZER.buildSettingName("a2"),
+                Settings.builder()
+                    .put(ANALYZER.buildSettingChildName("a2", "type"), "custom")
+                    .put(ANALYZER.buildSettingChildName("a2", TOKENIZER.getName()), "a2_mypattern")
+                    .build().toString())
+            .put(TOKENIZER.buildSettingName("a2_mypattern"),
+                Settings.builder()
+                    .put(TOKENIZER.buildSettingChildName("a2_mypattern", "type"), "pattern")
+                    .put(TOKENIZER.buildSettingChildName("a2_mypattern", "pattern"), ".*")
+                    .build().toString())
 
-            .put("crate.analysis.custom.analyzer.a3",
-                "{\"index\":{\"analysis\":{\"analyzer\":{\"a3\":{" +
-                "\"filter\":[\"a3_lowercase_german\",\"kstem\"]," +
-                "\"type\":\"custom\"}}}}}")
-            .put("crate.analysis.custom.filter.a3_lowercase_german",
-                "{\"index\":{\"analysis\":{\"filter\":{\"a3_lowercase_german\":{\"type\":\"lowercase\",\"language\":\"german\"}}}}}")
+            .put(ANALYZER.buildSettingName("a3"),
+                Settings.builder()
+                    .put(ANALYZER.buildSettingChildName("a3", "type"), "custom")
+                    .put(ANALYZER.buildSettingChildName("a3", TOKEN_FILTER.getName()), "a3_lowercase_german, kstem")
+                    .build().toString())
+            .put(TOKEN_FILTER.buildSettingName("a3_lowercase_german"),
+                Settings.builder()
+                    .put(TOKEN_FILTER.buildSettingChildName("a3_lowercase_german", "type"), "lowercase")
+                    .put(TOKEN_FILTER.buildSettingChildName("a3_lowercase_german", "language"), "german")
+                    .build().toString())
 
-            .put("crate.analysis.custom.analyzer.a4",
-                "{\"index\":{\"analysis\":{\"analyzer\":{\"a4\":{" +
-                "\"char_filter\":[\"html_strip\",\"a4_mymapping\"]," +
-                "\"type\":\"custom\"}}}}}")
-            .put("crate.analysis.custom.char_filter.a4_mymapping",
-                "{\"index\":{\"analysis\":{\"char_filter\":{\"a4_mymapping\":{\"type\":\"mapping\",\"mappings\":[\"foo=>bar\"]}}}}}")
-
+            .put(ANALYZER.buildSettingName("a4"),
+                Settings.builder()
+                    .put(ANALYZER.buildSettingChildName("a4", "type"), "custom")
+                    .put(ANALYZER.buildSettingChildName("a4", CHAR_FILTER.getName()), "a4_mymapping, html_strip]")
+                    .build().toString())
+            .put(CHAR_FILTER.buildSettingName("a4_mymapping"),
+                Settings.builder()
+                    .put(CHAR_FILTER.buildSettingChildName("a4_mymapping", "type"), "mapping")
+                    .put(CHAR_FILTER.buildSettingChildName("a4_mymapping", "mappings"), "\"foo=>bar\"")
+                    .build().toString())
             .build();
 
         ClusterState clusterState = ClusterState.builder(clusterService.state())
@@ -83,27 +102,27 @@ public class DropAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropAnalyzer() {
         DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a1");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a1");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), ANALYZER.buildSettingName("a1"));
     }
 
     @Test
     public void testDropAnalyzerWithCustomTokenizer() {
         DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a2");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a2");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.tokenizer.a2_mypattern");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), ANALYZER.buildSettingName("a2"));
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), TOKENIZER.buildSettingName("a2_mypattern"));
     }
 
     @Test
     public void testDropAnalyzerWithCustomTokenFilter() {
         DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a3");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a3");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.filter.a3_lowercase_german");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), ANALYZER.buildSettingName("a3"));
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), TOKEN_FILTER.buildSettingName("a3_lowercase_german"));
     }
 
     @Test
     public void testDropAnalyzerWithCustomCharFilter() {
         DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a4");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a4");
-        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.char_filter.a4_mymapping");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), ANALYZER.buildSettingName("a4"));
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), CHAR_FILTER.buildSettingName("a4_mymapping"));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/DropAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropAnalyzerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DropAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        Settings settings = Settings.builder()
+            .put("crate.analysis.custom.analyzer.a1", "{\"index\":{\"analysis\":{\"analyzer\":{\"a1\":{\"type\":\"custom\",\"tokenizer\":\"lowercase\"}}}}}")
+
+            .put("crate.analysis.custom.analyzer.a2",
+                "{\"index\":{\"analysis\":{\"analyzer\":{\"a2\":{" +
+                "\"tokenizer\":\"a2_mypattern\"," +
+                "\"type\":\"custom\"}}}}}")
+            .put("crate.analysis.custom.tokenizer.a2_mypattern",
+                "{\"index\":{\"analysis\":{\"tokenizer\":{\"a2_mypattern\":{\"pattern\":\".*\",\"type\":\"pattern\"}}}}}")
+
+            .put("crate.analysis.custom.analyzer.a3",
+                "{\"index\":{\"analysis\":{\"analyzer\":{\"a3\":{" +
+                "\"filter\":[\"a3_lowercase_german\",\"kstem\"]," +
+                "\"type\":\"custom\"}}}}}")
+            .put("crate.analysis.custom.filter.a3_lowercase_german",
+                "{\"index\":{\"analysis\":{\"filter\":{\"a3_lowercase_german\":{\"type\":\"lowercase\",\"language\":\"german\"}}}}}")
+
+            .put("crate.analysis.custom.analyzer.a4",
+                "{\"index\":{\"analysis\":{\"analyzer\":{\"a4\":{" +
+                "\"char_filter\":[\"html_strip\",\"a4_mymapping\"]," +
+                "\"type\":\"custom\"}}}}}")
+            .put("crate.analysis.custom.char_filter.a4_mymapping",
+                "{\"index\":{\"analysis\":{\"char_filter\":{\"a4_mymapping\":{\"type\":\"mapping\",\"mappings\":[\"foo=>bar\"]}}}}}")
+
+            .build();
+
+        ClusterState clusterState = ClusterState.builder(clusterService.state())
+            .metaData(MetaData.builder(clusterService.state().metaData())
+                .persistentSettings(settings))
+            .build();
+        ClusterServiceUtils.setState(clusterService, clusterState);
+
+        e = SQLExecutor.builder(clusterService).build();
+    }
+
+    private void assertIsMarkedToBeRemove(Settings settings, String settingName) {
+        assertThat(settings.keySet(), hasItem(settingName));
+        assertThat(settings.get(settingName), nullValue());
+    }
+
+    @Test
+    public void testDropAnalyzer() {
+        DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a1");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a1");
+    }
+
+    @Test
+    public void testDropAnalyzerWithCustomTokenizer() {
+        DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a2");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a2");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.tokenizer.a2_mypattern");
+    }
+
+    @Test
+    public void testDropAnalyzerWithCustomTokenFilter() {
+        DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a3");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a3");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.filter.a3_lowercase_german");
+    }
+
+    @Test
+    public void testDropAnalyzerWithCustomCharFilter() {
+        DropAnalyzerStatement analyzedStatement = e.analyze("drop analyzer a4");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.analyzer.a4");
+        assertIsMarkedToBeRemove(analyzedStatement.settingsForRemoval(), "crate.analysis.custom.char_filter.a4_mymapping");
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -39,6 +39,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.CHAR_FILTER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 import static io.crate.testing.SettingMatcher.hasEntry;
 import static io.crate.testing.SettingMatcher.hasKey;
 import static org.hamcrest.Matchers.allOf;
@@ -89,11 +93,11 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         assertThat(fullAnalyzerSettings.size(), is(2));
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a1.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a1", "type"), "custom")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a1.tokenizer", "lowercase")
+            hasEntry(ANALYZER.buildSettingChildName("a1", TOKENIZER.getName()), "lowercase")
         );
     }
 
@@ -110,18 +114,18 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         Settings fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a2");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a2.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a2", "type"), "custom")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a2.tokenizer", "a2_tok2")
+            hasEntry(ANALYZER.buildSettingChildName("a2", TOKENIZER.getName()), "a2_tok2")
         );
         assertThat(
             fullAnalyzerSettings,
             allOf(
-                hasEntry("index.analysis.tokenizer.a2_tok2.type", "ngram"),
-                hasEntry("index.analysis.tokenizer.a2_tok2.min_ngram", "2"),
-                hasEntry("index.analysis.tokenizer.a2_tok2.token_chars", "[letter, digits]")
+                hasEntry(TOKENIZER.buildSettingChildName("a2_tok2", "type"), "ngram"),
+                hasEntry(TOKENIZER.buildSettingChildName("a2_tok2", "min_ngram"), "2"),
+                hasEntry(TOKENIZER.buildSettingChildName("a2_tok2", "token_chars"), "[letter, digits]")
             )
         );
     }
@@ -142,23 +146,22 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         Settings fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a3");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a3.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a3", "type"), "custom")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a3.tokenizer", "lowercase")
+            hasEntry(ANALYZER.buildSettingChildName("a3", TOKENIZER.getName()), "lowercase")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a3.char_filter"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a3", CHAR_FILTER.getName())),
             containsInAnyOrder("html_strip", "a3_my_mapping")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.char_filter.a3_my_mapping.type", "mapping")
+            hasEntry(CHAR_FILTER.buildSettingChildName("a3_my_mapping","type"), "mapping")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.char_filter.a3_my_mapping" +
-                                            ".mappings"),
+            fullAnalyzerSettings.getAsList(CHAR_FILTER.buildSettingChildName("a3_my_mapping", "mappings")),
             containsInAnyOrder("ph=>f", "ß=>ss", "ö=>oe")
         );
         execute("CREATE TABLE t1(content " +
@@ -174,10 +177,10 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         Settings fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a4");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a4.type", "german")
+            hasEntry(ANALYZER.buildSettingChildName("a4", "type"), "german")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a4.stop_words"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a4", "stop_words")),
             containsInAnyOrder("der", "die", "das")
         );
 
@@ -189,10 +192,10 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a4e");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a4e.type", "german")
+            hasEntry(ANALYZER.buildSettingChildName("a4e", "type"), "german")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a4e.stop_words"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a4e", "stop_words")),
             containsInAnyOrder("der", "die", "das", "wer", "wie", "was")
         );
     }
@@ -211,8 +214,8 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         assertThat(
             fullAnalyzerSettings,
             allOf(
-                hasEntry("index.analysis.filter.builtin_filter_ngram.type", "ngram"),
-                hasEntry("index.analysis.filter.builtin_filter_ngram.min_gram", "1")
+                hasEntry(TOKEN_FILTER.buildSettingChildName("builtin_filter_ngram", "type"), "ngram"),
+                hasEntry(TOKEN_FILTER.buildSettingChildName("builtin_filter_ngram", "min_gram"), "1")
             )
         );
     }
@@ -232,21 +235,21 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         Settings fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a5");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a5.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a5", "type"), "custom")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a5.tokenizer", "whitespace")
+            hasEntry(ANALYZER.buildSettingChildName("a5", TOKENIZER.getName()), "whitespace")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a5.filter"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a5", TOKEN_FILTER.getName())),
             containsInAnyOrder("lowercase", "a5_germanstemmer")
         );
         assertThat(
             fullAnalyzerSettings,
             allOf(
-                hasEntry("index.analysis.filter.a5_germanstemmer.type", "stemmer"),
-                hasEntry("index.analysis.filter.a5_germanstemmer.language", "german")
+                hasEntry(TOKEN_FILTER.buildSettingChildName("a5_germanstemmer", "type"), "stemmer"),
+                hasEntry(TOKEN_FILTER.buildSettingChildName("a5_germanstemmer", "language"), "german")
             )
         );
 
@@ -264,25 +267,25 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         fullAnalyzerSettings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings("a5e");
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a5e.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a5e", "type"), "custom")
         );
         assertThat(
             fullAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a5e.tokenizer", "letter")
+            hasEntry(ANALYZER.buildSettingChildName("a5e", TOKENIZER.getName()), "letter")
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a5e.filter"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a5e", TOKEN_FILTER.getName())),
             containsInAnyOrder("lowercase", "a5_germanstemmer")
         );
         assertThat(
             fullAnalyzerSettings,
             allOf(
-                hasEntry("index.analysis.filter.a5_germanstemmer.type", "stemmer"),
-                hasEntry("index.analysis.filter.a5_germanstemmer.language", "german")
+                hasEntry(TOKEN_FILTER.buildSettingChildName("a5_germanstemmer", "type"), "stemmer"),
+                hasEntry(TOKEN_FILTER.buildSettingChildName("a5_germanstemmer", "language"), "german")
             )
         );
         assertThat(
-            fullAnalyzerSettings.getAsList("index.analysis.analyzer.a5e.char_filter"),
+            fullAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a5e", CHAR_FILTER.getName())),
             containsInAnyOrder("html_strip", "a5e_mymapping")
         );
     }
@@ -387,25 +390,25 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         assertThat(
             settings,
             allOf(
-                hasKey("crate.analysis.custom.analyzer.a7"),
-                hasKey("crate.analysis.custom.tokenizer.a7_mytok"),
-                hasKey("crate.analysis.custom.char_filter.a7_mypattern"),
-                hasKey("crate.analysis.custom.filter.a7_myshingle"),
-                hasKey("crate.analysis.custom.filter.a7_my_stemmer")
+                hasKey(ANALYZER.buildSettingName("a7")),
+                hasKey(TOKENIZER.buildSettingName("a7_mytok")),
+                hasKey(CHAR_FILTER.buildSettingName("a7_mypattern")),
+                hasKey(TOKEN_FILTER.buildSettingName("a7_myshingle")),
+                hasKey(TOKEN_FILTER.buildSettingName("a7_my_stemmer"))
             )
         );
-        Settings analyzerSettings = FulltextAnalyzerResolver.decodeSettings(settings.get("crate.analysis.custom.analyzer.a7"));
+        Settings analyzerSettings = FulltextAnalyzerResolver.decodeSettings(settings.get(ANALYZER.buildSettingName("a7")));
         assertThat(
-            analyzerSettings.getAsList("index.analysis.analyzer.a7.char_filter"),
+            analyzerSettings.getAsList(ANALYZER.buildSettingChildName("a7", CHAR_FILTER.getName())),
             containsInAnyOrder("a7_mypattern", "html_strip")
         );
         assertThat(
-            analyzerSettings.getAsList("index.analysis.analyzer.a7.filter"),
+            analyzerSettings.getAsList(ANALYZER.buildSettingChildName("a7", TOKEN_FILTER.getName())),
             containsInAnyOrder("a7_myshingle", "lowercase", "a7_my_stemmer")
         );
         assertThat(
             analyzerSettings,
-            hasEntry("index.analysis.analyzer.a7.tokenizer", "a7_mytok")
+            hasEntry(ANALYZER.buildSettingChildName("a7", TOKENIZER.getName()), "a7_mytok")
         );
         execute("CREATE ANALYZER a8 EXTENDS a7 (" +
                 "  token_filters (" +
@@ -417,25 +420,25 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         assertThat(
             extendedSettings,
             allOf(
-                hasKey("crate.analysis.custom.analyzer.a8"),
-                hasKey("crate.analysis.custom.tokenizer.a7_mytok")
+                hasKey(ANALYZER.buildSettingName("a8")),
+                hasKey(TOKENIZER.buildSettingName("a7_mytok"))
             )
         );
-        Settings extendedAnalyzerSettings = FulltextAnalyzerResolver.decodeSettings(extendedSettings.get("crate.analysis.custom.analyzer.a8"));
+        Settings extendedAnalyzerSettings = FulltextAnalyzerResolver.decodeSettings(extendedSettings.get(ANALYZER.buildSettingName("a8")));
         assertThat(
             extendedAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a8.type", "custom")
+            hasEntry(ANALYZER.buildSettingChildName("a8", "type"), "custom")
         );
         assertThat(
             extendedAnalyzerSettings,
-            hasEntry("index.analysis.analyzer.a8.tokenizer", "a7_mytok")
+            hasEntry(ANALYZER.buildSettingChildName("a8", TOKENIZER.getName()), "a7_mytok")
         );
         assertThat(
-            extendedAnalyzerSettings.getAsList("index.analysis.analyzer.a8.filter"),
+            extendedAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a8", TOKEN_FILTER.getName())),
             containsInAnyOrder("lowercase", "kstem")
         );
         assertThat(
-            extendedAnalyzerSettings.getAsList("index.analysis.analyzer.a8.char_filter"),
+            extendedAnalyzerSettings.getAsList(ANALYZER.buildSettingChildName("a8", CHAR_FILTER.getName())),
             containsInAnyOrder("a7_mypattern", "html_strip")
         );
 
@@ -486,13 +489,12 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
         assertThat(
             settings,
             allOf(
-                hasKey("crate.analysis.custom.analyzer.a11"),
-                hasKey("crate.analysis.custom.filter.a11_mystop")
+                hasKey(ANALYZER.buildSettingName("a11")),
+                hasKey(TOKEN_FILTER.buildSettingName("a11_mystop"))
             )
         );
-        Settings analyzerSettings = FulltextAnalyzerResolver.decodeSettings(settings.get("crate.analysis.custom.analyzer.a11"));
-        Settings tokenFilterSettings = FulltextAnalyzerResolver.decodeSettings(settings.get("crate" +
-                                                                                            ".analysis.custom.filter.a11_mystop"));
+        Settings analyzerSettings = FulltextAnalyzerResolver.decodeSettings(settings.get(ANALYZER.buildSettingName("a11")));
+        Settings tokenFilterSettings = FulltextAnalyzerResolver.decodeSettings(settings.get(TOKEN_FILTER.buildSettingName("a11_mystop")));
         Settings.Builder builder = Settings.builder();
         builder.put(analyzerSettings);
         builder.put(tokenFilterSettings);

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -494,20 +494,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals("ANALYZER", response.rows()[0][1]);
         assertEquals("myotheranalyzer", response.rows()[1][0]);
         assertEquals("ANALYZER", response.rows()[1][1]);
-        client().admin().cluster().prepareUpdateSettings()
-            .setPersistentSettings(
-                MapBuilder.<String, Object>newMapBuilder()
-                    .put("crate.analysis.custom.analyzer.myanalyzer", null)
-                    .put("crate.analysis.custom.analyzer.myotheranalyzer", null)
-                    .put("crate.analysis.custom.filter.myanalyzer_mytokenfilter", null)
-                    .map())
-            .setTransientSettings(
-                MapBuilder.<String, Object>newMapBuilder()
-                    .put("crate.analysis.custom.analyzer.myanalyzer", null)
-                    .put("crate.analysis.custom.analyzer.myotheranalyzer", null)
-                    .put("crate.analysis.custom.filter.myanalyzer_mytokenfilter", null)
-                    .map())
-            .execute().actionGet();
+
+        execute("drop analyzer myanalyzer");
+        execute("drop analyzer myotheranalyzer");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
@@ -59,7 +60,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.tables order by table_schema, table_name");
         assertEquals(35L, response.rowCount());
 
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| ingestion_rules| information_schema| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| key_column_usage| information_schema| BASE TABLE| NULL\n" +
@@ -143,7 +144,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "FROM information_schema.tables " +
                 "WHERE table_name LIKE 't1%' " +
                 "ORDER BY 1, 2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("BASE TABLE| t1| 2| 1\n" +
+        assertThat(printedTable(response.rows()), is("BASE TABLE| t1| 2| 1\n" +
                                                                     "VIEW| t1_view1| NULL| NULL\n" +
                                                                     "VIEW| t1_view2| NULL| NULL\n"));
 
@@ -169,7 +170,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "FROM information_schema.columns " +
                 "WHERE table_name LIKE 't1%' " +
                 "ORDER BY 1, 2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("t1| id\n" +
+        assertThat(printedTable(response.rows()), is("t1| id\n" +
                                                                     "t1| name\n" +
                                                                     "t1_view1| id\n" +
                                                                     "t1_view1| name\n" +
@@ -199,7 +200,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "FROM information_schema.columns " +
                 "WHERE table_name LIKE 't1%' " +
                 "ORDER BY 1, 2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is(""));
+        assertThat(printedTable(response.rows()), is(""));
 
         // Clean up metadata that does not show up in information_schema any more
         execute("DROP VIEW t1_view1, t1_view2");
@@ -276,7 +277,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "order by number_of_shards desc, table_name asc limit 2", new Object[]{sqlExecutor.getCurrentSchema()});
         assertEquals(2L, response.rowCount());
 
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "bar| 3\n" +
             "foo| 3\n"));
     }
@@ -392,7 +393,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("SELECT constraint_name, constraint_type, table_name, table_schema FROM " +
                 "information_schema.table_constraints ORDER BY table_schema ASC, table_name ASC");
         assertEquals(28L, response.rowCount());
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is(
                 "columns_pk| PRIMARY KEY| columns| information_schema\n" +
                 "information_schema_columns_column_name_not_null| CHECK| columns| information_schema\n" +
@@ -479,12 +480,15 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "  stopwords=[?, ?, ?]" +
                 ")", new Object[]{"der", "die", "das"});
         ensureGreen();
-        execute("SELECT routine_name, routine_type from INFORMATION_SCHEMA.routines " +
+        execute("SELECT routine_name, routine_type, routine_definition from INFORMATION_SCHEMA.routines " +
                 "where routine_name = 'myanalyzer' " +
                 "or routine_name = 'myotheranalyzer' " +
                 "and routine_type = 'ANALYZER' " +
                 "order by routine_name asc");
         assertEquals(2L, response.rowCount());
+        assertThat(printedTable(response.rows()), is(
+            "myanalyzer| ANALYZER| {\"filter\":[\"myanalyzer_mytokenfilter\",\"kstem\"],\"tokenizer\":\"whitespace\",\"type\":\"custom\"}\n" +
+            "myotheranalyzer| ANALYZER| {\"stopwords\":[\"der\",\"die\",\"das\"],\"type\":\"german\"}\n"));
 
         assertEquals("myanalyzer", response.rows()[0][0]);
         assertEquals("ANALYZER", response.rows()[0][1]);
@@ -597,7 +601,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     public void testColumnsColumns() {
         execute("select * from information_schema.columns where table_schema='information_schema' and table_name='columns' order by ordinal_position asc");
         assertThat(response.rowCount(), is(32L));
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_maximum_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 1| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_octet_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 2| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
@@ -920,7 +924,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureGreen();
 
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables where table_name='parted'");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("parted| 2| 0\n"));
+        assertThat(printedTable(response.rows()), is("parted| 2| 0\n"));
 
         execute("select * from information_schema.table_partitions where table_name='parted' order by table_name, partition_ident");
         assertThat(response.rowCount(), is(0L));
@@ -930,11 +934,11 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureGreen();
 
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables where table_name='parted'");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("parted| 2| 0\n"));
+        assertThat(printedTable(response.rows()), is("parted| 2| 0\n"));
 
         execute("select table_name, partition_ident, values, number_of_shards, number_of_replicas " +
                 "from information_schema.table_partitions where table_name='parted' order by table_name, partition_ident");
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "parted| 04132| {par=1}| 2| 0\n" +
             "parted| 04136| {par=3}| 2| 0\n"));
 
@@ -946,12 +950,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureGreen();
 
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables where table_name='parted'");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("parted| 6| 0\n"));
+        assertThat(printedTable(response.rows()), is("parted| 6| 0\n"));
 
         execute("select table_name, partition_ident, values, number_of_shards, number_of_replicas " +
                 "from information_schema.table_partitions where table_name='parted' order by table_name, partition_ident");
         assertThat(response.rowCount(), is(3L));
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "parted| 04132| {par=1}| 2| 0\n" +
             "parted| 04134| {par=2}| 6| 0\n" +
             "parted| 04136| {par=3}| 2| 0\n"));
@@ -962,12 +966,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
         // ensure newer index metadata does not override settings in template
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables where table_name='parted'");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("parted| 6| 0\n"));
+        assertThat(printedTable(response.rows()), is("parted| 6| 0\n"));
 
         execute("select table_name, partition_ident, values, number_of_shards, number_of_replicas " +
                 "from information_schema.table_partitions where table_name='parted' order by table_name, partition_ident");
         assertThat(response.rowCount(), is(3L));
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "parted| 04132| {par=1}| 2| 0\n" +
             "parted| 04134| {par=2}| 6| 0\n" +
             "parted| 04136| {par=3}| 2| 0\n"));
@@ -976,12 +980,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         waitNoPendingTasksOnAll();
 
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables where table_name='parted'");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("parted| 6| 0\n"));
+        assertThat(printedTable(response.rows()), is("parted| 6| 0\n"));
         waitNoPendingTasksOnAll();
         execute("select table_name, partition_ident, values, number_of_shards, number_of_replicas " +
                 "from information_schema.table_partitions where table_name='parted' order by table_name, partition_ident");
         assertThat(response.rowCount(), is(2L));
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "parted| 04132| {par=1}| 2| 0\n" +
             "parted| 04136| {par=3}| 2| 0\n"));
 
@@ -1037,7 +1041,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select table_name, partition_ident, values from information_schema.table_partitions order by table_name, partition_ident");
         assertEquals(2, response.rowCount());
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("my_table| 04130| {metadata['date']=0}\n" +
                "my_table| 04732d1g64p36d9i60o30c1g| {metadata['date']=1401235200000}\n"));
     }
@@ -1084,7 +1088,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                           "data_points| data['somelongroute']| long\n" +
                           "data_points| data['somestringroute']| string\n" +
                           "data_points| day| string\n";
-        assertEquals(expected, TestingHelpers.printedTable(response.rows()));
+        assertEquals(expected, printedTable(response.rows()));
     }
 
     @Test
@@ -1127,7 +1131,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t (lastname string, firstname string, name as (lastname || '_' || firstname)) " +
                 "with (number_of_replicas = 0)");
         execute("select column_name, is_generated, generation_expression from information_schema.columns where is_generated = true");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("name| true| concat(concat(lastname, '_'), firstname)\n"));
     }
 
@@ -1151,7 +1155,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testInformationRoutinesColumns() {
         execute("select column_name from information_schema.columns where table_name='routines' order by ordinal_position");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is(
               "data_type\n" +
               "is_deterministic\n" +

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -27,7 +27,6 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Test;
@@ -216,10 +215,7 @@ public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTes
         try {
             assertResponseWithTypes("create ANALYZER \"german_snowball\" extends snowball WITH (language='german')");
         } finally {
-            client().admin().cluster().prepareUpdateSettings()
-                .setPersistentSettings(MapBuilder.newMapBuilder().put("crate.analysis.custom.analyzer.german_snowball", null).map())
-                .setTransientSettings(MapBuilder.newMapBuilder().put("crate.analysis.custom.analyzer.german_snowball", null).map())
-                .execute().actionGet();
+            execute("drop analyzer german_snowball");
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Implement the `DROP ANALYZER` statement to support removal of custom analyzer definitions from the cluster.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
