### PR TITLE
Parser improvements: split ident rule into un/-quoted ident rules and use AST visitors for dataType child nodes.

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -533,10 +533,10 @@ rerouteOption
     ;
 
 dataType
-    : ident
-    | objectTypeDefinition
-    | arrayTypeDefinition
-    | setTypeDefinition
+    : ident                     #dataTypeIdent
+    | objectTypeDefinition      #objectDataType
+    | arrayTypeDefinition       #arrayDataType
+    | setTypeDefinition         #setDataType
     ;
 
 objectTypeDefinition

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -371,16 +371,20 @@ idents
     ;
 
 ident
-    : IDENTIFIER                                                                     #unquotedIdentifier
-    | quotedIdentifier                                                               #quotedIdentifierAlternative
-    | nonReserved                                                                    #unquotedIdentifier
-    | BACKQUOTED_IDENTIFIER                                                          #backQuotedIdentifier
-    | DIGIT_IDENTIFIER                                                               #digitIdentifier
-    | COLON_IDENT                                                                    #colonIdentifier
+    : unquotedIdent
+    | quotedIdent
     ;
 
-quotedIdentifier
-    : QUOTED_IDENTIFIER
+unquotedIdent
+    : IDENTIFIER                        #unquotedIdentifier
+    | nonReserved                       #unquotedIdentifier
+    | DIGIT_IDENTIFIER                  #digitIdentifier        // not supported
+    | COLON_IDENT                       #colonIdentifier        // not supported
+    ;
+
+quotedIdent
+    : QUOTED_IDENTIFIER                 #quotedIdentifier
+    | BACKQUOTED_IDENTIFIER             #backQuotedIdentifier   // not supported
     ;
 
 stringLiteralOrIdentifier
@@ -529,9 +533,7 @@ rerouteOption
     ;
 
 dataType
-    : IDENTIFIER
-    | quotedIdentifier
-    | nonReserved
+    : ident
     | objectTypeDefinition
     | arrayTypeDefinition
     | setTypeDefinition

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1600,17 +1600,25 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitDataType(SqlBaseParser.DataTypeContext context) {
-        if (context.objectTypeDefinition() != null) {
-            return new ObjectColumnType(
-                getObjectType(context.objectTypeDefinition().type),
-                visitCollection(context.objectTypeDefinition().columnDefinition(), ColumnDefinition.class));
-        } else if (context.arrayTypeDefinition() != null) {
-            return CollectionColumnType.array((ColumnType) visit(context.arrayTypeDefinition().dataType()));
-        } else if (context.setTypeDefinition() != null) {
-            return CollectionColumnType.set((ColumnType) visit(context.setTypeDefinition().dataType()));
-        }
+    public Node visitDataTypeIdent(SqlBaseParser.DataTypeIdentContext context) {
         return new ColumnType(getIdentText(context.ident()));
+    }
+
+    @Override
+    public Node visitArrayTypeDefinition(SqlBaseParser.ArrayTypeDefinitionContext context) {
+        return CollectionColumnType.array((ColumnType) visit(context.dataType()));
+    }
+
+    @Override
+    public Node visitObjectTypeDefinition(SqlBaseParser.ObjectTypeDefinitionContext context) {
+        return new ObjectColumnType(
+            getObjectType(context.type),
+            visitCollection(context.columnDefinition(), ColumnDefinition.class));
+    }
+
+    @Override
+    public Node visitSetTypeDefinition(SqlBaseParser.SetTypeDefinitionContext context) {
+        return CollectionColumnType.set((ColumnType) visit(context.dataType()));
     }
 
     private String getObjectType(Token type) {

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1053,8 +1053,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitQuotedIdentifierAlternative(SqlBaseParser.QuotedIdentifierAlternativeContext context) {
-        return new StringLiteral(context.getText().replace("\"\"", "\""));
+    public Node visitQuotedIdentifier(SqlBaseParser.QuotedIdentifierContext context) {
+        String token = context.getText();
+        String identifier = token.substring(1, token.length() - 1)
+            .replace("\"\"", "\"");
+        return new StringLiteral(identifier);
     }
 
     @Nullable
@@ -1607,7 +1610,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         } else if (context.setTypeDefinition() != null) {
             return CollectionColumnType.set((ColumnType) visit(context.setTypeDefinition().dataType()));
         }
-        return new ColumnType(context.getText().toLowerCase(Locale.ENGLISH));
+        return new ColumnType(getIdentText(context.ident()));
     }
 
     private String getObjectType(Token type) {

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1049,7 +1049,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     */
     @Override
     public Node visitUnquotedIdentifier(SqlBaseParser.UnquotedIdentifierContext context) {
-        return new StringLiteral(context.IDENTIFIER().getText().replace("``", "`").toLowerCase(Locale.ENGLISH));
+        return new StringLiteral(context.getText().toLowerCase(Locale.ENGLISH));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
@@ -162,20 +162,6 @@ public class SqlParser {
         }
 
         @Override
-        public void exitQuotedIdentifier(SqlBaseParser.QuotedIdentifierContext context) {
-            // Remove quotes
-            context.getParent().removeLastChild();
-
-            Token token = (Token) context.getChild(0).getPayload();
-            context.getParent().addChild(new CommonToken(
-                new Pair<>(token.getTokenSource(), token.getInputStream()),
-                SqlBaseLexer.IDENTIFIER,
-                token.getChannel(),
-                token.getStartIndex() + 1,
-                token.getStopIndex() - 1));
-        }
-
-        @Override
         public void exitNonReserved(SqlBaseParser.NonReservedContext context) {
             // replace nonReserved words with IDENT tokens
             context.getParent().removeLastChild();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
