### PR TITLE
Make reads against the metrics histogram thread-safe.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -132,3 +132,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue that could result in an ``ConcurrentModificationException``
+  error when querying the :ref:`sys-jobs-metrics` table.

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -28,6 +28,7 @@ import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.expression.reference.sys.operation.OperationContext;
 import io.crate.expression.reference.sys.operation.OperationContextLog;
 import io.crate.metadata.sys.ClassifiedMetrics;
+import io.crate.metadata.sys.MetricsView;
 import io.crate.planner.operators.StatementClassifier;
 import org.elasticsearch.common.collect.Tuple;
 
@@ -168,7 +169,7 @@ public class JobsLogs {
         }
     }
 
-    public Iterable<ClassifiedMetrics.Metrics> metrics() {
+    public Iterable<MetricsView> metrics() {
         return classifiedMetrics;
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/MetricsView.java
+++ b/sql/src/main/java/io/crate/metadata/sys/MetricsView.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import io.crate.planner.operators.StatementClassifier;
+import org.HdrHistogram.Histogram;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class MetricsView {
+
+    private final Histogram histogram;
+    private final long sumOfDurations;
+    private final long failedCount;
+    private final StatementClassifier.Classification classification;
+
+    /**
+     * Create a read-only view onto the provided metrics.
+     *
+     * The given histogram must not be modified by whoever creates the MetricsView.
+     */
+    public MetricsView(Histogram histogram,
+                       long sumOfDurations,
+                       long failedCount,
+                       StatementClassifier.Classification classification) {
+        this.histogram = histogram;
+        this.sumOfDurations = sumOfDurations;
+        this.failedCount = failedCount;
+        this.classification = classification;
+    }
+
+    public long totalCount() {
+        return histogram.getTotalCount();
+    }
+
+    public double mean() {
+        return histogram.getMean();
+    }
+
+    public double stdDeviation() {
+        return histogram.getStdDeviation();
+    }
+
+    public long maxValue() {
+        return histogram.getMaxValue();
+    }
+
+    public long minValue() {
+        long minValue = histogram.getMinValue();
+        return minValue == Long.MAX_VALUE ? 0L : minValue;
+    }
+
+    public long getValueAtPercentile(double percentile) {
+        return histogram.getValueAtPercentile(percentile);
+    }
+
+    public long sumOfDurations() {
+        return sumOfDurations;
+    }
+
+    public long failedCount() {
+        return failedCount;
+    }
+
+    public StatementClassifier.Classification classification() {
+        return classification;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -31,7 +31,6 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.sys.ClassifiedMetrics.Metrics;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.DataTypes;
@@ -98,30 +97,30 @@ public class SysMetricsTableInfo extends StaticTableInfo {
         );
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<Metrics>> expressions(Supplier<DiscoveryNode> localNode) {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Metrics>>builder()
-            .put(Columns.TOTAL_COUNT, () -> forFunction(h -> h.histogram().getTotalCount()))
-            .put(Columns.SUM_OF_DURATIONS, () -> forFunction(Metrics::sumOfDurations))
-            .put(Columns.FAILED_COUNT, () -> forFunction(Metrics::failedCount))
-            .put(Columns.MEAN, () -> forFunction(h -> h.histogram().getMean()))
-            .put(Columns.STDEV, () -> forFunction(h -> h.histogram().getStdDeviation()))
-            .put(Columns.MAX, () -> forFunction(h -> h.histogram().getMaxValue()))
-            .put(Columns.MIN, () -> forFunction(h -> h.histogram().getMinValue() == Long.MAX_VALUE ? 0L : h.histogram().getMinValue()))
-            .put(Columns.PERCENTILES, () -> forFunction(h -> ImmutableMap.builder()
-                .put("25", h.histogram().getValueAtPercentile(25.0))
-                .put("50", h.histogram().getValueAtPercentile(50.0))
-                .put("75", h.histogram().getValueAtPercentile(75.0))
-                .put("90", h.histogram().getValueAtPercentile(90.0))
-                .put("95", h.histogram().getValueAtPercentile(95.0))
-                .put("99", h.histogram().getValueAtPercentile(99.0))
+    public static Map<ColumnIdent, RowCollectExpressionFactory<MetricsView>> expressions(Supplier<DiscoveryNode> localNode) {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<MetricsView>>builder()
+            .put(Columns.TOTAL_COUNT, () -> forFunction(MetricsView::totalCount))
+            .put(Columns.SUM_OF_DURATIONS, () -> forFunction(MetricsView::sumOfDurations))
+            .put(Columns.FAILED_COUNT, () -> forFunction(MetricsView::failedCount))
+            .put(Columns.MEAN, () -> forFunction(MetricsView::mean))
+            .put(Columns.STDEV, () -> forFunction(MetricsView::stdDeviation))
+            .put(Columns.MAX, () -> forFunction(MetricsView::maxValue))
+            .put(Columns.MIN, () -> forFunction(MetricsView::minValue))
+            .put(Columns.PERCENTILES, () -> forFunction(m -> ImmutableMap.builder()
+                .put("25", m.getValueAtPercentile(25.0))
+                .put("50", m.getValueAtPercentile(50.0))
+                .put("75", m.getValueAtPercentile(75.0))
+                .put("90", m.getValueAtPercentile(90.0))
+                .put("95", m.getValueAtPercentile(95.0))
+                .put("99", m.getValueAtPercentile(99.0))
                 .build()
             ))
-            .put(Columns.P25, () -> forFunction(h -> h.histogram().getValueAtPercentile(25.0)))
-            .put(Columns.P50, () -> forFunction(h -> h.histogram().getValueAtPercentile(50.0)))
-            .put(Columns.P75, () -> forFunction(h -> h.histogram().getValueAtPercentile(75.0)))
-            .put(Columns.P90, () -> forFunction(h -> h.histogram().getValueAtPercentile(90.0)))
-            .put(Columns.P95, () -> forFunction(h -> h.histogram().getValueAtPercentile(95.0)))
-            .put(Columns.P99, () -> forFunction(h -> h.histogram().getValueAtPercentile(99.0)))
+            .put(Columns.P25, () -> forFunction(m -> m.getValueAtPercentile(25.0)))
+            .put(Columns.P50, () -> forFunction(m -> m.getValueAtPercentile(50.0)))
+            .put(Columns.P75, () -> forFunction(m -> m.getValueAtPercentile(75.0)))
+            .put(Columns.P90, () -> forFunction(m -> m.getValueAtPercentile(90.0)))
+            .put(Columns.P95, () -> forFunction(m -> m.getValueAtPercentile(95.0)))
+            .put(Columns.P99, () -> forFunction(m -> m.getValueAtPercentile(99.0)))
             .put(Columns.NODE, () -> forFunction(ignored -> ImmutableMap.builder()
                 .put("id", localNode.get().getId())
                 .put("name", localNode.get().getName())

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -32,11 +32,7 @@ import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.expression.reference.sys.operation.OperationContext;
 import io.crate.expression.reference.sys.operation.OperationContextLog;
-import io.crate.metadata.sys.ClassifiedMetrics;
-import io.crate.metadata.sys.ClassifiedMetrics.Metrics;
-import io.crate.planner.Plan;
-import io.crate.planner.Plan.StatementType;
-import io.crate.planner.operators.StatementClassifier;
+import io.crate.metadata.sys.MetricsView;
 import io.crate.planner.operators.StatementClassifier.Classification;
 import io.crate.plugin.SQLPlugin;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -68,10 +64,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import static io.crate.planner.Plan.StatementType.*;
+import static io.crate.planner.Plan.StatementType.SELECT;
+import static io.crate.planner.Plan.StatementType.UNDEFINED;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
 
@@ -411,10 +407,10 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
         jobsLogs.updateJobsLog(new QueueSink<>(q, ramAccountingContext::close));
         jobsLogs.logPreExecutionFailure(UUID.randomUUID(), "select foo", "stmt error", user);
 
-        List<Metrics> metrics = ImmutableList.copyOf(jobsLogs.metrics().iterator());
+        List<MetricsView> metrics = ImmutableList.copyOf(jobsLogs.metrics().iterator());
         assertThat(metrics.size(), is(1));
         assertThat(metrics.get(0).failedCount(), is(1L));
-        assertThat(metrics.get(0).histogram().getTotalCount(), is(1L));
+        assertThat(metrics.get(0).totalCount(), is(1L));
         assertThat(metrics.get(0).classification(), is(new Classification(UNDEFINED)));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -23,8 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.execution.engine.collect.stats.JobsLogService;
-import io.crate.metadata.sys.ClassifiedMetrics;
-import io.crate.metadata.sys.ClassifiedMetrics.Metrics;
+import io.crate.metadata.sys.MetricsView;
 import io.crate.planner.Plan;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -91,9 +90,9 @@ public class MetricsITest extends SQLTransportIntegrationTest {
         assertBusy(() -> {
             long cnt = 0;
             for (JobsLogService jobsLogService : internalCluster().getInstances(JobsLogService.class)) {
-                for (Metrics metrics: jobsLogService.get().metrics()) {
+                for (MetricsView metrics: jobsLogService.get().metrics()) {
                     if (metrics.classification().type() == Plan.StatementType.SELECT) {
-                        cnt += metrics.histogram().getTotalCount();
+                        cnt += metrics.totalCount();
                     }
                 }
             }

--- a/sql/src/test/java/io/crate/metadata/sys/ClassifiedMetricsTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/ClassifiedMetricsTest.java
@@ -22,13 +22,10 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.metadata.sys.ClassifiedMetrics.Metrics;
 import io.crate.planner.Plan;
 import io.crate.planner.operators.StatementClassifier;
-import org.HdrHistogram.Histogram;
 import org.junit.Test;
 
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -49,9 +46,9 @@ public class ClassifiedMetricsTest {
         ClassifiedMetrics histograms = new ClassifiedMetrics();
         histograms.recordValue(
             new StatementClassifier.Classification(Plan.StatementType.SELECT), -2);
-        Histogram histogram = histograms.iterator().next().histogram();
-        assertThat(histogram.getTotalCount(), is(1L));
-        assertThat(histogram.getMinValue(), is(0L));
+        MetricsView metricsView = histograms.iterator().next();
+        assertThat(metricsView.totalCount(), is(1L));
+        assertThat(metricsView.minValue(), is(0L));
     }
 
     @Test
@@ -66,7 +63,7 @@ public class ClassifiedMetricsTest {
         histograms.recordValue(
             new StatementClassifier.Classification(Plan.StatementType.UPDATE), SECONDS.toMillis(25));
 
-        for (Metrics metrics : histograms) {
+        for (MetricsView metrics : histograms) {
             if (metrics.classification().type().equals(Plan.StatementType.SELECT)) {
                 assertThat(metrics.sumOfDurations(), is(SECONDS.toMillis(45)));
             } else {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `ConcurrentHistogram` is only thread-safe for writes, not for reads.
As recommended in the documentation of the `ConcurrentHistogram` this
changes the code to use a `Recorder`.

It also introduces a `MetricsView` as a means of indirection to create a
"read-only" histogram only once. (The column expressions of the
`sys.jobs_metrics` table each called `histogram` individually)



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed