### PR TITLE
Fix null constraints check for partitioned columns

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -98,6 +98,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused ``INSERT INTO`` with a subquery to not insert into
+  partitioned tables where the partitioned by columns had a ``NOT NULL``
+  constraint.
+
 - Fixed a regression that caused inserts which create new dynamic columns to
   fail if the table was created in an earlier version of CrateDB.
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -42,6 +42,7 @@ public interface InsertSourceGen {
     static InsertSourceGen of(TransactionContext txnCtx,
                               Functions functions,
                               DocTableInfo table,
+                              String indexName,
                               GeneratedColumns.Validation validation,
                               List<Reference> targets) {
         if (targets.size() == 1 && targets.get(0).column().equals(DocSysColumns.RAW)) {
@@ -51,6 +52,6 @@ public interface InsertSourceGen {
                 return new GeneratedColsFromRawInsertSource(txnCtx, functions, table.generatedColumns());
             }
         }
-        return new InsertSourceFromCells(txnCtx, functions, table, validation, targets);
+        return new InsertSourceFromCells(txnCtx, functions, table, indexName, validation, targets);
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -115,7 +115,8 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                                                                         ShardUpsertRequest request,
                                                                                         AtomicBoolean killed) {
         ShardResponse shardResponse = new ShardResponse();
-        DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(request.index()), Operation.INSERT);
+        String indexName = request.index();
+        DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);
         Reference[] insertColumns = request.insertColumns();
         GeneratedColumns.Validation valueValidation = request.validateConstraints()
             ? GeneratedColumns.Validation.VALUE_MATCH
@@ -124,7 +125,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         TransactionContext txnCtx = TransactionContext.of(request.userName(), SearchPath.createSearchPathFrom(request.currentSchema()));
         InsertSourceGen insertSourceGen = insertColumns == null
             ? null
-            : InsertSourceGen.of(txnCtx, functions, tableInfo, valueValidation, Arrays.asList(insertColumns));
+            : InsertSourceGen.of(txnCtx, functions, tableInfo, indexName, valueValidation, Arrays.asList(insertColumns));
 
         UpdateSourceGen updateSourceGen = request.updateColumns() == null
             ? null

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.QueriedTable;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.common.collections.Maps;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
@@ -44,6 +45,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
@@ -63,6 +67,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.builder(clusterService)
             .addTable("create table t1 (x int, y int, z as x + y)")
             .addTable("create table t2 (obj object as (a int, c as obj['a'] + 3), b as obj['a'] + 1)")
+            .addPartitionedTable("create table t3 (p int not null) partitioned by (p)")
             .build();
         QueriedRelation relation = e.normalize("select x, y, z from t1");
         t1 = (DocTableInfo) ((QueriedTable) relation).tableRelation().tableInfo();
@@ -79,7 +84,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t1, GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
+            txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
         BytesReference source = sourceFromCells.generateSource(new Object[]{1, 2});
         assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":2,\"z\":3}"));
     }
@@ -87,7 +92,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGenerateSourceRaisesAnErrorIfGeneratedColumnValueIsSuppliedByUserAndDoesNotMatch() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t1, GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y, z));
+            txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y, z));
 
         expectedException.expectMessage("Given value 8 for generated column z does not match calculation (x + y) = 3");
         sourceFromCells.generateSource(new Object[]{1, 2, 8});
@@ -96,7 +101,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGeneratedColumnGenerationThatDependsOnNestedColumnOfObject() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t2, GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
+            txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
         BytesReference source = sourceFromCells.generateSource(new Object[]{m});
@@ -105,5 +110,31 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(map.get("b"), is(11));
         assertThat(Maps.getByPath(map, "obj.a"), is(10));
         assertThat(Maps.getByPath(map, "obj.c"), is(13));
+    }
+
+    @Test
+    public void testNullConstraintCheckCausesErrorIfRequiredPartitionedColumnValueIsNull() {
+        QueriedRelation relation = e.normalize("select p from t3");
+        DocTableInfo t3 = (DocTableInfo) ((QueriedTable) relation).tableRelation().tableInfo();
+        PartitionName partitionName = new PartitionName(t3.ident(), singletonList(null));
+
+        InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
+            txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
+
+        expectedException.expectMessage("\"p\" must not be null");
+        sourceFromCells.checkConstraints(new Object[0]);
+    }
+
+    @Test
+    public void testNullConstraintCheckPassesIfRequiredPartitionedColumnValueIsNotNull() {
+        QueriedRelation relation = e.normalize("select p from t3");
+        DocTableInfo t3 = (DocTableInfo) ((QueriedTable) relation).tableRelation().tableInfo();
+        PartitionName partitionName = new PartitionName(t3.ident(), singletonList("10"));
+
+        InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
+            txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
+
+        // this must pass without error
+        sourceFromCells.checkConstraints(new Object[0]);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1418,4 +1418,20 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
             is("1549929600000| {ts=1549966541034}\n")
         );
     }
+
+    @Test
+    public void testInsertIntoPartitionedTableFromPartitionedTable() {
+        execute("create table tsrc (country string not null, name string not null) " +
+                "partitioned by (country) " +
+                "clustered into 1 shards");
+        execute("insert into tsrc (country, name) values ('AR', 'Felipe')");
+        execute("refresh table tsrc");
+
+        execute("create table tdst (country string not null, name string not null) " +
+                "partitioned by (country) " +
+                "clustered into 1 shards");
+
+        execute("insert into tdst (country, name) (select country, name from tsrc)");
+        assertThat(response.rowCount(), is(1L));
+    }
 }

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -181,6 +181,7 @@ public final class QueryTester implements AutoCloseable {
                 CoordinatorTxnCtx.systemTransactionContext(),
                 sqlExecutor.functions(),
                 table,
+                table.concreteIndices()[0],
                 GeneratedColumns.Validation.NONE,
                 Collections.singletonList(table.getReference(ColumnIdent.fromPath(column)))
             );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `ReferenceResolver` used to resolve the values for the null
constraint checks always returned null values for partitioned columns.

This prevented inserts from subquery into partitioned tables with a not
nullable partitioned column from succeeding.

Fixes https://github.com/crate/crate/issues/8244




## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed