### PR TITLE
Added quote_ident scalar string function.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -137,6 +137,9 @@ Deprecations
 Changes
 =======
 
+- Added :ref:`quote_ident <scalar-quote-ident>` scalar string function that
+  quotes a string if it is needed.
+
 - Added missing Postgresql type mapping for the ``array(ip)`` collection type.
 
 - Added a new ``_docid`` :ref:`system column

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -333,6 +333,28 @@ Examples
    +---------------------+
    SELECT 1 row in set (... sec)
 
+.. _scalar-quote-ident:
+
+``quote_ident(text)``
+---------------------
+
+Returns: ``text``
+
+Quotes a provided string argument. The string is quoted only when in is need.
+For example, if it contains non-identifier characters, keywords or would be
+case-folded. Embedded quotes are properly doubled.
+
+The quoted string can be used as an identifier in an SQL statement.
+
+::
+
+   cr> select quote_ident('Column name');
+   +----------------------------+
+   | quote_ident('Column name') |
+   +----------------------------+
+   | "Column name"              |
+   +----------------------------+
+   SELECT 1 row in set (... sec)
 
 Date and Time Functions
 =======================

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -51,6 +51,7 @@ import io.crate.expression.scalar.regex.RegexpReplaceFunction;
 import io.crate.expression.scalar.string.HashFunctions;
 import io.crate.expression.scalar.string.InitCapFunction;
 import io.crate.expression.scalar.string.LengthFunction;
+import io.crate.expression.scalar.string.QuoteIdentFunction;
 import io.crate.expression.scalar.string.ReplaceFunction;
 import io.crate.expression.scalar.string.StringCaseFunction;
 import io.crate.expression.scalar.string.TrimFunctions;
@@ -133,6 +134,7 @@ public class ScalarFunctionModule extends AbstractModule {
         LengthFunction.register(this);
         HashFunctions.register(this);
         ReplaceFunction.register(this);
+        QuoteIdentFunction.register(this);
 
         Ignore3vlFunction.register(this);
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.UnaryScalar;
+import io.crate.sql.Identifiers;
+import io.crate.types.DataTypes;
+
+
+public final class QuoteIdentFunction {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new UnaryScalar<>(
+            "quote_ident",
+            DataTypes.STRING,
+            DataTypes.STRING,
+            Identifiers::quoteIfNeeded)
+        );
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class QuoteIdentFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void testZeroArguments() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: quote_ident()");
+        assertEvaluate("quote_ident()", null);
+    }
+
+    @Test
+    public void testQuoteIdentEvaluateNullInput() {
+        assertEvaluate("quote_ident(null)", null);
+    }
+
+    @Test
+    public void testQuoteIdentEvaluateWithNonIdentifierCharacters() {
+        assertEvaluate("quote_ident('Foo')", "\"Foo\"");
+        assertEvaluate("quote_ident('Foo bar')", "\"Foo bar\"");
+        assertEvaluate("quote_ident('foo\"bar')", "\"foo\"\"bar\"");
+    }
+
+    @Test
+    public void testQuoteIdentEvaluateWithRef() {
+        assertEvaluate(
+            "quote_ident(name)", "\"foo bar\"",
+            Literal.of(DataTypes.STRING, "foo bar"));
+    }
+
+    @Test
+    public void testQuoteIdentNormalize() {
+        assertNormalize("quote_ident('foo')", isLiteral("foo"));
+    }
+
+    @Test
+    public void testQuoteIdentNormalizeWithRefs() {
+        assertNormalize(
+            "quote_ident(name)",
+            isFunction("quote_ident", List.of(DataTypes.STRING)));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
