### PR TITLE
Make PARTITIONED_TABLE_PART package private

### DIFF
--- a/sql/src/main/java/io/crate/metadata/IndexParts.java
+++ b/sql/src/main/java/io/crate/metadata/IndexParts.java
@@ -36,14 +36,13 @@ import java.util.List;
  * 1) Class which unpacks and holds the different entities of a CrateDB index name.
  * 2) Static methods to check index names or generate them for RelationName or PartitionName
  */
-@SuppressWarnings("WeakerAccess")
 public class IndexParts {
 
     // Index names are only allowed to contain '.' as separators
     private static final Splitter SPLITTER = Splitter.on(".").limit(6);
     private static final String PARTITIONED_KEY_WORD = "partitioned";
     @VisibleForTesting
-    public static final String PARTITIONED_TABLE_PART = "." + PARTITIONED_KEY_WORD + ".";
+    static final String PARTITIONED_TABLE_PART = "." + PARTITIONED_KEY_WORD + ".";
 
     public static final List<String> DANGLING_INDICES_PREFIX_PATTERNS = ImmutableList.of(
         AlterTableOperation.RESIZE_PREFIX + "*"

--- a/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -239,7 +239,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testTableNameOfPartition() throws Exception {
         // expression should return the real table name
-        indexName = IndexParts.PARTITIONED_TABLE_PART + "wikipedia_de._1";
+        indexName = IndexParts.toIndexName("doc", "wikipedia_de", "foo");
         prepare();
         Reference refInfo = refInfo("sys.shards.table_name", DataTypes.STRING, RowGranularity.SHARD);
         NestableInput<String> shardExpression = (NestableInput<String>) resolver.getImplementation(refInfo);
@@ -251,11 +251,11 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testPartitionIdent() throws Exception {
-        indexName = IndexParts.PARTITIONED_TABLE_PART + "wikipedia_de._1";
+        indexName = IndexParts.toIndexName("doc", "wikipedia_d1", "foo");
         prepare();
         Reference refInfo = refInfo("sys.shards.partition_ident", DataTypes.STRING, RowGranularity.SHARD);
         NestableInput<String> shardExpression = (NestableInput<String>) resolver.getImplementation(refInfo);
-        assertEquals("_1", shardExpression.value());
+        assertEquals("foo", shardExpression.value());
 
         // reset indexName
         indexName = "wikipedia_de";
@@ -271,7 +271,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testOrphanPartition() throws Exception {
-        indexName = IndexParts.PARTITIONED_TABLE_PART + "wikipedia_de._1";
+        indexName = IndexParts.toIndexName("doc", "wikipedia_d1", "foo");
         prepare();
         Reference refInfo = refInfo("sys.shards.orphan_partition", DataTypes.STRING, RowGranularity.SHARD);
         NestableInput<Boolean> shardExpression = (NestableInput<Boolean>) resolver.getImplementation(refInfo);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Internals of the encoding scheme of indices or templates shouldn't leak
outside but be encapsulated within IndexParts.

This should help avoiding bugs like in 9380b8a3f71d652492d0e651f04160bc6d524406


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed