### PR TITLE
Mark setting 'cluster.graceful_stop.reallocate' as deprecated

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -170,10 +170,6 @@ auth:
 # shards but not replicas. Other options are "full" and "none".
 #cluster.graceful_stop.min_availability: primaries
 #
-# The cluster may reallocate shards to ensure minimum data availabillity
-# before a certain node shuts down.
-#cluster.graceful_stop.reallocate: true
-#
 # The time to wait for the reallocation process to be finished.
 #cluster.graceful_stop.timeout: 2h
 #

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,10 @@ None
 Changes
 =======
 
+- Marked the ``:ref:cluster.graceful_stop.reallocate`` setting as deprecated.
+  This setting was already being ignored, setting the value to `false`
+  has no effect.
+
 - Expose the total count and sum of durations metrics under the
   :ref:`query_stats_mbean` for ``QUERY``, ``INSERT``, ``UPDATE``, ``DELETE``,
   ``MANAGEMENT``, ``DDL`` and ``COPY`` statement types.

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -272,9 +272,9 @@ nodes of the cluster:
   before shutting down the node in order to ensure minimum data availability
   set with ``min_availability``.
 
-  ``false``: The ``graceful stop`` command will fail if the cluster would need
-  to reallocate shards in order to ensure the minimum data availability set
-  with ``min_availability``.
+  ``false``: This has no effect, meaning that the behaviour is the same as
+  setting this to `true`. For this reason, this setting is deprecated and
+  will be removed in a future release.
 
   .. WARNING::
 

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -73,8 +73,11 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
     public static final CrateSetting<DataAvailability> GRACEFUL_STOP_MIN_AVAILABILITY_SETTING = CrateSetting.of(new Setting<>(
         "cluster.graceful_stop.min_availability", DataAvailability.PRIMARIES.name(), DataAvailability::of,
         Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
-    public static final CrateSetting<Boolean> GRACEFUL_STOP_REALLOCATE_SETTING = CrateSetting.of(Setting.boolSetting(
-        "cluster.graceful_stop.reallocate", true, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.BOOLEAN);
+    public static final CrateSetting<Boolean> GRACEFUL_STOP_REALLOCATE_SETTING = CrateSetting.of(
+        Setting.boolSetting("cluster.graceful_stop.reallocate",
+            true,
+            Setting.Property.Dynamic, Setting.Property.NodeScope, Setting.Property.Deprecated),
+        DataTypes.BOOLEAN);
     public static final CrateSetting<Boolean> GRACEFUL_STOP_FORCE_SETTING = CrateSetting.of(Setting.boolSetting(
         "cluster.graceful_stop.force", false, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.BOOLEAN);
     public static final CrateSetting<TimeValue> GRACEFUL_STOP_TIMEOUT_SETTING = CrateSetting.of(Setting.positiveTimeSetting(

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
@@ -104,6 +104,7 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         assertThat(
             Maps.getByPath(values, DecommissioningService.GRACEFUL_STOP_MIN_AVAILABILITY_SETTING.getKey()), is("FULL"));
 
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting()});
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting(),
+                DecommissioningService.GRACEFUL_STOP_REALLOCATE_SETTING.setting()});
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
