### PR TITLE
Update the 'Writing Documentation' for developer docs

### DIFF
--- a/blackbox/build.gradle
+++ b/blackbox/build.gradle
@@ -65,6 +65,9 @@ task buildDocs(type: Exec, dependsOn: bootstrap) {
     commandLine "$projectDir/bin/sphinx"
 }
 
+task developDocs(type: Exec, dependsOn: bootstrap) {
+    commandLine "$projectDir/bin/sphinx", "dev"
+}
 
 hdfsTest.dependsOn(bootstrap, lessLogging, ignoreDiskThreshold,
         project(':es:es-repository-hdfs').blackBoxTestJar)

--- a/devs/docs/write_docs.rst
+++ b/devs/docs/write_docs.rst
@@ -14,14 +14,9 @@ To start working on the docs locally, you will need Python_ 3 in addition to
 Java_ (needed for the doctests_). Make sure that ``python3`` is on your
 ``$PATH``.
 
-Before you can get started, you need to bootstrap the docs::
+You can run the sphinx build as a development server, like so::
 
-    $ cd blackbox
-    $ ./bootstrap.sh
-
-Once this runs, you can build the docs and start the docs web server like so::
-
-    $ ./bin/sphinx dev
+    $ ./gradlew blackbox:developDocs
 
 Once the web server running, you can view your local copy of the docs by
 visiting http://127.0.0.1:8000 in a web browser.
@@ -30,19 +25,17 @@ This command also watches the file system and rebuilds the docs when changes
 are detected. Even better, it will automatically refresh the browser tab for
 you.
 
+Alternatively, you can just build the docs without starting the web server::
+
+    $ ./gradlew blackbox:buildDocs
+
+
 Many of the examples in the documentation are executable and function as
 doctests_.
 
 You can run the doctests like so::
 
-    $ ./bin/test
-
-If you want to test the doctests in a specific file, run this::
-
-    $ ./bin/test -1vt <filename>
-
-There is also a Gradle task called ``itest`` which will execute all of the
-above steps.
+    $ ./gradlew blackbox:itest
 
 *Note*: Your network connection should be up and running, or some of the tests
 will fail.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

These docs were outdated and no longer valid. Instead of invoking the
bash scripts directly, we can now advise that developers run the test
builds and tests via gradle, since this also ensures bootstrapping (and
the developer no longer needs to care about that).

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
