### PR TITLE
Fix parsing of 12-ea java version strings in node check

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
@@ -71,7 +71,8 @@ public final class JvmVersionNodeCheck extends AbstractSysNodeCheck {
             return new int[] {major, minor, hotfix};
         } catch (NumberFormatException e) {
             if (firstToken.endsWith("ea")) {
-                int major = Integer.parseInt(firstToken.substring(0, firstToken.length() - 2));
+                int offset = firstToken.endsWith("-ea") ? 3 : 2;
+                int major = Integer.parseInt(firstToken.substring(0, firstToken.length() - offset));
                 return new int[] {major, 0, 0};
             }
             throw e;

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
@@ -63,4 +63,9 @@ public class JvmVersionNodeCheckTest {
     public void testEAVersionStringCanBeParsed() {
         assertThat(JvmVersionNodeCheck.parseVersion("12ea"), is(new int[] { 12, 0, 0 }));
     }
+
+    @Test
+    public void testEAVersionWithDashCanBeParsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("12-ea"), is(new int[] { 12, 0, 0 }));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed