### PR TITLE
Remove unused Setting: 'cluster.graceful_stop.reallocate'

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -108,7 +108,6 @@ applied cluster settings.
     | settings['cluster']['graceful_stop']                                              | object       |
     | settings['cluster']['graceful_stop']['force']                                     | boolean      |
     | settings['cluster']['graceful_stop']['min_availability']                          | string       |
-    | settings['cluster']['graceful_stop']['reallocate']                                | boolean      |
     | settings['cluster']['graceful_stop']['timeout']                                   | string       |
     | settings['cluster']['info']                                                       | object       |
     | settings['cluster']['info']['update']                                             | object       |

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -29,8 +29,8 @@ Unreleased Changes
 .. When resetting this file during a release, leave the headers in place, but
 .. add a single paragraph to each section with the word "None".
 
-.. Always cluster items into bigger topics. Link to the documentation whenever feasible.  
-.. Remember to give the right level of information: Users should understand  
+.. Always cluster items into bigger topics. Link to the documentation whenever feasible.
+.. Remember to give the right level of information: Users should understand
 .. the impact of the change without going into the depth of tech.
 
 .. rubric:: Table of Contents
@@ -40,6 +40,8 @@ Unreleased Changes
 
 Breaking Changes
 ================
+
+- Removed the deprecated setting ``cluster.graceful_stop.reallocate``.
 
 - Removed the deprecated ``ON DUPLICATE KEY`` syntax of :ref:`ref-insert`
   statements.
@@ -71,10 +73,9 @@ Deprecations
   have been deprecated in favour of the new total count and sum of durations
   metrics.
 
-- Marked the
-  :ref:`cluster.graceful_stop.reallocate <cluster.graceful_stop.reallocate>`
-  setting as deprecated. This setting was already being ignored, setting the
-  value to `false` has no effect.
+- Marked the ``cluster.graceful_stop.reallocate`` setting as deprecated.
+  This setting was already being ignored, setting the value to `false` has
+  no effect.
 
 - The node decommission using the ``USR2`` :ref:`cli_signals` has been
   deprecated in favour of the

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -262,25 +262,6 @@ nodes of the cluster:
 
      This option is ignored if there is only 1 node in a cluster!
 
-.. _cluster.graceful_stop.reallocate:
-
-**cluster.graceful_stop.reallocate**
-  | *Default:*   ``true``
-  | *Runtime:*  ``yes``
-
-  ``true``: The ``graceful stop`` command allows shards to be reallocated
-  before shutting down the node in order to ensure minimum data availability
-  set with ``min_availability``.
-
-  ``false``: This has no effect, meaning that the behaviour is the same as
-  setting this to `true`. For this reason, this setting is deprecated and
-  will be removed in a future release.
-
-  .. WARNING::
-
-     Make sure you have enough nodes and enough disk space for the
-     reallocation.
-
 .. _cluster.graceful_stop.timeout:
 
 **cluster.graceful_stop.timeout**

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -73,11 +73,6 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
     public static final CrateSetting<DataAvailability> GRACEFUL_STOP_MIN_AVAILABILITY_SETTING = CrateSetting.of(new Setting<>(
         "cluster.graceful_stop.min_availability", DataAvailability.PRIMARIES.name(), DataAvailability::of,
         Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
-    public static final CrateSetting<Boolean> GRACEFUL_STOP_REALLOCATE_SETTING = CrateSetting.of(
-        Setting.boolSetting("cluster.graceful_stop.reallocate",
-            true,
-            Setting.Property.Dynamic, Setting.Property.NodeScope, Setting.Property.Deprecated),
-        DataTypes.BOOLEAN);
     public static final CrateSetting<Boolean> GRACEFUL_STOP_FORCE_SETTING = CrateSetting.of(Setting.boolSetting(
         "cluster.graceful_stop.force", false, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.BOOLEAN);
     public static final CrateSetting<TimeValue> GRACEFUL_STOP_TIMEOUT_SETTING = CrateSetting.of(Setting.positiveTimeSetting(

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -96,7 +96,6 @@ public final class CrateSettings implements ClusterStateListener {
             // GRACEFUL STOP
             DecommissioningService.DECOMMISSION_INTERNAL_SETTING_GROUP,
             DecommissioningService.GRACEFUL_STOP_MIN_AVAILABILITY_SETTING,
-            DecommissioningService.GRACEFUL_STOP_REALLOCATE_SETTING,
             DecommissioningService.GRACEFUL_STOP_TIMEOUT_SETTING,
             DecommissioningService.GRACEFUL_STOP_FORCE_SETTING,
 

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
@@ -104,7 +104,6 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         assertThat(
             Maps.getByPath(values, DecommissioningService.GRACEFUL_STOP_MIN_AVAILABILITY_SETTING.getKey()), is("FULL"));
 
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting(),
-                DecommissioningService.GRACEFUL_STOP_REALLOCATE_SETTING.setting()});
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting()});
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -583,7 +583,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(656, response.rowCount());
+        assertEquals(655, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Setting 'cluster.graceful_stop.reallocate' exists and is also documented but its setting-value has no effect during the graceful stop. Thus I removed it.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed