### PR TITLE
Run blackbox tests also on each PR

### DIFF
--- a/blackbox/docs/src/doc_tests/process_test.py
+++ b/blackbox/docs/src/doc_tests/process_test.py
@@ -159,6 +159,7 @@ class GracefulStopTest(unittest.TestCase):
                     "cluster.routing.allocation.disk.watermark.high": "10k",
                     "cluster.routing.allocation.disk.watermark.flood_stage": "1k",
                 },
+                env=os.environ.copy(),
                 cluster_name=self.__class__.__name__)
             client = Client(layer.crate_servers)
             self.crates.append(layer)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We should catch failures before we merge changes to master.
The blackbox tests take up another 10 minutes, but since we can run them in parallel it shouldn't affect the testing time too much (and we usually have to wait for the azure pipelines test to complete - which are roughly 30 minutes)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed