### PR TITLE
Only throttle on upsert if source IT involves IO

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -75,6 +75,8 @@ Changes
 Fixes
 =====
 
+- Fixed performance regression when inserting data using ``unnest()``.
+
 - Fixed an issue where an ordered query with a specified limit that was much
   larger than the available rows would result in ``OutOfMemoryError`` even
   though the number of available rows could fit in memory.

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -75,6 +75,8 @@ Changes
 Fixes
 =====
 
+- Fixed performance regression on ``UPDATE`` and ``DELETE`` operations.
+
 - Fixed performance regression when inserting data using ``unnest()``.
 
 - Fixed an issue where an ordered query with a specified limit that was much

--- a/dex/src/main/java/io/crate/data/AsyncCompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncCompositeBatchIterator.java
@@ -161,4 +161,14 @@ public class AsyncCompositeBatchIterator<T> implements BatchIterator<T> {
             iterator.kill(throwable);
         }
     }
+
+    @Override
+    public boolean involvesIO() {
+        for (BatchIterator iterator : iterators) {
+            if (iterator.involvesIO()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -193,6 +193,11 @@ public class AsyncOperationBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
+    public boolean involvesIO() {
+        return source.involvesIO();
+    }
+
+    @Override
     public String toString() {
         return "AsyncOperationBatchIterator{" +
                "source=" + source +

--- a/dex/src/main/java/io/crate/data/BatchIterator.java
+++ b/dex/src/main/java/io/crate/data/BatchIterator.java
@@ -127,4 +127,9 @@ public interface BatchIterator<T> extends Killable {
      * @return true if no more batches can be loaded
      */
     boolean allLoaded();
+
+    /**
+     * @return true if any IO (disk, network) is used
+     */
+    boolean involvesIO();
 }

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -93,4 +93,9 @@ public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
         delegate.kill(throwable);
         killed = throwable;
     }
+
+    @Override
+    public boolean involvesIO() {
+        return delegate.involvesIO();
+    }
 }

--- a/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
@@ -117,4 +117,14 @@ public class CompositeBatchIterator<T> implements BatchIterator<T> {
             iterator.kill(throwable);
         }
     }
+
+    @Override
+    public boolean involvesIO() {
+        for (BatchIterator iterator : iterators) {
+            if (iterator.involvesIO()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
@@ -97,4 +97,9 @@ public final class FlatMapBatchIterator<TIn, TOut> implements BatchIterator<TOut
     public void kill(@Nonnull Throwable throwable) {
         source.kill(throwable);
     }
+
+    @Override
+    public boolean involvesIO() {
+        return source.involvesIO();
+    }
 }

--- a/dex/src/main/java/io/crate/data/ForwardingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/ForwardingBatchIterator.java
@@ -31,4 +31,10 @@ public abstract class ForwardingBatchIterator<T> extends MappedForwardingBatchIt
     public T currentElement() {
         return delegate().currentElement();
     }
+
+
+    @Override
+    public boolean involvesIO() {
+        return delegate().involvesIO();
+    }
 }

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -105,4 +105,9 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     public void kill(@Nonnull Throwable throwable) {
         // handled by CloseAssertingBatchIterator
     }
+
+    @Override
+    public boolean involvesIO() {
+        return false;
+    }
 }

--- a/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
@@ -61,4 +61,9 @@ public abstract class MappedForwardingBatchIterator<I, O> implements BatchIterat
     public void kill(@Nonnull Throwable throwable) {
         delegate().kill(throwable);
     }
+
+    @Override
+    public boolean involvesIO() {
+        return delegate().involvesIO();
+    }
 }

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
@@ -111,4 +111,12 @@ public abstract class JoinBatchIterator<L, R, C> implements BatchIterator<C> {
         left.kill(throwable);
         right.kill(throwable);
     }
+
+    @Override
+    public boolean involvesIO() {
+        if (left.involvesIO()) {
+            return true;
+        }
+        return right.involvesIO();
+    }
 }

--- a/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
@@ -159,4 +159,9 @@ class SemiJoinNLBatchIterator<L, R, C> implements BatchIterator<L> {
         }
         return false;
     }
+
+    @Override
+    public boolean involvesIO() {
+        return false;
+    }
 }

--- a/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
@@ -79,7 +79,8 @@ public class CollectingBatchIteratorTest {
         BatchIterator<Row> collectingBatchIterator = CollectingBatchIterator.newInstance(
             () -> {},
             t -> {},
-            () -> loadItemsFuture);
+            () -> loadItemsFuture,
+            false);
         loadItemsFuture.completeExceptionally(new RuntimeException());
         assertThat(collectingBatchIterator.loadNextBatch().toCompletableFuture().isCompletedExceptionally(), is(true));
     }

--- a/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
+++ b/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
@@ -151,4 +151,9 @@ public class BatchSimulatingIterator<T> implements BatchIterator<T> {
     public int getMovetoStartCalls() {
         return moveToStartCalls;
     }
+
+    @Override
+    public boolean involvesIO() {
+        return delegate.involvesIO();
+    }
 }

--- a/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -71,7 +71,8 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
         lazyBatchIterator = CollectingBatchIterator.newInstance(
             () -> {},
             t -> {},
-            () -> processingFuture);
+            () -> processingFuture,
+            true);
         rowConsumer.accept(lazyBatchIterator, null);
         accumulateRowsFunction = (Bucket rows) -> {
             try {

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -199,7 +199,8 @@ final class GroupByOptimizedIterator {
                     } catch (Throwable t) {
                         return failedFuture(t);
                     }
-                }
+                },
+                true
             );
         } catch (Throwable t) {
             searcher.close();

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -119,7 +119,8 @@ public class RemoteCollectorFactory {
             () -> {
                 shardStateAwareRemoteCollector.doCollect();
                 return consumer.resultFuture().thenApply(results -> results.stream().map(Buckets.arrayToSharedRow())::iterator);
-            }
+            },
+            true
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -203,6 +203,11 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
         return true;
     }
 
+    @Override
+    public boolean involvesIO() {
+        return true;
+    }
+
     private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {
         if (liveDocs == null) {
             return false;

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
@@ -77,7 +77,8 @@ public final class NodeStats {
                 nodes,
                 txnCtx,
                 inputFactory
-            )
+            ),
+            true
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -269,6 +269,11 @@ public class FileReadingIterator implements BatchIterator<Row> {
         return true;
     }
 
+    @Override
+    public boolean involvesIO() {
+        return true;
+    }
+
     private static class UriWithGlob {
         final URI uri;
         final URI preGlobUri;

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -144,7 +144,9 @@ public class SystemCollectSource implements CollectSource {
                             supportMoveToStart,
                             records
                         )
-                    )
+                    ),
+            // Most system resources are in-memory but some are not and involves IO.
+            true
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -148,6 +148,11 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
         return isUpstreamExhausted.getAsBoolean();
     }
 
+    @Override
+    public boolean involvesIO() {
+        return true;
+    }
+
     private void raiseIfClosedOrKilled() {
         Throwable err;
         synchronized (this) {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -133,7 +133,7 @@ public class ColumnIndexWriterProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor);
+        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.involvesIO());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
@@ -37,7 +37,7 @@ public class DMLProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, batchAccumulator);
+        return CollectingBatchIterator.newInstance(batchIterator, batchAccumulator, batchIterator.involvesIO());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -138,7 +138,7 @@ public class IndexWriterProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor);
+        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.involvesIO());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -69,7 +69,6 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     private final Supplier<TReq> requestFactory;
     private final Function<String, TItem> itemFactory;
     private final BiConsumer<TReq, ActionListener<ShardResponse>> operation;
-    private final Predicate<TReq> shouldPause;
     private final String localNodeId;
 
     private int numItems = -1;
@@ -92,9 +91,6 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         this.itemFactory = itemFactory;
         this.operation = transportAction;
         this.localNodeId = getLocalNodeId(clusterService);
-
-        this.shouldPause = ignored ->
-            nodeJobsCounter.getInProgressJobsForNode(localNodeId) >= MAX_NODE_CONCURRENT_OPERATIONS;
     }
 
     private void addRowToRequest(TReq req, Row row) {
@@ -126,6 +122,15 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
             BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest, r -> false);
         BinaryOperator<Long> combinePartialResult = (a, b) -> a + b;
         long initialResult = 0L;
+
+        // If the source batch iterator does not involve IO, mostly in-memory structures are used which we want to free
+        // as soon as possible. We do not want to throttle based on the targets node counter in such cases.
+        Predicate<TReq> shouldPause = ignored -> true;
+        if (batchIterator.involvesIO()) {
+            shouldPause = ignored ->
+                nodeJobsCounter.getInProgressJobsForNode(localNodeId) >= MAX_NODE_CONCURRENT_OPERATIONS;
+        }
+
         return new BatchIteratorBackpressureExecutor<>(
             scheduler,
             executor,


### PR DESCRIPTION
If IO (disk, network) is involved the source iterator should pause when
the target node reaches a concurrent job counter limit.
Without IO, we assume that the source iterates over in-memory structures
which should be processed as fast as possible to free resources.

Benchmark results compared to MASTER:
```
Q: insert into id_int_value_str (id, value) (select col1, col2 from unnest(?, ?))
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        9.005 ±    3.863 |      2.042 |      7.613 |     10.296 |     42.579 |
|   V2    |        8.255 ±    2.626 |      2.086 |      7.403 |      8.732 |     21.355 |
mean:   -   8.68%
median: -   2.80%
Likely significant
```


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
