### PR TITLE
Replace usages of ES search API in tests

### DIFF
--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -32,7 +32,8 @@ import io.crate.metadata.doc.DocSysColumns;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public class DocRefResolverTest extends CrateUnitTest {
     private static final DocRefResolver REF_RESOLVER =
         new DocRefResolver(Collections.emptyList());
     private static final Doc GET_RESULT =
-        new Doc("t1", "abc", 1L, SourceLookup.sourceAsMap(SOURCE), SOURCE::utf8ToString);
+        new Doc("t1", "abc", 1L, XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2(), SOURCE::utf8ToString);
 
     @Test
     public void testSystemColumnsCollectExpressions() throws Exception {
@@ -68,7 +69,7 @@ public class DocRefResolverTest extends CrateUnitTest {
 
         assertThat(collectExpressions.get(0).value(), is("abc"));
         assertThat(collectExpressions.get(1).value(), is(1L));
-        assertThat(collectExpressions.get(2).value(), is(SourceLookup.sourceAsMap(SOURCE)));
+        assertThat(collectExpressions.get(2).value(), is(XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2()));
         assertThat(collectExpressions.get(3).value(), is(SOURCE.utf8ToString()));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
@@ -25,10 +25,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -258,21 +255,14 @@ public class FulltextIntegrationTest extends SQLTransportIntegrationTest  {
         this.setup.setUpLocations();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch(getFqn("locations"))
-            .setTypes("default")
-            .setQuery(QueryBuilders.multiMatchQuery("planet earth", "kind^0.8", "name_description_ft^0.6"))
-            .get(TimeValue.timeValueSeconds(1));
-
         execute("select name, _score from locations where match((kind 0.8, name_description_ft 0.6), 'planet earth') " +
                 "using best_fields order by _score desc");
-
-        SearchHit[] hits = searchResponse.getHits().getHits();
-        for (int i = 0; i < hits.length; i++) {
-            assertThat(hits[i].getScore(), is(((float) response.rows()[i][1])));
-        }
-
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is("Alpha Centauri| 1.3665153\nBartledan| 1.008085\n| 0.4665413\nAllosimanius Syneca| 0.35026485\nGalactic Sector QQ7 Active J Gamma| 0.28038445\n"));
+            is("Alpha Centauri| 1.3665153\n" +
+               "Bartledan| 1.008085\n" +
+               "| 0.4665413\n" +
+               "Allosimanius Syneca| 0.35026485\n" +
+               "Galactic Sector QQ7 Active J Gamma| 0.28038445\n"));
 
         execute("select name, _score from locations where match((kind 0.6, name_description_ft 0.8), 'planet earth') using most_fields order by _score desc");
         assertThat(TestingHelpers.printedTable(response.rows()),

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -35,7 +35,6 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
@@ -50,7 +49,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -75,6 +73,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.Constants.DEFAULT_MAPPING_TYPE;
 import static io.crate.Version.CRATEDB_VERSION_KEY;
 import static io.crate.Version.ES_VERSION_KEY;
@@ -310,12 +309,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
             .getState().metaData();
         assertNotNull(metaData.indices().get(partitionName).getAliases().get(getFqn("parted")));
-        assertThat(
-            client().prepareSearch(partitionName).setTypes(DEFAULT_MAPPING_TYPE)
-                .setSize(0).setQuery(new MatchAllQueryBuilder())
-                .execute().actionGet().getHits().getTotalHits(),
-            is(1L)
-        );
 
         execute("select id, name, date from parted");
         assertThat(response.rowCount(), is(1L));
@@ -325,54 +318,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     }
 
     private void validateInsertPartitionedTable() {
-        Set<String> indexUUIDs = new HashSet<>(3);
-
-        String partitionName = new PartitionName(
-            new RelationName(sqlExecutor.getCurrentSchema(), "parted"),
-            Collections.singletonList(String.valueOf(13959981214861L))
-        ).asIndexName();
-        assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
-        IndexMetaData indexMetaData = client().admin().cluster().prepareState().execute().actionGet()
-            .getState().metaData().indices().get(partitionName);
-        indexUUIDs.add(indexMetaData.getIndexUUID());
-        assertThat(indexMetaData.getAliases().get(getFqn("parted")), notNullValue());
+        execute("select table_name, partition_ident from information_schema.table_partitions order by 2 ");
         assertThat(
-            client().prepareSearch(partitionName).setTypes(DEFAULT_MAPPING_TYPE)
-                .setSize(0).setQuery(new MatchAllQueryBuilder())
-                .execute().actionGet().getHits().getTotalHits(),
-            is(1L)
-        );
-
-        partitionName = new PartitionName(
-            new RelationName(sqlExecutor.getCurrentSchema(), "parted"),
-            Collections.singletonList(String.valueOf(0L))).asIndexName();
-        assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
-        indexMetaData = client().admin().cluster().prepareState().execute().actionGet()
-            .getState().metaData().indices().get(partitionName);
-        indexUUIDs.add(indexMetaData.getIndexUUID());
-        assertThat(indexMetaData.getAliases().get(getFqn("parted")), notNullValue());
-        assertThat(
-            client().prepareSearch(partitionName).setTypes(DEFAULT_MAPPING_TYPE)
-                .setSize(0).setQuery(new MatchAllQueryBuilder())
-                .execute().actionGet().getHits().getTotalHits(),
-            is(1L)
-        );
-
-        partitionName = new PartitionName(
-            new RelationName(sqlExecutor.getCurrentSchema(), "parted"), Collections.singletonList(null)).asIndexName();
-        assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
-        indexMetaData = client().admin().cluster().prepareState().execute().actionGet()
-            .getState().metaData().indices().get(partitionName);
-        indexUUIDs.add(indexMetaData.getIndexUUID());
-        assertThat(indexMetaData.getAliases().get(getFqn("parted")), notNullValue());
-        assertThat(
-            client().prepareSearch(partitionName).setTypes(DEFAULT_MAPPING_TYPE)
-                .setSize(0).setQuery(new MatchAllQueryBuilder())
-                .execute().actionGet().getHits().getTotalHits(),
-            is(1L)
-        );
-
-        assertThat(indexUUIDs.size(), is(3));
+            printedTable(response.rows()),
+            is("parted| 0400\n" +
+               "parted| 04130\n" +
+               "parted| 047j2cpp6ksjie1h68oj8e1m64\n"));
     }
 
     @Test
@@ -418,25 +369,23 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("insert into parted (name, date) values (?, ?)",
             new Object[]{"Ford", 13959981214861L});
         assertThat(response.rowCount(), is(1L));
-        ensureYellow();
-        refresh();
-        String partitionName = new PartitionName(
+
+        execute("refresh table parted");
+
+        PartitionName partitionName = new PartitionName(
             new RelationName(sqlExecutor.getCurrentSchema(), "parted"),
             Arrays.asList("Ford", String.valueOf(13959981214861L))
-        ).asIndexName();
-        assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
-            .getState().metaData().indices().get(partitionName).getAliases().get(getFqn("parted")));
-        assertThat(
-            client().prepareSearch(partitionName).setTypes(DEFAULT_MAPPING_TYPE)
-                .setSize(0).setQuery(new MatchAllQueryBuilder())
-                .execute().actionGet().getHits().getTotalHits(),
-            is(1L)
         );
+
+        execute(
+            "select count(*) from information_schema.table_partitions where partition_ident = ?",
+            $(partitionName.ident()));
+        assertThat(response.rows()[0][0], is(1L));
+
         execute("select * from parted");
-        assertThat(response.rowCount(), is(1L));
-        assertThat(response.cols(), arrayContaining("date", "name"));
-        assertThat((Long) response.rows()[0][0], is(13959981214861L));
-        assertThat((String) response.rows()[0][1], is("Ford"));
+        assertThat(
+            printedTable(response.rows()),
+            is("13959981214861| Ford\n"));
     }
 
     @Test


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed