### PR TITLE
Limit HEAP of license blackbox test instances to 256MB

### DIFF
--- a/blackbox/test_licensing.py
+++ b/blackbox/test_licensing.py
@@ -59,7 +59,8 @@ class CommunityLicenseITest(unittest.TestCase):
                 port=http_port,
                 transport_port=transport_port_range,
                 settings=CRATE_SETTINGS,
-                env={'JAVA_HOME': os.environ.get('JAVA_HOME', '')},
+                env={'JAVA_HOME': os.environ.get('JAVA_HOME', ''),
+                     'CRATE_HEAP_SIZE': '256M'},
                 cluster_name=cls.__class__.__name__)
             layer.start()
             cls.HTTP_PORTS.append(http_port)


### PR DESCRIPTION
As multiple instances are started by this test suite, HEAP should be limited to avoid any OOM. Also instance in this test do not require much HEAP.
