### PR TITLE
Remove the http.enabled and http.pipelining settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     runtime project(':enterprise:functions')
 
     testCompile project(':integration-testing')
+    testCompile project(':http')
     testCompile project(path: ':sql', configuration: 'testOutput')
     testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
         exclude group: 'net.java.dev.jna', module: 'jna'

--- a/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +55,7 @@ public class PluginLoaderTest extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singletonList(PluginLoaderPlugin.class);
+        return Arrays.asList(PluginLoaderPlugin.class, HttpTransportPlugin.class);
     }
 
     @Test

--- a/azure-discovery/build.gradle
+++ b/azure-discovery/build.gradle
@@ -31,6 +31,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
     testCompile project(':integration-testing')
+    testCompile project(':http')
     testCompile('com.microsoft.azure:azure-mgmt-utility:0.9.8') {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'javax.mail', module: 'mail'

--- a/azure-discovery/src/test/java/io/crate/azure/AzureSimpleTests.java
+++ b/azure-discovery/src/test/java/io/crate/azure/AzureSimpleTests.java
@@ -22,12 +22,14 @@ package io.crate.azure;
 import io.crate.azure.management.AzureComputeService.Discovery;
 import io.crate.azure.management.AzureComputeService.Management;
 import io.crate.azure.plugin.AzureDiscoveryPlugin;
+import io.crate.plugin.HttpTransportPlugin;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -41,7 +43,7 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singletonList(AzureDiscoveryPlugin.class);
+        return Arrays.asList(AzureDiscoveryPlugin.class, HttpTransportPlugin.class);
     }
 
     @Test

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -49,6 +49,9 @@ Breaking Changes
   thread-pool. The JMX ``getBulk`` property of the ``ThreadPools`` bean has
   been renamed too ``getWrite``.
 
+- Removed the deprecated ``http.enabled`` setting. ``HTTP`` is now always
+  enabled and can no longer be disabled.
+
 Changes
 =======
 

--- a/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.common.network.NetworkModule.HTTP_ENABLED;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_COMPRESSION;
@@ -69,7 +68,6 @@ public abstract class BlobIntegrationTestBase extends ESIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
-            .put(HTTP_ENABLED.getKey(), true)
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
             .put(SETTING_HTTP_COMPRESSION.getKey(), false)

--- a/enterprise/users/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -50,7 +50,6 @@ public class AuthenticationIntegrationTest extends SQLTransportIntegrationTest {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put("network.host", "127.0.0.1")
-            .put("http.enabled", true)
             .put("http.host", "127.0.0.1")
             .put("http.cors.enabled", true)
             .put("http.cors.allow-origin", "*")

--- a/es/es-server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -68,8 +68,6 @@ public final class NetworkModule {
             Property.NodeScope);
     public static final Setting<String> HTTP_DEFAULT_TYPE_SETTING = Setting.simpleString(HTTP_TYPE_DEFAULT_KEY, Property.NodeScope);
     public static final Setting<String> HTTP_TYPE_SETTING = Setting.simpleString(HTTP_TYPE_KEY, Property.NodeScope);
-    public static final Setting<Boolean> HTTP_ENABLED = Setting.boolSetting("http.enabled", true,
-        Property.NodeScope, Property.Deprecated);
     public static final Setting<String> TRANSPORT_TYPE_SETTING = Setting.simpleString(TRANSPORT_TYPE_KEY, Property.NodeScope);
 
     private final Settings settings;
@@ -107,12 +105,10 @@ public final class NetworkModule {
                          NetworkService networkService, HttpServerTransport.Dispatcher dispatcher) {
         this.settings = settings;
         for (NetworkPlugin plugin : plugins) {
-            if (HTTP_ENABLED.get(settings)) {
-                Map<String, Supplier<HttpServerTransport>> httpTransportFactory = plugin.getHttpTransports(settings, threadPool, bigArrays,
-                    circuitBreakerService, namedWriteableRegistry, xContentRegistry, networkService, dispatcher);
-                for (Map.Entry<String, Supplier<HttpServerTransport>> entry : httpTransportFactory.entrySet()) {
-                    registerHttpTransport(entry.getKey(), entry.getValue());
-                }
+            Map<String, Supplier<HttpServerTransport>> httpTransportFactory = plugin.getHttpTransports(settings, threadPool, bigArrays,
+                circuitBreakerService, namedWriteableRegistry, xContentRegistry, networkService, dispatcher);
+            for (Map.Entry<String, Supplier<HttpServerTransport>> entry : httpTransportFactory.entrySet()) {
+                registerHttpTransport(entry.getKey(), entry.getValue());
             }
             Map<String, Supplier<Transport>> transportFactory = plugin.getTransports(settings, threadPool, bigArrays, pageCacheRecycler,
                 circuitBreakerService, namedWriteableRegistry, networkService);
@@ -178,10 +174,6 @@ public final class NetworkModule {
             throw new IllegalStateException("Unsupported http.type [" + name + "]");
         }
         return factory;
-    }
-
-    public boolean isHttpEnabled() {
-        return HTTP_ENABLED.get(settings);
     }
 
     public Supplier<Transport> getTransportSupplier() {

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -213,7 +213,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     HttpTransportSettings.SETTING_CORS_ENABLED,
                     HttpTransportSettings.SETTING_CORS_MAX_AGE,
                     HttpTransportSettings.SETTING_HTTP_DETAILED_ERRORS_ENABLED,
-                    HttpTransportSettings.SETTING_PIPELINING,
                     HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN,
                     HttpTransportSettings.SETTING_HTTP_HOST,
                     HttpTransportSettings.SETTING_HTTP_PUBLISH_HOST,

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -205,7 +205,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     GatewayService.RECOVER_AFTER_MASTER_NODES_SETTING,
                     GatewayService.RECOVER_AFTER_NODES_SETTING,
                     GatewayService.RECOVER_AFTER_TIME_SETTING,
-                    NetworkModule.HTTP_ENABLED,
                     NetworkModule.HTTP_DEFAULT_TYPE_SETTING,
                     NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING,
                     NetworkModule.HTTP_TYPE_SETTING,

--- a/es/es-server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -49,9 +49,6 @@ public final class HttpTransportSettings {
         new Setting<>("http.cors.allow-headers", "X-Requested-With,Content-Type,Content-Length", (value) -> value, Property.NodeScope);
     public static final Setting<Boolean> SETTING_CORS_ALLOW_CREDENTIALS =
         Setting.boolSetting("http.cors.allow-credentials", false, Property.NodeScope);
-    // In 7.0 pipelining support will always be enabled and this setting will be removed.
-    public static final Setting<Boolean> SETTING_PIPELINING =
-        Setting.boolSetting("http.pipelining", true, Property.NodeScope, Property.Deprecated);
     public static final Setting<Integer> SETTING_PIPELINING_MAX_EVENTS =
         Setting.intSetting("http.pipelining.max_events", 10000, Property.NodeScope);
     public static final Setting<Boolean> SETTING_HTTP_COMPRESSION =

--- a/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1451,7 +1451,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         return new InternalTestCluster(seed, createTempDir(), supportsDedicatedMasters, getAutoMinMasterNodes(),
             minNumDataNodes, maxNumDataNodes,
             InternalTestCluster.clusterName(scope.name(), seed) + "-cluster", nodeConfigurationSource, getNumClientNodes(),
-            InternalTestCluster.DEFAULT_ENABLE_HTTP_PIPELINING, nodePrefix, mockPlugins, getClientWrapper(), forbidPrivateIndexSettings());
+            nodePrefix, mockPlugins, getClientWrapper(), forbidPrivateIndexSettings());
     }
 
     protected NodeConfigurationSource getNodeConfigSource() {

--- a/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1464,7 +1464,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
                 return Settings.builder()
-                    .put(NetworkModule.HTTP_ENABLED.getKey(), false)
                     .put(networkSettings.build())
                     .put(ESIntegTestCase.this.nodeSettings(nodeOrdinal)).build();
             }

--- a/es/es-testing/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -182,7 +182,6 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), createTempDir().getParent())
             .put("node.name", "node_s_0")
             .put(EsExecutors.PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
-            .put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .put("transport.type", getTestTransportType())
             .put(Node.NODE_DATA_SETTING.getKey(), true)
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())

--- a/es/es-testing/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -178,8 +178,6 @@ public final class InternalTestCluster extends TestCluster {
     static final int DEFAULT_MIN_NUM_CLIENT_NODES = 0;
     static final int DEFAULT_MAX_NUM_CLIENT_NODES = 1;
 
-    static final boolean DEFAULT_ENABLE_HTTP_PIPELINING = true;
-
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();
 
@@ -235,7 +233,6 @@ public final class InternalTestCluster extends TestCluster {
             final String clusterName,
             final NodeConfigurationSource nodeConfigurationSource,
             final int numClientNodes,
-            final boolean enableHttpPipelining,
             final String nodePrefix,
             final Collection<Class<? extends Plugin>> mockPlugins,
             final Function<Client, Client> clientWrapper) {
@@ -249,7 +246,6 @@ public final class InternalTestCluster extends TestCluster {
                 clusterName,
                 nodeConfigurationSource,
                 numClientNodes,
-                enableHttpPipelining,
                 nodePrefix,
                 mockPlugins,
                 clientWrapper,
@@ -266,7 +262,6 @@ public final class InternalTestCluster extends TestCluster {
             final String clusterName,
             final NodeConfigurationSource nodeConfigurationSource,
             final int numClientNodes,
-            final boolean enableHttpPipelining,
             final String nodePrefix,
             final Collection<Class<? extends Plugin>> mockPlugins,
             final Function<Client, Client> clientWrapper,
@@ -351,7 +346,6 @@ public final class InternalTestCluster extends TestCluster {
         builder.put(Environment.PATH_REPO_SETTING.getKey(), baseDir.resolve("repos"));
         builder.put(TcpTransport.PORT.getKey(), 0);
         builder.put("http.port", 0);
-        builder.put("http.pipelining", enableHttpPipelining);
         if (Strings.hasLength(System.getProperty("tests.es.logger.level"))) {
             builder.put("logger.level", System.getProperty("tests.es.logger.level"));
         }

--- a/es/es-testing/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -138,7 +138,6 @@ public class ClusterDiscoveryConfiguration extends NodeConfigurationSource {
                 // we need to pin the node port & host so we'd know where to point things
                 builder.put(TcpTransport.PORT.getKey(), unicastHostPorts[nodeOrdinal]);
                 builder.put(TcpTransport.HOST.getKey(), IP_ADDR); // only bind on one IF we use v4 here by default
-                builder.put(NetworkModule.HTTP_ENABLED.getKey(), false);
                 for (int i = 0; i < unicastHostOrdinals.length; i++) {
                     unicastHosts[i] = IP_ADDR + ":" + (unicastHostPorts[unicastHostOrdinals[i]]);
                 }

--- a/es/es-testing/src/test/java/org/elasticsearch/node/MockNodeTests.java
+++ b/es/es-testing/src/test/java/org/elasticsearch/node/MockNodeTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.node;
 
-import org.elasticsearch.common.network.NetworkModule;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
@@ -41,7 +39,6 @@ public class MockNodeTests extends ESTestCase {
         Settings settings = Settings.builder() // All these are required or MockNode will fail to build.
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put("transport.type", getTestTransportType())
-                .put("http.enabled", false)
                 .build();
         List<Class<? extends Plugin>> plugins = new ArrayList<>();
         plugins.add(getTestTransportPlugin());
@@ -57,6 +54,5 @@ public class MockNodeTests extends ESTestCase {
                 assertSame(bigArrays.getClass(), BigArrays.class);
             }
         }
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] {NetworkModule.HTTP_ENABLED});
     }
 }

--- a/es/es-testing/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/es/es-testing/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -71,7 +71,7 @@ import static org.hamcrest.Matchers.not;
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // doesn't work with potential multi data path from test cluster yet
 public class InternalTestClusterTests extends ESTestCase {
 
-    private static final Setting<?>[] DEPRECATED_SETTINGS = {NetworkModule.HTTP_ENABLED, HttpTransportSettings.SETTING_PIPELINING};
+    private static final Setting<?>[] DEPRECATED_SETTINGS = {HttpTransportSettings.SETTING_PIPELINING};
 
     public void testInitializiationIsConsistent() {
         long clusterSeed = randomLong();
@@ -189,7 +189,6 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 * ((masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes))
-                    .put(NetworkModule.HTTP_ENABLED.getKey(), false)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
                 if (autoManageMinMasterNodes == false) {
                     assert minNumDataNodes == maxNumDataNodes;
@@ -252,9 +251,6 @@ public class InternalTestClusterTests extends ESTestCase {
             cluster1.afterTest();
         } finally {
             IOUtils.close(cluster0, cluster1);
-            if (shouldAssertSettingsDeprecationsAndWarnings) {
-                assertSettingDeprecationsAndWarnings(new Setting<?>[] {NetworkModule.HTTP_ENABLED});
-            }
         }
     }
 
@@ -270,7 +266,7 @@ public class InternalTestClusterTests extends ESTestCase {
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
-                return Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
+                return Settings.builder()
                     .put(
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
@@ -383,7 +379,6 @@ public class InternalTestClusterTests extends ESTestCase {
             public Settings nodeSettings(int nodeOrdinal) {
                 return Settings.builder()
                         .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), numNodes)
-                        .put(NetworkModule.HTTP_ENABLED.getKey(), false)
                         .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                         .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0)
                         // speedup join timeout as setting initial state timeout to 0 makes split
@@ -469,7 +464,7 @@ public class InternalTestClusterTests extends ESTestCase {
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
-                return Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
+                return Settings.builder()
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .build();

--- a/es/es-testing/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/es/es-testing/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -71,8 +71,6 @@ import static org.hamcrest.Matchers.not;
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // doesn't work with potential multi data path from test cluster yet
 public class InternalTestClusterTests extends ESTestCase {
 
-    private static final Setting<?>[] DEPRECATED_SETTINGS = {HttpTransportSettings.SETTING_PIPELINING};
-
     public void testInitializiationIsConsistent() {
         long clusterSeed = randomLong();
         boolean masterNodes = randomBoolean();
@@ -81,16 +79,15 @@ public class InternalTestClusterTests extends ESTestCase {
         String clusterName = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
         NodeConfigurationSource nodeConfigurationSource = NodeConfigurationSource.EMPTY;
         int numClientNodes = randomIntBetween(0, 10);
-        boolean enableHttpPipelining = randomBoolean();
         String nodePrefix = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
 
         Path baseDir = createTempDir();
         InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             randomBoolean(), minNumDataNodes, maxNumDataNodes, clusterName, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, Collections.emptyList(), Function.identity());
+            nodePrefix, Collections.emptyList(), Function.identity());
         InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             randomBoolean(), minNumDataNodes, maxNumDataNodes, clusterName, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, Collections.emptyList(), Function.identity());
+            nodePrefix, Collections.emptyList(), Function.identity());
         // TODO: this is not ideal - we should have a way to make sure ports are initialized in the same way
         assertClusters(cluster0, cluster1, false);
 
@@ -210,17 +207,16 @@ public class InternalTestClusterTests extends ESTestCase {
             }
         };
 
-        boolean enableHttpPipelining = randomBoolean();
         String nodePrefix = "foobar";
 
         Path baseDir = createTempDir();
         final List<Class<? extends Plugin>> mockPlugins = Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class);
         InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             autoManageMinMasterNodes, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, mockPlugins, Function.identity());
+            nodePrefix, mockPlugins, Function.identity());
         InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             autoManageMinMasterNodes, minNumDataNodes, maxNumDataNodes, clusterName2, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, mockPlugins, Function.identity());
+            nodePrefix, mockPlugins, Function.identity());
 
         assertClusters(cluster0, cluster1, false);
         long seed = randomLong();
@@ -235,10 +231,6 @@ public class InternalTestClusterTests extends ESTestCase {
                 cluster1.beforeTest(random);
             }
             assertArrayEquals(cluster0.getNodeNames(), cluster1.getNodeNames());
-            if (cluster0.getNodeNames().length > 0) {
-                shouldAssertSettingsDeprecationsAndWarnings = true;
-                assertSettingDeprecationsAndWarnings(DEPRECATED_SETTINGS);
-            }
             Iterator<Client> iterator1 = cluster1.getClients().iterator();
             for (Client client : cluster0.getClients()) {
                 assertTrue(iterator1.hasNext());
@@ -285,12 +277,11 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, transportClient).build();
             }
         };
-        boolean enableHttpPipelining = randomBoolean();
         String nodePrefix = "test";
         Path baseDir = createTempDir();
         InternalTestCluster cluster = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             true, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class),
+            nodePrefix, Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class),
             Function.identity());
         try {
             cluster.beforeTest(random());
@@ -356,7 +347,6 @@ public class InternalTestClusterTests extends ESTestCase {
         } finally {
             cluster.close();
         }
-        assertSettingDeprecationsAndWarnings(DEPRECATED_SETTINGS);
     }
 
     private Path[] getNodePaths(InternalTestCluster cluster, String name) {
@@ -397,7 +387,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                         .put(NetworkModule.TRANSPORT_TYPE_KEY, transportClient).build();
             }
-        }, 0, randomBoolean(), "", Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
+        }, 0, "", Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
         cluster.beforeTest(random());
         List<DiscoveryNode.Role> roles = new ArrayList<>();
         for (int i = 0; i < numNodes; i++) {
@@ -456,7 +446,6 @@ public class InternalTestClusterTests extends ESTestCase {
         } finally {
             cluster.close();
         }
-        assertSettingDeprecationsAndWarnings(DEPRECATED_SETTINGS);
     }
 
     public void testTwoNodeCluster() throws Exception {
@@ -481,13 +470,12 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, transportClient).build();
             }
         };
-        boolean enableHttpPipelining = randomBoolean();
         String nodePrefix = "test";
         Path baseDir = createTempDir();
         List<Class<? extends Plugin>> plugins = new ArrayList<>(Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class));
         plugins.add(NodeAttrCheckPlugin.class);
         InternalTestCluster cluster = new InternalTestCluster(randomLong(), baseDir, false, true, 2, 2,
-            "test", nodeConfigurationSource, 0, enableHttpPipelining, nodePrefix,
+            "test", nodeConfigurationSource, 0, nodePrefix,
             plugins, Function.identity());
         try {
             cluster.beforeTest(random());
@@ -522,7 +510,6 @@ public class InternalTestClusterTests extends ESTestCase {
         } finally {
             cluster.close();
         }
-        assertSettingDeprecationsAndWarnings(DEPRECATED_SETTINGS);
     }
 
     /**

--- a/es/es-transport/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestHandler.java
+++ b/es/es-transport/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestHandler.java
@@ -39,13 +39,11 @@ import java.util.Collections;
 class Netty4HttpRequestHandler extends SimpleChannelInboundHandler<Object> {
 
     private final Netty4HttpServerTransport serverTransport;
-    private final boolean httpPipeliningEnabled;
     private final boolean detailedErrorsEnabled;
     private final ThreadContext threadContext;
 
     Netty4HttpRequestHandler(Netty4HttpServerTransport serverTransport, boolean detailedErrorsEnabled, ThreadContext threadContext) {
         this.serverTransport = serverTransport;
-        this.httpPipeliningEnabled = serverTransport.pipelining;
         this.detailedErrorsEnabled = detailedErrorsEnabled;
         this.threadContext = threadContext;
     }
@@ -54,7 +52,7 @@ class Netty4HttpRequestHandler extends SimpleChannelInboundHandler<Object> {
     protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
         final FullHttpRequest request;
         final HttpPipelinedRequest pipelinedRequest;
-        if (this.httpPipeliningEnabled && msg instanceof HttpPipelinedRequest) {
+        if (msg instanceof HttpPipelinedRequest) {
             pipelinedRequest = (HttpPipelinedRequest) msg;
             request = (FullHttpRequest) pipelinedRequest.last();
         } else {

--- a/es/es-transport/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/es/es-transport/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -117,7 +117,6 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_TCP_NO_D
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_TCP_RECEIVE_BUFFER_SIZE;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_TCP_REUSE_ADDRESS;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_TCP_SEND_BUFFER_SIZE;
-import static org.elasticsearch.http.HttpTransportSettings.SETTING_PIPELINING;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_PIPELINING_MAX_EVENTS;
 import static org.elasticsearch.http.netty4.cors.Netty4CorsHandler.ANY_ORIGIN;
 
@@ -198,8 +197,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
     protected final ByteSizeValue maxChunkSize;
 
     protected final int workerCount;
-
-    protected final boolean pipelining;
 
     protected final int pipeliningMaxEvents;
 
@@ -294,7 +291,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
 
         this.compression = SETTING_HTTP_COMPRESSION.get(settings);
         this.compressionLevel = SETTING_HTTP_COMPRESSION_LEVEL.get(settings);
-        this.pipelining = SETTING_PIPELINING.get(settings);
         this.pipeliningMaxEvents = SETTING_PIPELINING_MAX_EVENTS.get(settings);
         this.corsConfig = buildCorsConfig(settings);
 
@@ -309,9 +305,9 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         this.maxContentLength = maxContentLength;
 
         logger.debug("using max_chunk_size[{}], max_header_size[{}], max_initial_line_length[{}], max_content_length[{}], " +
-                "receive_predictor[{}->{}], max_composite_buffer_components[{}], pipelining[{}], pipelining_max_events[{}]",
+                "receive_predictor[{}->{}], max_composite_buffer_components[{}], pipelining_max_events[{}]",
             maxChunkSize, maxHeaderSize, maxInitialLineLength, this.maxContentLength,
-            receivePredictorMin, receivePredictorMax, maxCompositeBufferComponents, pipelining, pipeliningMaxEvents);
+            receivePredictorMin, receivePredictorMax, maxCompositeBufferComponents, pipeliningMaxEvents);
     }
 
     public Settings settings() {
@@ -618,9 +614,7 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
             if (SETTING_CORS_ENABLED.get(transport.settings())) {
                 ch.pipeline().addLast("cors", new Netty4CorsHandler(transport.getCorsConfig()));
             }
-            if (transport.pipelining) {
-                ch.pipeline().addLast("pipelining", new HttpPipeliningHandler(transport.logger, transport.pipeliningMaxEvents));
-            }
+            ch.pipeline().addLast("pipelining", new HttpPipeliningHandler(transport.logger, transport.pipeliningMaxEvents));
             ch.pipeline().addLast("handler", requestHandler);
         }
 

--- a/http/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
+++ b/http/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.common.network.NetworkModule.HTTP_DEFAULT_TYPE_SETTING;
-import static org.elasticsearch.common.network.NetworkModule.HTTP_ENABLED;
 import static org.hamcrest.core.Is.is;
 
 public abstract class AdminUIHttpIntegrationTest extends ESIntegTestCase {
@@ -66,7 +65,6 @@ public abstract class AdminUIHttpIntegrationTest extends ESIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
-            .put(HTTP_ENABLED.getKey(), true)
             .put(HTTP_DEFAULT_TYPE_SETTING.getKey(), "netty4")
             .build();
     }

--- a/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
@@ -46,7 +46,6 @@ public class BelowMinNumberOfNodesITest extends SQLTransportIntegrationTest {
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
-            .put("http.enabled", true)
             .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), 2)
             .build();
     }

--- a/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -66,7 +66,6 @@ public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
-            .put("http.enabled", true)
             .put("http.host", "127.0.0.1")
             .build();
     }

--- a/sql/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -33,14 +33,6 @@ import static org.hamcrest.Matchers.startsWith;
 @ESIntegTestCase.ClusterScope(numClientNodes = 0)
 public class SysNodesITest extends SQLTransportIntegrationTest {
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put("http.enabled", true)
-            .build();
-    }
-
     @Test
     public void testNoMatchingNode() throws Exception {
         execute("select id, name, hostname from sys.nodes where id = 'does-not-exist'");


### PR DESCRIPTION
Both were deprecated and the second one wasn't documented in CrateDB.


 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed