### PR TITLE
Use a threshold to decide if we'll use a bounded or unbounded q for limited sorted queries.

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.sort;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.data.BatchIterator;
+import io.crate.data.Bucket;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.testing.RowGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static io.crate.data.SentinelRow.SENTINEL;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class SortingTopNCollectorBenchmark {
+
+    private static final Comparator<Object[]> COMPARATOR = (o1, o2) -> Integer.compare((int) o2[0], (int) o1[0]);
+    private static final InputCollectExpression INPUT = new InputCollectExpression(0);
+    private static final List<Input<?>> INPUTS = ImmutableList.of(INPUT);
+    private static final Iterable<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = ImmutableList.of(INPUT);
+
+    private List<Row> rows = StreamSupport.stream(RowGenerator.range(0, 10_000_000).spliterator(), false)
+        .map(Row::materialize)
+        .map(RowN::new)
+        .collect(Collectors.toList());
+
+    private Collector<Row, ?, Bucket> boundedSortingCollector;
+    private Collector<Row, ?, Bucket> unboundedSortingCollector;
+
+    @Setup
+    public void setUp() {
+        boundedSortingCollector = new BoundedSortingTopNCollector(
+            INPUTS,
+            COLLECT_EXPRESSIONS,
+            1,
+            COMPARATOR,
+            10_000,
+            0);
+
+        unboundedSortingCollector = new UnboundedSortingTopNCollector(
+            INPUTS,
+            COLLECT_EXPRESSIONS,
+            1,
+            COMPARATOR,
+            10_000,
+            10_000,
+            0);
+    }
+
+    @Benchmark
+    public Object measureBoundedSortingCollector() {
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, boundedSortingCollector);
+        return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();
+    }
+
+    @Benchmark
+    public Object measureUnboundedSortingCollector() {
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, unboundedSortingCollector);
+        return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();
+    }
+}

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -74,3 +74,7 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue where an ordered query with a specified limit that was much
+  larger than the available rows would result in ``OutOfMemoryError`` even
+  though the number of available rows could fit in memory.

--- a/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
@@ -62,7 +62,7 @@ public class RamBlockSizeCalculator implements IntSupplier {
         blockSize = Math.min(defaultBlockSize, blockSize);
 
         // In case no mem available from circuit breaker then still allocate a small blockSize,
-        // so that at least some rows (min 1) could be processed and a CircuitBreakerException can be triggered.
+        // so that at least some rows (min 10) could be processed and a CircuitBreakerException can be triggered.
         return blockSize <= 0 ? 10 : blockSize;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -120,6 +120,19 @@ import java.util.function.Supplier;
 public class ProjectionToProjectorVisitor
     extends ProjectionVisitor<ProjectionToProjectorVisitor.Context, Projector> implements ProjectorFactory {
 
+    /**
+     * Represents the minimum number of rows that have to be processed in a sorted TopN projector context after which
+     * we'll use an unbounded collector ie. {@link io.crate.execution.engine.sort.UnboundedSortingTopNCollector}. If
+     * less rows are needed (ie. limit + offset < threshold) a bounded collector will be used (a collector that
+     * pre-allocates the underlying structure in order to execute the sort and limit operation).
+     *
+     * We've chosen 10_000 because the usual user required limits are lower and our default limit applied over HTTP is
+     * 10_000. These most common cases will be accommodated by a bounded collector which is slightly faster than the
+     * unbounded one (however benchmarks have shown that using a collector that grows the underlying structure adds
+     * an overhead of around 1-5% so performance will not be grossly affected even for larger limits).
+     */
+    private static final int UNBOUNDED_COLLECTOR_THRESHOLD = 10_000;
+
     private final ClusterService clusterService;
     private final NodeJobsCounter nodeJobsCounter;
     private final Functions functions;
@@ -228,7 +241,8 @@ public class ProjectionToProjectorVisitor
                 numOutputs,
                 OrderingByPosition.arrayOrdering(orderByIndices, projection.reverseFlags(), projection.nullsFirst()),
                 projection.limit(),
-                projection.offset()
+                projection.offset(),
+                UNBOUNDED_COLLECTOR_THRESHOLD
             );
         }
         return new SortingProjector(

--- a/sql/src/main/java/io/crate/execution/engine/sort/UnboundedSortingTopNCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/UnboundedSortingTopNCollector.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.sort;
+
+import com.google.common.base.Preconditions;
+import io.crate.data.ArrayBucket;
+import io.crate.data.Bucket;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.CollectExpression;
+import org.apache.lucene.util.ArrayUtil;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+
+/**
+ * Collector implementation which collects rows into an unbounded priorityQueue in order to sort the rows and apply a
+ * limit + offset.
+ * The final result is a sorted bucket with limit and offset applied.
+ */
+public class UnboundedSortingTopNCollector implements Collector<Row, PriorityQueue<Object[]>, Bucket> {
+
+    private final Collection<? extends Input<?>> inputs;
+    private final Iterable<? extends CollectExpression<Row, ?>> expressions;
+    private final int numOutputs;
+    private final Comparator<Object[]> comparator;
+    private final int initialCapacity;
+    private final int offset;
+    private final int maxNumberOfRowsInQueue;
+
+    /**
+     * @param inputs          contains output {@link Input}s and orderBy {@link Input}s
+     * @param expressions     expressions linked to the inputs
+     * @param numOutputs      number of output columns
+     * @param comparator      used to sort the rows
+     * @param initialCapacity the initial capacity of the backing queue
+     * @param limit           the max number of rows the result should contain
+     * @param offset          the number of rows to skip (after sort)
+     */
+    public UnboundedSortingTopNCollector(Collection<? extends Input<?>> inputs,
+                                         Iterable<? extends CollectExpression<Row, ?>> expressions,
+                                         int numOutputs,
+                                         Comparator<Object[]> comparator,
+                                         int initialCapacity,
+                                         int limit,
+                                         int offset) {
+        Preconditions.checkArgument(
+            initialCapacity > 0, "Invalid initial capacity: value must be > 0; got: " + initialCapacity);
+        Preconditions.checkArgument(limit > 0, "Invalid LIMIT: value must be > 0; got: " + limit);
+        Preconditions.checkArgument(offset >= 0, "Invalid OFFSET: value must be >= 0; got: " + offset);
+
+        this.inputs = inputs;
+        this.expressions = expressions;
+        this.numOutputs = numOutputs;
+        this.comparator = comparator;
+        this.initialCapacity = initialCapacity;
+        this.offset = offset;
+        this.maxNumberOfRowsInQueue = limit + offset;
+
+        if (maxNumberOfRowsInQueue >= ArrayUtil.MAX_ARRAY_LENGTH || maxNumberOfRowsInQueue < 0) {
+            // Throw exception to prevent confusing OOME in PriorityQueue
+            // 1) if offset + limit exceeds maximum array length
+            // 2) if offset + limit exceeds Integer.MAX_VALUE (then maxSize is negative!)
+            throw new IllegalArgumentException(
+                "Invalid LIMIT + OFFSET: value must be <= " + (ArrayUtil.MAX_ARRAY_LENGTH - 1) + "; got: " + maxNumberOfRowsInQueue);
+        }
+    }
+
+    @Override
+    public Supplier<PriorityQueue<Object[]>> supplier() {
+        return () -> new PriorityQueue<>(initialCapacity, comparator);
+    }
+
+    @Override
+    public BiConsumer<PriorityQueue<Object[]>, Row> accumulator() {
+        return this::onNextRow;
+    }
+
+    @Override
+    public BinaryOperator<PriorityQueue<Object[]>> combiner() {
+        return (pq1, pq2) -> {
+            throw new UnsupportedOperationException("combine not supported");
+        };
+    }
+
+    @Override
+    public Function<PriorityQueue<Object[]>, Bucket> finisher() {
+        return this::pqToIterable;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return Collections.emptySet();
+    }
+
+    private void onNextRow(PriorityQueue<Object[]> pq, Row row) {
+        for (CollectExpression<Row, ?> expression : expressions) {
+            expression.setNextRow(row);
+        }
+        Object[] rowCells = new Object[inputs.size()];
+        int i = 0;
+        for (Input<?> input : inputs) {
+            rowCells[i] = input.value();
+            i++;
+        }
+
+        if (pq.size() == maxNumberOfRowsInQueue) {
+            Object[] highestElementInOrder = pq.peek();
+            if (highestElementInOrder == null || comparator.compare(rowCells, highestElementInOrder) > 0) {
+                pq.poll();
+                pq.add(rowCells);
+            }
+        } else {
+            pq.add(rowCells);
+        }
+    }
+
+    private Bucket pqToIterable(PriorityQueue<Object[]> pq) {
+        if (offset > pq.size()) {
+            return new ArrayBucket(new Object[0][0], numOutputs);
+        }
+        int resultSize = Math.max(Math.min(maxNumberOfRowsInQueue - offset, pq.size() - offset), 0);
+
+        Object[][] rows = new Object[resultSize][];
+        for (int i = resultSize - 1; i >= 0; i--) {
+            rows[i] = pq.poll();
+        }
+        return new ArrayBucket(rows, numOutputs);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We ran a few benchmarks to see if we could choose a "good threshold". The results are below:

```limit 5000
initial capacity 5000 (for the unbounded collector)


Benchmark                                                       Mode  Cnt    Score   Error  Units
SortingTopNCollectorBenchmark.measureBoundedSortingCollector    avgt  200  194.532 ± 0.859  ms/op
SortingTopNCollectorBenchmark.measureUnboundedSortingCollector  avgt  200  198.883 ± 1.014  ms/op

limit 10_000
initial capacity 10_000 (for the unbounded collector)


Benchmark                                                       Mode  Cnt    Score   Error  Units
SortingTopNCollectorBenchmark.measureBoundedSortingCollector    avgt  200  190.078 ± 1.226  ms/op
SortingTopNCollectorBenchmark.measureUnboundedSortingCollector  avgt  200  199.472 ± 0.997  ms/op

limit 100_000
initial capacity 100_000 (for the unbounded collector)


Benchmark                                                       Mode  Cnt    Score   Error  Units
SortingTopNCollectorBenchmark.measureBoundedSortingCollector    avgt  200  220.131 ± 1.274  ms/op
SortingTopNCollectorBenchmark.measureUnboundedSortingCollector  avgt  200  222.861 ± 2.679  ms/op

limit 100_000
initial capacity 10_000 (for the unbounded collector)


Benchmark                                                       Mode  Cnt    Score   Error  Units
SortingTopNCollectorBenchmark.measureBoundedSortingCollector    avgt  200  219.745 ± 0.977  ms/op
SortingTopNCollectorBenchmark.measureUnboundedSortingCollector  avgt  200  221.110 ± 1.941  ms/op


```


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
