### PR TITLE
Fix memory accounting of window functions

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -139,3 +139,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed circuit breaker memory accounting of window functions to prevent OOM
+  exceptions.

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
@@ -116,12 +116,12 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
 
         this.order = windowDefinition.orderBy();
 
-        // adding 8 extra bytes as some cells of each row will be part of a LinkedList which adds the overhead of
-        // 2 pointers for prev and next element (4 bytes each with compressed oops)
-        int extraRowOverhead = 8;
+        // adding 32 extra bytes as some cells of each row will be part of a LinkedList which adds the overhead of
+        // 24 bytes for each element (32 bytes each with compressed oops)
+        int extraRowOverhead = 32;
         if (standaloneInputs.size() > 0) {
             // another LinkedList is used for standalone inputs
-            extraRowOverhead += 8;
+            extraRowOverhead += 32;
         }
         RowAccountingWithEstimators rowAccounting =
             new RowAccountingWithEstimators(standaloneInputTypes, ramAccountingContext, extraRowOverhead);


### PR DESCRIPTION
A LinkedList entry will consume 32 bytes in worst case scenarios, accounting less
will result in OOM exceptions on heap pressure.
