### PR TITLE
Fix pg function resolution when schema is included

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -146,5 +146,9 @@ Changes
 Fixes
 =====
 
+- Fixed function resolution for postgresql functions ``pg_backend_pid``,
+  ``pg_get_expr`` and ``current_database`` when the schema prefix
+  ``pg_catalog`` is included.
+
 - Fixed circuit breaker memory accounting of window functions to prevent OOM
   exceptions.

--- a/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -26,16 +26,20 @@ import io.crate.Constants;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import java.util.Collections;
 
 final class CurrentDatabaseFunction extends Scalar<String, Void> {
 
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, "current_database");
+
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent("current_database", Collections.emptyList()), DataTypes.STRING);
+        new FunctionIdent(FQN, Collections.emptyList()), DataTypes.STRING);
 
     @Override
     public FunctionInfo info() {

--- a/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -29,8 +29,10 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import java.util.Collections;
@@ -38,9 +40,11 @@ import java.util.Collections;
 public class PgBackendPidFunction extends Scalar<Integer, Void> {
 
     public static final String NAME = "pg_backend_pid";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
 
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, Collections.emptyList()),
+        new FunctionIdent(FQN, Collections.emptyList()),
         DataTypes.INTEGER,
         FunctionInfo.Type.SCALAR,
         FunctionInfo.NO_FEATURES);

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -26,8 +26,10 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import java.util.Arrays;
@@ -35,6 +37,7 @@ import java.util.Arrays;
 public class PgGetExpr extends Scalar<String, Object> {
 
     public static final String NAME = "pg_get_expr";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
     public static void register(ScalarFunctionModule scalarFunctionModule) {
         scalarFunctionModule.register(new PgGetExpr());
@@ -48,7 +51,7 @@ public class PgGetExpr extends Scalar<String, Object> {
     @Override
     public FunctionInfo info() {
         return new FunctionInfo(
-            new FunctionIdent(NAME, Arrays.asList(DataTypes.STRING, DataTypes.INTEGER)),
+            new FunctionIdent(FQN, Arrays.asList(DataTypes.STRING, DataTypes.INTEGER)),
             DataTypes.STRING);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
@@ -36,6 +36,11 @@ public class PgBackendPidFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void testPgBackendPidWithFQNFunctionName() throws Exception {
+        assertEvaluate("pg_catalog.pg_backend_pid()", -1);
+    }
+
+    @Test
     public void testInvalidType() throws Exception {
         expectedException.expectMessage("unknown function: pg_backend_pid(undefined)");
         sqlExpressions.asSymbol("pg_backend_pid(null)");

--- a/sql/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
@@ -20,20 +20,22 @@
  * agreement.
  */
 
-package io.crate.expression.scalar;
+package io.crate.expression.scalar.postgres;
 
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import org.junit.Test;
 
-public class CurrentDatabaseFunctionTest extends AbstractScalarFunctionsTest {
+import static io.crate.testing.SymbolMatchers.isLiteral;
 
+public class PgGetExprFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
-    public void testCurrentDatabaseReturnsTheDefaultDBName() {
-        assertEvaluate("current_database()", "crate");
+    public void testPgGetExpr() throws Exception {
+        assertEvaluate("pg_get_expr('whatever', 1)", null);
     }
 
     @Test
-    public void testCurrentDatabaseWithFQNFunctionName() {
-        assertEvaluate("pg_catalog.current_database()", "crate");
+    public void testPgGetExprWithFQNFunctionName() throws Exception {
+        assertNormalize("pg_catalog.pg_get_expr('whatever', 1)", isLiteral(null));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes the following issue:
When trying to resolve the specific pg functions including the schema,
eg. `pg_catalog.pg_backend_pid()`, results in an `unknown function` error.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed