### PR TITLE
Changes `information_schema.columns` table definition according to SQL Standard. 

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -41,6 +41,9 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Changed type of column ``information_schema.columns.is_generated`` to ``STRING``
+  with value ``NEVER`` or ``ALWAYS`` for SQL standard compatibility.
+
 - Removed the deprecated average duration and query frequency JMX metrics. The
   total counts and sum of durations as documented in :ref:`query_stats_mbean`
   should be used instead.

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -41,6 +41,9 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Renamed ``information_schema.columns.user_defined_type_*`` columns to
+  ``information_schema_columns.udt_*`` for SQL standard compatibility.
+
 - Changed type of column ``information_schema.columns.is_generated`` to ``STRING``
   with value ``NEVER`` or ``ALWAYS`` for SQL standard compatibility.
 

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -328,7 +328,7 @@ infinite recursion of your mind, beware!)::
     | generation_expression     | string    |               18 |
     | interval_precision        | integer   |               19 |
     | interval_type             | string    |               20 |
-    | is_generated              | boolean   |               21 |
+    | is_generated              | string    |               21 |
     | is_nullable               | boolean   |               22 |
     | numeric_precision         | integer   |               23 |
     | numeric_precision_radix   | integer   |               24 |
@@ -437,8 +437,8 @@ infinite recursion of your mind, beware!)::
 |                               | If the column is not generated ``NULL`` is    |               |
 |                               | returned.                                     |               |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``is_generated``              | Returns ``true`` or ``false`` wether the      | ``Boolean``   |
-|                               | column is generated or not                    |               |
+| ``is_generated``              | Returns ``ALWAYS`` or ``NEVER`` wether the    | ``String``    |
+|                               | column is generated or not.                   |               |
 +-------------------------------+-----------------------------------------------+---------------+
 
 

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -305,42 +305,42 @@ infinite recursion of your mind, beware!)::
     ... from information_schema.columns
     ... where table_schema = 'information_schema'
     ... and table_name = 'columns' order by ordinal_position asc;
-    +---------------------------+-----------+------------------+
-    | column_name               | data_type | ordinal_position |
-    +---------------------------+-----------+------------------+
-    | character_maximum_length  | integer   |                1 |
-    | character_octet_length    | integer   |                2 |
-    | character_set_catalog     | string    |                3 |
-    | character_set_name        | string    |                4 |
-    | character_set_schema      | string    |                5 |
-    | check_action              | integer   |                6 |
-    | check_references          | string    |                7 |
-    | collation_catalog         | string    |                8 |
-    | collation_name            | string    |                9 |
-    | collation_schema          | string    |               10 |
-    | column_default            | string    |               11 |
-    | column_name               | string    |               12 |
-    | data_type                 | string    |               13 |
-    | datetime_precision        | integer   |               14 |
-    | domain_catalog            | string    |               15 |
-    | domain_name               | string    |               16 |
-    | domain_schema             | string    |               17 |
-    | generation_expression     | string    |               18 |
-    | interval_precision        | integer   |               19 |
-    | interval_type             | string    |               20 |
-    | is_generated              | string    |               21 |
-    | is_nullable               | boolean   |               22 |
-    | numeric_precision         | integer   |               23 |
-    | numeric_precision_radix   | integer   |               24 |
-    | numeric_scale             | integer   |               25 |
-    | ordinal_position          | short     |               26 |
-    | table_catalog             | string    |               27 |
-    | table_name                | string    |               28 |
-    | table_schema              | string    |               29 |
-    | user_defined_type_catalog | string    |               30 |
-    | user_defined_type_name    | string    |               31 |
-    | user_defined_type_schema  | string    |               32 |
-    +---------------------------+-----------+------------------+
+    +--------------------------+-----------+------------------+
+    | column_name              | data_type | ordinal_position |
+    +--------------------------+-----------+------------------+
+    | character_maximum_length | integer   |                1 |
+    | character_octet_length   | integer   |                2 |
+    | character_set_catalog    | string    |                3 |
+    | character_set_name       | string    |                4 |
+    | character_set_schema     | string    |                5 |
+    | check_action             | integer   |                6 |
+    | check_references         | string    |                7 |
+    | collation_catalog        | string    |                8 |
+    | collation_name           | string    |                9 |
+    | collation_schema         | string    |               10 |
+    | column_default           | string    |               11 |
+    | column_name              | string    |               12 |
+    | data_type                | string    |               13 |
+    | datetime_precision       | integer   |               14 |
+    | domain_catalog           | string    |               15 |
+    | domain_name              | string    |               16 |
+    | domain_schema            | string    |               17 |
+    | generation_expression    | string    |               18 |
+    | interval_precision       | integer   |               19 |
+    | interval_type            | string    |               20 |
+    | is_generated             | string    |               21 |
+    | is_nullable              | boolean   |               22 |
+    | numeric_precision        | integer   |               23 |
+    | numeric_precision_radix  | integer   |               24 |
+    | numeric_scale            | integer   |               25 |
+    | ordinal_position         | short     |               26 |
+    | table_catalog            | string    |               27 |
+    | table_name               | string    |               28 |
+    | table_schema             | string    |               29 |
+    | udt_catalog              | string    |               30 |
+    | udt_name                 | string    |               31 |
+    | udt_schema               | string    |               32 |
+    +--------------------------+-----------+------------------+
     SELECT 32 rows in set (... sec)
 
 .. NOTE::
@@ -423,11 +423,11 @@ infinite recursion of your mind, beware!)::
 +-------------------------------+-----------------------------------------------+---------------+
 | ``domain_name``               | Not implemented (always returns ``NULL``)     | ``String``    |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``user_defined_type_catalog`` | Not implemented (always returns ``NULL``)     | ``String``    |
+| ``udt_catalog``               | Not implemented (always returns ``NULL``)     | ``String``    |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``user_defined_type_schema``  | Not implemented (always returns ``NULL``)     | ``String``    |
+| ``udt_schema``                | Not implemented (always returns ``NULL``)     | ``String``    |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``user_defined_type_name``    | Not implemented (always returns ``NULL``)     | ``String``    |
+| ``udt_name``                  | Not implemented (always returns ``NULL``)     | ``String``    |
 +-------------------------------+-----------------------------------------------+---------------+
 | ``check_references``          | Not implemented (always returns ``NULL``)     | ``String``    |
 +-------------------------------+-----------------------------------------------+---------------+

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -47,6 +47,9 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
     public static final String NAME = "columns";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
+    private static final String IS_GENERATED_NEVER = "NEVER";
+    private static final String IS_GENERATED_ALWAYS = "ALWAYS";
+
     public static class Columns {
         static final ColumnIdent TABLE_SCHEMA = new ColumnIdent("table_schema");
         static final ColumnIdent TABLE_NAME = new ColumnIdent("table_name");
@@ -90,7 +93,7 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
             .register(Columns.COLUMN_NAME, DataTypes.STRING, false)
             .register(Columns.ORDINAL_POSITION, DataTypes.SHORT, false)
             .register(Columns.DATA_TYPE, DataTypes.STRING, false)
-            .register(Columns.IS_GENERATED, DataTypes.BOOLEAN, false)
+            .register(Columns.IS_GENERATED, DataTypes.STRING, false)
             .register(Columns.IS_NULLABLE, DataTypes.BOOLEAN, false)
             .register(Columns.GENERATION_EXPRESSION, DataTypes.STRING)
             .register(Columns.COLUMN_DEFAULT, DataTypes.STRING)
@@ -189,7 +192,12 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
             .put(Columns.CHECK_ACTION,
                 () -> NestableCollectExpression.constant(null))
             .put(Columns.IS_GENERATED,
-                () -> NestableCollectExpression.forFunction(r -> r.info instanceof GeneratedReference))
+                () -> NestableCollectExpression.forFunction(r -> {
+                    if (r.info instanceof GeneratedReference) {
+                        return IS_GENERATED_ALWAYS;
+                    }
+                    return IS_GENERATED_NEVER;
+                }))
             .put(Columns.IS_NULLABLE,
                 () -> NestableCollectExpression.forFunction(r ->
                     !r.tableInfo.primaryKey().contains(r.info.column()) && r.info.isNullable()))

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -78,9 +78,9 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
         static final ColumnIdent DOMAIN_CATALOG = new ColumnIdent("domain_catalog");
         static final ColumnIdent DOMAIN_SCHEMA = new ColumnIdent("domain_schema");
         static final ColumnIdent DOMAIN_NAME = new ColumnIdent("domain_name");
-        static final ColumnIdent USER_DEFINED_TYPE_CATALOG = new ColumnIdent("user_defined_type_catalog");
-        static final ColumnIdent USER_DEFINED_TYPE_SCHEMA = new ColumnIdent("user_defined_type_schema");
-        static final ColumnIdent USER_DEFINED_TYPE_NAME = new ColumnIdent("user_defined_type_name");
+        static final ColumnIdent USER_DEFINED_TYPE_CATALOG = new ColumnIdent("udt_catalog");
+        static final ColumnIdent USER_DEFINED_TYPE_SCHEMA = new ColumnIdent("udt_schema");
+        static final ColumnIdent USER_DEFINED_TYPE_NAME = new ColumnIdent("udt_name");
         static final ColumnIdent CHECK_REFERENCES = new ColumnIdent("check_references");
         static final ColumnIdent CHECK_ACTION = new ColumnIdent("check_action");
     }

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -170,12 +170,12 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         Bucket result = collect(collectNode);
 
         String expected =
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| id| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 1| sys| cluster| sys| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license| object| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 2| sys| cluster| sys| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['expiry_date']| timestamp| 3| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['issued_to']| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| master_node| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| sys| cluster| sys| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 4| sys| cluster| sys| NULL| NULL| NULL";
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| id| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 1| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license| object| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 2| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['expiry_date']| timestamp| 3| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| license['issued_to']| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| NULL| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| master_node| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 3| sys| cluster| sys| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 4| sys| cluster| sys| NULL| NULL| NULL";
 
 
         assertThat(TestingHelpers.printedTable(result), Matchers.containsString(expected));

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -621,9 +621,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 27| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 28| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
             "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 29| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 30| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 31| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 32| information_schema| columns| information_schema| NULL| NULL| NULL\n")
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| udt_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 30| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| udt_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 31| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| udt_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 32| information_schema| columns| information_schema| NULL| NULL| NULL\n")
         );
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -592,38 +592,38 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.columns where table_schema='information_schema' and table_name='columns' order by ordinal_position asc");
         assertThat(response.rowCount(), is(32L));
         assertThat(printedTable(response.rows()), is(
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_maximum_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 1| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_octet_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 2| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 4| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 5| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_action| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 6| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_references| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 7| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 8| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 9| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 10| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_default| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 11| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 12| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| data_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 13| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| datetime_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 14| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 15| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 16| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 17| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| generation_expression| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 18| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 19| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 20| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_generated| boolean| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 21| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_nullable| boolean| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 22| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 23| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision_radix| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 24| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_scale| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 25| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| ordinal_position| short| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| 16| 2| NULL| 26| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 27| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 28| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 29| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 30| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 31| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
-            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 32| information_schema| columns| information_schema| NULL| NULL| NULL\n")
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_maximum_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 1| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_octet_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 2| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 3| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 4| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 5| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_action| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 6| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_references| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 7| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 8| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 9| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 10| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_default| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 11| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 12| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| data_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 13| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| datetime_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 14| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 15| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 16| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 17| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| generation_expression| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 18| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 19| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 20| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_generated| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 21| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_nullable| boolean| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 22| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 23| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision_radix| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 24| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_scale| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| 32| 2| NULL| 25| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| ordinal_position| short| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| 16| 2| NULL| 26| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 27| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 28| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| false| NULL| NULL| NULL| 29| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 30| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 31| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NEVER| true| NULL| NULL| NULL| 32| information_schema| columns| information_schema| NULL| NULL| NULL\n")
         );
     }
 
@@ -672,7 +672,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals("age", response.rows()[0][11]); // column_name
         assertEquals("integer", response.rows()[0][12]); // data_type
         assertEquals(null, response.rows()[0][13]); // datetime_precision
-        assertEquals(false, response.rows()[0][20]); // is_generated
+        assertEquals("NEVER", response.rows()[0][20]); // is_generated
         assertEquals(false, response.rows()[0][21]); // is_nullable
         assertEquals(32, response.rows()[0][22]); // numeric_precision
         assertEquals(2, response.rows()[0][23]); // numeric_precision_radix
@@ -1141,9 +1141,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     public void testSelectGeneratedColumnFromInformationSchemaColumns() {
         execute("create table t (lastname string, firstname string, name as (lastname || '_' || firstname)) " +
                 "with (number_of_replicas = 0)");
-        execute("select column_name, is_generated, generation_expression from information_schema.columns where is_generated = true");
+        execute("select column_name, is_generated, generation_expression from information_schema.columns where is_generated = 'ALWAYS'");
         assertThat(printedTable(response.rows()),
-            is("name| true| concat(concat(lastname, '_'), firstname)\n"));
+            is("name| ALWAYS| concat(concat(lastname, '_'), firstname)\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
See commits.
Updated version of https://github.com/crate/crate/pull/8040 as these commits were reverted because they contained breaking changes and should not go into any 3.x release. 

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
