### PR TITLE
Fix generated partition column handling in inserts

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -90,4 +90,7 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused inserts into partitioned tables where the
+  partitioned column is generated and based on the child of an object to fail.
+
 - Fixed an issue that caused the Basic Authentication prompt to fail in Safari.

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -23,6 +23,7 @@ package io.crate.execution.dsl.projection;
 
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -66,6 +67,8 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        Settings settings,
                                        boolean autoCreateIndices) {
         super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
+        assert partitionedBySymbols.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
+            : "All references and fields in partitionedBySymbols must be resolved to inputColumns, got: " + partitionedBySymbols;
         this.partitionedBySymbols = partitionedBySymbols;
         this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;

--- a/sql/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -24,6 +24,7 @@ package io.crate.expression.symbol;
 import com.google.common.collect.Lists;
 import io.crate.Streamer;
 import io.crate.expression.symbol.format.SymbolPrinter;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
@@ -37,6 +38,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 public class Symbols {
@@ -60,6 +62,16 @@ public class Symbols {
         return streamers;
     }
 
+    @Nullable
+    public static <V> V lookupValueByColumn(Map<? extends Symbol, V> valuesBySymbol, ColumnIdent column) {
+        for (Map.Entry<? extends Symbol, V> entry : valuesBySymbol.entrySet()) {
+            Symbol key = entry.getKey();
+            if (key instanceof Reference && ((Reference) key).column().equals(column)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
 
     /**
      * returns true if the symbol contains the given columnIdent.

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1402,4 +1402,20 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("select x, obj['y'], obj['z'] from t");
         assertThat(printedTable(response.rows()), is("10| 11| 4\n"));
     }
+
+    @Test
+    public void testInsertIntoTablePartitionedOnGeneratedColumnBasedOnColumnWithinObject() {
+        execute("create table t (" +
+                "   day as date_trunc('day', obj['ts'])," +
+                "   obj object (strict) as (" +
+                "       ts timestamp" +
+                "   )" +
+                ") partitioned by (day) clustered into 1 shards");
+        execute("insert into t (obj) (select {ts=1549966541034})");
+        execute("refresh table t");
+        assertThat(
+            printedTable(execute("select day, obj from t").rows()),
+            is("1549929600000| {ts=1549966541034}\n")
+        );
+    }
 }


### PR DESCRIPTION
The logic to resolve an `InputColumn` didn't work correctly if the
partitioned column of a table is based on a generated column which uses
a child column of an object column.


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed