### PR TITLE
Expose _docid

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -113,6 +113,9 @@ Deprecations
 Changes
 =======
 
+- Added a new ``_docid`` :ref:`system column
+  <sql_administration_system_columns>`.
+
 - Added :ref:`trim <scalar-trim>` scalar string function that trims
   the (leading, trailing or both) set of characters from an input string.
 

--- a/blackbox/docs/general/ddl/system-columns.rst
+++ b/blackbox/docs/general/ddl/system-columns.rst
@@ -4,7 +4,7 @@
 System Columns
 ==============
 
-On every table CrateDB implements several implicitly defined system columns.
+On every user table CrateDB implements several implicitly defined system columns.
 Their names are reserved and cannot be used as user-defined column names. All
 system columns are prefixed with an underscore, consist of lowercase letters
 and might contain underscores in between.
@@ -42,3 +42,9 @@ _id
   shards.
 
 .. _Optimistic Concurrency Control: http://en.wikipedia.org/wiki/Optimistic_concurrency_control
+
+
+_docid
+  ``_docid`` exposes the internal id a document has within a Lucene segment.
+  Although the id is unique within a segment, it is not unique across segments
+  or shards and can change the value in case segments are merged.

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -131,6 +131,7 @@ public final class PKLookupOperation {
                     throw new RuntimeException(e);
                 }
                 return new Doc(
+                    docIdAndVersion.docId,
                     shard.shardId().getIndexName(),
                     id,
                     docIdAndVersion.version,

--- a/sql/src/main/java/io/crate/expression/reference/Doc.java
+++ b/sql/src/main/java/io/crate/expression/reference/Doc.java
@@ -33,20 +33,27 @@ public final class Doc {
 
     private final Map<String, Object> source;
     private final Supplier<String> raw;
+    private final int docId;
     private final String index;
     private final String id;
     private final long version;
 
-    public Doc(String index,
+    public Doc(int docId,
+               String index,
                String id,
                long version,
                Map<String, Object> source,
                Supplier<String> raw) {
+        this.docId = docId;
         this.index = index;
         this.id = id;
         this.version = version;
         this.source = source;
         this.raw = raw;
+    }
+
+    public int docId() {
+        return docId;
     }
 
     public long getVersion() {
@@ -71,6 +78,7 @@ public final class Doc {
 
     public Doc withUpdatedSource(Map<String, Object> updatedSource) {
         return new Doc(
+            docId,
             index,
             id,
             version,

--- a/sql/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -57,6 +57,9 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
             case DocSysColumns.Names.ID:
                 return NestableCollectExpression.forFunction(Doc::getId);
 
+            case DocSysColumns.Names.DOCID:
+                return forFunction(Doc::docId);
+
             case DocSysColumns.Names.RAW:
                 return forFunction(Doc::getRaw);
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocIdCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocIdCollectorExpression.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+public final class DocIdCollectorExpression extends LuceneCollectorExpression<Integer> {
+
+    private Integer doc = null;
+
+    @Override
+    public void setNextDocId(int doc) {
+        this.doc = doc;
+    }
+
+    @Override
+    public Integer value() {
+        return doc;
+    }
+}

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -87,6 +87,9 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             case DocSysColumns.Names.FETCHID:
                 return new FetchIdCollectorExpression();
 
+            case DocSysColumns.Names.DOCID:
+                return new DocIdCollectorExpression();
+
             case DocSysColumns.Names.SCORE:
                 return new ScoreCollectorExpression();
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -53,6 +53,7 @@ public class DocSysColumns {
          * See {@link FetchId}
          */
         public static final String FETCHID = "_fetchid";
+        public static final String DOCID = "_docid";
     }
 
     public static final ColumnIdent ID = new ColumnIdent(Names.ID);
@@ -66,6 +67,7 @@ public class DocSysColumns {
      * See {@link Names#FETCHID}
      */
     public static final ColumnIdent FETCHID = new ColumnIdent(Names.FETCHID);
+    public static final ColumnIdent DOCID = new ColumnIdent(Names.DOCID);
 
     public static final ImmutableMap<ColumnIdent, DataType> COLUMN_IDENTS = ImmutableMap.<ColumnIdent, DataType>builder()
         .put(DOC, ObjectType.untyped())
@@ -75,6 +77,7 @@ public class DocSysColumns {
         .put(SCORE, DataTypes.FLOAT)
         .put(UID, DataTypes.STRING)
         .put(VERSION, DataTypes.LONG)
+        .put(DOCID, DataTypes.INTEGER)
         .build();
 
     private static final ImmutableMap<ColumnIdent, String> LUCENE_COLUMN_NAMES = ImmutableMap.<ColumnIdent, String>builder()

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -24,7 +24,6 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -425,12 +424,5 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                                    "group by name having sum(power(power(id::double, id::double), id::double)) > 0");
         assertThat(relation.querySpec().having().query(),
             isSQL("(sum(power(power(to_double(doc.users.id), to_double(doc.users.id)), to_double(doc.users.id))) > 0.0)"));
-    }
-
-    @Test
-    public void testGroupByHiddenColumn() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column _docid unknown");
-        analyze("select count(*) from users group by _docid");
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1725,34 +1725,6 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testSelectHiddenColumn() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column _docid unknown");
-        analyze("select _docid + 1 from users");
-    }
-
-    @Test
-    public void testOrderByHiddenColumn() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column _docid unknown");
-        analyze("select * from users order by _docid");
-    }
-
-    @Test
-    public void testWhereHiddenColumn() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column _docid unknown");
-        analyze("select * from users where _docid = 0");
-    }
-
-    @Test
-    public void testHavingHiddenColumn() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column _docid unknown");
-        analyze("select count(*) from users group by id having _docid > 0");
-    }
-
-    @Test
     public void testStarToFieldsInMultiSelect() throws Exception {
         QueriedRelation relation = analyze(
             "select jobs.stmt, operations.* from sys.jobs, sys.operations where jobs.id = operations.job_id");

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -72,6 +72,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
             .endObject()
             .endObject());
         generatedColumns.setNextRow(new Doc(
+            1,
             table.concreteIndices()[0],
             "1",
             1,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -70,6 +70,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = singletonMap("x", 1);
         BytesReference updatedSource = updateSourceGen.generateSource(
             new Doc(
+                1,
                 table.concreteIndices()[0],
                 "1",
                 1,
@@ -109,6 +110,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .endObject());
         BytesReference updatedSource = updateSourceGen.generateSource(
             new Doc(
+                1,
                 table.concreteIndices()[0],
                 "4",
                 1,
@@ -137,6 +139,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         );
         BytesReference updatedSource = updateSourceGen.generateSource(
             new Doc(
+                1,
                 table.concreteIndices()[0],
                 "1",
                 1,
@@ -166,7 +169,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         );
 
         BytesReference source = sourceGen.generateSource(
-            new Doc(table.concreteIndices()[0], "1", 1, emptyMap(), () -> "{}"),
+            new Doc(1, table.concreteIndices()[0], "1", 1, emptyMap(), () -> "{}"),
             assignments.sources(),
             new Object[0]
         );

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -49,7 +49,7 @@ public class DocRefResolverTest extends CrateUnitTest {
     private static final DocRefResolver REF_RESOLVER =
         new DocRefResolver(Collections.emptyList());
     private static final Doc GET_RESULT =
-        new Doc("t1", "abc", 1L, XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2(), SOURCE::utf8ToString);
+        new Doc(2, "t1", "abc", 1L, XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2(), SOURCE::utf8ToString);
 
     @Test
     public void testSystemColumnsCollectExpressions() throws Exception {
@@ -57,7 +57,8 @@ public class DocRefResolverTest extends CrateUnitTest {
             refInfo("t1._id", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.ID), RowGranularity.DOC),
             refInfo("t1._version", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.VERSION), RowGranularity.DOC),
             refInfo("t1._doc", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.DOC), RowGranularity.DOC),
-            refInfo("t1._raw", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.RAW), RowGranularity.DOC)
+            refInfo("t1._raw", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.RAW), RowGranularity.DOC),
+            refInfo("t1._docid", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.DOCID), RowGranularity.DOC)
         );
 
         List<CollectExpression<Doc, ?>> collectExpressions = new ArrayList<>(4);
@@ -71,5 +72,6 @@ public class DocRefResolverTest extends CrateUnitTest {
         assertThat(collectExpressions.get(1).value(), is(1L));
         assertThat(collectExpressions.get(2).value(), is(XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2()));
         assertThat(collectExpressions.get(3).value(), is(SOURCE.utf8ToString()));
+        assertThat(collectExpressions.get(4).value(), is(2));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -461,20 +461,22 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertFromQueryWithSysColumn() throws Exception {
-        execute("create table target (name string, a string, b string) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("create table target (name string, a string, b string, docid int) " +
+                "clustered into 1 shards with (number_of_replicas = 0)");
         execute("create table source (name string) clustered into 1 shards with (number_of_replicas = 0)");
         ensureYellow();
 
         execute("insert into source (name) values ('yalla')");
         execute("refresh table source");
 
-        execute("insert into target (name, a, b) (select name, _raw, _id from source)");
+        execute("insert into target (name, a, b, docid) (select name, _raw, _id, _docid from source)");
         execute("refresh table target");
 
-        execute("select name, a, b from target");
-        assertThat((String) response.rows()[0][0], is("yalla"));
-        assertThat((String) response.rows()[0][1], is("{\"name\":\"yalla\"}"));
-        assertThat((String) response.rows()[0][2], IsNull.notNullValue());
+        execute("select name, a, b, docid from target");
+        assertThat(response.rows()[0][0], is("yalla"));
+        assertThat(response.rows()[0][1], is("{\"name\":\"yalla\"}"));
+        assertThat(response.rows()[0][2], IsNull.notNullValue());
+        assertThat(response.rows()[0][3], is(0));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -179,7 +179,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetaData metaData = getIndexMetaData("test1", builder);
         DocIndexMetaData md = newMeta(metaData, "test1");
         assertThat(md.columns().size(), is(4));
-        assertThat(md.references().size(), is(17));
+        assertThat(md.references().size(), is(18));
         assertThat(md.references().get(new ColumnIdent("implicit_dynamic")).columnPolicy(), is(ColumnPolicy.DYNAMIC));
         assertThat(md.references().get(new ColumnIdent("explicit_dynamic")).columnPolicy(), is(ColumnPolicy.DYNAMIC));
         assertThat(md.references().get(new ColumnIdent("ignored")).columnPolicy(), is(ColumnPolicy.IGNORED));
@@ -252,7 +252,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         DocIndexMetaData md = newMeta(metaData, "test1");
 
         assertThat(md.columns().size(), is(11));
-        assertThat(md.references().size(), is(20));
+        assertThat(md.references().size(), is(21));
 
         Reference birthday = md.references().get(new ColumnIdent("person", "birthday"));
         assertThat(birthday.valueType(), is(DataTypes.TIMESTAMP));
@@ -289,15 +289,9 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(stringAnalyzedBWC.indexType(), is(Reference.IndexType.ANALYZED));
 
         ImmutableList<Reference> references = ImmutableList.copyOf(md.references().values());
-        List<String> fqns = Lists.transform(references, new Function<Reference, String>() {
-            @Nullable
-            @Override
-            public String apply(@Nullable Reference input) {
-                return input.column().fqn();
-            }
-        });
+        List<String> fqns = Lists.transform(references, r -> r.column().fqn());
         assertThat(fqns, Matchers.is(
-            ImmutableList.of("_doc", "_fetchid", "_id", "_raw", "_score", "_uid", "_version",
+            ImmutableList.of("_doc", "_fetchid", "_id", "_raw", "_score", "_uid", "_version", "_docid",
                 "integerIndexed", "integerIndexedBWC", "integerNotIndexed", "integerNotIndexedBWC",
                 "person", "person.birthday", "person.first_name",
                 "stringAnalyzed", "stringAnalyzedBWC", "stringNotAnalyzed", "stringNotAnalyzedBWC",
@@ -358,7 +352,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         DocIndexMetaData md = newMeta(metaData, "test1");
 
         assertEquals(6, md.columns().size());
-        assertEquals(16, md.references().size());
+        assertEquals(17, md.references().size());
         assertEquals(1, md.partitionedByColumns().size());
         assertEquals(DataTypes.TIMESTAMP, md.partitionedByColumns().get(0).valueType());
         assertThat(md.partitionedByColumns().get(0).column().fqn(), is("datum"));
@@ -392,7 +386,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         // partitioned by column is not added twice
         assertEquals(2, md.columns().size());
-        assertEquals(9, md.references().size());
+        assertEquals(10, md.references().size());
         assertEquals(1, md.partitionedByColumns().size());
     }
 
@@ -426,7 +420,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         // partitioned by column is not added twice
         assertEquals(2, md.columns().size());
-        assertEquals(10, md.references().size());
+        assertEquals(11, md.references().size());
         assertEquals(1, md.partitionedByColumns().size());
     }
 
@@ -493,14 +487,18 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
 
         DocIndexMetaData metaData = newMeta(getIndexMetaData("test", builder), "test");
-        Reference id = metaData.references().get(new ColumnIdent("_id"));
+        Map<ColumnIdent,Reference> references = metaData.references();
+        Reference id = references.get(new ColumnIdent("_id"));
         assertNotNull(id);
 
-        Reference version = metaData.references().get(new ColumnIdent("_version"));
+        Reference version = references.get(new ColumnIdent("_version"));
         assertNotNull(version);
 
-        Reference score = metaData.references().get(new ColumnIdent("_score"));
+        Reference score = references.get(new ColumnIdent("_score"));
         assertNotNull(score);
+
+        Reference docId = references.get(new ColumnIdent("_docid"));
+        assertNotNull(docId);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This provides users a fairly cheap way to reduce the amount of records
considered for otherwise expensive queries where the accuracy doesn't
matter too mach. By filtering on `_docid` using a modulo operation users
can reduce the amount of records before hitting a GROUP BY or global
aggregation.

A more detailed description of this will be part of the guide.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed