### PR TITLE
Prepare 3.2.6 release

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.2.6.rst
+++ b/blackbox/docs/appendices/release-notes/3.2.6.rst
@@ -1,0 +1,66 @@
+.. _version_3.2.6:
+
+=============
+Version 3.2.6
+=============
+
+Released on 2019/03/25.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.2.6.
+
+    We recommend that you upgrade to the latest 3.1 release before moving to
+    3.2.6.
+
+    If you want to perform a `rolling upgrade`_, your current CrateDB version
+    number must be at least :ref:`version_3.2.0`. Any upgrade from a version
+    prior to this will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+    Please consult the :ref:`version_3.0.0_upgrade_notes` before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.2 and must be recreated before moving to 3.2.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Fixes
+-----
+
+- Fixed an issue which caused an ``IndexOutOfBoundsException`` when a
+  :ref:`window function <window-functions>` with an ordered window was selected
+  in a ``JOIN`` statement.
+
+- Fixed an issue which caused a ``NullPointerException`` when executing a
+  :ref:`window function <window-functions>` over an ordered window which
+  contained null values under the ordered column.
+
+- Fixed an issue which causes sub-select queries with certain ``ORDER BY``
+  constructs to fail.
+
+- Fixed circuit breaker memory accounting of window functions to prevent Out Of
+  Memory exceptions.
+

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.2.6
     3.2.5
     3.2.4
     3.2.3

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,17 +46,3 @@ None
 
 Fixes
 =====
-
-- Fixed an issue which caused an ``IndexOutOfBoundsException`` when a
-  :ref:`window function <window-functions>` with an ordered window was selected
-  in a ``join`` statement.
-
-- Fixed an issue which caused a ``NullPointerException`` when executing a
-  :ref:`window function <window-functions>` over an ordered window which
-  contains null values under the ordered column.
-
-- Fixed an issue which causes sub-select queries with certain ``ORDER BY``
-  constructs to fail.
-
-- Fixed circuit breaker memory accounting of window functions to prevent OOM
-  exceptions.

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -40,7 +40,7 @@ public class Version {
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 
-    public static final boolean SNAPSHOT = true;
+    public static final boolean SNAPSHOT = false;
     public static final Version CURRENT = new Version(3020699, SNAPSHOT, org.elasticsearch.Version.CURRENT);
 
     static {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Prepares release notes and snapshot status for the immanent 3.2.6 release.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
