### PR TITLE
Fix flaky sys.nodes time out test.

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -51,6 +51,9 @@ public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTes
      */
     @Test
     public void testTimingOutNode() throws Exception {
+        // wait until no master cluster state tasks are pending, otherwise this test may fail due to master task timeouts
+        waitNoPendingTasksOnAll();
+
         String[] nodeNames = internalCluster().getNodeNames();
         String n1 = nodeNames[0];
         String n2 = nodeNames[1];


### PR DESCRIPTION
If cluster state tasks are still pending on the master node, this
test may fail with "no-more-master" related exception. Lets wait
until all tasks are done to prevent that.
