### PR TITLE
Replace ES branding with CrateDB in some log messages

### DIFF
--- a/app/src/main/java/io/crate/plugin/PluginLoader.java
+++ b/app/src/main/java/io/crate/plugin/PluginLoader.java
@@ -195,7 +195,7 @@ public class PluginLoader {
             Collection<Class<? extends Plugin>> implementations = findImplementations(pluginUrls);
             if (implementations == null || implementations.isEmpty()) {
                 String msg = String.format(Locale.ENGLISH,
-                    "Path [%s] does not contain a valid Crate or Elasticsearch plugin", plugin.getAbsolutePath());
+                    "Path [%s] does not contain a valid CrateDB plugin", plugin.getAbsolutePath());
                 RuntimeException e = new RuntimeException(msg);
                 logger.error(msg, e);
                 throw e;

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -215,7 +215,7 @@ class S3Repository extends BlobStoreRepository {
         if (S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
             // provided repository settings
             deprecationLogger.deprecated("Using s3 access/secret key from repository settings. Instead "
-                    + "store these in named clients and the elasticsearch keystore for secure settings.");
+                    + "store these in named clients and the CrateDB keystore for secure settings.");
             final BasicAWSCredentials insecureCredentials = S3ClientSettings.loadDeprecatedCredentials(metadata.settings());
             final S3ClientSettings s3ClientSettings = S3ClientSettings.getClientSettings(metadata, insecureCredentials);
             this.reference = new AmazonS3Reference(service.buildClient(s3ClientSettings));

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -168,7 +168,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         }
         if (index.contains(":")) {
             deprecationLogger.deprecated("index or alias name [" + index +
-                            "] containing ':' is deprecated. Elasticsearch 7.x will read, " +
+                            "] containing ':' is deprecated. CrateDB 4.x will read, " +
                             "but not allow creation of new indices containing ':'");
         }
         if (index.charAt(0) == '_' || index.charAt(0) == '-' || index.charAt(0) == '+') {

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -111,13 +111,12 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
      * before they can be opened by this version of elasticsearch.
      */
     private void checkSupportedVersion(IndexMetaData indexMetaData, Version minimumIndexCompatibilityVersion) {
-        if (indexMetaData.getState() == IndexMetaData.State.OPEN && isSupportedVersion(indexMetaData,
-            minimumIndexCompatibilityVersion) == false) {
+        if (indexMetaData.getState() == IndexMetaData.State.OPEN
+            && isSupportedVersion(indexMetaData, minimumIndexCompatibilityVersion) == false) {
             throw new IllegalStateException("The index [" + indexMetaData.getIndex() + "] was created with version ["
                 + indexMetaData.getCreationVersion() + "] but the minimum compatible version is ["
-
-                + minimumIndexCompatibilityVersion + "]. It should be re-indexed in Elasticsearch " + minimumIndexCompatibilityVersion.major
-                + ".x before upgrading to " + Version.CURRENT + ".");
+                + minimumIndexCompatibilityVersion + "]."
+                + "It should be re-indexed in the previous major version of CrateDB before upgrading to " + Version.CURRENT + ".");
         }
     }
 

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -498,7 +498,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                             "can not update internal setting [" + setting.getKey() + "]; this setting is managed via a dedicated API");
                 } else if (setting.isPrivateIndex()) {
                     throw new IllegalArgumentException(
-                            "can not update private setting [" + setting.getKey() + "]; this setting is managed by Elasticsearch");
+                            "can not update private setting [" + setting.getKey() + "]; this setting is managed by CrateDB");
                 }
             }
         }

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -86,7 +86,7 @@ public abstract class SecureSetting<T> extends Setting<T> {
         if (secureSettings == null || secureSettings.getSettingNames().contains(getKey()) == false) {
             if (super.exists(settings)) {
                 throw new IllegalArgumentException("Setting [" + getKey() + "] is a secure setting" +
-                    " and must be stored inside the Elasticsearch keystore, but was found inside elasticsearch.yml");
+                    " and must be stored inside the CrateDB keystore, but was found inside crate.yml");
             }
             return getFallback(settings);
         }

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -469,7 +469,7 @@ public class Setting<T> implements ToXContentObject {
             final String key = getKey();
             Settings.DeprecationLoggerHolder.deprecationLogger.deprecatedAndMaybeLog(
                     key,
-                    "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                    "[{}] setting was deprecated in CrateDB and will be removed in a future release! "
                             + "See the breaking changes documentation for the next major version.",
                     key);
         }

--- a/es/es-server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -143,7 +143,7 @@ public class EsExecutors {
 
     public static String threadName(final String nodeName, final String namePrefix) {
         // TODO missing node names should only be allowed in tests
-        return "elasticsearch" + (nodeName.isEmpty() ? "" : "[") + nodeName + (nodeName.isEmpty() ? "" : "]") + "[" + namePrefix + "]";
+        return "cratedb" + (nodeName.isEmpty() ? "" : "[") + nodeName + (nodeName.isEmpty() ? "" : "]") + "[" + namePrefix + "]";
     }
 
     public static ThreadFactory daemonThreadFactory(Settings settings, String namePrefix) {

--- a/es/es-server/src/main/java/org/elasticsearch/node/Node.java
+++ b/es/es-server/src/main/java/org/elasticsearch/node/Node.java
@@ -569,10 +569,10 @@ public abstract class Node implements Closeable {
         warnIfPreRelease(Version.CURRENT, Version.CURRENT.isSnapshot(), logger);
     }
 
-    static void warnIfPreRelease(final Version version, final boolean isSnapshot, final Logger logger) {
+    private static void warnIfPreRelease(final Version version, final boolean isSnapshot, final Logger logger) {
         if (!version.isRelease() || isSnapshot) {
             logger.warn(
-                "version [{}] is a pre-release version of Elasticsearch and is not suitable for production",
+                "version [{}] is a pre-release version of CrateDB and is not suitable for production",
                 Version.displayVersion(version, isSnapshot));
         }
     }

--- a/es/es-server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -821,7 +821,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
         }
         if (Version.CURRENT.before(snapshotInfo.version())) {
             throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
-                                               "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
+                                               "the snapshot was created with CrateDB version [" + snapshotInfo.version() +
                                                    "] which is higher than the version of this node [" + Version.CURRENT + "]");
         }
     }

--- a/es/es-server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/es/es-server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -297,7 +297,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
      */
     public static SnapshotInfo incompatible(SnapshotId snapshotId) {
         return new SnapshotInfo(snapshotId, Collections.emptyList(), SnapshotState.INCOMPATIBLE,
-                                "the snapshot is incompatible with the current version of Elasticsearch and its exact version is unknown",
+                                "the snapshot is incompatible with the current version of CrateDB and its exact version is unknown",
                                 null, 0L, 0L, 0, 0, Collections.emptyList(), null);
     }
 

--- a/es/es-testing/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -385,7 +385,7 @@ public abstract class ESTestCase extends LuceneTestCase {
                 Stream.concat(
                         Arrays
                                 .stream(settings)
-                                .map(k -> "[" + k + "] setting was deprecated in Elasticsearch and will be removed in a future release! " +
+                                .map(k -> "[" + k + "] setting was deprecated in CrateDB and will be removed in a future release! " +
                                         "See the breaking changes documentation for the next major version."),
                         Arrays.stream(warnings))
                         .toArray(String[]::new));


### PR DESCRIPTION
- [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed