### PR TITLE
Migrate gradle dependency definitions away from compile

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
     }
+    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
 
     compileNotTransitive project(':common')
     compileNotTransitive project(':es:es-core')

--- a/azure-discovery/build.gradle
+++ b/azure-discovery/build.gradle
@@ -30,9 +30,9 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
-    testCompile project(':integration-testing')
-    testCompile project(':http')
-    testCompile('com.microsoft.azure:azure-mgmt-utility:0.9.8') {
+    testImplementation project(':integration-testing')
+    testImplementation project(':http')
+    testImplementation('com.microsoft.azure:azure-mgmt-utility:0.9.8') {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'javax.mail', module: 'mail'
         exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/azure-discovery/build.gradle
+++ b/azure-discovery/build.gradle
@@ -20,6 +20,7 @@ task writePropertiesFile {
 jar.dependsOn('writePropertiesFile')
 
 dependencies {
+    implementation project(':es:es-server')
     compileOnly project(':common')
     compileOnly('com.microsoft.azure:azure-mgmt-utility:0.9.8') {
         exclude group: 'stax', module: 'stax-api'

--- a/blob/build.gradle
+++ b/blob/build.gradle
@@ -3,10 +3,15 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-blob'
 
 dependencies {
-    compile project(':common')
-    compile project(':http')
-    compile project(':es:es-transport')
-    testCompile project(':integration-testing')
+    implementation project(':es:es-server')
+    implementation project(':common')
+    implementation project(':http')
+    implementation project(':es:es-transport')
+    implementation "io.netty:netty-codec-http:${versions.netty4}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    implementation "com.google.guava:guava:${versions.guava}"
+    testImplementation project(':integration-testing')
+    testImplementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
 }
 
 test {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,9 +4,9 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-common'
 
 dependencies {
-    compile project(':es:es-server')
-    compile "com.google.guava:guava:${versions.guava}"
-    testCompile project(':integration-testing')
+    implementation project(':es:es-server')
+    implementation "com.google.guava:guava:${versions.guava}"
+    testImplementation project(':integration-testing')
 }
 
 test {

--- a/dex/build.gradle
+++ b/dex/build.gradle
@@ -8,14 +8,14 @@ configurations {
 }
 
 dependencies {
-    compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
-    compile "com.google.guava:guava:${versions.guava}"
-    compile "org.apache.lucene:lucene-core:${versions.lucene}"
-    compile "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
-    compile project(':shared')
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    implementation "com.google.guava:guava:${versions.guava}"
+    implementation "org.apache.lucene:lucene-core:${versions.lucene}"
+    implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
+    implementation project(':shared')
 
-    testCompile "junit:junit:${versions.junit}"
-    testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
 }
 
 task jarTest (type: Jar) {

--- a/dns-discovery/build.gradle
+++ b/dns-discovery/build.gradle
@@ -5,6 +5,8 @@ group = 'io.crate'
 
 dependencies {
     implementation project(':common')
+    implementation project(':es:es-server')
+    implementation "com.google.guava:guava:${versions.guava}"
     implementation "io.netty:netty-resolver-dns:${versions.netty4}"
     testImplementation project(':integration-testing')
 }

--- a/dns-discovery/build.gradle
+++ b/dns-discovery/build.gradle
@@ -4,7 +4,7 @@ archivesBaseName = 'crate-dns-discovery'
 group = 'io.crate'
 
 dependencies {
-    compile project(':common')
-    compile "io.netty:netty-resolver-dns:${versions.netty4}"
-    testCompile project(':integration-testing')
+    implementation project(':common')
+    implementation "io.netty:netty-resolver-dns:${versions.netty4}"
+    testImplementation project(':integration-testing')
 }

--- a/enterprise/functions/build.gradle
+++ b/enterprise/functions/build.gradle
@@ -10,13 +10,13 @@ configurations {
 }
 
 dependencies {
-    compile project(':sql')
+    implementation project(':sql')
 
-    testCompile project(path: ':sql', configuration: 'testOutput')
-    testCompile project(path: ':dex', configuration: 'testOutput')
-    testCompile project(':integration-testing')
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
+    testImplementation project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(path: ':dex', configuration: 'testOutput')
+    testImplementation project(':integration-testing')
+    testImplementation "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testImplementation("io.crate:crate-jdbc:${versions.crate_jdbc}") {
             exclude group: 'net.java.dev.jna', module: 'jna'
             exclude group: 'commons-logging', module: 'commons-logging'
             exclude group: 'org.slf4j', module: 'jcl-over-slf4j'

--- a/enterprise/jmx-monitoring/build.gradle
+++ b/enterprise/jmx-monitoring/build.gradle
@@ -5,9 +5,9 @@ group = 'io.crate'
 description = 'CrateDB JMX monitoring plugin'
 
 dependencies {
-    compile project(':dex')
-    compile project(':sql')
+    implementation project(':dex')
+    implementation project(':sql')
 
-    testCompile project(':integration-testing')
-    testCompile project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(':integration-testing')
+    testImplementation project(path: ':sql', configuration: 'testOutput')
 }

--- a/enterprise/lang-js/build.gradle
+++ b/enterprise/lang-js/build.gradle
@@ -20,13 +20,13 @@ task writePropertiesFile {
 
 jar.dependsOn('writePropertiesFile')
 dependencies {
-    compile project(':sql')
-    testCompile project(':integration-testing')
-    testCompile project(path: ':sql', configuration: 'testOutput')
-    testCompile project(path: ':dex', configuration: 'testOutput')
-    testCompile 'org.skyscreamer:jsonassert:1.3.0'
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
+    implementation project(':sql')
+    testImplementation project(':integration-testing')
+    testImplementation project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(path: ':dex', configuration: 'testOutput')
+    testImplementation 'org.skyscreamer:jsonassert:1.3.0'
+    testImplementation "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testImplementation("io.crate:crate-jdbc:${versions.crate_jdbc}") {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'

--- a/enterprise/licensing/build.gradle
+++ b/enterprise/licensing/build.gradle
@@ -37,14 +37,14 @@ group = 'io.crate'
 description = 'CrateDB License Management'
 
 dependencies {
-    compile project(':es:es-core')
-    compile project(':common')
-    compile project(':sql')
-    testCompile project(':integration-testing')
-    testCompile project(path: ':sql', configuration: 'testOutput')
-    testCompile project(path: ':dex', configuration: 'testOutput')
-    testCompile "junit:junit:${versions.junit}"
-    testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
+    implementation project(':es:es-core')
+    implementation project(':common')
+    implementation project(':sql')
+    testImplementation project(':integration-testing')
+    testImplementation project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(path: ':dex', configuration: 'testOutput')
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation("io.crate:crate-jdbc:${versions.crate_jdbc}") {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'

--- a/enterprise/ssl-impl/build.gradle
+++ b/enterprise/ssl-impl/build.gradle
@@ -5,7 +5,12 @@ group = 'io.crate'
 description = 'SSL Encryption Implementation for CrateDB'
 
 dependencies {
+    implementation project(':common')
     implementation project(':ssl')
+    implementation project(':es:es-server')
+    implementation project(':es:es-transport')
+    implementation "io.netty:netty-handler:${versions.netty4}"
+    implementation "org.apache.logging.log4j:log4j-api:${versions.log4j2}"
 
     testImplementation project(':sql')
     testImplementation project(':integration-testing')

--- a/enterprise/ssl-impl/build.gradle
+++ b/enterprise/ssl-impl/build.gradle
@@ -5,13 +5,13 @@ group = 'io.crate'
 description = 'SSL Encryption Implementation for CrateDB'
 
 dependencies {
-    compile project(':ssl')
+    implementation project(':ssl')
 
-    testCompile project(':sql')
-    testCompile project(':integration-testing')
-    testCompile project(path: ':sql', configuration: 'testOutput')
-    testCompile project(path: ':dex', configuration: 'testOutput')
-    testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
+    testImplementation project(':sql')
+    testImplementation project(':integration-testing')
+    testImplementation project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(path: ':dex', configuration: 'testOutput')
+    testImplementation("io.crate:crate-jdbc:${versions.crate_jdbc}") {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'

--- a/enterprise/users/build.gradle
+++ b/enterprise/users/build.gradle
@@ -5,13 +5,13 @@ group = 'io.crate'
 description = 'User Management for CrateDB'
 
 dependencies {
-    compile project(':sql')
-    testCompile project(':integration-testing')
-    testCompile project(':enterprise:ssl-impl')
-    testCompile project(path: ':sql', configuration: 'testOutput')
-    testCompile project(path: ':dex', configuration: 'testOutput')
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    testCompile("io.crate:crate-jdbc:${versions.crate_jdbc}") {
+    implementation project(':sql')
+    testImplementation project(':integration-testing')
+    testImplementation project(':enterprise:ssl-impl')
+    testImplementation project(path: ':sql', configuration: 'testOutput')
+    testImplementation project(path: ':dex', configuration: 'testOutput')
+    testImplementation "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testImplementation("io.crate:crate-jdbc:${versions.crate_jdbc}") {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'

--- a/enterprise/users/build.gradle
+++ b/enterprise/users/build.gradle
@@ -6,6 +6,9 @@ description = 'User Management for CrateDB'
 
 dependencies {
     implementation project(':sql')
+    implementation project(':http')
+    implementation project(':es:es-transport')
+    implementation "io.netty:netty-codec-http:${versions.netty4}"
     testImplementation project(':integration-testing')
     testImplementation project(':enterprise:ssl-impl')
     testImplementation project(path: ':sql', configuration: 'testOutput')

--- a/es/es-core/build.gradle
+++ b/es/es-core/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+    implementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
 }

--- a/es/es-testing/build.gradle
+++ b/es/es-testing/build.gradle
@@ -1,20 +1,21 @@
-dependencies {
-    compile project(':es:es-server')
+apply plugin: 'java-library'
 
-    // same deps as in es/upstream/test/framework/build.gradle  except ES/ES-client (we compile the project)
-    compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-    compile "junit:junit:${versions.junit}"
-    compile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    compile "org.apache.lucene:lucene-test-framework:${versions.lucene}"
-    compile "org.apache.lucene:lucene-codecs:${versions.lucene}"
-    compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"
-    compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-    compile "commons-logging:commons-logging:${versions.commonslogging}"
-    compile "commons-codec:commons-codec:${versions.commonscodec}"
-    compile "org.elasticsearch:mocksocket:${versions.mocksocket}"
-    compile "org.mockito:mockito-core:${versions.mockito}"
+dependencies {
+    implementation project(':es:es-server')
+
+    api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+    api "junit:junit:${versions.junit}"
+    api "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    api "org.apache.lucene:lucene-test-framework:${versions.lucene}"
+    api "org.apache.lucene:lucene-codecs:${versions.lucene}"
+    api "org.mockito:mockito-core:${versions.mockito}"
+    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+    implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+    implementation "commons-logging:commons-logging:${versions.commonslogging}"
+    implementation "commons-codec:commons-codec:${versions.commonscodec}"
+    implementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 
     // crate extra dependencies
-    compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
-    compile "com.google.guava:guava:${versions.guava}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    implementation "com.google.guava:guava:${versions.guava}"
 }

--- a/es/es-transport/build.gradle
+++ b/es/es-transport/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    compile project(':es:es-server')
-    compile "io.netty:netty-buffer:${versions.netty4}"
-    compile "io.netty:netty-codec:${versions.netty4}"
-    compile "io.netty:netty-codec-http:${versions.netty4}"
-    compile "io.netty:netty-common:${versions.netty4}"
-    compile "io.netty:netty-handler:${versions.netty4}"
-    compile "io.netty:netty-resolver:${versions.netty4}"
-    compile "io.netty:netty-transport:${versions.netty4}"
+    implementation project(':es:es-server')
+    implementation "io.netty:netty-buffer:${versions.netty4}"
+    implementation "io.netty:netty-codec:${versions.netty4}"
+    implementation "io.netty:netty-codec-http:${versions.netty4}"
+    implementation "io.netty:netty-common:${versions.netty4}"
+    implementation "io.netty:netty-handler:${versions.netty4}"
+    implementation "io.netty:netty-resolver:${versions.netty4}"
+    implementation "io.netty:netty-transport:${versions.netty4}"
 }

--- a/es/es-x-content/build.gradle
+++ b/es/es-x-content/build.gradle
@@ -1,9 +1,8 @@
 dependencies {
-    compile project(':es:es-core')
+    implementation project(':es:es-core')
 
-    //compile "org.yaml:snakeyaml:${versions.snakeyaml}"
-    compile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
 }

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -3,9 +3,14 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-http-transport'
 
 dependencies {
-    compile project(':es:es-transport')
-    compile project(':common')
-    testCompile project(':integration-testing')
+    implementation project(':es:es-server')
+    implementation project(':es:es-transport')
+    implementation project(':common')
+    implementation "io.netty:netty-buffer:${versions.netty4}"
+    implementation "io.netty:netty-codec-http:${versions.netty4}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    testImplementation project(':integration-testing')
+    testImplementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
 }
 
 test {

--- a/http/src/main/java/io/crate/protocols/http/StaticSite.java
+++ b/http/src/main/java/io/crate/protocols/http/StaticSite.java
@@ -22,7 +22,6 @@
 
 package io.crate.protocols.http;
 
-import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -99,27 +98,27 @@ public final class StaticSite {
         return DEFAULT_MIME_TYPES.getOrDefault(extension, "");
     }
 
-    private static final Map<String, String> DEFAULT_MIME_TYPES = new ImmutableMap.Builder<String, String>()
-        .put("txt", "text/plain")
-        .put("css", "text/css")
-        .put("csv", "text/csv")
-        .put("htm", "text/html")
-        .put("html", "text/html")
-        .put("xml", "text/xml")
-        .put("js", "text/javascript") // Technically it should be application/javascript (RFC 4329), but IE8 struggles with that
-        .put("xhtml", "application/xhtml+xml")
-        .put("json", "application/json")
-        .put("pdf", "application/pdf")
-        .put("zip", "application/zip")
-        .put("tar", "application/x-tar")
-        .put("gif", "image/gif")
-        .put("jpeg", "image/jpeg")
-        .put("jpg", "image/jpeg")
-        .put("tiff", "image/tiff")
-        .put("tif", "image/tiff")
-        .put("png", "image/png")
-        .put("svg", "image/svg+xml")
-        .put("ico", "image/vnd.microsoft.icon")
-        .put("mp3", "audio/mpeg")
-        .build();
+    private static final Map<String, String> DEFAULT_MIME_TYPES = Map.ofEntries(
+        Map.entry("txt", "text/plain"),
+        Map.entry("css", "text/css"),
+        Map.entry("csv", "text/csv"),
+        Map.entry("htm", "text/html"),
+        Map.entry("html", "text/html"),
+        Map.entry("xml", "text/xml"),
+        Map.entry("js", "text/javascript"), // Technically it should be application/javascript (RFC 4329), but IE8 struggles with that
+        Map.entry("xhtml", "application/xhtml+xml"),
+        Map.entry("json", "application/json"),
+        Map.entry("pdf", "application/pdf"),
+        Map.entry("zip", "application/zip"),
+        Map.entry("tar", "application/x-tar"),
+        Map.entry("gif", "image/gif"),
+        Map.entry("jpeg", "image/jpeg"),
+        Map.entry("jpg", "image/jpeg"),
+        Map.entry("tiff", "image/tiff"),
+        Map.entry("tif", "image/tiff"),
+        Map.entry("png", "image/png"),
+        Map.entry("svg", "image/svg+xml"),
+        Map.entry("ico", "image/vnd.microsoft.icon"),
+        Map.entry("mp3", "audio/mpeg")
+    );
 }

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -1,12 +1,15 @@
 apply from: "$rootDir/gradle/javaModule.gradle"
+apply plugin: 'java-library'
 
 archivesBaseName = 'crate-testing'
 
 dependencies {
-    compile "org.codehaus.jackson:jackson-mapper-asl:${versions.jacksonasl}"
-    compile "org.apache.commons:commons-lang3:${versions.commonslang3}"
+    api project(':es:es-testing')
+    api "org.codehaus.jackson:jackson-mapper-asl:${versions.jacksonasl}"
+    api "org.apache.commons:commons-lang3:${versions.commonslang3}"
 
-    compile project(':es:es-testing')
+    implementation project(':es:es-server')
+    implementation "com.google.guava:guava:${versions.guava}"
 }
 
 test {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -3,9 +3,8 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-shared'
 
 dependencies {
-    compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
-
-    testCompile "junit:junit:${versions.junit}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    testImplementation "junit:junit:${versions.junit}"
 }
 
 test {

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -10,11 +10,15 @@ configurations {
 dependencies {
     compile project(':shared')
     compile project(':common')
+    implementation project(':http')
+    implementation project(':es:es-server')
+    implementation project(':es:es-transport')
     compile project(':dex')
     compile project(':blob')
     compile project(':sql-parser')
     compile project(':udc')
     compile project(':ssl')
+    implementation "io.netty:netty-codec-http:${versions.netty4}"
     compile "io.netty:netty-transport:${versions.netty4}"
     compile "io.netty:netty-codec:${versions.netty4}"
     compile "io.netty:netty-buffer:${versions.netty4}"

--- a/ssl/build.gradle
+++ b/ssl/build.gradle
@@ -5,7 +5,8 @@ group = 'io.crate'
 description = 'SSL Encryption for CrateDB'
 
 dependencies {
-    compile project(':common')
-    compile "io.netty:netty-handler:${versions.netty4}"
-    compile project(':http')
+    implementation project(':common')
+    implementation project(':es:es-server')
+    implementation "io.netty:netty-handler:${versions.netty4}"
+    implementation project(':http')
 }

--- a/udc/build.gradle
+++ b/udc/build.gradle
@@ -2,10 +2,13 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-udc'
 
 dependencies {
-    compile project(':common')
-    testCompile project(':integration-testing')
-    testCompile "io.netty:netty-transport:${versions.netty4}"
-    testCompile "io.netty:netty-codec-http:${versions.netty4}"
+    implementation project(':common')
+    implementation project(':es:es-server')
+    implementation "com.google.guava:guava:${versions.guava}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    testImplementation project(':integration-testing')
+    testImplementation "io.netty:netty-transport:${versions.netty4}"
+    testImplementation "io.netty:netty-codec-http:${versions.netty4}"
 }
 
 test {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`compile` is deprecated:

https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management

This is still missing some modules (sql, app, es-server), but changing those is more effort. I'd still like to get this in already to have some `implementation` usages in our files. So that if people touch the dependencies they'll think more about which one to use.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed