### PR TITLE
Upgrade Admin-UI to 1.13.0

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -19,7 +19,7 @@ jacksondatabind=2.0.1
 jacksondataformatcsv=2.5.1
 
 # Admin UI
-crate_admin_ui = 1.12.0
+crate_admin_ui = 1.13.0
 
 # Crate JDBC
 crate_jdbc=2.5.1


### PR DESCRIPTION
This release won't depend on the deprecated `license.enterprise` setting anymore to distinguish between enterprise and community edition.
