### PR TITLE
Update sum_of_durations docs to specify the value is in ms.

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1201,7 +1201,7 @@ statements.
 | ``failed_count``             | Total number of queries that failed to complete    | ``LONG``         |  
 |                              | successfully.                                      |                  | 
 +------------------------------+----------------------------------------------------+------------------+
-| ``sum_of_durations``         | Sum of durations of all executed queries per       | ``LONG``         |
+| ``sum_of_durations``         | Sum of durations in ms of all executed queries per | ``LONG``         |
 |                              | statement type.                                    |                  |
 +------------------------------+----------------------------------------------------+------------------+
 | ``stdev``                    | The standard deviation of the query latencies      | ``DOUBLE``       |

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1158,6 +1158,8 @@ Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request
 that tries to query a non-existent table) will not show up as jobs.
 
+.. _sys-jobs-metrics:
+
 Jobs Metrics
 ------------
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -90,7 +90,7 @@ Changes
 
 - Expose the sum of statement durations, total, and failed count classified by
   statement type under the sum_of_durations, total_count and failed_count
-  columns, respectively, in the sys.jobs_metric table.
+  columns, respectively, in the :ref:`sys-jobs-metrics` table.
 
 - Added a node check that checks the JVM version under which CrateDB is
   running. We recommend users to upgrade to JVM 11 as support for older


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
