### PR TITLE
Fix order-by push down on sub-select queries

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -157,6 +157,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which causes sub-select queries with certain ``ORDER BY``
+  constructs to fail.
+
 - Fixed function resolution for postgresql functions ``pg_backend_pid``,
   ``pg_get_expr`` and ``current_database`` when the schema prefix
   ``pg_catalog`` is included.

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -715,6 +715,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
     }
 
+    @Test
     public void testSubscriptOnSubSelect() {
         execute("create table t1 (a object, c object)");
         execute("insert into t1 (a, c) values ({ b = 1 }, { d = { e = 2 }})");
@@ -728,5 +729,15 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     public void testSubscriptOnSubSelectFromUnnestWithObjectLiteral() {
         execute("select col1['b'] from (select * from unnest([{b=1}])) t1");
         assertThat(printedTable(response.rows()), is(""));
+    }
+
+    @Test
+    public void testOrderByFunctionWithColumnOfSubSelect() {
+        execute("create table t1 (id int)");
+        execute("insert into t1 (id) values (1), (2)");
+        execute("refresh table t1");
+        execute("select id + 1 from (select id from t1) tt order by 1 desc");
+        assertThat(printedTable(response.rows()), is("3\n" +
+                                                     "2\n"));
     }
 }


### PR DESCRIPTION
When optimizing a sub-select query, new source outputs of a boundary
were not processed and thus wrong outputs were returned to an upper
logical plan which resulted in mapping errors.