### PR TITLE
Add a node check that checks the JVM version

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -784,8 +784,9 @@ Example query::
   |  5 | ...         | The high disk watermark is exceeded on the node. The cluster ... |
   |  6 | ...         | The low disk watermark is exceeded on the node. The cluster w... |
   |  7 | ...         | The flood stage disk watermark is exceeded on the node. Table... |
+  |  8 | ...         | The JVM version with which CrateDB is running should be >= 11... |
   +----+---------...-+--------------------------------------------------------------...-+
-  SELECT 6 rows in set (... sec)
+  SELECT 7 rows in set (... sec)
 
 .. _sys-node-checks-ack:
 
@@ -872,6 +873,18 @@ watermark for the node disk usage. The check verifies that the low watermark is
 not exceeded on the current node. The verification is done against each disk
 for configured CrateDB data paths. The check is not passed if the verification
 for one or more disk fails.
+
+
+JVM Version
+...........
+
+
+The check for the JVM version checks if CrateDB is running under Java 11 or
+later. If not the check fails as we're dropping support for earlier versions in
+future release. This is a low severity check that doesn't require immediate
+action. But to be able to upgrade to future version the JVM should be upgraded
+eventually.
+
 
 .. _sys-shards:
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ None
 Changes
 =======
 
+- Added a node check that checks the JVM version under which CrateDB is
+  running. We recommend users to upgrade to JVM 11 as support for older
+  versions will be dropped in the future.
+
 - Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` command that
   triggers the existing node decommission functionality.
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.sys.check.node;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
+import java.util.StringTokenizer;
+
+@Singleton
+public final class JvmVersionNodeCheck extends AbstractSysNodeCheck {
+
+    public static final int ID = 8;
+    private static final Logger LOGGER = LogManager.getLogger(JvmVersionNodeCheck.class);
+
+    private static final String DESCRIPTION =
+        "The JVM version with which CrateDB is running should be >= 11. " +
+        "Support for older versions will be removed in the future. Current version is: " + Constants.JAVA_VERSION;
+
+    @Inject
+    public JvmVersionNodeCheck() {
+        super(ID, DESCRIPTION, Severity.LOW);
+    }
+
+    @Override
+    public boolean validate() {
+        try {
+            return isOnOrAfter11(Constants.JAVA_VERSION);
+        } catch (Exception e) {
+            LOGGER.error("Error parsing java version={} error={}", Constants.JAVA_VERSION, e);
+            return false;
+        }
+    }
+
+    /**
+     * Parse a Java version string into an array of [major, minor, hotfix]
+     */
+    static int[] parseVersion(String javaVersion) {
+        StringTokenizer stBuild = new StringTokenizer(javaVersion, "_");
+        String javaVersionWithoutBuildNumber = stBuild.nextToken();
+
+        StringTokenizer stVersionParts = new StringTokenizer(javaVersionWithoutBuildNumber, ".");
+        String firstToken = stVersionParts.nextToken();
+        try {
+            int major = Integer.parseInt(firstToken);
+            int minor = Integer.parseInt(stVersionParts.nextToken());
+            int hotfix = Integer.parseInt(stVersionParts.nextToken());
+            return new int[] {major, minor, hotfix};
+        } catch (NumberFormatException e) {
+            if (firstToken.endsWith("ea")) {
+                int major = Integer.parseInt(firstToken.substring(0, firstToken.length() - 2));
+                return new int[] {major, 0, 0};
+            }
+            throw e;
+        }
+    }
+
+    static boolean isOnOrAfter11(String javaVersion) {
+        int[] version = parseVersion(javaVersion);
+        return version[0] >= 11;
+    }
+}

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/SysNodeChecksModule.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/SysNodeChecksModule.java
@@ -40,5 +40,6 @@ public class SysNodeChecksModule extends AbstractModule {
         b.addBinding(HighDiskWatermarkNodesSysCheck.ID).to(HighDiskWatermarkNodesSysCheck.class);
         b.addBinding(LowDiskWatermarkNodesSysCheck.ID).to(LowDiskWatermarkNodesSysCheck.class);
         b.addBinding(FloodStageDiskWatermarkNodesSysCheck.ID).to(FloodStageDiskWatermarkNodesSysCheck.class);
+        b.addBinding(JvmVersionNodeCheck.ID).to(JvmVersionNodeCheck.class);
     }
 }

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.sys.check.node;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class JvmVersionNodeCheckTest {
+
+    @Test
+    public void testCheckValidatesSuccessfullyOnJava11() {
+        assertThat(JvmVersionNodeCheck.isOnOrAfter11("11.0.2"), is(true));
+    }
+
+    @Test
+    public void testCheckFailsOnEarlierJavaVersions() {
+        assertThat(JvmVersionNodeCheck.isOnOrAfter11("10.0.2"), is(false));
+    }
+
+    @Test
+    public void testJava8VersionStringCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("1.8.0_202"), is(new int[] { 1, 8, 0 }));
+    }
+
+    @Test
+    public void testJava9VersionStringCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("9.0.1"), is(new int[] { 9, 0, 1 }));
+    }
+
+    @Test
+    public void testJava10VersionStringCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("10.0.2"), is(new int[] { 10, 0, 2 }));
+    }
+
+    @Test
+    public void testJava11VersionStringCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("11.0.2"), is(new int[] { 11, 0, 2 }));
+    }
+
+    @Test
+    public void testEAVersionStringCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("12ea"), is(new int[] { 12, 0, 0 }));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -36,7 +36,10 @@ public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testChecksPresenceAndSeverityLevels() throws Exception {
-        SQLResponse response = execute("select id, severity, passed from sys.node_checks order by id, node_id asc");
+        SQLResponse response = execute("select id, severity, passed " +
+                                       "from sys.node_checks " +
+                                       "where id != 8 " +
+                                       "order by id, node_id asc");
         assertThat(response.rowCount(), equalTo(12L));
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("1| 3| false\n" +  // 1 = recoveryExpectedNodesCheck


### PR DESCRIPTION
We're planning to drop support for JVM < 11 with CrateDB 4.0. This adds
a node check to inform users about it.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed