### PR TITLE
NestedLoopJoin: don't switch tables if order by was pushed down.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -130,6 +130,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would cause the results of a nested loop join statement
+  ordered by fields from a single relation, in the form of
+  ``SELECT t1.x, t2.x FROM t2 INNER JOIN t1 ON t1.x = t2.x ORDER BY t2.y``, to
+  be out of order.
+
 - Fixed an issue that caused the Admin UI monitoring graphs to be cut off.
 
 - Fixed an issue that caused a ``stream has already been operated upon or

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -97,7 +97,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             JoinOperations.buildRelationsToJoinPairsMap(
                 JoinOperations.convertImplicitJoinConditionsToJoinPairs(mss.joinPairs(), queryParts));
 
-        final boolean orderByCanBePushedDown = joinPairs.values().stream().noneMatch(p -> p.joinType().isOuter());
+        final boolean noOuterJoin = joinPairs.values().stream().noneMatch(p -> p.joinType().isOuter());
 
         Collection<QualifiedName> orderedRelationNames;
         if (mss.sources().size() > 2) {
@@ -159,7 +159,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             lhs,
             rhs,
             query,
-            orderByCanBePushedDown,
+            noOuterJoin,
             txnCtx.sessionContext(),
             tableStats);
 
@@ -175,7 +175,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 joinPairs,
                 queryParts,
                 subqueryPlanner,
-                orderByCanBePushedDown,
+                noOuterJoin,
                 lhs,
                 functions,
                 txnCtx);


### PR DESCRIPTION
We allow order by push down optimisation for the nested loop join if the
order by is on fields from the left relation because the nested loop preserves
the order of the left input relation.
This commit prevents further applying the "swap left and right relation"
optimisation as then, the previos left and ordered relation would end up
on the right side and the join results would not be ordered anymore.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
