### PR TITLE
Mark the node decommissioning using USR2 as deprecated

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,8 +46,9 @@ Changes
   running. We recommend users to upgrade to JVM 11 as support for older
   versions will be dropped in the future.
 
-- Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` command that
-  triggers the existing node decommission functionality.
+- Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` statement that
+  triggers the existing node decommission functionality. In addition,
+  node decommission using the ``USR2`` signal is marked as deprecated.
 
 - Added ``pg_type.typlen`` and ``pg_type.typnamespace`` columns for improved
   postgresql compatibility.

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -307,6 +307,9 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
 
     @Override
     public void handle(Signal signal) {
+        deprecationLogger.deprecated(
+            "Node decommission using 'USR2' signal has been deprecated and will be removed in the future. " +
+            "It is recommended to use the 'ALTER CLUSTER DECOMMISSION' statement.");
         decommission();
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Added the USR2 signal deprecation in release notes
- Added a deprecation log when this is used for node decommission

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed