### PR TITLE
Handle dynamic property and _meta version changes in template schema updates

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -90,6 +90,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression that caused inserts which create new dynamic columns to
+  fail if the table was created in an earlier version of CrateDB.
+
 - Fixed an issue that caused inserts into partitioned tables where the
   partitioned column is generated and based on the child of an object to fail.
 

--- a/sql/src/main/java/io/crate/collections/Lists2.java
+++ b/sql/src/main/java/io/crate/collections/Lists2.java
@@ -48,6 +48,13 @@ public final class Lists2 {
         return list;
     }
 
+    public static <T> List<T> concat(Collection<? extends T> list1, T item) {
+        ArrayList<T> xs = new ArrayList<>(list1.size() + 1);
+        xs.addAll(list1);
+        xs.add(item);
+        return xs;
+    }
+
     public static <T> List<T> concatUnique(List<? extends T> list1, List<? extends T> list2) {
         List<T> result = new ArrayList<>(list1.size() + list2.size());
         result.addAll(list1);

--- a/sql/src/test/java/io/crate/collections/Lists2Test.java
+++ b/sql/src/test/java/io/crate/collections/Lists2Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.collections;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class Lists2Test {
+
+    @Test
+    public void testConcatReturnsANewListWithOneItemAdded() {
+        assertThat(Lists2.concat(Arrays.asList(1, 2), 3), Matchers.contains(1, 2, 3));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adding a dynamic column to a table created in an earlier version could
fail with an error like `Can't overwrite elasticsearch=6010499 with
6050199` or `Can't overwrite dynamic=true with true`

See https://github.com/crate/crate-qa/pull/104 for complete end-to-end
integration tests.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed