### PR TITLE
Remove PortPool from blackbox tests

### DIFF
--- a/blackbox/test_decommission.py
+++ b/blackbox/test_decommission.py
@@ -30,7 +30,7 @@ from crate.testing.layer import CrateLayer
 from crate.client.http import Client
 from crate.client.exceptions import ProgrammingError, ConnectionError
 from testutils.paths import crate_path
-from testutils.ports import GLOBAL_PORT_POOL
+from testutils.ports import bind_range, bind_port
 
 
 def decommission_using_signal(process):
@@ -134,13 +134,13 @@ class GracefulStopTest(unittest.TestCase):
         self.clients = []
         self.node_names = []
         # auto-discovery with unicast on the same host only works if all nodes are configured with the same port range
-        transport_port_range = GLOBAL_PORT_POOL.get_range(range_size=self.num_servers)
+        transport_port_range = bind_range(range_size=self.num_servers)
         for i in range(self.num_servers):
             layer = GracefulStopCrateLayer(
                 self.node_name(i),
                 crate_path(),
                 host='localhost',
-                port=GLOBAL_PORT_POOL.get(),
+                port=bind_port(),
                 transport_port=transport_port_range,
                 settings={
                     # The disk.watermark settings can be removed once crate-python > 0.21.1 has been released

--- a/blackbox/test_dns_discovery.py
+++ b/blackbox/test_dns_discovery.py
@@ -23,7 +23,7 @@
 # and conditions of your Enterprise or Subscription Agreement with Crate.
 
 from testutils.paths import crate_path
-from testutils.ports import GLOBAL_PORT_POOL
+from testutils.ports import bind_port
 from crate.testing.layer import CrateLayer
 from crate.client import connect
 from dnslib.server import DNSServer
@@ -33,8 +33,8 @@ from dnslib.zoneresolver import ZoneResolver
 def main():
     num_nodes = 3
 
-    node0_http_port = GLOBAL_PORT_POOL.get()
-    dns_port = GLOBAL_PORT_POOL.get()
+    node0_http_port = bind_port()
+    dns_port = bind_port()
     transport_ports = []
     zone_file = '''
 crate.internal.               600   IN   SOA   localhost localhost ( 2007120710 1d 2h 4w 1h )
@@ -42,7 +42,7 @@ crate.internal.               400   IN   NS    localhost
 crate.internal.               600   IN   A     127.0.0.1'''
 
     for i in range(0, num_nodes):
-        port = GLOBAL_PORT_POOL.get()
+        port = bind_port()
         transport_ports.append(port)
         zone_file += '''
 _test._srv.crate.internal.    600   IN   SRV   1 10 {port} 127.0.0.1.'''.format(port=port)
@@ -56,10 +56,10 @@ _test._srv.crate.internal.    600   IN   SRV   1 10 {port} 127.0.0.1.'''.format(
             'node-' + str(i),
             cluster_name='crate-dns-discovery',
             crate_home=crate_path(),
-            port=node0_http_port if i == 0 else GLOBAL_PORT_POOL.get(),
+            port=node0_http_port if i == 0 else bind_port(),
             transport_port=transport_ports[i],
             settings={
-                'psql.port': GLOBAL_PORT_POOL.get(),
+                'psql.port': bind_port(),
                 "discovery.zen.hosts_provider": "srv",
                 "discovery.srv.query": "_test._srv.crate.internal.",
                 "discovery.srv.resolver": "127.0.0.1:" + str(dns_port)

--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -34,14 +34,13 @@ import subprocess
 import unittest
 from functools import partial
 from testutils.paths import crate_path, project_path
-from testutils.ports import GLOBAL_PORT_POOL
+from testutils.ports import bind_port
 from crate.crash.command import CrateShell
 from crate.crash.printer import PrintWrapper, ColorPrinter
 from crate.client import connect
 
 
-CRATE_HTTP_PORT = GLOBAL_PORT_POOL.get()
-CRATE_TRANSPORT_PORT = GLOBAL_PORT_POOL.get()
+CRATE_HTTP_PORT = bind_port()
 CRATE_DSN = 'localhost:' + str(CRATE_HTTP_PORT)
 
 log = logging.getLogger('crate.testing.layer')
@@ -409,12 +408,12 @@ crate_layer = ConnectingCrateLayer(
     host='localhost',
     crate_home=crate_path(),
     port=CRATE_HTTP_PORT,
-    transport_port=CRATE_TRANSPORT_PORT,
+    transport_port=0,
     env={'JAVA_HOME': os.environ.get('JAVA_HOME', '')},
     settings={
         'license.enterprise': 'true',
         'lang.js.enabled': 'true',
-        'psql.port': GLOBAL_PORT_POOL.get(),
+        'psql.port': 0,
     }
 )
 

--- a/blackbox/test_hdfs.py
+++ b/blackbox/test_hdfs.py
@@ -28,7 +28,7 @@ import shutil
 import time
 import tarfile
 import logging
-from testutils.ports import GLOBAL_PORT_POOL
+from testutils.ports import bind_port
 from testutils.paths import crate_path, project_root
 from crate.testing.layer import CrateLayer
 from crate.client import connect
@@ -42,9 +42,8 @@ CACHE_DIR = os.environ.get(
     'XDG_CACHE_HOME', os.path.join(os.path.expanduser('~'), '.cache', 'crate-tests'))
 
 
-CRATE_HTTP_PORT = GLOBAL_PORT_POOL.get()
-CRATE_TRANSPORT_PORT = GLOBAL_PORT_POOL.get()
-NN_PORT = '49000'
+CRATE_HTTP_PORT = bind_port()
+NN_PORT = bind_port()
 
 
 hdfs_repo_libs_path = os.path.join(
@@ -113,7 +112,7 @@ class HadoopLayer:
         cmd = [
             self.hadoop_bin, 'jar',
             self.hadoop_mapreduce_client, 'minicluster',
-            '-nnport', NN_PORT, '-nomr', '-format',
+            '-nnport', str(NN_PORT), '-nomr', '-format',
             '-D', 'dfs.replication=1',
             '-D', 'dfs.client.use.datanode.hostname=true',
             '-D', 'dfs.datanode.use.datanode.hostname=true',
@@ -152,9 +151,9 @@ crate = HdfsCrateLayer(
     host='localhost',
     crate_home=crate_path(),
     port=CRATE_HTTP_PORT,
-    transport_port=CRATE_TRANSPORT_PORT,
+    transport_port=0,
     settings={
-        'psql.port': GLOBAL_PORT_POOL.get(),
+        'psql.port': 0,
     },
     env=os.environ.copy()
 )

--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -29,15 +29,15 @@ import unittest
 import time
 import logging
 from crate.client import connect
-from testutils.ports import GLOBAL_PORT_POOL
+from testutils.ports import bind_port
 from testutils.paths import crate_path
 from crate.testing.layer import CrateLayer
 from subprocess import PIPE, Popen
 from urllib.request import urlretrieve
 
-JMX_PORT = GLOBAL_PORT_POOL.get()
-CRATE_HTTP_PORT = GLOBAL_PORT_POOL.get()
-JMX_PORT_ENTERPRISE_DISABLED = GLOBAL_PORT_POOL.get()
+JMX_PORT = bind_port()
+CRATE_HTTP_PORT = bind_port()
+JMX_PORT_ENTERPRISE_DISABLED = bind_port()
 
 JMX_OPTS = '''
      -Dcom.sun.management.jmxremote
@@ -58,11 +58,10 @@ enterprise_crate = CrateLayer(
     'crate-enterprise',
     crate_home=crate_path(),
     port=CRATE_HTTP_PORT,
-    transport_port=GLOBAL_PORT_POOL.get(),
+    transport_port=0,
     env=env,
     settings={
         'license.enterprise': True,
-        'psql.port': GLOBAL_PORT_POOL.get(),
     }
 )
 
@@ -71,8 +70,8 @@ env["CRATE_JAVA_OPTS"] = JMX_OPTS.format(JMX_PORT_ENTERPRISE_DISABLED)
 community_crate = CrateLayer(
     'crate',
     crate_home=crate_path(),
-    port=GLOBAL_PORT_POOL.get(),
-    transport_port=GLOBAL_PORT_POOL.get(),
+    port=bind_port(),
+    transport_port=0,
     env=env,
     settings={
         'license.enterprise': False,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The global `GLOBAL_PORT_POOL` instance was misleading. The way we invoke
the tests in our CI (`./gradlew hdfsTest monitoringTest gtest`) we call
3 separate processes in sequential order. Each process does a new
import. So we had 3 `GLOBAL_PORT_POOL` instances.

This removes the `PortPool` altogether, as the locking was also
unnecessary. (We're not running the tests multi threaded)

This all gave a false sense of security that didn't function the way it
was intended.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed