### PR TITLE
Quote identifiers that contain leading digits or whitespace.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -204,6 +204,9 @@ Changes
 Fixes
 =====
 
+- Fix quoting of identifiers that contain leading digits or spaces when
+  printing relation or column names.
+
 - Fixed function resolution for postgresql functions ``pg_backend_pid``,
   ``pg_get_expr`` and ``current_database`` when the schema prefix
   ``pg_catalog`` is included.

--- a/sql-parser/src/main/java/io/crate/sql/Identifiers.java
+++ b/sql-parser/src/main/java/io/crate/sql/Identifiers.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 
 public class Identifiers {
 
-    private static final Pattern IDENTIFIER = Pattern.compile("'([A-Z_]+)'");
+    private static final Pattern IDENTIFIER = Pattern.compile("(^[a-z_]+[0-9_]*)");
     private static final Pattern ESCAPE_REPLACE_RE = Pattern.compile("\"", Pattern.LITERAL);
     private static final String ESCAPE_REPLACEMENT = Matcher.quoteReplacement("\"\"");
 
@@ -65,13 +65,7 @@ public class Identifiers {
     }
 
     private static boolean areQuotesRequired(String identifier) {
-        for (int i = 0; i < identifier.length(); i++) {
-            int cp = identifier.codePointAt(i);
-            if (cp == '"' || cp == '[' || cp == ']' || cp == '(' || cp == ')' || Character.isUpperCase(cp)) {
-                return true;
-            }
-        }
-        return isKeyWord(identifier);
+        return isKeyWord(identifier) || !IDENTIFIER.matcher(identifier).matches();
     }
 
     public static boolean isKeyWord(String identifier) {
@@ -90,13 +84,15 @@ public class Identifiers {
         HashSet<String> candidates = new HashSet<>();
         Vocabulary vocabulary = SqlBaseLexer.VOCABULARY;
         for (int i = 0; i < vocabulary.getMaxTokenType(); i++) {
-            String literalName = vocabulary.getLiteralName(i);
-            if (literalName == null) {
+            String literal = vocabulary.getLiteralName(i);
+            if (literal == null) {
                 continue;
             }
-            Matcher matcher = IDENTIFIER.matcher(literalName);
+            literal = literal.replace("'", "");
+
+            Matcher matcher = IDENTIFIER.matcher(literal.toLowerCase(Locale.ENGLISH));
             if (matcher.matches()) {
-                candidates.add(matcher.group(1));
+                candidates.add(literal);
             }
         }
         return candidates;

--- a/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.core.Is.is;
 public class IdentifiersTest {
 
     @Test
-    public void testEscape() throws Exception {
+    public void testEscape() {
         assertThat(Identifiers.escape(""), is(""));
         assertThat(Identifiers.escape("\""), is("\"\""));
         assertThat(Identifiers.escape("ABC\""), is("ABC\"\""));
@@ -41,7 +41,7 @@ public class IdentifiersTest {
     }
 
     @Test
-    public void testQuote() throws Exception {
+    public void testQuote() {
         assertThat(Identifiers.quote(""), is("\"\""));
         assertThat(Identifiers.quote("\""), is("\"\"\"\""));
         assertThat(Identifiers.quote("ABC"), is("\"ABC\""));
@@ -49,13 +49,15 @@ public class IdentifiersTest {
     }
 
     @Test
-    public void testQuoteIfNeeded() throws Exception {
-        assertThat(Identifiers.quoteIfNeeded(""), is(""));
+    public void testQuoteIfNeeded() {
+        assertThat(Identifiers.quoteIfNeeded(""), is("\"\""));
         assertThat(Identifiers.quoteIfNeeded("\""), is("\"\"\"\""));
         assertThat(Identifiers.quoteIfNeeded("fhjgadhjgfhs"), is("fhjgadhjgfhs"));
         assertThat(Identifiers.quoteIfNeeded("fhjgadhjgfhsÖ"), is("\"fhjgadhjgfhsÖ\""));
         assertThat(Identifiers.quoteIfNeeded("ABC"), is("\"ABC\""));
         assertThat(Identifiers.quoteIfNeeded("abc\""), is("\"abc\"\"\""));
         assertThat(Identifiers.quoteIfNeeded("select"), is("\"select\"")); // keyword
+        assertThat(Identifiers.quoteIfNeeded("1column"), is("\"1column\""));
+        assertThat(Identifiers.quoteIfNeeded("column name"), is("\"column name\""));
     }
 }

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -71,6 +71,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
             .add("foo", DataTypes.STRING)
             .add("bar", DataTypes.LONG)
             .add("CraZy", DataTypes.IP)
+            .add("1a", DataTypes.INTEGER)
             .add("select", DataTypes.BYTE)
             .add("idx", DataTypes.INTEGER)
             .add("s_arr", new ArrayType(DataTypes.STRING))
@@ -274,10 +275,14 @@ public class SymbolPrinterTest extends CrateUnitTest {
     }
 
     @Test
-    public void testFormatQualified() throws Exception {
+    public void testFormatQualified() {
         Symbol ref = sqlExpressions.asSymbol("formatter.\"CraZy\"");
         assertThat(printer.printQualified(ref), is("doc.formatter.\"CraZy\""));
         assertThat(printer.printUnqualified(ref), is("\"CraZy\""));
+
+        ref = sqlExpressions.asSymbol("formatter.\"1a\"");
+        assertThat(printer.printQualified(ref), is("doc.formatter.\"1a\""));
+        assertThat(printer.printUnqualified(ref), is("\"1a\""));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
