### PR TITLE
Deprecate the `license.enterprise` setting

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -51,23 +51,6 @@
 #node.attr.rack: ${RACK_ENV_VAR}
 
 
-############################# Enterprise Features ############################
-
-# CrateDB ships by default with all Enterprise Features enabled. See
-# <https://crate.io/docs/crate/reference/en/latest/enterprise/index.html> for
-# more information.
-
-# Setting this to `false` disables the Enterprise Features.
-#license.enterprise: true
-
-# To use any of these features, Crate.io must have given you permission to
-# enable and use such Enterprise Features and you must have a valid Enterprise
-# or Subscription Agreement with Crate.io.  If you enable or use the Enterprise
-# Features, you represent and warrant that you have a valid Enterprise or
-# Subscription Agreement with Crate.io.  Your use of the Enterprise Features if
-# governed by the terms and conditions of your Enterprise or Subscription
-# Agreement with Crate.io.
-
 #/////////////////////////// JMX Monitoring Plugin ///////////////////////////
 
 # The JMX monitoring plugin requires that stat collection is enabled.

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -680,6 +680,11 @@ Enterprise License
   | *Default:*  ``true``
   | *Runtime:*  ``no``
 
-  Setting this to ``false`` disables the `Enterprise Edition`_ of CrateDB.
+  This is a deprecated setting that allows you to disable the `Enterprise
+  Edition`_ features of CrateDB, enabling you to use all community edition
+  features of CrateDB without restrictions or license.
+  The setting will be removed in CrateDB 4.0 and instead you'll have to
+  `Acquire a license`_ or switch to the :ref:`community-edition` distribution.
 
 .. _`Enterprise Edition`: https://crate.io/enterprise-edition/
+.. _`Acquire a license`: https://crate.io/pricing/

--- a/blackbox/docs/editions/community.rst
+++ b/blackbox/docs/editions/community.rst
@@ -1,0 +1,22 @@
+.. _community-edition:
+
+=================
+Community Edition
+=================
+
+The community edition (``CE``) of CrateDB is a distribution that excludes
+enterprise modules which are licensed under a more restrictive license. The
+``CE`` can be used under the terms of the Apache License version 2 without
+further restrictions.
+
+The :ref:`enterprise_features` are not available within the ``CE``.
+
+The community edition distribution must be built from source::
+
+   $ git clone https://github.com/crate/crate
+   $ cd crate
+   $ git submodule update --init
+   $ [git checkout <tag> ]
+   $ ./gradlew clean communityEditionDistTar
+
+The built tarball will be available under ``app/build/distributions``.

--- a/blackbox/docs/editions/enterprise.rst
+++ b/blackbox/docs/editions/enterprise.rst
@@ -12,9 +12,8 @@ Enterprise Features
 Feature List
 ============
 
-When you first download CrateDB, the :ref:`license.enterprise
-<conf-node-enterprise-license>` setting is set to ``true`` and the following
-enterprise features are enabled:
+The default distribution of CrateDB contains the following enterprise features:
+
 
 - :ref:`administration_user_management`: manage multiple database users
 - :ref:`administration-privileges`: configure user privileges
@@ -32,6 +31,12 @@ enterprise features are enabled:
 - :ref:`window-function-nthvalue`: ``nth_value`` window function
 - `The CrateDB admin UI`_: `shards browser`_, `monitoring overview`_,
   `privileges browser`_
+
+
+.. note::
+
+   It is also possible to build a :ref:`community-edition` which won't contain
+   these features but which can be used without licensing restrictions.
 
 .. _enterprise_trial:
 
@@ -53,12 +58,8 @@ LICENSE <ref-set-license>` statement.
       <information_schema>` and :ref:`sys <system-information>` schemas only)
 
 If you wish to continue using CrateDB without an enterprise license after the
-trial period ends you must set :ref:`license.enterprise
-<conf-node-enterprise-license>` to ``false``. This activates the `community
-edition`_ of CrateDB and restores all functionality except for the enterprise
-features.
+trial period ends you must switch to the :ref:`community-edition`.
 
-.. _community Edition: https://crate.io/products/cratedb-editions/
 .. _enterprise license: https://crate.io/products/cratedb-editions/
 .. _HyperLogLog++: https://research.google.com/pubs/pub40671.html
 .. _monitoring overview: https://crate.io/docs/clients/admin-ui/en/latest/monitoring.html

--- a/blackbox/docs/editions/index.rst
+++ b/blackbox/docs/editions/index.rst
@@ -1,0 +1,7 @@
+================
+CrateDB Editions
+================
+
+.. toctree::
+   enterprise
+   community

--- a/blackbox/docs/index.rst
+++ b/blackbox/docs/index.rst
@@ -31,7 +31,7 @@ massive amounts of machine data in real-time.
    admin/index
    sql/index
    interfaces/index
-   enterprise/index
+   editions/index
    appendices/index
 
 .. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/

--- a/common/src/main/java/io/crate/settings/SharedSettings.java
+++ b/common/src/main/java/io/crate/settings/SharedSettings.java
@@ -27,8 +27,13 @@ import org.elasticsearch.common.settings.Setting;
 
 public class SharedSettings {
 
+    /**
+     * @deprecated This will be removed in 4.0;
+     * We're switching to have 2 distributions: One with enterprise modules included and one without.
+     */
+    @Deprecated()
     public static final CrateSetting<Boolean> ENTERPRISE_LICENSE_SETTING = CrateSetting.of(Setting.boolSetting(
-        "license.enterprise", true, Setting.Property.NodeScope),
+        "license.enterprise", true, Setting.Property.NodeScope, Setting.Property.Deprecated),
         DataTypes.BOOLEAN);
 
     /**

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -21,7 +21,6 @@ package io.crate.protocols.http;
 import io.crate.plugin.PipelineRegistry;
 import io.crate.protocols.ssl.SslConfigSettings;
 import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -60,7 +59,6 @@ public class CrateHttpsTransportTest extends CrateUnitTest {
     @Test
     public void testPipelineConfiguration() throws Exception {
         Settings settings = Settings.builder()
-            .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true)
             .put(PATH_HOME_SETTING.getKey(), "/tmp")
             .put(SslConfigSettings.SSL_HTTP_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.getKey(), trustStoreFile.getAbsolutePath())

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
@@ -19,7 +19,6 @@
 package io.crate.protocols.ssl;
 
 import io.crate.plugin.PipelineRegistry;
-import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.handler.ssl.SslContext;
 import org.elasticsearch.common.settings.Settings;
@@ -49,7 +48,6 @@ public class SslContextProviderTest extends CrateUnitTest {
     public void testClassLoadingWithInvalidConfiguration() {
         // empty ssl configuration which is invalid
         Settings settings = Settings.builder()
-            .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true)
             .put(SslConfigSettings.SSL_HTTP_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_PSQL_ENABLED.getKey(), true)
             .build();
@@ -62,7 +60,6 @@ public class SslContextProviderTest extends CrateUnitTest {
     @Test
     public void testClassLoadingWithValidConfiguration() {
         Settings settings = Settings.builder()
-            .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true)
             .put(SslConfigSettings.SSL_HTTP_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_PSQL_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.getKey(), trustStoreFile.getAbsolutePath())

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseExpiryCheckTest.java
@@ -26,8 +26,11 @@ import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.license.DecryptedLicenseData;
 import io.crate.license.LicenseExpiryNotification;
 import io.crate.license.LicenseService;
+import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +50,11 @@ public class LicenseExpiryCheckTest extends CrateUnitTest {
         licenseService = mock(LicenseService.class);
         Settings settings = Settings.builder().put("license.enterprise", true).build();
         expirationCheck = new LicenseExpiryCheck(settings, licenseService);
+    }
+
+    @After
+    public void assertSettingDeprecation() {
+        assertSettingDeprecationsAndWarnings(new Setting[] {SharedSettings.ENTERPRISE_LICENSE_SETTING.setting() });
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
@@ -104,6 +104,8 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         assertThat(
             Maps.getByPath(values, DecommissioningService.GRACEFUL_STOP_MIN_AVAILABILITY_SETTING.getKey()), is("FULL"));
 
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] {SharedSettings.LICENSE_IDENT_SETTING.setting()});
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {
+            SharedSettings.LICENSE_IDENT_SETTING.setting(),
+            SharedSettings.ENTERPRISE_LICENSE_SETTING.setting()});
     }
 }

--- a/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
+++ b/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
@@ -32,6 +32,7 @@ import io.crate.settings.SharedSettings;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -99,13 +100,17 @@ public class PingTaskTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testIsEnterpriseField() throws Exception {
         PingTask pingTask = createPingTask();
-        assertThat(pingTask.isEnterprise(), is(SharedSettings.ENTERPRISE_LICENSE_SETTING.getDefault().toString()));
+        try {
+            assertThat(pingTask.isEnterprise(), is(SharedSettings.ENTERPRISE_LICENSE_SETTING.getDefault().toString()));
 
-        pingTask = createPingTask(
-            "http://dummy",
-            Settings.builder().put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), false).build()
-        );
-        assertThat(pingTask.isEnterprise(), is("false"));
+            pingTask = createPingTask(
+                "http://dummy",
+                Settings.builder().put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), false).build()
+            );
+            assertThat(pingTask.isEnterprise(), is("false"));
+        } finally {
+            assertSettingDeprecationsAndWarnings(new Setting[] { SharedSettings.ENTERPRISE_LICENSE_SETTING.setting() });
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commit messages.


Note that not everything works correctly yet using the community edition
(E.g. since the `license.enterprise` flag is still there and defaults to
true, the license service will generate a trial license and the
expiration logic is in place). We'll have to follow up on this to take
the availability of the enterprise modules into consideration.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed



Co-authored-by: Savvas Makalias <savvas@crate.io>