### PR TITLE
lgtm: Set java version

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -14,3 +14,6 @@ extraction:
   python:
     python_setup:
       version: 3
+  java:
+    index:
+      java_version: 11


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Otherwise it attempts to build with Java 8


This will still fail because the commit in master can't be built. But the build of the merge should hopefully pass: https://lgtm.com/projects/g/crate/crate/logs/rev/pr-480f5bde3b3b047d8be31051968eb4ef17abb613/lang:java/stage:Build%20merge%20(2c0573d)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed