### PR TITLE
Support '\\' and '\'' in Escaped String Literals

### DIFF
--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -63,7 +63,8 @@ Escape Sequence                                       Interpretation
 ==================================================   ================
 
 For instance, the escape string literal ``e'\u0061\x61\141'``
-is equivalent to the ``'aaa'`` string literal::
+is equivalent to the ``'aaa'`` string literal.
+::
 
     cr> select e'\u0061\x61\141' as col1;
     +------+
@@ -74,7 +75,9 @@ is equivalent to the ``'aaa'`` string literal::
     SELECT 1 row in set (... sec)
 
 Any other character following a backslash is taken literally. Thus, to include
-a backslash character ``\``, two backslashes need to be used (i.e. ``\\``)::
+a backslash character ``\``, two adjacent backslashes need to be used
+(i.e. ``\\``).
+::
 
     cr> select e'aa\\nbb' as col1;
     +--------+
@@ -82,6 +85,19 @@ a backslash character ``\``, two backslashes need to be used (i.e. ``\\``)::
     +--------+
     | aa\nbb |
     +--------+
+    SELECT 1 row in set (... sec)
+
+Finally, a single quote can be included in an escape string literal
+by also using the escape backslash character: ``\'``, in addition to the
+single-quote described in :ref:`String Literals <string_literal>`.
+::
+
+    cr> select e'aa\'bb' as col1;
+    +-------+
+    | col1  |
+    +-------+
+    | aa'bb |
+    +-------+
     SELECT 1 row in set (... sec)
 
 .. _sql_lexical_keywords_identifiers:
@@ -103,26 +119,25 @@ quoted if used as identifiers.
     CURRENT_SCHEMA, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_USER
     DEFAULT, DELETE, DENY, DESC
     DESCRIBE, DIRECTORY, DISTINCT, DOUBLE
-    DROP, E, ELSE, END
-    ESCAPE, EXCEPT, EXISTS, EXTRACT
-    FALSE, FIRST, FLOAT, FOR
-    FROM, FULL, FUNCTION, GRANT
-    GROUP, HAVING, IF, IN
-    INDEX, INNER, INPUT, INSERT
-    INT, INTEGER, INTERSECT, INTO
-    IP, IS, JOIN, LAST
-    LEFT, LICENSE, LIKE, LIMIT
-    LONG, MATCH, NATURAL, NOT
-    NULL, NULLS, OBJECT, OFFSET
-    ON, OR, ORDER, OUTER
-    PERSISTENT, PRIMARY, RECURSIVE, REPLACE
-    RESET, RETURNS, REVOKE, RIGHT
-    SELECT, SESSION_USER, SET, SHORT
-    SOME, STRATIFY, STRING, SUBSTRING
-    TABLE, THEN, TRANSIENT, TRUE
-    TRY_CAST, UNBOUNDED, UNION, UPDATE
-    USER, USING, WHEN, WHERE
-    WITH
+    DROP, ELSE, END, ESCAPE
+    EXCEPT, EXISTS, EXTRACT, FALSE
+    FIRST, FLOAT, FOR, FROM
+    FULL, FUNCTION, GRANT, GROUP
+    HAVING, IF, IN, INDEX
+    INNER, INPUT, INSERT, INT
+    INTEGER, INTERSECT, INTO, IP
+    IS, JOIN, LAST, LEFT
+    LICENSE, LIKE, LIMIT, LONG
+    MATCH, NATURAL, NOT, NULL
+    NULLS, OBJECT, OFFSET, ON
+    OR, ORDER, OUTER, PERSISTENT
+    PRIMARY, RECURSIVE, REPLACE, RESET
+    RETURNS, REVOKE, RIGHT, SELECT
+    SESSION_USER, SET, SHORT, SOME
+    STRATIFY, STRING, SUBSTRING, TABLE
+    THEN, TRANSIENT, TRUE, TRY_CAST
+    UNBOUNDED, UNION, UPDATE, USER
+    USING, WHEN, WHERE, WITH
 
 Tokens such as ``my_table``, ``id``, ``name``, or ``data`` in the example above
 are **identifiers**, which identify names of tables, columns, and other

--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -73,6 +73,17 @@ is equivalent to the ``'aaa'`` string literal::
     +------+
     SELECT 1 row in set (... sec)
 
+Any other character following a backslash is taken literally. Thus, to include
+a backslash character ``\``, two backslashes need to be used (i.e. ``\\``)::
+
+    cr> select e'aa\\nbb' as col1;
+    +--------+
+    | col1   |
+    +--------+
+    | aa\nbb |
+    +--------+
+    SELECT 1 row in set (... sec)
+
 .. _sql_lexical_keywords_identifiers:
 
 Key Words and Identifiers

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -304,7 +304,7 @@ nullLiteral
     ;
 
 escapedCharsStringLiteral
-    : EPSILON STRING
+    : ESCAPED_STRING
     ;
 
 stringLiteral
@@ -655,7 +655,7 @@ nonReserved
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN
-    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | EPSILON
+    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION
     ;
 
 SELECT: 'SELECT';
@@ -919,10 +919,12 @@ CONCAT: '||';
 CAST_OPERATOR: '::';
 SEMICOLON: ';';
 
-EPSILON: 'E';
-
 STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''
+    ;
+
+ESCAPED_STRING
+    : 'E' '\'' ( ~'\'' | '\'\'' | '\\\'' )* '\''
     ;
 
 INTEGER_VALUE

--- a/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -79,7 +79,8 @@ public class Literals {
                         i++;
                         break;
                     case '\\':
-                        builder.append('\\');
+                    case '\'':
+                        builder.append(nextChar);
                         i++;
                         break;
                     case 'u':

--- a/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -78,6 +78,10 @@ public class Literals {
                         builder.append('\t');
                         i++;
                         break;
+                    case '\\':
+                        builder.append('\\');
+                        i++;
+                        break;
                     case 'u':
                     case 'U':
                         // handle unicode case

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1526,7 +1526,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitEscapedCharsStringLiteral(SqlBaseParser.EscapedCharsStringLiteralContext ctx) {
-        return new EscapedCharStringLiteral(unquote(ctx.STRING().getText()));
+        // use beginIndex = 2 to account for the 'E' literal
+        return new EscapedCharStringLiteral(unquote(ctx.ESCAPED_STRING().getText(), 2));
     }
 
     @Override
@@ -1657,7 +1658,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     private static String unquote(String value) {
-        return value.substring(1, value.length() - 1)
+        return unquote(value, 1);
+    }
+
+    private static String unquote(String value, int beginIndex) {
+        return value.substring(beginIndex, value.length() - 1)
             .replace("''", "'");
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -54,7 +54,7 @@ public class LiteralsTest {
     }
 
     @Test
-    public void tesThatNoEscapedCharsAreNotReplaced() throws Exception {
+    public void testThatNoEscapedCharsAreNotReplaced() throws Exception {
         assertThat(Literals.replaceEscapedChars(""), is(""));
         assertThat(Literals.replaceEscapedChars("Hello World"), is("Hello World"));
     }
@@ -111,6 +111,11 @@ public class LiteralsTest {
     @Test
     public void testThatCharEscapeWithoutAnySequenceIsNotReplaced() throws Exception {
         assertThat(Literals.replaceEscapedChars("\\"), is("\\"));
+    }
+
+    @Test
+    public void testThatEscapedBackslashCharIsReplacedAndNotConsideredAsEscapeChar() throws Exception {
+        assertThat(Literals.replaceEscapedChars("\\\\141"), is("\\141"));
     }
 
     @Test

--- a/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -119,6 +119,11 @@ public class LiteralsTest {
     }
 
     @Test
+    public void testThatEscapedQuoteCharIsReplaced() throws Exception {
+        assertThat(Literals.replaceEscapedChars("\\'141"), is("'141"));
+    }
+
+    @Test
     public void testThatInvalidEscapeSequenceIsNotReplaced() throws Exception {
         assertThat(Literals.replaceEscapedChars("\\s"), is("\\s"));
     }
@@ -239,7 +244,6 @@ public class LiteralsTest {
         expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
         Literals.replaceEscapedChars("\\u006G");
     }
-
 
     @Test
     public void testThatEscaped32BitUnicodeCharsAreReplaced() throws Exception {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -783,6 +783,7 @@ public class TestStatementBuilder {
         printStatement("select * from t where a like E'aValue'");
         printStatement("select * from t where a = E'\\141Value'");
         printStatement("select * from t where a = e'\\141Value'");
+        printStatement("select * from t where a = e'aa\\'bb'");
         printStatement("select e.a from t e where e.a = E'\\141Value'");
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commit messages

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
