### PR TITLE
idea: Change unused import inspection level to error

### DIFF
--- a/idea/codeInspection.xml
+++ b/idea/codeInspection.xml
@@ -3,5 +3,6 @@
     <option name="myName" value="Project Default"/>
     <inspection_tool class="ForCanBeForeach" enabled_by_default="false"/>
     <inspection_tool class="PointlessBooleanExpression" enabled_by_default="false"/>
+    <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To align with checkstyle which prevents us from having unused imports.

This doesn't prevent intellij from compiling code with unused imports,
but makes unused imports a bit more visible.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed