### PR TITLE
add support for the `ROLLBACK` statement

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,10 @@ Deprecations
 Changes
 =======
 
+- Added the full PostgreSQL syntax of the ``ROLLBACK`` statement.
+  This improves the support for clients that are based on the Postgres wire
+  protocol. The ``ROLLBACK`` statement and its parameters are simply ignored.
+
 - Added support for :ref:`sql_escape_string_literals`.
 
 - Expose the sum of durations, total, and failed count metrics under the

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -199,12 +199,12 @@ is implemented::
     +-----------------------+
     SHOW 1 row in set (... sec)
 
-BEGIN/COMMIT Statements
------------------------
+BEGIN/COMMIT/ROLLBACK Statements
+--------------------------------
 
 For compatibility with clients that use the Postgres wire protocol, such as the
-Golang lib/pq and pgx drivers, the full PostgreSQL syntax of the ``BEGIN`` and
-``COMMIT`` statements is implemented, for example::
+Golang lib/pq and pgx drivers, the full PostgreSQL syntax of the ``BEGIN``,
+``COMMIT`` and ``ROLLBACK`` statements is implemented, for example::
 
     cr> BEGIN TRANSACTION ISOLATION LEVEL READ UNCOMMITTED,
     ...                   READ ONLY,
@@ -214,8 +214,11 @@ Golang lib/pq and pgx drivers, the full PostgreSQL syntax of the ``BEGIN`` and
     cr> COMMIT
     COMMIT OK, 0 rows affected  (... sec)
 
-Since CrateDB does not support transactions, both the ``COMMIT`` and the
-``BEGIN`` statement and any of its parameters are ignored.
+    cr> ROLLBACK
+    ROLLBACK OK, 0 rows affected  (... sec)
+
+Since CrateDB does not support transactions, all the above mentioned statements
+and any of its parameters are ignored.
 
 Client Compatibility
 ====================

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -28,6 +28,7 @@ import io.crate.analyze.AlterUserAnalyzedStatement;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedDeleteStatement;
+import io.crate.analyze.AnalyzedRollback;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.AnalyzedUpdateStatement;
@@ -444,6 +445,11 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
         @Override
         public Void visitCommit(AnalyzedCommit analyzedCommit, User user) {
+            return null;
+        }
+
+        @Override
+        public Void visitRollback(AnalyzedRollback analyzedRollback, User user) {
             return null;
         }
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -34,6 +34,7 @@ statement
     : query                                                                          #default
     | BEGIN (WORK | TRANSACTION)? (transactionMode (',' transactionMode)*)?          #begin
     | COMMIT                                                                         #commit
+    | ROLLBACK (WORK | TRANSACTION)?                                                 #rollback
     | EXPLAIN (ANALYZE)? statement                                                   #explain
     | OPTIMIZE TABLE tableWithPartitions withProperties?                             #optimize
     | REFRESH TABLE tableWithPartitions                                              #refreshTable
@@ -648,7 +649,7 @@ nonReserved
     | PRECEDING | RANGE | REFRESH | ROW | ROWS | SCHEMAS | SECOND | SESSION
     | SHARDS | SHOW | STORAGE | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
     | TIMESTAMP | TO | TOKENIZER | TOKEN_FILTERS | TYPE | VALUES | VIEW | YEAR
-    | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN | COMMIT
+    | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN | COMMIT | ROLLBACK
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | PREPARE
     | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED
@@ -789,6 +790,7 @@ LICENSE : 'LICENSE';
 
 BEGIN: 'BEGIN';
 COMMIT: 'COMMIT';
+ROLLBACK: 'ROLLBACK';
 WORK: 'WORK';
 TRANSACTION: 'TRANSACTION';
 TRANSACTION_ISOLATION: 'TRANSACTION_ISOLATION';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -147,6 +147,7 @@ import io.crate.sql.tree.RerouteOption;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.RevokePrivilege;
+import io.crate.sql.tree.RollbackStatement;
 import io.crate.sql.tree.SearchedCaseExpression;
 import io.crate.sql.tree.Select;
 import io.crate.sql.tree.SelectItem;
@@ -224,6 +225,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitCommit(SqlBaseParser.CommitContext context) {
         return new CommitStatement();
+    }
+
+    @Override
+    public Node visitRollback(SqlBaseParser.RollbackContext context) {
+        return new RollbackStatement();
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -565,6 +565,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitRollback(RollbackStatement node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitShowTransaction(ShowTransaction showTransaction, C context) {
         return visitStatement(showTransaction, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/RollbackStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RollbackStatement.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+public class RollbackStatement extends Statement {
+
+    public RollbackStatement() {
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public String toString() {
+        return "ROLLBACK";
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRollback(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -99,6 +99,13 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testRollback() {
+        printStatement("ROLLBACK");
+        printStatement("ROLLBACK WORK");
+        printStatement("ROLLBACK TRANSACTION");
+    }
+
+    @Test
     public void testEmptyOverClauseAfterFunction() {
         printStatement("SELECT avg(x) OVER () FROM t");
     }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedRollback.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedRollback.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+public class AnalyzedRollback implements AnalyzedStatement {
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
+        return analyzedStatementVisitor.visitRollback(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return false;
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -195,6 +195,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitAnalyzedStatement(analyzedCommit, context);
     }
 
+    public R visitRollback(AnalyzedRollback analyzedRollback, C context) {
+        return visitAnalyzedStatement(analyzedRollback, context);
+    }
+
     public R visitPrivilegesStatement(PrivilegesAnalyzedStatement analysis, C context) {
         return visitDCLStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -80,6 +80,7 @@ import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.RevokePrivilege;
+import io.crate.sql.tree.RollbackStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -493,6 +494,11 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitCommit(CommitStatement node, Analysis context) {
             return new AnalyzedCommit();
+        }
+
+        @Override
+        public AnalyzedStatement visitRollback(RollbackStatement node, Analysis context) {
+            return new AnalyzedRollback();
         }
 
         @Override

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -29,6 +29,7 @@ import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedDecommissionNodeStatement;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
+import io.crate.analyze.AnalyzedRollback;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.AnalyzedSwapTable;
@@ -183,6 +184,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitCommit(AnalyzedCommit analyzedCommit, PlannerContext context) {
+        return NoopPlan.INSTANCE;
+    }
+
+    @Override
+    public Plan visitRollback(AnalyzedRollback analyzedRollback, PlannerContext context) {
         return NoopPlan.INSTANCE;
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -85,6 +85,20 @@ public class PostgresCompatIntegrationTest extends SQLTransportIntegrationTest {
         assertNoErrorResponse(response);
     }
 
+    @Test
+    public void testRollbackStatement() {
+        execute("ROLLBACK");
+        assertNoErrorResponse(response);
+    }
+
+    @Test
+    public void testRollbackStatementWithParameters() {
+        execute("ROLLBACK WORK");
+        assertNoErrorResponse(response);
+        execute("ROLLBACK TRANSACTION");
+        assertNoErrorResponse(response);
+    }
+
     /**
      * In CrateDB -1 means row-count unknown, and -2 means error.
      * In JDBC -2 means row-count unknown and -3 means error.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This improves the support for clients that are based on the Postgres wire protocol.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
