### PR TITLE
Add missing PG mapping for ``array(ip)``

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -116,6 +116,8 @@ Deprecations
 Changes
 =======
 
+- Added missing Postgresql type mapping for the ``array(ip)`` collection type.
+
 - Added a new ``_docid`` :ref:`system column
   <sql_administration_system_columns>`.
 

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -52,7 +52,6 @@ public class PGTypes {
         .put(DataTypes.TIMESTAMP, TimestampType.INSTANCE)
         .put(DataTypes.IP, VarCharType.INSTANCE) // postgres has no IP type, so map it to varchar - it matches the client representation
         .put(DataTypes.UNDEFINED, VarCharType.INSTANCE)
-        .put(DataTypes.GEO_POINT, PGArray.FLOAT8_ARRAY)
         .put(DataTypes.GEO_SHAPE, JsonType.INSTANCE)
         .put(new ArrayType(DataTypes.BYTE), PGArray.CHAR_ARRAY)
         .put(new ArrayType(DataTypes.SHORT), PGArray.INT2_ARRAY)
@@ -63,6 +62,7 @@ public class PGTypes {
         .put(new ArrayType(DataTypes.BOOLEAN), PGArray.BOOL_ARRAY)
         .put(new ArrayType(DataTypes.TIMESTAMP), PGArray.TIMESTAMPZ_ARRAY)
         .put(new ArrayType(DataTypes.STRING), PGArray.VARCHAR_ARRAY)
+        .put(new ArrayType(DataTypes.IP), PGArray.VARCHAR_ARRAY)
         .put(new ArrayType(DataTypes.GEO_POINT), PGArray.FLOAT8_ARRAY)
         .put(new ArrayType(DataTypes.GEO_SHAPE), PGArray.JSON_ARRAY)
         .put(new ArrayType(ObjectType.untyped()), JsonType.INSTANCE)
@@ -75,9 +75,11 @@ public class PGTypes {
         .put(new SetType(DataTypes.BOOLEAN), PGArray.BOOL_ARRAY)
         .put(new SetType(DataTypes.TIMESTAMP), PGArray.TIMESTAMPZ_ARRAY)
         .put(new SetType(DataTypes.STRING), PGArray.VARCHAR_ARRAY)
+        .put(new SetType(DataTypes.IP), PGArray.VARCHAR_ARRAY)
         .put(new SetType(DataTypes.GEO_POINT), PGArray.FLOAT8_ARRAY)
         .put(new SetType(DataTypes.GEO_SHAPE), PGArray.JSON_ARRAY)
         .put(new SetType(ObjectType.untyped()), JsonType.INSTANCE)
+        .put(DataTypes.GEO_POINT, PGArray.FLOAT8_ARRAY)     // Must come after array(double) -> float8-array mapping to avoid override in the static block further below
         .build();
 
     private static final IntObjectMap<DataType> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -37,13 +37,16 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
+import static io.crate.types.DataTypes.GEO_POINT;
+import static io.crate.types.DataTypes.GEO_SHAPE;
+import static io.crate.types.DataTypes.PRIMITIVE_TYPES;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 public class PGTypesTest extends CrateUnitTest {
 
     @Test
-    public void testCrate2PGType() throws Exception {
+    public void testCrate2PGType() {
         assertThat(PGTypes.get(DataTypes.STRING), instanceOf(VarCharType.class));
         assertThat(PGTypes.get(ObjectType.untyped()), instanceOf(JsonType.class));
         assertThat(PGTypes.get(DataTypes.BOOLEAN), instanceOf(BooleanType.class));
@@ -54,14 +57,10 @@ public class PGTypesTest extends CrateUnitTest {
         assertThat(PGTypes.get(DataTypes.DOUBLE), instanceOf(DoubleType.class));
         assertThat("Crate IP type is mapped to PG varchar", PGTypes.get(DataTypes.IP),
             instanceOf(VarCharType.class));
-        assertThat("Crate array type is mapped to PGArray", PGTypes.get(new ArrayType(DataTypes.BYTE)),
-            instanceOf(PGArray.class));
-        assertThat("Crate set type is mapped to PGArray", PGTypes.get(new SetType(DataTypes.BYTE)),
-            instanceOf(PGArray.class));
     }
 
     @Test
-    public void testPG2CrateType() throws Exception {
+    public void testPG2CrateType() {
         assertThat(PGTypes.fromOID(VarCharType.OID), instanceOf(StringType.class));
         assertThat(PGTypes.fromOID(JsonType.OID), instanceOf(ObjectType.class));
         assertThat(PGTypes.fromOID(BooleanType.OID), instanceOf(io.crate.types.BooleanType.class));
@@ -70,14 +69,40 @@ public class PGTypesTest extends CrateUnitTest {
         assertThat(PGTypes.fromOID(BigIntType.OID), instanceOf(LongType.class));
         assertThat(PGTypes.fromOID(RealType.OID), instanceOf(FloatType.class));
         assertThat(PGTypes.fromOID(DoubleType.OID), instanceOf(io.crate.types.DoubleType.class));
-        assertThat("PG array is mapped to Crate Array", PGTypes.fromOID(PGArray.CHAR_ARRAY.oid()),
-            instanceOf(io.crate.types.ArrayType.class));
     }
 
     @Test
     public void testTextOidIsMappedToString() {
         assertThat(PGTypes.fromOID(25), is(DataTypes.STRING));
         assertThat(PGTypes.fromOID(1009), is(new ArrayType(DataTypes.STRING)));
+    }
+
+    @Test
+    public void testCrateCollection2PgType() {
+        for (DataType type : PRIMITIVE_TYPES) {
+            assertThat(PGTypes.get(new ArrayType(type)), instanceOf(PGArray.class));
+            assertThat(PGTypes.get(new SetType(type)), instanceOf(PGArray.class));
+        }
+
+        assertThat(PGTypes.get(new ArrayType(GEO_POINT)), instanceOf(PGArray.class));
+        assertThat(PGTypes.get(new SetType(GEO_POINT)), instanceOf(PGArray.class));
+
+        assertThat(PGTypes.get(new ArrayType(GEO_SHAPE)), instanceOf(PGArray.class));
+        assertThat(PGTypes.get(new SetType(GEO_SHAPE)), instanceOf(PGArray.class));
+    }
+
+    @Test
+    public void testPgArray2CrateType() {
+        assertThat(PGTypes.fromOID(PGArray.CHAR_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.INT2_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.INT4_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.INT8_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.FLOAT4_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.FLOAT8_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.BOOL_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.TIMESTAMPZ_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.VARCHAR_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.JSON_ARRAY.oid()), instanceOf(ArrayType.class));
     }
 
     private static class Entry {


### PR DESCRIPTION
Also ensure that a PGArray.FLOAT8_ARRAY will be mapped to a
``array(double)`` instead of a ``geo_point``.

This issue was raised by running `crate-jdbc` against latest nightly which includes the "default table column policy is strict" change. 

```org.postgresql.util.PSQLException: ERROR: No type mapping from 'ip_array' to pg_type```