### PR TITLE
By-pass license validation on development instances

### DIFF
--- a/licensing/src/test/java/io/crate/license/LicenseServiceTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseServiceTest.java
@@ -25,6 +25,7 @@ package io.crate.license;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +69,11 @@ public class LicenseServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void setupLicenseService() {
-        licenseService = new LicenseService(Settings.EMPTY, mock(TransportSetLicenseAction.class), clusterService);
+        licenseService = new LicenseService(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            mock(TransportSetLicenseAction.class),
+            clusterService);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This ensures that we have non-flaky tests once we merge the max-node
limitation (https://github.com/crate/crate/pull/8322) by treating
instances that are bound to loopback as development instances.

This is the same pattern we use to check if we should enforce bootstrap
checks.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed