### PR TITLE
Include a trial-prefix in the `issued_to` of trial licenses

### DIFF
--- a/licensing/src/main/java/io/crate/license/LicenseService.java
+++ b/licensing/src/main/java/io/crate/license/LicenseService.java
@@ -207,13 +207,12 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             if (nodes.isLocalNodeElectedMaster()) {
                 DecryptedLicenseData licenseData = new DecryptedLicenseData(
                     DecryptedLicenseData.UNLIMITED_EXPIRY_DATE_IN_MS,
-                    clusterState.getClusterName().value(),
+                    "Trial-" + clusterState.getClusterName().value(),
                     DecryptedLicenseData.MAX_NODES_FOR_V2_LICENSES
                 );
-                LicenseKey licenseKey = TrialLicense.createLicenseKey(
-                    LicenseKey.VERSION, licenseData);
+                LicenseKey licenseKey = TrialLicense.createLicenseKey(LicenseKey.VERSION, licenseData);
                 registerLicense(licenseKey,
-                    new ActionListener<SetLicenseResponse>() {
+                    new ActionListener<>() {
 
                         @Override
                         public void onResponse(SetLicenseResponse setLicenseResponse) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Enables us to easier distinguish trial licenses in the UDC pings we
receive.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed