### PR TITLE
Move most ReadOnlyNodeIntegrationTest test cases into a unit test

### DIFF
--- a/sql/src/test/java/io/crate/analyze/IsWriteOperationTest.java
+++ b/sql/src/test/java/io/crate/analyze/IsWriteOperationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.RelationName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+public class IsWriteOperationTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (x int)")
+            .addBlobTable(TableDefinitions.createBlobTable(new RelationName("blob", "blobs")))
+            .build();
+    }
+
+    private void assertWriteOperation(String stmt) {
+        assertThat(
+            "Must be a write operation: " + stmt,
+            e.analyze(stmt).isWriteOperation(),
+            is(true)
+        );
+    }
+
+
+    private void assertNoWriteOperation(String stmt) {
+        assertThat(
+            "Must not be a write operation: " + stmt,
+            e.analyze(stmt).isWriteOperation(),
+            is(false)
+        );
+    }
+
+    @Test
+    public void testSelectFromTableIsNoWriteOperation() {
+        assertNoWriteOperation("select x from t1");
+    }
+
+    @Test
+    public void testExplainIsNoWriteOperation() {
+        assertNoWriteOperation("explain select x from t1");
+    }
+
+    @Test
+    public void testExplainOnWriteOperationIsNoWriteOperation() {
+        assertNoWriteOperation("explain copy t1 from '/dummy'");
+    }
+
+    @Test
+    public void testShowCreateTableIsNoWriteOperation() {
+        assertNoWriteOperation("show create table t1");
+    }
+
+    @Test
+    public void testCopyToIsNoWriteOperation() {
+        assertNoWriteOperation("copy t1 to directory '/dummy'");
+    }
+
+    @Test
+    public void testDropTableIsAWriteOperation() {
+        assertWriteOperation("drop table t1");
+    }
+
+    @Test
+    public void testCreateBlobTableIsAWriteOperation() {
+        assertWriteOperation("create blob table myblobs");
+    }
+
+    @Test
+    public void testDropBlobTableIsAWriteOperation() {
+        assertWriteOperation("drop blob table blobs");
+    }
+
+    @Test
+    public void testCopyFromIsAWriteOperation() {
+        assertWriteOperation("copy t1 from 'dummy'");
+    }
+
+    @Test
+    public void testInsertIntoIsAWriteOperation() {
+        assertWriteOperation("insert into t1 (x) values (1)");
+    }
+
+    @Test
+    public void testInsertIntoOnConflictIsAWriteOperation() {
+        assertWriteOperation("insert into t1 (x) values (1) on conflict (_id) do nothing");
+    }
+
+    @Test
+    public void testInsertFromQueryIsAWriteOperation() {
+        assertWriteOperation("insert into t1 (x) (select col1 from unnest([1, 2]))");
+    }
+
+    @Test
+    public void testUpdateIsAWriteOperation() {
+        assertWriteOperation("update t1 set x = x + 1");
+    }
+
+    @Test
+    public void testDeleteIsAWriteOperation() {
+        assertWriteOperation("delete from t1");
+    }
+
+    @Test
+    public void testAlterTableIsAWriteOperation() {
+        assertWriteOperation("alter table t1 set (number_of_replicas = 0)");
+    }
+
+    @Test
+    public void testAlterTableAddColumnIsAWriteOperation() {
+        assertWriteOperation("alter table t1 add column y int");
+    }
+
+    @Test
+    public void testAlterTableRenameIsAWriteOperation() {
+        assertWriteOperation("alter table t1 rename to t2");
+    }
+
+    @Test
+    public void testSetGlobalIsAWriteOperation() {
+        assertWriteOperation("set global persistent stats.enabled = false");
+    }
+
+    @Test
+    public void testRefreshIsAWriteOperation() {
+        assertWriteOperation("refresh table t1");
+    }
+
+    @Test
+    public void testCreateRepoIsAWriteOperation() {
+        assertWriteOperation("create repository repo1 type fs with (location = 'DUMMY')");
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -23,7 +23,6 @@
 package io.crate.integrationtests;
 
 
-import com.google.common.base.Joiner;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.testing.SQLResponse;
@@ -39,17 +38,15 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1)
 @UseRandomizedSchema(random = false)
 public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
-    private SQLTransportExecutor readOnlyExecutor;
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+    private SQLTransportExecutor writeExecutor;
 
     public ReadOnlyNodeIntegrationTest() {
         super(new SQLTransportExecutor(
@@ -84,17 +81,16 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Before
-    public void setUpTestData() throws Exception {
-        executeWrite("create table write_test (id int primary key, name string) with (number_of_replicas=0)");
-        executeWrite("create table write_test2 (id int, name string) with (number_of_replicas=0)");
-        executeWrite("create blob table write_blob_test with (number_of_replicas=0)");
-        executeWrite("create repository existing_repo TYPE \"fs\" with (location=?, compress=True)", new Object[]{folder});
-        ensureYellow();
+    public void setUpTestData() {
+        executeWrite(
+            "create repository existing_repo TYPE \"fs\" with (location=?, compress=True)",
+            new Object[] { folder }
+        );
     }
 
     private SQLResponse executeWrite(String stmt, Object[] args) {
-        if (readOnlyExecutor == null) {
-            readOnlyExecutor = new SQLTransportExecutor(
+        if (writeExecutor == null) {
+            writeExecutor = new SQLTransportExecutor(
                 new SQLTransportExecutor.ClientProvider() {
                     @Override
                     public Client client() {
@@ -116,12 +112,8 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
                 }
             );
         }
-        response = readOnlyExecutor.exec(stmt, args);
+        response = writeExecutor.exec(stmt, args);
         return response;
-    }
-
-    private SQLResponse executeWrite(String stmt) {
-        return executeWrite(stmt, null);
     }
 
     private void assertReadOnly(String stmt, Object[] args) throws Exception {
@@ -134,10 +126,6 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
         assertReadOnly(stmt, null);
     }
 
-    /**
-     * ALLOWED STATEMENT TESTS
-     **/
-
     @Test
     public void testAllowedSelectSys() throws Exception {
         execute("select name from sys.cluster");
@@ -145,128 +133,10 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testAllowedSelect() throws Exception {
-        execute("select name from write_test");
-        assertThat(response.rowCount(), is(0L));
-    }
-
-    @Test
-    public void testAllowedExplainSelect() throws Exception {
-        execute("explain select name from write_test");
-        assertThat(response.rowCount(), is(1L));
-    }
-
-    @Test
-    public void testAllowedExplainWhichIncludesNestedWrite() throws Exception {
-        String copyFilePath = getClass().getResource("/essetup/data/copy").getPath();
-        String uriPath = Joiner.on("/").join(copyFilePath, "test_copy_from.json");
-
-        execute("explain copy write_test from ?", new Object[]{uriPath});
-        assertThat(response.rowCount(), is(1L));
-    }
-
-    @Test
-    public void testAllowedShowCreateTable() throws Exception {
-        execute("show create table write_test");
-        assertThat(response.rowCount(), is(1L));
-    }
-
-    @Test
-    public void testAllowedCopyTo() throws Exception {
-        String uri = folder.getRoot().toURI().toString();
-        SQLResponse response = execute("copy write_test to directory ?", new Object[]{uri});
-        assertThat(response.rowCount(), greaterThanOrEqualTo(0L));
-    }
-
-
-    /**
-     * FORBIDDEN STATEMENT TESTS
-     **/
-
-    @Test
     public void testForbiddenCreateTable() throws Exception {
         assertReadOnly("create table test (id int)");
     }
 
-    @Test
-    public void testForbiddenDropTable() throws Exception {
-        assertReadOnly("drop table write_test");
-    }
-
-    @Test
-    public void testForbiddenCreateBlobTable() throws Exception {
-        assertReadOnly("create blob table blobs_test");
-    }
-
-    @Test
-    public void testForbiddenDropBlobTable() throws Exception {
-        assertReadOnly("drop blob table write_blob_test");
-    }
-
-    @Test
-    public void testForbiddenCopyFrom() throws Exception {
-        assertReadOnly("copy write_test from '/tmp/copy.json'");
-    }
-
-    @Test
-    public void testForbiddenInsertFromValues() throws Exception {
-        assertReadOnly("insert into write_test (id) values (1)");
-    }
-
-    @Test
-    public void testForbiddenInsertFromValuesOnDuplicateKey() throws Exception {
-        assertReadOnly("insert into write_test (id) values (1) on conflict (id) do update set name = 'foo'");
-    }
-
-    @Test
-    public void testForbiddenInsertFromQuery() throws Exception {
-        assertReadOnly("insert into write_test2 (select * from write_test)");
-    }
-
-    @Test
-    public void testForbiddenUpdate() throws Exception {
-        assertReadOnly("update write_test set name = 'foo'");
-    }
-
-    @Test
-    public void testForbiddenDelete() throws Exception {
-        assertReadOnly("delete from write_test");
-    }
-
-    @Test
-    public void testForbiddenAlterTableSetParameter() throws Exception {
-        assertReadOnly("alter table write_test set (number_of_replicas=1)");
-    }
-
-    @Test
-    public void testForbiddenAlterTableAddColumn() throws Exception {
-        assertReadOnly("alter table write_test add column new_column_name string");
-    }
-
-    @Test
-    public void testForbiddenAlterTableRename() throws Exception {
-        assertReadOnly("ALTER TABLE write_test RENAME TO write_test_new");
-    }
-
-    @Test
-    public void testForbiddenSetGlobal() throws Exception {
-        assertReadOnly("set global PERSISTENT stats.enabled = false");
-    }
-
-    @Test
-    public void testForbiddenResetGlobal() throws Exception {
-        assertReadOnly("reset global stats.enabled");
-    }
-
-    @Test
-    public void testForbiddenRefresh() throws Exception {
-        assertReadOnly("refresh table write_test");
-    }
-
-    @Test
-    public void testForbiddenCreateRepository() throws Exception {
-        assertReadOnly("create repository new_repo type fs with (location=?)", new Object[]{folder});
-    }
 
     @Test
     public void testForbiddenDropRepository() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We don't need to spin up nodes and everything to verify that we
categorize the statement correctly.

One integration test to make sure things are wired up correctly would be
enough. This still keeps some more as integration tests because we
currently don't have an easy way to generate the repositories in the
`SQLExecutor` cluster state and the statements in question to eager
repository/snapshot validation.



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed