### PR TITLE
Add subscript expression support on sub-relation columns.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -98,6 +98,10 @@ Deprecations
 Changes
 =======
 
+- Added support for subscript expressions on an object column of a sub-relation.
+  Examples: ``select a['b'] from (select a from t1)`` or ``select a['b'] from
+  my_view`` where ``my_view`` is defined as ``select a from t1``.
+
 - Changed the trial license introduced in 3.2 to no longer have an expiration
   date, but instead be limited to 3 nodes. See :ref:`enterprise_features`.
 

--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -42,6 +42,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public final class DataTypes {
 
@@ -383,4 +384,7 @@ public final class DataTypes {
         return TYPE_REGISTRY.get(id).get();
     }
 
+    public static List<DataType> allRegisteredTypes() {
+        return TYPE_REGISTRY.values().stream().map(Supplier::get).collect(Collectors.toList());
+    }
 }

--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -31,10 +31,12 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ObjectType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
@@ -84,6 +86,26 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     public DataType innerType(String key) {
         return innerTypes.getOrDefault(key, UndefinedType.INSTANCE);
+    }
+
+    @Nullable
+    public DataType resolveInnerType(List<String> path) {
+        if (path.isEmpty()) {
+            return null;
+        }
+
+        DataType innerType = null;
+        ObjectType currentObject = this;
+        for (int i = 0; i < path.size(); i++) {
+            innerType = currentObject.innerTypes().get(path.get(i));
+            if (innerType == null) {
+                return null;
+            }
+            if (innerType.id() == ID) {
+                currentObject = (ObjectType) innerType;
+            }
+        }
+        return innerType;
     }
 
     @Override

--- a/common/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/common/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -172,5 +173,17 @@ public class ObjectTypeTest extends CrateUnitTest {
 
         assertThat(v.get("s"), is(map.get("s")));
         assertThat(Objects.deepEquals(v.get("obj_array"), innerArray), is(true));
+    }
+
+    @Test
+    public void testResolveInnerType() {
+        ObjectType type = ObjectType.builder()
+            .setInnerType("s", DataTypes.STRING)
+            .setInnerType("inner", ObjectType.builder()
+                .setInnerType("i", DataTypes.INTEGER)
+                .build())
+            .build();
+
+        assertThat(type.resolveInnerType(List.of("s", "inner", "i")), is(DataTypes.INTEGER));
     }
 }

--- a/sql/src/main/java/io/crate/collections/Lists2.java
+++ b/sql/src/main/java/io/crate/collections/Lists2.java
@@ -114,4 +114,13 @@ public final class Lists2 {
                 throw new IllegalArgumentException("Expected 1 element, got: " + items.size());
         }
     }
+
+    public static <O, I> List<O> mapTail(O head, List<I> tail, Function<I, O> mapper) {
+        ArrayList<O> list = new ArrayList<>(tail.size() + 1);
+        list.add(head);
+        for (I input : tail) {
+            list.add(mapper.apply(input));
+        }
+        return list;
+    }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -63,4 +63,9 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
     public void testFunctionCanBeUsedAsIndexInSubscript() {
         assertNormalize("{\"x\" = 10}['x' || '']", isLiteral(10L));
     }
+
+    @Test
+    public void testSubscriptOnObjectWithPath() {
+        assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", 10L);
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -147,4 +147,15 @@ public class ViewsITest extends SQLTransportIntegrationTest {
     public void testDropViewDoesNotFailIfViewIsMissingAndIfExistsIsUsed() {
         execute("drop view if exists v1");
     }
+
+    @Test
+    public void testSubscriptOnViews() {
+        execute("create table t1 (a object as (b integer), c object as (d object as (e integer))) ");
+        execute("insert into t1 (a, c) values ({ b = 1 }, { d = { e = 2 }})");
+        execute("refresh table t1");
+        execute("create view v1 as select * from t1");
+        // must not throw an exception, subscript must be resolved
+        execute("select a['b'], c['d']['e'] from v1");
+        assertThat(printedTable(response.rows()), is("1| 2\n"));
+    }
 }


### PR DESCRIPTION
This adds support for subscript expressions on an object column of a sub-relation.
Examples: ``select a['b'] from (select a from t1)`` or
``select a['b'] from my_view`` where ``my_view`` is defined as ``select a from t1``.