### PR TITLE
docs: Clarify that sys checks won't be disabled with the fs allocation decider

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -849,6 +849,7 @@ then :ref:`gateway.recover_after_time <gateway.recover_after_time>` must not be
 set to ``0s``, otherwise the ``gateway.recover_after_nodes`` setting wouldn't
 have any effect.
 
+.. _node_checks_watermark_high:
 
 Routing Allocation Disk Watermark High
 ......................................
@@ -858,6 +859,9 @@ The check for the :ref:`cluster.routing.allocation.disk.watermark.high
 high watermark is not exceeded on the current node. The usage of each disk for
 configured CrateDB data paths is verified against the threshold setting. If one
 or more verification fails the check is marked as not passed.
+
+
+.. _node_checks_watermark_low:
 
 Routing Allocation Disk Watermark Low
 .....................................

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -824,6 +824,14 @@ By default, the cluster will retrieve information about the disk usage of the
 nodes every 30 seconds. This can also be changed by setting the
 `cluster.info.update.interval`_ setting.
 
+.. NOTE::
+
+   The watermark settings are also used for the
+   :ref:`node_checks_watermark_low` and :ref:`node_checks_watermark_high` node
+   check. Setting ``cluster.routing.allocation.disk.threshold_enabled`` to
+   false will disable the allocation decider, but the node checks will still be
+   active and warn users about running low on disk space.
+
 Recovery
 --------
 


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed