### PR TITLE
Make error more user friendly if a user attempts to decommission a node

### DIFF
--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -85,7 +85,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     @Test
     public void testNormalUserGrantsPrivilegeThrowsException() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("UnauthorizedException: User \"normal\" is not authorized to execute statement");
+        expectedException.expectMessage("UnauthorizedException: User \"normal\" is not authorized to execute the statement");
         executeAsNormalUser("grant DQL to " + TEST_USERNAME);
     }
 
@@ -346,7 +346,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         assertThat(response.rowCount(), is (0L));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage(containsString("UnauthorizedException: User \"normal\" is not authorized to execute statement"));
+        expectedException.expectMessage(containsString("UnauthorizedException: User \"normal\" is not authorized to execute the statement"));
         executeAsNormalUser("alter cluster reroute retry failed");
     }
 

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
@@ -139,21 +139,21 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
     @Test
     public void testDropUserUnAuthorized() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute statement");
+        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement");
         executeAsNormalUser("drop user ford");
     }
 
     @Test
     public void testCreateUserUnAuthorized() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute statement");
+        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement");
         executeAsNormalUser("create user ford");
     }
 
     @Test
     public void testCreateNormalUserUnAuthorized() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute statement");
+        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement");
         executeAsNormalUser("create user ford");
     }
 

--- a/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
+++ b/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
@@ -56,7 +56,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
         .put("auth.host_based.config.0.user", "crate")
         .build();
 
-    // UserLookup always returns null, so there are no users (even no default crate super user)
+    // UserLookup always returns null, so there are no users (even no default crate superuser)
     private final Authentication authService = new HostBasedAuthentication(hbaEnabled, userName -> null);
 
     private static void assertUnauthorized(DefaultFullHttpResponse resp, String expectedBody) {

--- a/sql/src/main/java/io/crate/user/StubUserManager.java
+++ b/sql/src/main/java/io/crate/user/StubUserManager.java
@@ -67,7 +67,7 @@ public class StubUserManager implements UserManager {
     @Nullable
     @Override
     public User findUser(String userName) {
-        // Without enterprise enabled everything runs as super user
+        // Without enterprise enabled everything runs as superuser
         return User.CRATE_USER;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Instead of:

    UnsupportedFeatureException: Can't handle "AnalyzedDecommissionNodeStatement{nodeIdOrName=Literal{Wilde Leck, type=string}}

The users will now get:

    User "<name>" is not authorized to execute statement


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed