### PR TITLE
Upgrade Admin-UI to v1.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -290,7 +290,6 @@ uploadArchives {
 
 ext {
     downloadDir = new File(buildDir, 'downloads')
-    adminui_version = '1.11.4'
 }
 
 def rootDir = project.parent.projectDir
@@ -539,8 +538,8 @@ task downloadAdminUI {
         } else {
             dest = download(
                 downloadDir,
-                "https://cdn.crate.io/downloads/releases/crate-admin-${adminui_version}.tar.gz",
-                "crate-admin-${adminui_version}.tar.gz"
+                "https://cdn.crate.io/downloads/releases/crate-admin-${versions.crate_admin_ui}.tar.gz",
+                "crate-admin-${versions.crate_admin_ui}.tar.gz"
             )
         }
         extractTopfolder(dest, "${buildDir}/crate-admin/_site")

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -18,6 +18,9 @@ jaxb_api=2.2.2
 jacksondatabind=2.0.1
 jacksondataformatcsv=2.5.1
 
+# Admin UI
+crate_admin_ui = 1.12.0
+
 # Crate JDBC
 crate_jdbc=2.5.1
 


### PR DESCRIPTION
This new version contains support for displaying the `max_nodes` of 
an enterprise license.