### PR TITLE
Ensure the license tool jar name contains no classifier suffix.

### DIFF
--- a/licensing/build.gradle
+++ b/licensing/build.gradle
@@ -57,3 +57,8 @@ processResources {
     println "No crate public key provided"
   }
 }
+
+shadowJar {
+    // Ensure we'll end up in a file called `crate-license.jar` without any classifier suffix.
+    classifier = null
+}


### PR DESCRIPTION
Since Gradle 5.1, the classifier is null and thus the shadowJar tool
will create a JAR without any classifier suffix.
By setting the `classifier` to null explicit, the output JAR name
of the licensing tool will always be the same.

Relates to https://github.com/crate/jenkins-dsl/pull/587.

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
