### PR TITLE
Mark ingest framework as deprecated

### DIFF
--- a/blackbox/docs/admin/ingestion/index.rst
+++ b/blackbox/docs/admin/ingestion/index.rst
@@ -9,6 +9,10 @@ Ingestion Framework
    .. figure:: ingestion-01.png
       :alt: A diagram of the ingestion framework
 
+.. WARNING::
+
+   The ingestion framework is deprecated and will be removed in a future release.
+
 As well as allowing you to ingest data via standard SQL inserts, CrateDB
 provides an ingestion framework that allows you to ingest data through custom
 event-based ingestion sources.

--- a/blackbox/docs/admin/ingestion/rules.rst
+++ b/blackbox/docs/admin/ingestion/rules.rst
@@ -19,6 +19,10 @@ Ingestion rules define where and how the incoming data of a specific
 :ref:`ingestion source <administration-ingestion-sources>` should be routed and
 stored.
 
+   .. WARNING::
+
+      Ingestion rules are deprecated and will be removed in a future release.
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ None
 Changes
 =======
 
+- Marked ``CREATE INGEST RULE`` and ``DROP INGEST RULE`` as deprecated. Given
+  that the only implementation (MQTT) was deprecated and will be removed, the
+  framework itself will also be removed.
+
 - Added ``current_schemas(boolean)`` scalar function which will return the
   names of schemas in the ``search_path``.
 

--- a/blackbox/docs/sql/statements/create-ingest-rule.rst
+++ b/blackbox/docs/sql/statements/create-ingest-rule.rst
@@ -6,6 +6,10 @@
 
 Defines a new ingestion rule.
 
+   .. WARNING::
+
+      This statement has been deprecated and will be removed in the future.
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/sql/statements/drop-ingest-rule.rst
+++ b/blackbox/docs/sql/statements/drop-ingest-rule.rst
@@ -8,6 +8,10 @@
 
 Deletes an existing ingestion rule.
 
+   .. WARNING::
+
+      This statement has been deprecated and will be removed in the future.
+
 .. rubric:: Table of Contents
 
 .. contents::


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed