### PR TITLE
Ignore .gradletasknamecache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .floo
 .flooignore
+.gradletasknamecache
 *~
 
 # Java files


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add .gradletasknamecache to .gitignore

.gradletasknamecache is generated by the `ohMyZsh` plugin and caches the available gradle tasks.
You can then use autocomplete when using gradle.


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed