### PR TITLE
Fix exception handling in SysSnapshots

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -137,6 +137,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause queries on the :ref:`sys.snapshots
+  <sys-snapshots>` table to raise an error if a snapshot couldn't be retrieved.
+
 - Fixed an issue that caused inserts into partitioned tables to fail with an
   ``unknown setting`` error if the table was created in an earlier version of
   CrateDB using settings that have been removed in later versions.

--- a/sql/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
@@ -28,12 +28,12 @@ public class SysSnapshot {
     private final String name;
     private final String repository;
     private final List<String> concreteIndices;
-    private final long started;
-    private final long finished;
+    private final Long started;
+    private final Long finished;
     private final String version;
     private final String state;
 
-    public SysSnapshot(String name, String repository, List<String> concreteIndices, long started, long finished, String version, String state) {
+    public SysSnapshot(String name, String repository, List<String> concreteIndices, Long started, Long finished, String version, String state) {
         this.name = name;
         this.repository = repository;
         this.concreteIndices = concreteIndices;
@@ -55,11 +55,11 @@ public class SysSnapshot {
         return concreteIndices;
     }
 
-    public long started() {
+    public Long started() {
         return started;
     }
 
-    public long finished() {
+    public Long finished() {
         return finished;
     }
 

--- a/sql/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.sys.snapshot;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.snapshots.SnapshotException;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SysSnapshotsTest extends CrateUnitTest {
+
+    @Test
+    public void testUnavailableSnapshotsAreFilteredOut() {
+        HashMap<String, SnapshotId> snapshots = new HashMap<>();
+        SnapshotId s1 = new SnapshotId("s1", UUIDs.randomBase64UUID());
+        SnapshotId s2 = new SnapshotId("s2", UUIDs.randomBase64UUID());
+        snapshots.put(s1.getUUID(), s1);
+        snapshots.put(s2.getUUID(), s2);
+        RepositoryData repositoryData = new RepositoryData(
+            1, snapshots, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
+
+        Repository r1 = mock(Repository.class);
+        when(r1.getRepositoryData()).thenReturn(repositoryData);
+        when(r1.getMetadata()).thenReturn(new RepositoryMetaData("repo1", "fs", Settings.EMPTY));
+        when(r1.getSnapshotInfo(eq(s1))).thenThrow(new SnapshotException("repo1", "s1", "Everything is wrong"));
+        when(r1.getSnapshotInfo(eq(s2))).thenReturn(new SnapshotInfo(s2, Collections.emptyList(), SnapshotState.SUCCESS));
+
+        SysSnapshots sysSnapshots = new SysSnapshots(() -> Collections.singletonList(r1));
+        List<SysSnapshot> currentSnapshots = ImmutableList.copyOf(sysSnapshots.currentSnapshots());
+        assertThat(
+            currentSnapshots.stream().map(SysSnapshot::name).collect(Collectors.toList()),
+            containsInAnyOrder("s1", "s2")
+        );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`repository.getSnapshotInfo` can raise an exception if the snapshot is
unavailable or can't be read.

This shouldn't affect queries on `sys.snapshots`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed