### PR TITLE
Reflect 3.2.5/6 releases and prepare 3.3.0

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.2.5.rst
+++ b/blackbox/docs/appendices/release-notes/3.2.5.rst
@@ -1,0 +1,61 @@
+.. _version_3.2.5:
+
+=============
+Version 3.2.5
+=============
+
+Released on 2019/03/11.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.2.5.
+
+    We recommend that you upgrade to the latest 3.1 release before moving to
+    3.2.5.
+
+    If you want to perform a `rolling upgrade`_, your current CrateDB version
+    number must be at least :ref:`version_3.2.0`. Any upgrade from a version
+    prior to this will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+    Please consult the :ref:`version_3.0.0_upgrade_notes` before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.2 and must be recreated before moving to 3.2.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Fixes
+-----
+
+- Fixed an issue that could cause queries on the :ref:`sys.snapshots
+  <sys-snapshots>` table to raise an error if a snapshot couldn't be retrieved.
+
+- Fixed an issue that caused inserts into partitioned tables to fail with an
+  ``unknown setting`` error if the table was created in an earlier version of
+  CrateDB using settings that have been removed in later versions.
+
+- Fixed an issue that could result in a ``ConcurrentModificationException``
+  error when querying the ``sys.jobs_metrics`` table.

--- a/blackbox/docs/appendices/release-notes/3.2.6.rst
+++ b/blackbox/docs/appendices/release-notes/3.2.6.rst
@@ -1,0 +1,66 @@
+.. _version_3.2.6:
+
+=============
+Version 3.2.6
+=============
+
+Released on 2019/03/25.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.2.6.
+
+    We recommend that you upgrade to the latest 3.1 release before moving to
+    3.2.6.
+
+    If you want to perform a `rolling upgrade`_, your current CrateDB version
+    number must be at least :ref:`version_3.2.0`. Any upgrade from a version
+    prior to this will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+    Please consult the :ref:`version_3.0.0_upgrade_notes` before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.2 and must be recreated before moving to 3.2.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Fixes
+-----
+
+- Fixed an issue which caused an ``IndexOutOfBoundsException`` when a
+  :ref:`window function <window-functions>` with an ordered window was selected
+  in a ``JOIN`` statement.
+
+- Fixed an issue which caused a ``NullPointerException`` when executing a
+  :ref:`window function <window-functions>` over an ordered window which
+  contained null values under the ordered column.
+
+- Fixed an issue which causes sub-select queries with certain ``ORDER BY``
+  constructs to fail.
+
+- Fixed circuit breaker memory accounting of window functions to prevent Out Of
+  Memory exceptions.
+

--- a/blackbox/docs/appendices/release-notes/3.3.0.rst
+++ b/blackbox/docs/appendices/release-notes/3.3.0.rst
@@ -1,0 +1,164 @@
+.. _version_3.3.0:
+
+=============
+Version 3.3.0
+=============
+
+Released on 2019/03/27.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.3.0.
+
+    We recommend that you upgrade to the latest 3.2 release before moving to
+    3.3.0.
+
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
+    version will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+    Please consult the :ref:`version_3.0.0_upgrade_notes` before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.3 and must be recreated before moving to 3.3.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+.. _version_3.3.0_upgrade_notes:
+
+Upgrade Notes
+=============
+
+Deprecated Settings and Features
+--------------------------------
+
+The query frequency and average duration :ref:`query_stats_mbean` metrics
+has now been deprecated, in favour of the new total count and sum of durations
+metrics.
+
+The :ref:`cluster.graceful_stop.reallocate <cluster.graceful_stop.reallocate>`
+setting has been marked as deprecated. This setting was already being ignored,
+and setting the value to ``false`` had no effect.
+
+The node decommission using the ``USR2`` :ref:`signals <cli_signals>` has now
+been deprecated in favour of the :ref:`ALTER CLUSTER DECOMISSION
+<alter_cluster_decommission>` statement.
+
+The :ref:`create-ingest-rule` and :ref:`drop-ingest-rule` rules have been marked
+as deprecated. Given that the only implementation (MQTT) was deprecated
+and will be removed, the framework itself will also be removed.
+
+
+Changelog
+=========
+
+Changes
+-------
+
+New Features
+~~~~~~~~~~~~
+
+- Exposed the sum of durations, total, and failed count metrics under the
+  :ref:`query_stats_mbean` for ``QUERY``, ``INSERT``, ``UPDATE``, ``DELETE``,
+  ``MANAGEMENT``, ``DDL``, and ``COPY`` statement types.
+
+- Exposed the sum of statement durations, total, and failed count classified by
+  statement type under the ``sum_of_durations``, ``total_count`` and
+  ``failed_count`` columns, respectively, in the :ref:`sys-jobs-metrics` table.
+
+SQL Improvements
+~~~~~~~~~~~~~~~~
+
+- Added ``current_schemas(boolean)`` scalar function which will return the
+  names of schemas in the ``search_path``.
+
+- Added support for the ``first_value``, ``last_value``, and ``nth_value``
+  window functions as enterprise features.
+
+- Added the ``DROP ANALYZER`` statement to support removal of custom
+  analyzer definitions from the cluster.
+
+- Output the custom analyzer, tokenizer, token_filter, and char_filter
+  definition inside the ``information_schema.routines.routine_definition``
+  column.
+
+- Added support for the ``row_number()`` window function.
+
+- Added support for using any expression in the operand of a ``CASE`` clause.
+
+- Fix quoting of identifiers that contain leading digits or spaces when
+  printing relation or column names.
+
+PostgreSQL Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added ``pg_type`` columns: ``typlen``, ``typarray``, ``typnotnull``,
+  and ``typnamespace`` for improved PostgreSQL compatibility.
+
+- Added a ``pg_description`` table to the ``pg_catalog`` schema for improved
+  PostgreSQL compatibility.
+
+- Fixed function resolution for PostgreSQL functions ``pg_backend_pid``,
+  ``pg_get_expr``, and ``current_database`` when the schema prefix
+  ``pg_catalog`` is included.
+
+Database Administration
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added a node check for the JVM version number.
+
+- Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` statement that
+  triggers the existing node decommission functionality.
+
+- Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` statement that
+  triggers the existing node decommission functionality.
+
+- Changed the trial license introduced in 3.2 to no longer have an expiration
+  date, but instead be limited to three nodes. See :ref:`enterprise_features`.
+
+- The :ref:`usage_data_collector` now includes information about the available
+  number of processors.
+
+Deprecations
+~~~~~~~~~~~~
+
+- The query frequency and average duration :ref:`query_stats_mbean` metrics
+  has been deprecated in favour of the new total count and sum of durations
+  metrics.
+
+- Marked the :ref:`cluster.graceful_stop.reallocate
+  <cluster.graceful_stop.reallocate>` setting as deprecated. This setting was
+  already being ignored, setting the value to ``false`` has no effect.
+
+- The node decommission using the ``USR2`` :ref:`signal <cli_signals>` has been
+  deprecated in favour of the :ref:`ALTER CLUSTER DECOMISSION
+  <alter_cluster_decommission>` statement.
+
+- Marked :ref:`create-ingest-rule` and :ref:`drop-ingest-rule` as deprecated.
+  Given that the only implementation (MQTT) was deprecated and will be removed,
+  the framework itself will also be removed.
+
+Other
+~~~~~
+
+- Buffer the file output of ``COPY TO`` operations to improve performance by not
+  writing to disk on every row.

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.2.6
     3.2.5
     3.2.4
     3.2.3

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.2.5
     3.2.4
     3.2.3
     3.2.2

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -25,6 +25,14 @@ Versions
 3.x
 ---
 
+3.3.x
+.....
+
+.. toctree::
+    :maxdepth: 1
+
+    3.3.0
+
 3.2.x
 .....
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -43,83 +43,12 @@ Breaking Changes
 
 None
 
-Deprecations
-============
-
-- The query frequency and average duration :ref:`query_stats_mbean` metrics
-  have been deprecated in favour of the new total count and sum of durations
-  metrics.
-
-- Marked the
-  :ref:`cluster.graceful_stop.reallocate <cluster.graceful_stop.reallocate>`
-  setting as deprecated. This setting was already being ignored, setting the
-  value to `false` has no effect.
-
-- The node decommission using the ``USR2`` :ref:`cli_signals` has been
-  deprecated in favour of the
-  :ref:`ALTER CLUSTER DECOMISSION <alter_cluster_decommission>` statement.
-
-- Marked :ref:`create-ingest-rule` and :ref:`drop-ingest-rule` as deprecated.
-  Given that the only implementation (MQTT) was deprecated and will be removed,
-  the framework itself will also be removed.
-
 Changes
 =======
 
-- Changed the trial license introduced in 3.2 to no longer have an expiration
-  date, but instead be limited to 3 nodes. See :ref:`enterprise_features`.
-
-- The :ref:`usage_data_collector` now includes information about the available
-  number of processors.
-
-- Added support for :ref:`sql_escape_string_literals`.
-
-- Expose the sum of durations, total, and failed count metrics under the
-  :ref:`query_stats_mbean` for ``QUERY``, ``INSERT``, ``UPDATE``, ``DELETE``,
-  ``MANAGEMENT``, ``DDL`` and ``COPY`` statement types.
-
-- Expose the sum of statement durations, total, and failed count classified by
-  statement type under the sum_of_durations, total_count and failed_count
-  columns, respectively, in the :ref:`sys-jobs-metrics` table.
-
-- Added a node check that checks the JVM version under which CrateDB is
-  running. We recommend users to upgrade to JVM 11 as support for older
-  versions will be dropped in the future.
-
-- Added ``ALTER CLUSTER DECOMMISSION <nodeId | nodeName>`` statement that
-  triggers the existing node decommission functionality.
-
-- Added ``pg_type`` columns: ``typlen``, ``typarray``, ``typnotnull``
-  and ``typnamespace`` for improved postgresql compatibility.
-
-- Added ``current_schemas(boolean)`` scalar function which will return the
-  names of schemas in the ``search_path``.
-
-- Added support for the ``first_value``, ``last_value`` and ``nth_value``
-  window functions as enterprise features.
-
-- Implemented the ``DROP ANALYZER`` statement to support removal of custom
-  analyzer definitions from the cluster.
-
-- Output the custom analyzer/tokenizer/token_filter/char_filter definition inside
-  the ``information_schema.routines.routine_definition`` column.
-
-- Added a ``pg_description`` table to the ``pg_catalog`` schema for improved
-  postgresql compatibility.
-
-- Added support for window function ``row_number()``.
-
-- Added support to use any expression in the operand of a ``CASE`` clause.
-
-- Buffer the file output of ``COPY TO`` operations to improve performance by not
-  writing to disk on every row.
+None
 
 Fixes
 =====
 
-- Fix quoting of identifiers that contain leading digits or spaces when
-  printing relation or column names.
-
-- Fixed function resolution for postgresql functions ``pg_backend_pid``,
-  ``pg_get_expr`` and ``current_database`` when the schema prefix
-  ``pg_catalog`` is included.
+None

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -29,8 +29,8 @@ Unreleased Changes
 .. When resetting this file during a release, leave the headers in place, but
 .. add a single paragraph to each section with the word "None".
 
-.. Always cluster items into bigger topics. Link to the documentation whenever feasible.  
-.. Remember to give the right level of information: Users should understand  
+.. Always cluster items into bigger topics. Link to the documentation whenever feasible.
+.. Remember to give the right level of information: Users should understand
 .. the impact of the change without going into the depth of tech.
 
 .. rubric:: Table of Contents
@@ -137,13 +137,3 @@ Fixes
 
 - Fixed circuit breaker memory accounting of window functions to prevent OOM
   exceptions.
-
-- Fixed an issue that could cause queries on the :ref:`sys.snapshots
-  <sys-snapshots>` table to raise an error if a snapshot couldn't be retrieved.
-
-- Fixed an issue that caused inserts into partitioned tables to fail with an
-  ``unknown setting`` error if the table was created in an earlier version of
-  CrateDB using settings that have been removed in later versions.
-
-- Fixed an issue that could result in an ``ConcurrentModificationException``
-  error when querying the :ref:`sys-jobs-metrics` table.

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -120,20 +120,6 @@ Fixes
 - Fix quoting of identifiers that contain leading digits or spaces when
   printing relation or column names.
 
-- Fixed an issue which caused a ``NullPointerException`` when executing a
-  :ref:`window function <window-functions>` over an ordered window which
-  contains null values under the ordered column.
-
-- Fixed an issue which caused an ``IndexOutOfBoundsException`` when a
-  :ref:`window function <window-functions>` with an ordered window was selected
-  in a ``join`` statement.
-
-- Fixed an issue which causes sub-select queries with certain ``ORDER BY``
-  constructs to fail.
-
 - Fixed function resolution for postgresql functions ``pg_backend_pid``,
   ``pg_get_expr`` and ``current_database`` when the schema prefix
   ``pg_catalog`` is included.
-
-- Fixed circuit breaker memory accounting of window functions to prevent OOM
-  exceptions.

--- a/common/src/main/java/io/crate/Version.java
+++ b/common/src/main/java/io/crate/Version.java
@@ -40,7 +40,7 @@ public class Version {
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 
-    public static final boolean SNAPSHOT = true;
+    public static final boolean SNAPSHOT = false;
     public static final Version CURRENT = new Version(3030099, SNAPSHOT, org.elasticsearch.Version.CURRENT);
 
     static {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR reflects the release notes of the last 3.2.x releases into the 3.3 branch, and then prepares the release notes for 3.3.0.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
