### PR TITLE
license change to support max number of nodes / Deprecate setting 'license.enterprise'

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -57,9 +57,6 @@
 # <https://crate.io/docs/crate/reference/en/latest/enterprise/index.html> for
 # more information.
 
-# Setting this to `false` disables the Enterprise Features.
-#license.enterprise: true
-
 # To use any of these features, Crate.io must have given you permission to
 # enable and use such Enterprise Features and you must have a valid Enterprise
 # or Subscription Agreement with Crate.io.  If you enable or use the Enterprise

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,10 @@ Breaking Changes
 Deprecations
 ============
 
+- Marked the :ref:`license.enterprise <conf-node-enterprise-license>`
+  setting as deprecated as we are moving away from checking for enterprise
+  features based on this setting.
+
 - The query frequency and average duration :ref:`query_stats_mbean` metrics
   have been deprecated in favour of the new total count and sum of durations
   metrics.

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -682,4 +682,8 @@ Enterprise License
 
   Setting this to ``false`` disables the `Enterprise Edition`_ of CrateDB.
 
+.. NOTE::
+
+   This setting is now deprecated and will be removed in the future.
+
 .. _`Enterprise Edition`: https://crate.io/enterprise-edition/

--- a/blackbox/docs/enterprise/index.rst
+++ b/blackbox/docs/enterprise/index.rst
@@ -12,10 +12,6 @@ Enterprise Features
 Feature List
 ============
 
-When you first download CrateDB, the :ref:`license.enterprise
-<conf-node-enterprise-license>` setting is set to ``true`` and the following
-enterprise features are enabled:
-
 - :ref:`administration_user_management`: manage multiple database users
 - :ref:`administration-privileges`: configure user privileges
 - :ref:`admin_auth`: manage your database with authentication, and
@@ -32,6 +28,16 @@ enterprise features are enabled:
 - :ref:`window-function-nthvalue`: ``nth_value`` window function
 - `The CrateDB admin UI`_: `shards browser`_, `monitoring overview`_,
   `privileges browser`_
+
+.. NOTE::
+
+   When you first download CrateDB, the :ref:`license.enterprise
+   <conf-node-enterprise-license>` setting is set to ``true`` which
+   results in the enterprise features being enabled.
+   However, we are currently moving away from checking for enterprise features
+   based on that setting. Thus the :ref:`license.enterprise
+   <conf-node-enterprise-license>` setting is now deprecated
+   and will be removed in the future.
 
 .. _enterprise_trial:
 
@@ -57,6 +63,13 @@ trial period ends you must set :ref:`license.enterprise
 <conf-node-enterprise-license>` to ``false``. This activates the `community
 edition`_ of CrateDB and restores all functionality except for the enterprise
 features.
+
+.. NOTE::
+
+   As we are currently changing the way for switching to the CrateDB
+   `community edition`_, the :ref:`license.enterprise
+   <conf-node-enterprise-license>` setting is deprecated
+   and will be removed in the future.
 
 .. _community Edition: https://crate.io/products/cratedb-editions/
 .. _enterprise license: https://crate.io/products/cratedb-editions/

--- a/common/src/main/java/io/crate/settings/SharedSettings.java
+++ b/common/src/main/java/io/crate/settings/SharedSettings.java
@@ -27,8 +27,12 @@ import org.elasticsearch.common.settings.Setting;
 
 public class SharedSettings {
 
+    /**
+        @deprecated
+     */
+    @Deprecated
     public static final CrateSetting<Boolean> ENTERPRISE_LICENSE_SETTING = CrateSetting.of(Setting.boolSetting(
-        "license.enterprise", true, Setting.Property.NodeScope),
+        "license.enterprise", true, Setting.Property.NodeScope, Setting.Property.Deprecated),
         DataTypes.BOOLEAN);
 
     /**

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.ssl.SslHandler;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -107,6 +108,7 @@ public class CrateHttpsTransportTest extends CrateUnitTest {
             assertThat(channel.pipeline().first(), instanceOf(SslHandler.class));
 
         } finally {
+            assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
             transport.stop();
             transport.close();
             channel.close().awaitUninterruptibly();

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
@@ -22,7 +22,9 @@ import io.crate.plugin.PipelineRegistry;
 import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.handler.ssl.SslContext;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,6 +45,13 @@ public class SslContextProviderTest extends CrateUnitTest {
     public static void beforeTests() throws IOException {
         trustStoreFile = getAbsoluteFilePathFromClassPath("truststore.jks");
         keyStoreFile = getAbsoluteFilePathFromClassPath("keystore.jks");
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
+        super.tearDown();
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/metadata/PrivilegesMetaDataUpgraderTest.java
+++ b/enterprise/users/src/test/java/io/crate/metadata/PrivilegesMetaDataUpgraderTest.java
@@ -25,6 +25,7 @@ import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.junit.Test;
@@ -54,6 +55,7 @@ public class PrivilegesMetaDataUpgraderTest extends CrateUnitTest {
             .build();
         Map<String, MetaData.Custom> newCustomMap = UPGRADER.apply(settings, customMap);
         assertThat(newCustomMap, is(oldCustomMap));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
     }
 
     @Test

--- a/licensing/src/main/java/io/crate/license/DecryptedLicenseData.java
+++ b/licensing/src/main/java/io/crate/license/DecryptedLicenseData.java
@@ -33,18 +33,25 @@ import org.elasticsearch.common.xcontent.XContentType;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.function.IntSupplier;
 
 public class DecryptedLicenseData {
 
-    public static final String EXPIRY_DATE_IN_MS = "expiryDateInMs";
-    public static final String ISSUED_TO = "issuedTo";
+    static final long DEFAULT_EXPIRY_DATE_IN_MS = Long.MAX_VALUE;
+    public static final int DEFAULT_MAX_NUMBER_OF_NODES = Integer.MAX_VALUE;
+
+    static final String EXPIRY_DATE_IN_MS = "expiryDateInMs";
+    static final String ISSUED_TO = "issuedTo";
+    private static final String MAX_NUMBER_OF_NODES = "MaxNumberOfNodes";
 
     private final long expiryDateInMs;
     private final String issuedTo;
+    private final int maxNumberOfNodes;
 
-    public DecryptedLicenseData(long expiryDateInMs, String issuedTo) {
+    public DecryptedLicenseData(long expiryDateInMs, String issuedTo, int maxNumberOfNodes) {
         this.expiryDateInMs = expiryDateInMs;
         this.issuedTo = issuedTo;
+        this.maxNumberOfNodes = maxNumberOfNodes;
     }
 
     public long expiryDateInMs() {
@@ -59,6 +66,10 @@ public class DecryptedLicenseData {
         return issuedTo;
     }
 
+    public int maxNumberOfNodes() {
+        return maxNumberOfNodes;
+    }
+
     boolean isExpired() {
         return millisToExpiration() < 0;
     }
@@ -70,6 +81,7 @@ public class DecryptedLicenseData {
      *      {
      *          "expiryDateInMs": "XXX",
      *          "issuedTo": "YYY"
+     *          "maxNumberOfNodes": "ZZ"
      *      }
      * </pre>
      */
@@ -79,6 +91,7 @@ public class DecryptedLicenseData {
             contentBuilder.startObject()
                 .field(EXPIRY_DATE_IN_MS, expiryDateInMs)
                 .field(ISSUED_TO, issuedTo)
+                .field(MAX_NUMBER_OF_NODES, maxNumberOfNodes)
                 .endObject();
             return Strings.toString(contentBuilder).getBytes(StandardCharsets.UTF_8);
         } catch (IOException e) {
@@ -86,12 +99,14 @@ public class DecryptedLicenseData {
         }
     }
 
-    static DecryptedLicenseData fromFormattedLicenseData(byte[] licenseData) throws IOException {
+    static DecryptedLicenseData fromFormattedLicenseData(byte[] licenseData,
+                                                         IntSupplier defaultMaxNumberOfNodesSupplier) throws IOException {
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, licenseData)) {
             XContentParser.Token token;
-            long expiryDate = 0;
+            long expiryDate = DEFAULT_EXPIRY_DATE_IN_MS;
             String issuedTo = null;
+            int maxNumberOfNodes = defaultMaxNumberOfNodesSupplier.getAsInt();
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     String currentFieldName = parser.currentName();
@@ -100,10 +115,12 @@ public class DecryptedLicenseData {
                         expiryDate = parser.longValue();
                     } else if (currentFieldName.equals(ISSUED_TO)) {
                         issuedTo = parser.text();
+                    } else if (currentFieldName.equals(MAX_NUMBER_OF_NODES)) {
+                        maxNumberOfNodes = parser.intValue();
                     }
                 }
             }
-            return new DecryptedLicenseData(expiryDate, issuedTo);
+            return new DecryptedLicenseData(expiryDate, issuedTo, maxNumberOfNodes);
         }
     }
 
@@ -113,11 +130,12 @@ public class DecryptedLicenseData {
         if (o == null || getClass() != o.getClass()) return false;
         DecryptedLicenseData that = (DecryptedLicenseData) o;
         return expiryDateInMs == that.expiryDateInMs &&
+               maxNumberOfNodes == that.maxNumberOfNodes &&
                Objects.equals(issuedTo, that.issuedTo);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(expiryDateInMs, issuedTo);
+        return Objects.hash(expiryDateInMs, issuedTo, maxNumberOfNodes);
     }
 }

--- a/licensing/src/main/java/io/crate/license/EnterpriseLicense.java
+++ b/licensing/src/main/java/io/crate/license/EnterpriseLicense.java
@@ -30,6 +30,8 @@ import java.io.InputStream;
 
 final class EnterpriseLicense {
 
+    static final int DEFAULT_MAX_NUMBER_OF_NODES = 10;
+
     private EnterpriseLicense() {
     }
 

--- a/licensing/src/main/java/io/crate/license/LicenseKey.java
+++ b/licensing/src/main/java/io/crate/license/LicenseKey.java
@@ -68,7 +68,7 @@ public class LicenseKey extends AbstractNamedDiffable<MetaData.Custom> implement
         }
     }
 
-    static final int VERSION = 1;
+    static final int VERSION = 2;
 
     // limit the maximum license content number of bytes (this can vary based on the algorithm used for encryption and
     // the length of the client's name the license is issued to

--- a/licensing/src/main/java/io/crate/license/LicenseTool.java
+++ b/licensing/src/main/java/io/crate/license/LicenseTool.java
@@ -50,15 +50,21 @@ public class LicenseTool {
         ArgumentAcceptingOptionSpec<String> issuedToArg = parser.accepts("issued-to")
             .withRequiredArg()
             .ofType(String.class);
+        ArgumentAcceptingOptionSpec<Integer> maxNodesArg = parser.accepts("max-nodes")
+            .withRequiredArg()
+            .ofType(Integer.class);
 
         String keyPath;
         long expirationDate;
         String issuedTo;
+        int maxNodes;
         try {
             OptionSet optionSet = parser.parse(args);
             keyPath = keyArg.value(optionSet);
             expirationDate = DataTypes.TIMESTAMP.value(expirationDateArg.value(optionSet));
             issuedTo = issuedToArg.value(optionSet);
+            maxNodes = maxNodesArg.value(optionSet);
+            if (maxNodes <= 0) throw new IllegalArgumentException("max-nodes needs to be a positive number");
         } catch (Exception e) {
             parser.printHelpOn(System.err);
             System.exit(1);
@@ -69,16 +75,16 @@ public class LicenseTool {
         PrivateKey privateKey = KeyFactory.getInstance(CryptoUtils.RSA_CIPHER_ALGORITHM)
             .generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
 
-        byte[] licenseData = new DecryptedLicenseData(
-            expirationDate,
-            issuedTo
-        ).formatLicenseData();
+        byte[] licenseData = new DecryptedLicenseData(expirationDate, issuedTo, maxNodes).formatLicenseData();
         byte[] encryptedLicenseData = CryptoUtils.crypto(
                 CryptoUtils.RSA_CIPHER_ALGORITHM,  
                 Cipher.ENCRYPT_MODE,
                 privateKey,
                 licenseData);
-        LicenseKey licenseKey = LicenseKey.createLicenseKey(LicenseKey.LicenseType.ENTERPRISE, 1, encryptedLicenseData);
+        LicenseKey licenseKey = LicenseKey.createLicenseKey(
+            LicenseKey.LicenseType.ENTERPRISE,
+            2,
+            encryptedLicenseData);
         System.out.println(licenseKey.licenseKey());
     }
 }

--- a/licensing/src/test/java/io/crate/license/DecryptedLicenseDataV1.java
+++ b/licensing/src/test/java/io/crate/license/DecryptedLicenseDataV1.java
@@ -20,24 +20,28 @@
  * agreement.
  */
 
-package io.crate.exceptions;
+package io.crate.license;
 
-import java.util.Locale;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
 
-public class ExpiredLicenseException extends ValidationException implements ClusterScopeException {
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-    private static final String MESSAGE_TEMPLATE = "License is expired - %s. " +
-                                                   "Please request a new license and " +
-                                                   "use 'SET LICENSE' statement to register it " +
-                                                   "or use the 'ALTER CLUSTER DECOMMISSION' statement " +
-                                                   "to downscale your cluster to [3] nodes";
+public class DecryptedLicenseDataV1 {
 
-    public ExpiredLicenseException(String effect) {
-        super(String.format(Locale.ENGLISH, MESSAGE_TEMPLATE, effect));
-    }
-
-    @Override
-    public int errorCode() {
-        return 9;
+    static byte[] formatLicenseData(long expiryDateInMs, String issuedTo) {
+        try {
+            XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+            contentBuilder.startObject()
+                .field(DecryptedLicenseData.EXPIRY_DATE_IN_MS, expiryDateInMs)
+                .field(DecryptedLicenseData.ISSUED_TO, issuedTo)
+                .endObject();
+            return Strings.toString(contentBuilder).getBytes(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/sql/src/main/java/io/crate/exceptions/ExpiredLicenseException.java
+++ b/sql/src/main/java/io/crate/exceptions/ExpiredLicenseException.java
@@ -28,7 +28,9 @@ public class ExpiredLicenseException extends ValidationException implements Clus
 
     private static final String MESSAGE_TEMPLATE = "License is expired - %s. " +
                                                    "Please request a new license and " +
-                                                   "use 'SET LICENSE' statement to register it";
+                                                   "use 'SET LICENSE' statement to register it " +
+                                                   "or use the 'ALTER CLUSTER DECOMMISSION' statement " +
+                                                   "to downscale your cluster to [3] nodes";
 
     public ExpiredLicenseException(String effect) {
         super(String.format(Locale.ENGLISH, MESSAGE_TEMPLATE, effect));

--- a/sql/src/main/java/io/crate/exceptions/LicenseViolationException.java
+++ b/sql/src/main/java/io/crate/exceptions/LicenseViolationException.java
@@ -20,36 +20,26 @@
  * agreement.
  */
 
-package io.crate.license;
+package io.crate.exceptions;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.util.Locale;
 
-import static io.crate.license.LicenseKey.LicenseType;
+public class LicenseViolationException extends ValidationException implements ClusterScopeException {
 
-final class TrialLicense {
+    private static final String MESSAGE_TEMPLATE = "License is violated - %s. " +
+                                                   "If expired or more cluster nodes are in need, " +
+                                                   "please request a new license and " +
+                                                   "use 'SET LICENSE' statement to register it. " +
+                                                   "Alternatively, if the allowed number of nodes is exceeded, " +
+                                                   "use the 'ALTER CLUSTER DECOMMISSION' statement " +
+                                                   "to downscale your cluster";
 
-    static final int DEFAULT_MAX_NUMBER_OF_NODES = 3;
-
-    private TrialLicense() {
+    public LicenseViolationException(String effect) {
+        super(String.format(Locale.ENGLISH, MESSAGE_TEMPLATE, effect));
     }
 
-    static LicenseKey createLicenseKey(int version, DecryptedLicenseData decryptedLicenseData) {
-        return createLicenseKey(version, decryptedLicenseData.formatLicenseData());
-    }
-
-    @VisibleForTesting
-    static LicenseKey createLicenseKey(int version, byte[] decryptedContent) {
-        byte[] encryptedContent = encrypt(decryptedContent);
-        return LicenseKey.createLicenseKey(LicenseType.TRIAL,
-            version,
-            encryptedContent);
-    }
-
-    private static byte[] encrypt(byte[] data) {
-        return CryptoUtils.encryptAES(data);
-    }
-
-    static byte[] decrypt(byte[] encryptedContent) {
-        return CryptoUtils.decryptAES(encryptedContent);
+    @Override
+    public int errorCode() {
+        return 9;
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheck.java
@@ -26,10 +26,8 @@ import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.license.DecryptedLicenseData;
 import io.crate.license.LicenseExpiryNotification;
 import io.crate.license.LicenseService;
-import io.crate.settings.SharedSettings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.settings.Settings;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -44,26 +42,20 @@ public class LicenseExpiryCheck implements SysCheck {
 
     private static final int ID = 6;
     private static final String LICENSE_NOT_CLOSE_TO_EXPIRY_DESCRIPTION = "Your CrateDB license is not close to expiry. Enjoy CrateDB!";
-    private static final String LICENSE_NA_COMMUNITY_DESCRIPTION = "CrateDB enterprise is not enabled. Enjoy the community edition!";
-    private final boolean enterpriseEnabled;
 
     private String description;
     private Severity severity = Severity.LOW;
     private final LicenseService licenseService;
 
     @Inject
-    public LicenseExpiryCheck(Settings settings, LicenseService licenseService) {
-        enterpriseEnabled = SharedSettings.ENTERPRISE_LICENSE_SETTING.setting().get(settings);
-        description = (enterpriseEnabled) ? LICENSE_NOT_CLOSE_TO_EXPIRY_DESCRIPTION : LICENSE_NA_COMMUNITY_DESCRIPTION;
+    public LicenseExpiryCheck(LicenseService licenseService) {
+
+        this.description = LICENSE_NOT_CLOSE_TO_EXPIRY_DESCRIPTION;
         this.licenseService = licenseService;
     }
 
     @Override
     public boolean validate() {
-        if (!enterpriseEnabled) {
-            return true;
-        }
-
         DecryptedLicenseData currentLicense = licenseService.currentLicense();
         if (currentLicense == null) {
             // node might've not received the license cluster state

--- a/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
@@ -35,6 +35,7 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
     public static final String NAME = "license";
     public static final String EXPIRY_DATE = "expiry_date";
     public static final String ISSUED_TO = "issued_to";
+    public static final String MAX_NODES = "max_nodes";
 
     private final LicenseService licenseService;
 
@@ -54,9 +55,11 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
         if (decryptedLicenseData != null) {
             childImplementations.put(EXPIRY_DATE, () -> decryptedLicenseData.expiryDateInMs());
             childImplementations.put(ISSUED_TO, () -> decryptedLicenseData.issuedTo());
+            childImplementations.put(MAX_NODES, () -> decryptedLicenseData.maxNumberOfNodes());
         } else {
             childImplementations.put(EXPIRY_DATE, () -> null);
             childImplementations.put(ISSUED_TO, () -> null);
+            childImplementations.put(MAX_NODES, () -> null);
         }
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.EXPIRY_DATE;
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.ISSUED_TO;
+import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.MAX_NODES;
 
 public class SysClusterTableInfo extends StaticTableInfo {
 
@@ -75,6 +76,7 @@ public class SysClusterTableInfo extends StaticTableInfo {
             .register("license", DataTypes.OBJECT, null)
             .register(new ColumnIdent("license", EXPIRY_DATE), DataTypes.TIMESTAMP)
             .register(new ColumnIdent("license", ISSUED_TO), DataTypes.STRING)
+            .register(new ColumnIdent("license", MAX_NODES), DataTypes.INTEGER)
             .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, null)
             // custom registration of logger expressions
             .register(ClusterSettingsExpression.NAME, new ArrayType(DataTypes.OBJECT), ImmutableList.of(

--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner;
 
+import io.crate.analyze.AnalyzedDecommissionNodeStatement;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QueriedSelectRelation;
@@ -57,7 +58,8 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
             return true;
         }
 
-        if (analyzedStatement instanceof SetLicenseAnalyzedStatement) {
+        if (analyzedStatement instanceof SetLicenseAnalyzedStatement ||
+            analyzedStatement instanceof AnalyzedDecommissionNodeStatement) {
             return true;
         }
         if (analyzedStatement instanceof SetAnalyzedStatement) {

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -55,7 +55,7 @@ import io.crate.analyze.SetLicenseAnalyzedStatement;
 import io.crate.analyze.ShowCreateTableAnalyzedStatement;
 import io.crate.analyze.ShowSessionParameterAnalyzedStatement;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.exceptions.ExpiredLicenseException;
+import io.crate.exceptions.LicenseViolationException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.license.LicenseService;
 import io.crate.metadata.Functions;
@@ -165,7 +165,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
      */
     public Plan plan(AnalyzedStatement analyzedStatement, PlannerContext plannerContext) {
         if (isStatementExecutionAllowed.test(analyzedStatement) == false) {
-            throw new ExpiredLicenseException("Statement not allowed");
+            throw new LicenseViolationException("Statement not allowed");
         }
         return process(analyzedStatement, plannerContext);
     }

--- a/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -39,11 +39,13 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.doc.TestingDocTableInfoFactory;
 import io.crate.metadata.table.TestingTableInfo;
+import io.crate.settings.SharedSettings;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
@@ -293,7 +295,11 @@ public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest 
         e = SQLExecutor.builder(clusterService)
             .settings(Settings.builder().put(ENTERPRISE_LICENSE_SETTING.getKey(), false).build())
             .build();
-        e.analyze("GRANT DQL TO test");
+        try {
+            e.analyze("GRANT DQL TO test");
+        } finally {
+            assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
+        }
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -174,6 +174,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license| object| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 2| sys| cluster| sys| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['expiry_date']| timestamp| 3| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['issued_to']| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['max_nodes']| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| master_node| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| sys| cluster| sys| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 4| sys| cluster| sys| NULL| NULL| NULL";
 

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheckTest.java
@@ -26,8 +26,11 @@ import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.license.DecryptedLicenseData;
 import io.crate.license.LicenseExpiryNotification;
 import io.crate.license.LicenseService;
+import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +50,12 @@ public class LicenseExpiryCheckTest extends CrateUnitTest {
         licenseService = mock(LicenseService.class);
         Settings settings = Settings.builder().put("license.enterprise", true).build();
         expirationCheck = new LicenseExpiryCheck(settings, licenseService);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
+        super.tearDown();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpressionTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.EXPIRY_DATE;
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.ISSUED_TO;
+import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.MAX_NODES;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.Mockito.mock;
@@ -59,40 +60,46 @@ public class ClusterLicenseExpressionTest extends CrateUnitTest {
         when(licenseService.currentLicense()).thenReturn(null);
         assertThat(licenseExpression.getChild(EXPIRY_DATE).value(), is(nullValue()));
         assertThat(licenseExpression.getChild(ISSUED_TO).value(), is(nullValue()));
+        assertThat(licenseExpression.getChild(MAX_NODES).value(), is(nullValue()));
     }
 
     @Test
     public void testExpressionValueReturnsLicenseFields() {
-        when(licenseService.currentLicense()).thenReturn(new DecryptedLicenseData(3L, "test"));
+        when(licenseService.currentLicense())
+            .thenReturn(new DecryptedLicenseData(3L, "test", 2));
 
         Map<String, Object> expressionValues = licenseExpression.value();
-        assertThat(expressionValues.size(), is(2));
+        assertThat(expressionValues.size(), is(3));
         assertThat(expressionValues.get(EXPIRY_DATE), is(3L));
         assertThat(expressionValues.get(ISSUED_TO), is("test"));
+        assertThat(expressionValues.get(MAX_NODES), is(2));
     }
 
     @Test
     public void testGetChild() {
         when(licenseService.currentLicense())
-            .thenReturn(new DecryptedLicenseData(3L, "test"));
+            .thenReturn(new DecryptedLicenseData(3L, "test", 2));
 
         assertThat(licenseExpression.getChild(EXPIRY_DATE).value(), is(3L));
         assertThat(licenseExpression.getChild(ISSUED_TO).value(), is("test"));
+        assertThat(licenseExpression.getChild(MAX_NODES).value(), is(2));
     }
 
     @Test
     public void testGetChildAfterValueCallReturnsUpdatedLicenseFields() {
         when(licenseService.currentLicense())
-            .thenReturn(new DecryptedLicenseData(3L, "test"))
-            .thenReturn(new DecryptedLicenseData(4L, "test2"))
-            .thenReturn(new DecryptedLicenseData(4L, "test2"));
+            .thenReturn(new DecryptedLicenseData(3L, "test", 2))
+            .thenReturn(new DecryptedLicenseData(4L, "test2", 3))
+            .thenReturn(new DecryptedLicenseData(4L, "test2", 3));
 
         Map<String, Object> expressionValues = licenseExpression.value();
-        assertThat(expressionValues.size(), is(2));
+        assertThat(expressionValues.size(), is(3));
         assertThat(expressionValues.get(EXPIRY_DATE), is(3L));
         assertThat(expressionValues.get(ISSUED_TO), is("test"));
+        assertThat(expressionValues.get(MAX_NODES), is(2));
 
         assertThat(licenseExpression.getChild(EXPIRY_DATE).value(), is(4L));
         assertThat(licenseExpression.getChild(ISSUED_TO).value(), is("test2"));
+        assertThat(licenseExpression.getChild(MAX_NODES).value(), is(3));
     }
 }

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
@@ -104,6 +104,7 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         assertThat(
             Maps.getByPath(values, DecommissioningService.GRACEFUL_STOP_MIN_AVAILABILITY_SETTING.getKey()), is("FULL"));
 
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting()});
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting(),
+            SharedSettings.LICENSE_IDENT_SETTING.setting()});
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -583,7 +583,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(655, response.rowCount());
+        assertEquals(656, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/LicenseViolationITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LicenseViolationITest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.action.sql.SQLActionException;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 3)
+public class LicenseViolationITest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testThatOperationIsAllowedWhenNodesAreWithinMaxNodesThreshold() throws Exception {
+        execute("create table t1 (i int)");
+        assertThat(response.rowCount(), is(1L));
+    }
+
+    @Test
+    public void testThatOperationIsNotAllowedWhenNodesExceedMaxNodesThreshold() throws Exception {
+        // start another node so the number of nodes is exceeds the license threshold
+        internalCluster().startNodes(1);
+
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("License is violated");
+        execute("create table t1 (i int)");
+    }
+
+    @Test
+    public void testThatOperationIsAllowedWhenNodesAreBackWithinMaxNodesThreshold() throws Exception {
+        // stop any node so the number of nodes is within the license threshold
+        internalCluster().stopRandomDataNode();
+
+        execute("create table t1 (i int)");
+        assertThat(response.rowCount(), is(1L));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
@@ -225,6 +225,12 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
     }
 
     @Test
+    public void testDecommissionNodeIsAllowed() {
+        Plan plan = e.plan("alter cluster decommission 'XXX'");
+        assertThat(plan, instanceOf(DecommissionNodePlan.class));
+    }
+
+    @Test
     public void testQueryOnTableFunctionIsAllowedIfLicenseIsExpired() {
         ExecutionPlan plan = e.plan("select null as \"user\", current_schema as \"schema\"");
         assertThat(plan, instanceOf(Collect.class));

--- a/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExpiredLicensePlannerTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner;
 
-import io.crate.exceptions.ExpiredLicenseException;
+import io.crate.exceptions.LicenseViolationException;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.join.Join;
@@ -56,7 +56,7 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testSelectPlanOnUserSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select id from users where id = 1");
     }
@@ -83,7 +83,7 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testUnionSelectPlanOnUserSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select * from users where id = 1 " +
                "union all " +
@@ -92,7 +92,7 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testUnionSelectPlanOnMixedSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select name from sys.cluster " +
                "union all " +
@@ -110,7 +110,7 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOrderedLimitedPlanOUserSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select * from users where id = 1 " +
                "union all " +
@@ -120,7 +120,7 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOrderedLimitedPlanOMixedSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select name from sys.cluster where id = 1 " +
                "union all " +
@@ -136,84 +136,84 @@ public class ExpiredLicensePlannerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testMultiSourceSelectPlanOUserSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select t1.x, t2.y from t1, t2 where t1.x = 10");
     }
 
     @Test
     public void testMultiSourceSelectPlanOnMixedSchemaThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("select t1.x, sh.id from t1, sys.shards sh where t1.x = 10");
     }
 
     @Test
     public void testInsertPlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("insert into users (id, name) values (42, 'Deep Thought')");
     }
 
     @Test
     public void testUpdatePlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("update users set name='Vogon lyric fan' where id = 1");
     }
 
     @Test
     public void testDeletePlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("delete from users where id = 1");
     }
 
     @Test
     public void testExplainPlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("explain analyze select id from users where id = 1");
     }
 
     @Test
     public void testCreateTablePlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("create table users2(name string)");
     }
 
     @Test
     public void testDropTablePlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("drop table users");
     }
 
     @Test
     public void testCopyPlanThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("copy users (name) to directory '/tmp'");
     }
 
     @Test
     public void testCreateViewThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("create view v2 as select * from users");
     }
 
     @Test
     public void testDropViewThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("drop view v1");
     }
 
     @Test
     public void testSetGlobalThrowsException() {
-        expectedException.expect(ExpiredLicenseException.class);
+        expectedException.expect(LicenseViolationException.class);
         expectedException.expectMessage("Statement not allowed");
         e.plan("set global transient stats.enabled=false,stats.jobs_log_size=0");
     }

--- a/udc/src/main/java/io/crate/udc/ping/PingTask.java
+++ b/udc/src/main/java/io/crate/udc/ping/PingTask.java
@@ -132,6 +132,7 @@ public class PingTask extends TimerTask {
         if (license != null) {
             queryMap.put("license_expiry_date", String.valueOf(license.expiryDateInMs()));
             queryMap.put("license_issued_to", license.issuedTo());
+            queryMap.put("license_max_nodes", String.valueOf(license.maxNumberOfNodes()));
         }
 
         if (logger.isDebugEnabled()) {

--- a/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
+++ b/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
@@ -54,7 +54,8 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
 
     static private DecryptedLicenseData LICENSE = new DecryptedLicenseData(
         System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30),
-        "crate"
+        "crate" ,
+        3
         );
 
     private ExtendedNodeInfo extendedNodeInfo;
@@ -160,6 +161,8 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
             assertThat(map.get("license_expiry_date"), is(String.valueOf(LICENSE.expiryDateInMs())));
             assertThat(map, hasKey("license_issued_to"));
             assertThat(map.get("license_issued_to"), is(LICENSE.issuedTo()));
+            assertThat(map, hasKey("license_max_nodes"));
+            assertThat(map.get("license_max_nodes"), is(String.valueOf(LICENSE.maxNumberOfNodes())));
         }
     }
 
@@ -187,6 +190,7 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(map, not(hasKey("license_expiry_date")));
         assertThat(map, not(hasKey("license_issued_to")));
+        assertThat(map, not(hasKey("license_max_nodes")));
     }
 
     @Test
@@ -240,6 +244,8 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
             assertThat(map.get("license_expiry_date"), is(notNullValue()));
             assertThat(map, hasKey("license_issued_to"));
             assertThat(map.get("license_issued_to"), is(notNullValue()));
+            assertThat(map, hasKey("license_max_nodes"));
+            assertThat(map.get("license_max_nodes"), is(notNullValue()));
         }
     }
 }

--- a/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
+++ b/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
@@ -32,6 +32,7 @@ import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -106,6 +107,7 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder().put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), false).build()
         );
         assertThat(pingTask.isEnterprise(), is("false"));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Setting deprecation tests and doc are subject to change

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
