### PR TITLE
Char sequence `\\'` in Escaped String Literals result in ParsingException

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -213,7 +213,7 @@ public final class ExpressionFormatter {
 
         @Override
         protected String visitEscapedCharStringLiteral(EscapedCharStringLiteral node, Void context) {
-            return Literals.escapeAndQuoteStringLiteral(node.getRawValue());
+            return Literals.quoteEscapedStringLiteral(node.getRawValue());
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -36,8 +36,8 @@ public class Literals {
         return "'" + escapeStringLiteral(literal) + "'";
     }
 
-    public static String escapeAndQuoteStringLiteral(String literal) {
-        return EPSILON + Literals.quoteStringLiteral(literal);
+    public static String quoteEscapedStringLiteral(String literal) {
+        return EPSILON + "'" + literal + "'";
     }
 
     @VisibleForTesting
@@ -130,6 +130,15 @@ public class Literals {
                     default:
                         // non-valid escaped char sequence
                         builder.append(currentChar);
+                }
+            } else if (currentChar == '\'' && i > 1 && i + 1 < length) {
+                // handle normal escaped quote: ''
+                char nextChar = input.charAt(i + 1);
+                if (nextChar == '\'') {
+                    builder.append(currentChar);
+                    i++;
+                } else {
+                    throw new IllegalArgumentException("Invalid Escaped String Literal " + input);
                 }
             } else {
                 builder.append(currentChar);

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -506,7 +506,7 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitEscapedCharStringLiteral(EscapedCharStringLiteral node, Integer context) {
-            builder.append(Literals.escapeAndQuoteStringLiteral(node.getRawValue()));
+            builder.append(Literals.quoteEscapedStringLiteral(node.getRawValue()));
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1526,8 +1526,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitEscapedCharsStringLiteral(SqlBaseParser.EscapedCharsStringLiteralContext ctx) {
-        // use beginIndex = 2 to account for the 'E' literal
-        return new EscapedCharStringLiteral(unquote(ctx.ESCAPED_STRING().getText(), 2));
+        return new EscapedCharStringLiteral(unquoteEscaped(ctx.ESCAPED_STRING().getText()));
     }
 
     @Override
@@ -1658,12 +1657,15 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     private static String unquote(String value) {
-        return unquote(value, 1);
+        return value.substring(1, value.length() - 1)
+            .replace("''", "'");
     }
 
-    private static String unquote(String value, int beginIndex) {
-        return value.substring(beginIndex, value.length() - 1)
-            .replace("''", "'");
+    private static String unquoteEscaped(String value) {
+        // start from index: 2 to account for the 'E' literal
+        // single quote escaping is handled at later stage
+        // as we require more context on the surrounding characters
+        return value.substring(2, value.length() - 1);
     }
 
     private QualifiedName getQualifiedName(SqlBaseParser.QnameContext context) {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -779,12 +779,20 @@ public class TestStatementBuilder {
         printStatement("select * from t where 'source' !~ 'pattern'");
         printStatement("select * from t where source_column ~ pattern_column");
         printStatement("select * from t where ? !~ ?");
-        // escaped chars related
-        printStatement("select * from t where a like E'aValue'");
-        printStatement("select * from t where a = E'\\141Value'");
-        printStatement("select * from t where a = e'\\141Value'");
-        printStatement("select * from t where a = e'aa\\'bb'");
-        printStatement("select e.a from t e where e.a = E'\\141Value'");
+    }
+
+    @Test
+    public void testEscapedStringLiteralBuilder() throws Exception {
+        printStatement("select E'aValue'");
+        printStatement("select E'\\141Value'");
+        printStatement("select e'aa\\\'bb'");
+    }
+
+    @Test
+    public void testThatEscapedStringLiteralContainingDoubleBackSlashAndSingleQuoteThrowsException() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid Escaped String Literal");
+        printStatement("select e'aa\\\\\'bb' as col1");
     }
 
     @Test
@@ -1188,7 +1196,7 @@ public class TestStatementBuilder {
     public void testEscapedStringLiteral() throws Exception {
         String input = "this is a triple-a:\\141\\x61\\u0061";
         String expectedValue = "this is a triple-a:aaa";
-        Expression expr = SqlParser.createExpression(Literals.escapeAndQuoteStringLiteral(input));
+        Expression expr = SqlParser.createExpression(Literals.quoteEscapedStringLiteral(input));
         EscapedCharStringLiteral escapedCharStringLiteral = (EscapedCharStringLiteral) expr;
         assertThat(escapedCharStringLiteral.getRawValue(), is(input));
         assertThat(escapedCharStringLiteral.getValue(), is(expectedValue));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB



## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
