### PR TITLE
Support string literals with c-style character espaces

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -87,6 +87,8 @@ Deprecations
 Changes
 =======
 
+- Added support for :ref:`sql_escape_string_literals`.
+
 - Expose the sum of durations, total, and failed count metrics under the
   :ref:`query_stats_mbean` for ``QUERY``, ``INSERT``, ``UPDATE``, ``DELETE``,
   ``MANAGEMENT``, ``DDL`` and ``COPY`` statement types.

--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -39,6 +39,40 @@ single quotes, e.g. ``'Jack''s car'``.
    Two adjacent single quotes are **not** equivalent to the double-quote
    character ``"``.
 
+.. _sql_escape_string_literals:
+
+String Literals with C-Style Escapes
+------------------------------------
+
+In addition to the escaped character ``'``, CrateDB supports C-Style escaped
+string sequences. Such a sequence is constructed by prefixing the string
+literal with the letter ``E`` or ``e``, for example, ``e'hello\nWorld'``.
+The following escaped sequences are supported:
+
+==================================================   ================
+Escape Sequence                                       Interpretation
+==================================================   ================
+``\b``                                                backspace
+``\f``                                                form feed
+``\n``                                                newline
+``\r``                                                carriage return
+``\t``                                                tab
+``\o``, ``\oo``, ``\ooo`` (``o`` = [0-7])             octal byte value
+``\xh``, ``xhh`` (``h`` = [0-9,A-F,a-f])              hexadecimal byte value
+``\uxxxx``, ``\Uxxxxxxxx`` (``x`` = [0-9,A-F,a-f])    16 or 32-bit hexadecimal Unicode character value
+==================================================   ================
+
+For instance, the escape string literal ``e'\u0061\x61\141'``
+is equivalent to the ``'aaa'`` string literal::
+
+    cr> select e'\u0061\x61\141' as col1;
+    +------+
+    | col1 |
+    +------+
+    | aaa  |
+    +------+
+    SELECT 1 row in set (... sec)
+
 .. _sql_lexical_keywords_identifiers:
 
 Key Words and Identifiers
@@ -58,25 +92,26 @@ quoted if used as identifiers.
     CURRENT_SCHEMA, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_USER
     DEFAULT, DELETE, DENY, DESC
     DESCRIBE, DIRECTORY, DISTINCT, DOUBLE
-    DROP, ELSE, END, ESCAPE
-    EXCEPT, EXISTS, EXTRACT, FALSE
-    FIRST, FLOAT, FOR, FROM
-    FULL, FUNCTION, GRANT, GROUP
-    HAVING, IF, IN, INDEX
-    INNER, INPUT, INSERT, INT
-    INTEGER, INTERSECT, INTO, IP
-    IS, JOIN, LAST, LEFT
-    LIKE, LIMIT, LONG, MATCH
-    NATURAL, NOT, NULL, NULLS
-    OBJECT, OFFSET, ON, OR
-    ORDER, OUTER, PERSISTENT, PRIMARY
-    RECURSIVE, REPLACE, RESET, RETURNS
-    REVOKE, RIGHT, SELECT, SESSION_USER
-    SET, SHORT, SOME, STRATIFY
-    STRING, SUBSTRING, TABLE, THEN
-    TRANSIENT, TRUE, TRY_CAST, UNBOUNDED
-    UNION, UPDATE, USER, USING
-    WHEN, WHERE, WITH,
+    DROP, E, ELSE, END
+    ESCAPE, EXCEPT, EXISTS, EXTRACT
+    FALSE, FIRST, FLOAT, FOR
+    FROM, FULL, FUNCTION, GRANT
+    GROUP, HAVING, IF, IN
+    INDEX, INNER, INPUT, INSERT
+    INT, INTEGER, INTERSECT, INTO
+    IP, IS, JOIN, LAST
+    LEFT, LICENSE, LIKE, LIMIT
+    LONG, MATCH, NATURAL, NOT
+    NULL, NULLS, OBJECT, OFFSET
+    ON, OR, ORDER, OUTER
+    PERSISTENT, PRIMARY, RECURSIVE, REPLACE
+    RESET, RETURNS, REVOKE, RIGHT
+    SELECT, SESSION_USER, SET, SHORT
+    SOME, STRATIFY, STRING, SUBSTRING
+    TABLE, THEN, TRANSIENT, TRUE
+    TRY_CAST, UNBOUNDED, UNION, UPDATE
+    USER, USING, WHEN, WHERE
+    WITH
 
 Tokens such as ``my_table``, ``id``, ``name``, or ``data`` in the example above
 are **identifiers**, which identify names of tables, columns, and other

--- a/blackbox/docs/src/doc_tests/tests.py
+++ b/blackbox/docs/src/doc_tests/tests.py
@@ -470,7 +470,8 @@ def create_doctest_suite():
                             'general/dql/selects.rst',
                             'interfaces/postgres.rst',
                             'general/ddl/views.rst',
-                            'sql/general/value-expressions.rst'):
+                            'sql/general/value-expressions.rst',
+                            'sql/general/lexical-structure.rst'):
         s = docsuite(fn, setUp=setUpLocationsAndQuotes)
         s.layer = crate_layer
         tests.append(s)

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -272,6 +272,7 @@ parameterOrLiteral
 
 parameterOrSimpleLiteral
     : nullLiteral
+    | escapedCharsStringLiteral
     | stringLiteral
     | numericLiteral
     | booleanLiteral
@@ -300,6 +301,10 @@ parameterExpr
 
 nullLiteral
     : NULL
+    ;
+
+escapedCharsStringLiteral
+    : EPSILON STRING
     ;
 
 stringLiteral
@@ -650,7 +655,7 @@ nonReserved
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN
-    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION
+    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | EPSILON
     ;
 
 SELECT: 'SELECT';
@@ -913,6 +918,8 @@ PERCENT: '%';
 CONCAT: '||';
 CAST_OPERATOR: '::';
 SEMICOLON: ';';
+
+EPSILON: 'E';
 
 STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -41,6 +41,7 @@ import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CurrentTime;
 import io.crate.sql.tree.DateLiteral;
 import io.crate.sql.tree.DoubleLiteral;
+import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.ExistsPredicate;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Extract;
@@ -208,6 +209,11 @@ public final class ExpressionFormatter {
         @Override
         protected String visitStringLiteral(StringLiteral node, Void context) {
             return Literals.quoteStringLiteral(node.getValue());
+        }
+
+        @Override
+        protected String visitEscapedCharStringLiteral(EscapedCharStringLiteral node, Void context) {
+            return Literals.escapeAndQuoteStringLiteral(node.getRawValue());
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -24,14 +24,152 @@ package io.crate.sql;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.function.Predicate;
+
 public class Literals {
+
+    private static final String EPSILON = "E";
+
+    static final String ESCAPED_UNICODE_ERROR = "Invalid Unicode escape (must be \\uXXXX or \\UXXXXXXXX)";
 
     public static String quoteStringLiteral(String literal) {
         return "'" + escapeStringLiteral(literal) + "'";
     }
 
+    public static String escapeAndQuoteStringLiteral(String literal) {
+        return EPSILON + Literals.quoteStringLiteral(literal);
+    }
+
     @VisibleForTesting
     static String escapeStringLiteral(String literal) {
         return literal.replace("'", "''");
+    }
+
+    public static String replaceEscapedChars(String input) {
+        int length = input.length();
+        if (input.length() <= 1) {
+            return input;
+        }
+
+        StringBuilder builder = new StringBuilder(length);
+        int endIdx;
+        for (int i = 0; i < length; i++) {
+            char currentChar = input.charAt(i);
+            if (currentChar == '\\' && i + 1 < length) {
+                char nextChar = input.charAt(i + 1);
+                switch (nextChar) {
+                    case 'b':
+                        builder.append('\b');
+                        i++;
+                        break;
+                    case 'f':
+                        builder.append('\f');
+                        i++;
+                        break;
+                    case 'n':
+                        builder.append('\n');
+                        i++;
+                        break;
+                    case 'r':
+                        builder.append('\r');
+                        i++;
+                        break;
+                    case 't':
+                        builder.append('\t');
+                        i++;
+                        break;
+                    case 'u':
+                    case 'U':
+                        // handle unicode case
+                        final int charsToConsume = (nextChar == 'u') ? 4 : 8;
+                        if (i + 1 + charsToConsume >= length) {
+                            throw new IllegalArgumentException(ESCAPED_UNICODE_ERROR);
+                        }
+                        endIdx = calculateMaxCharsInSequence(input,
+                            i + 2,
+                            charsToConsume,
+                            Literals::isHexDigit);
+                        if (endIdx != i + 2 + charsToConsume) {
+                            throw new IllegalArgumentException(ESCAPED_UNICODE_ERROR);
+                        }
+                        builder.appendCodePoint(Integer.parseInt(input, i + 2, endIdx, 16));
+                        i = endIdx - 1; // skip already consumed chars
+                        break;
+                    case 'x':
+                        // handle hex byte case - up to 2 chars for hex value
+                        endIdx = calculateMaxCharsInSequence(input,
+                            i + 2,
+                            2,
+                            Literals::isHexDigit);
+                        if (endIdx > i + 2) {
+                            builder.appendCodePoint(Integer.parseInt(input, i + 2, endIdx, 16));
+                            i = endIdx - 1; // skip already consumed chars
+                        } else {
+                            // hex sequence unmatched - output original char
+                            builder.append(nextChar);
+                            i++;
+                        }
+                        break;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                        // handle octal case - up to 3 chars
+                        endIdx = calculateMaxCharsInSequence(input,
+                            i + 2,
+                            2,      // first char is already "consumed"
+                            Literals::isOctalDigit);
+                        builder.appendCodePoint(Integer.parseInt(input, i + 1, endIdx, 8));
+                        i = endIdx - 1; // skip already consumed chars
+                        break;
+                    default:
+                        // non-valid escaped char sequence
+                        builder.append(currentChar);
+                }
+            } else {
+                builder.append(currentChar);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static boolean isOctalDigit(final char ch) {
+        return ch >= '0' && ch <= '7';
+    }
+
+    private static boolean isHexDigit(final char ch) {
+        return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f');
+    }
+
+    /**
+     * Calculates the maximum number of consecutive characters of the {@link CharSequence} argument,
+     * starting from {@code beginIndex}, that match a given {@link Predicate}.
+     * The number of characters to match are either capped from the {@code maxCharsToMatch} parameter
+     * or the sequence length.
+     *
+     * Examples:
+     * <pre>
+     * {@code
+     *    calculateMaxCharsInSequence("12345", 0, 2, Character::isDigit) -> 2
+     *    calculateMaxCharsInSequence("12345", 3, 2, Character::isDigit) -> 5
+     *    calculateMaxCharsInSequence("12345", 4, 2, Character::isDigit) -> 5
+     * }
+     * </pre>
+     *
+     * This is used to identify the ending index of an Escaped Char Sequence
+     * {@see Literals::replaceEscapedChars}
+     *
+     * @return the index of the first non-matching character
+     */
+    private static int calculateMaxCharsInSequence(CharSequence seq,
+                                                   int beginIndex,
+                                                   int maxCharsToMatch,
+                                                   Predicate<Character> predicate) {
+        int idx = beginIndex;
+        final int end = Math.min(seq.length(), beginIndex + maxCharsToMatch);
+        while (idx < end && predicate.test(seq.charAt(idx))) {
+            idx++;
+        }
+        return idx;
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -43,6 +43,7 @@ import io.crate.sql.tree.DecommissionNodeStatement;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DropRepository;
 import io.crate.sql.tree.DropUser;
+import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Explain;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionArgument;
@@ -500,6 +501,12 @@ public final class SqlFormatter {
         @Override
         protected Void visitStringLiteral(StringLiteral node, Integer indent) {
             builder.append(Literals.quoteStringLiteral(node.getValue()));
+            return null;
+        }
+
+        @Override
+        protected Void visitEscapedCharStringLiteral(EscapedCharStringLiteral node, Integer context) {
+            builder.append(Literals.escapeAndQuoteStringLiteral(node.getRawValue()));
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -85,6 +85,7 @@ import io.crate.sql.tree.DropSnapshot;
 import io.crate.sql.tree.DropTable;
 import io.crate.sql.tree.DropUser;
 import io.crate.sql.tree.DropView;
+import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Except;
 import io.crate.sql.tree.ExistsPredicate;
 import io.crate.sql.tree.Explain;
@@ -1521,6 +1522,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitStringLiteral(SqlBaseParser.StringLiteralContext context) {
         return new StringLiteral(unquote(context.STRING().getText()));
+    }
+
+    @Override
+    public Node visitEscapedCharsStringLiteral(SqlBaseParser.EscapedCharsStringLiteralContext ctx) {
+        return new EscapedCharStringLiteral(unquote(ctx.STRING().getText()));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -153,6 +153,10 @@ public abstract class AstVisitor<R, C> {
         return visitLiteral(node, context);
     }
 
+    protected R visitEscapedCharStringLiteral(EscapedCharStringLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
     protected R visitBooleanLiteral(BooleanLiteral node, C context) {
         return visitLiteral(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/EscapedCharStringLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/EscapedCharStringLiteral.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import io.crate.sql.Literals;
+
+public class EscapedCharStringLiteral extends StringLiteral {
+    private final String rawValue;
+
+    public EscapedCharStringLiteral(String rawValue) {
+        super(Literals.replaceEscapedChars(rawValue));
+        this.rawValue = rawValue;
+    }
+
+    public String getRawValue() {
+        return rawValue;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitEscapedCharStringLiteral(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -39,6 +39,7 @@ import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DropUser;
+import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.GCDanglingArtifacts;
@@ -778,6 +779,11 @@ public class TestStatementBuilder {
         printStatement("select * from t where 'source' !~ 'pattern'");
         printStatement("select * from t where source_column ~ pattern_column");
         printStatement("select * from t where ? !~ ?");
+        // escaped chars related
+        printStatement("select * from t where a like E'aValue'");
+        printStatement("select * from t where a = E'\\141Value'");
+        printStatement("select * from t where a = e'\\141Value'");
+        printStatement("select e.a from t e where e.a = E'\\141Value'");
     }
 
     @Test
@@ -1175,6 +1181,16 @@ public class TestStatementBuilder {
             Expression expr = SqlParser.createExpression(Literals.quoteStringLiteral(s));
             assertThat(((StringLiteral) expr).getValue(), is(s));
         }
+    }
+
+    @Test
+    public void testEscapedStringLiteral() throws Exception {
+        String input = "this is a triple-a:\\141\\x61\\u0061";
+        String expectedValue = "this is a triple-a:aaa";
+        Expression expr = SqlParser.createExpression(Literals.escapeAndQuoteStringLiteral(input));
+        EscapedCharStringLiteral escapedCharStringLiteral = (EscapedCharStringLiteral) expr;
+        assertThat(escapedCharStringLiteral.getRawValue(), is(input));
+        assertThat(escapedCharStringLiteral.getValue(), is(expectedValue));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -92,6 +92,7 @@ import io.crate.sql.tree.Cast;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CurrentTime;
 import io.crate.sql.tree.DoubleLiteral;
+import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Extract;
 import io.crate.sql.tree.FrameBound;
@@ -784,6 +785,11 @@ public class ExpressionAnalyzer {
 
         @Override
         protected Symbol visitStringLiteral(StringLiteral node, ExpressionAnalysisContext context) {
+            return Literal.of(node.getValue());
+        }
+
+        @Override
+        protected Symbol visitEscapedCharStringLiteral(EscapedCharStringLiteral node, ExpressionAnalysisContext context) {
             return Literal.of(node.getValue());
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Support string literals with c-style character escapes

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed