### PR TITLE
Create a new stream every time we request the iterator of a stream backed iterable.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -127,6 +127,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused a ``stream has already been operated upon or
+  closed`` exception to be thrown when joining on a right subquery that
+  contained a ``group by`` clause on one number column.
+
 - Fixed an issue that caused ``INSERT INTO`` with a subquery to not insert into
   partitioned tables where the partitioned by columns had a ``NOT NULL``
   constraint.

--- a/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
@@ -36,7 +36,7 @@ public class RamBlockSizeCalculator implements IntSupplier {
     private final long estimatedRowSizeForLeft;
     private final long numberOfRowsForLeft;
 
-    RamBlockSizeCalculator(int defaultBlockSize,
+    public RamBlockSizeCalculator(int defaultBlockSize,
                            CircuitBreaker circuitBreaker,
                            long estimatedRowSizeForLeft,
                            long numberOfRowsForLeft) {

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollectorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import io.crate.breaker.RamAccountingContext;
+import io.crate.data.BatchIterator;
+import io.crate.data.BatchIterators;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
+import io.crate.execution.engine.aggregation.impl.SumAggregation;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.Functions;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.util.BigArrays;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.crate.data.SentinelRow.SENTINEL;
+import static org.hamcrest.Matchers.is;
+
+public class GroupBySingleNumberCollectorTest extends CrateUnitTest {
+
+    private static final RamAccountingContext RAM_ACCOUNTING_CONTEXT =
+        new RamAccountingContext("dummy", new NoopCircuitBreaker(CircuitBreaker.FIELDDATA));
+
+    @Test
+    public void testIterateOverResultTwice() throws Exception {
+        Functions functions = new ModulesBuilder().add(new AggregationImplModule())
+            .createInjector().getInstance(Functions.class);
+        AggregationFunction sumAgg = (AggregationFunction) functions.getQualified(
+            new FunctionIdent(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER)));
+        InputCollectExpression keyInput = new InputCollectExpression(0);
+
+        GroupBySingleNumberCollector groupBySingleNumberCollector = new GroupBySingleNumberCollector(
+            DataTypes.INTEGER,
+            new CollectExpression[]{keyInput},
+            AggregateMode.ITER_FINAL,
+            new AggregationFunction[]{sumAgg},
+            new Input[][]{new Input[]{keyInput}},
+            RAM_ACCOUNTING_CONTEXT,
+            keyInput,
+            Version.CURRENT,
+            BigArrays.NON_RECYCLING_INSTANCE
+        );
+
+        BatchIterator<Row> inputRowsIterator = InMemoryBatchIterator.of(
+            IntStream.range(0, 10).mapToObj(Row1::new).collect(Collectors.toList()),
+            SENTINEL
+        );
+
+        Iterable<Row> rows = BatchIterators.collect(inputRowsIterator, groupBySingleNumberCollector)
+            .get(10, TimeUnit.SECONDS);
+        IntStream.range(0, 2).forEach(i -> {
+            int index = 0;
+            for (Row row : rows) {
+                assertThat(row.get(0), is(index));
+                index++;
+            }
+        });
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -22,20 +22,25 @@
 package io.crate.integrationtests;
 
 import com.carrotsearch.hppc.ObjectObjectHashMap;
+import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.data.CollectionBucket;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.execution.engine.join.RamBlockSizeCalculator;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.metadata.RelationName;
 import io.crate.planner.TableStats;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseHashJoins;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import static io.crate.testing.TestingHelpers.printRows;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -812,6 +817,12 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t1 (a) values (0), (0), (1), (2), (4)");
         execute("insert into t2 (x) values (1), (3), (3), (4), (4)");
         execute("refresh table t1, t2");
+
+        configureQueryCircuitBreakerForCluster(20L);
+        CircuitBreaker breaker = internalCluster().getInstance(CrateCircuitBreakerService.class).getBreaker(CrateCircuitBreakerService.QUERY);
+        randomiseAndConfigureJoinBlockSize("t1", 5L, breaker);
+        randomiseAndConfigureJoinBlockSize("t2", 5L, breaker);
+
         execute("select a, x from t1 join t2 on t1.a + 1 = t2.x order by a, x");
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("0| 1\n" +
@@ -872,6 +883,58 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("0| 0| 0\n" +
                "1| 1| 1\n"));
+    }
+
+    @Test
+    public void testBlockHashJoinWithBlockLoadingAndGroupByOnRightSide() {
+        execute("create table t1 (x integer)");
+        execute("insert into t1 (x) values (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)");
+        execute("refresh table t1");
+
+        configureQueryCircuitBreakerForCluster(40L);
+        CircuitBreaker breaker = internalCluster().getInstance(CrateCircuitBreakerService.class).getBreaker(CrateCircuitBreakerService.QUERY);
+        randomiseAndConfigureJoinBlockSize("t1", 10L, breaker);
+
+        execute("select x from t1 left_rel JOIN (select x x2, count(x) from t1 group by x2) right_rel " +
+                "ON left_rel.x = right_rel.x2 order by left_rel.x");
+
+        assertThat(TestingHelpers.printedTable(response.rows()),
+            is("0\n" +
+               "1\n" +
+               "2\n" +
+               "3\n" +
+               "4\n" +
+               "5\n" +
+               "6\n" +
+               "7\n" +
+               "8\n" +
+               "9\n"));
+    }
+
+    private void configureQueryCircuitBreakerForCluster(long availableMemory) {
+        for (CrateCircuitBreakerService circuitBreakerService : internalCluster().getInstances(CrateCircuitBreakerService.class)) {
+            circuitBreakerService.registerBreaker(new BreakerSettings(CrateCircuitBreakerService.QUERY, availableMemory, 1.00d));
+        }
+    }
+
+    private void randomiseAndConfigureJoinBlockSize(String relationName, long rowsCount, CircuitBreaker circuitBreaker) {
+        long availableMemory = circuitBreaker.getLimit() - circuitBreaker.getUsed();
+        // We're randomising the table size we configure in the stats in a way such that the number of rows that fit
+        // in memory is sometimes less than the row count of the table (ie. multiple blocks are created) and sometimes
+        // the entire table fits in memory (ie. one block is used)
+        long tableSizeInBytes = new Random().nextInt(3 * (int) availableMemory);
+        long rowSizeBytes = tableSizeInBytes / rowsCount;
+
+        for (TableStats tableStats : internalCluster().getInstances(TableStats.class)) {
+            ObjectObjectHashMap<RelationName, TableStats.Stats> newStats = new ObjectObjectHashMap<>();
+            newStats.put(new RelationName(sqlExecutor.getCurrentSchema(), relationName), new TableStats.Stats(rowsCount, tableSizeInBytes));
+            tableStats.updateTableStats(newStats);
+        }
+
+        RamBlockSizeCalculator ramBlockSizeCalculator = new RamBlockSizeCalculator(500_000, circuitBreaker, rowSizeBytes, rowsCount);
+        logger.info("\n\tThe block size for relation {}, total size {} bytes, with row count {} and row size {} bytes, " +
+                    "if it would be used in a block join algorithm, would be {}",
+            relationName, tableSizeInBytes, rowsCount, rowSizeBytes, ramBlockSizeCalculator.getAsInt());
     }
 
     @Test


### PR DESCRIPTION
The GroupBySingleNumberCollector exposed an Iterable backed by a Stream
as a final (finisher) result. Iterable doesn't prevent the user from calling
iterator() multiple times but java streams cannot be re-iterated.
This fixes a possible "stream has already been operated upon or closed"
exception by using a new stream on every Iterable.iterator() call.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
