### PR TITLE
Force Pygments to 2.3.1 for rtd builds

### DIFF
--- a/blackbox/docs/requirements.txt
+++ b/blackbox/docs/requirements.txt
@@ -1,3 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
 crate-docs-theme
 sphinx-csv-filter
+Pygments==2.3.1


### PR DESCRIPTION
Looks like rtd defaults to Pygments 2.2.0
(https://github.com/rtfd/readthedocs.org/blob/8f0c78dde5edcc85acf90462a8518735a25482d3/readthedocs/doc_builder/python_environments.py#L281)

Which then fails because it is used with python 3.7:

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/crate/envs/latest/lib/python3.7/site-packages/pygments/lexers/sql.py", line 350, in get_tokens_unprocessed
    line = next(lines)
  File "/home/docs/checkouts/readthedocs.org/user_builds/crate/envs/latest/lib/python3.7/site-packages/pygments/lexers/sql.py", line 284, in __next__
    return next(self.iter)
StopIteration
```


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed