### PR TITLE
Refactor TransactionContext to serialise session-related information

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -1,6 +1,8 @@
 package io.crate.execution.engine.reader;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -11,7 +13,6 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -31,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.CSV;
@@ -43,7 +45,9 @@ public class CsvReaderBenchmark {
 
     private String fileUri;
     private InputFactory inputFactory;
-    private TransactionContext txnCtx = TransactionContext.of("dummyUser", SearchPath.createSearchPathFrom("dummySchema"));
+    private TransactionContext txnCtx = TransactionContext.of(
+        new SessionSettings("dummyUser",
+                            SearchPath.createSearchPathFrom("dummySchema")));
     File tempFile;
 
     @Setup

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -1,6 +1,8 @@
 package io.crate.execution.engine.reader;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -11,7 +13,6 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -31,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.JSON;
@@ -43,7 +45,9 @@ public class JsonReaderBenchmark {
 
     private String fileUri;
     private InputFactory inputFactory;
-    private TransactionContext txnCtx = TransactionContext.of("dummyUser", SearchPath.createSearchPathFrom("dummySchema"));
+    private TransactionContext txnCtx = TransactionContext.of(
+        new SessionSettings("dummyUser",
+                            SearchPath.createSearchPathFrom("dummySchema")));
     File tempFile;
 
     @Setup

--- a/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
+++ b/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
@@ -26,8 +26,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -58,7 +58,7 @@ public class UserFunction extends Scalar<String, Object> implements FunctionForm
     @Override
     public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
-        return txnCtx.userName();
+        return txnCtx.sessionSettings().userName();
     }
 
     @Override
@@ -66,7 +66,7 @@ public class UserFunction extends Scalar<String, Object> implements FunctionForm
         if (txnCtx == null) {
             return Literal.NULL;
         }
-        return Literal.of(txnCtx.userName());
+        return Literal.of(txnCtx.sessionSettings().userName());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -110,8 +110,7 @@ public class LegacyUpsertByIdTask {
         this.isPartitioned = upsertById.isPartitioned();
 
         reqBuilder = new ShardUpsertRequest.Builder(
-            txnCtx.userName(),
-            txnCtx.currentSchema(),
+            txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             upsertById.isIgnoreDuplicateKeys() ? DuplicateKeyAction.IGNORE : DuplicateKeyAction.UPDATE_OR_FAIL,
             upsertById.numBulkResponses() > 0 || items.size() > 1,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -38,7 +38,6 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -119,7 +118,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             ? GeneratedColumns.Validation.VALUE_MATCH
             : GeneratedColumns.Validation.NONE;
 
-        TransactionContext txnCtx = TransactionContext.of(request.userName(), SearchPath.createSearchPathFrom(request.currentSchema()));
+        TransactionContext txnCtx = TransactionContext.of(request.sessionSettings());
         InsertSourceGen insertSourceGen = insertColumns == null
             ? null
             : InsertSourceGen.of(txnCtx, functions, tableInfo, indexName, valueValidation, Arrays.asList(insertColumns));

--- a/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -201,8 +201,7 @@ public final class JobLauncher {
         RootTask.Builder builder = tasksService.newBuilder(jobId, localNodeId, operationByServer.keySet());
         SharedShardContexts sharedShardContexts = maybeInstrumentProfiler(builder);
         List<CompletableFuture<StreamBucket>> directResponseFutures = jobSetup.prepareOnHandler(
-            txnCtx.userName(),
-            txnCtx.currentSchema(),
+            txnCtx.sessionSettings(),
             localNodeOperations,
             builder,
             handlerPhaseAndReceiver,
@@ -308,7 +307,11 @@ public final class JobLauncher {
         for (Map.Entry<String, Collection<NodeOperation>> entry : operationByServer.entrySet()) {
             String serverNodeId = entry.getKey();
             JobRequest request = new JobRequest(
-                jobId, txnCtx.userName(), txnCtx.currentSchema(), localNodeId, entry.getValue(), enableProfiling);
+                jobId,
+                txnCtx.sessionSettings(),
+                localNodeId,
+                entry.getValue(),
+                enableProfiling);
             if (hasDirectResponse) {
                 transportJobAction.execute(serverNodeId, request,
                     BucketForwarder.asActionListener(pageBucketReceivers, bucketIdx, initializationTracker));

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -148,8 +148,7 @@ public class RemoteCollectorFactory {
         String localNode = clusterService.localNode().getId();
         return remoteNode -> new RemoteCollector(
             jobId,
-            collectTask.txnCtx().userName(),
-            collectTask.txnCtx().currentSchema(),
+            collectTask.txnCtx().sessionSettings(),
             localNode,
             remoteNode,
             transportActionProvider.transportJobInitAction(),

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -55,8 +56,7 @@ public class RemoteCollector {
     private static final int RECEIVER_PHASE_ID = 1;
 
     private final UUID jobId;
-    private final String userName;
-    private final String currentSchema;
+    private final SessionSettings sessionSettings;
     private final String localNode;
     private final String remoteNode;
     private final Executor executor;
@@ -74,8 +74,7 @@ public class RemoteCollector {
     private boolean collectorKilled = false;
 
     public RemoteCollector(UUID jobId,
-                           String userName,
-                           String currentSchema,
+                           SessionSettings sessionSettings,
                            String localNode,
                            String remoteNode,
                            TransportJobAction transportJobAction,
@@ -86,8 +85,7 @@ public class RemoteCollector {
                            RowConsumer consumer,
                            RoutedCollectPhase collectPhase) {
         this.jobId = jobId;
-        this.userName = userName;
-        this.currentSchema = currentSchema;
+        this.sessionSettings = sessionSettings;
         this.localNode = localNode;
         this.remoteNode = remoteNode;
         this.executor = executor;
@@ -149,8 +147,7 @@ public class RemoteCollector {
                 remoteNode,
                 new JobRequest(
                     jobId,
-                    userName,
-                    currentSchema,
+                    sessionSettings,
                     localNode,
                     Collections.singletonList(nodeOperation),
                     enableProfiling

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -42,9 +42,9 @@ import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.StaticTableDefinition;
 import io.crate.expression.reference.sys.SysRowUpdater;
 import io.crate.expression.reference.sys.check.node.SysNodeChecks;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.information.InformationSchemaTableDefinitions;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -128,7 +128,7 @@ public class SystemCollectSource implements CollectSource {
         String table = Iterables.getOnlyElement(locations.get(clusterService.localNode().getId()).keySet());
         RelationName relationName = RelationName.fromIndexName(table);
         StaticTableDefinition<?> tableDefinition = tableDefinition(relationName);
-        User user = requireNonNull(userLookup.findUser(txnCtx.userName()), "User who invoked a statement must exist");
+        User user = requireNonNull(userLookup.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");
 
         return CollectingBatchIterator.newInstance(
             () -> {},

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -95,8 +95,7 @@ public class ColumnIndexWriterProjector implements Projector {
             assignments = convert.sources();
         }
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
-            txnCtx.userName(),
-            txnCtx.currentSchema(),
+            txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             ignoreDuplicateKeys ? DuplicateKeyAction.IGNORE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true, // continueOnErrors

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -101,8 +101,7 @@ public class IndexWriterProjector implements Projector {
         RowShardResolver rowShardResolver = new RowShardResolver(
             txnCtx, functions, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
-            txnCtx.userName(),
-            txnCtx.currentSchema(),
+            txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             overwriteDuplicates ? DuplicateKeyAction.OVERWRITE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true,

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -479,8 +479,7 @@ public class ProjectionToProjectorVisitor
     public Projector visitUpdateProjection(final UpdateProjection projection, Context context) {
         checkShardLevel("Update projection can only be executed on a shard");
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
-            context.txnCtx.userName(),
-            context.txnCtx.currentSchema(),
+            context.txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
             false,

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -36,6 +36,7 @@ import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.carrotsearch.hppc.procedures.ObjectProcedure;
 import com.google.common.base.MoreObjects;
 import io.crate.Streamer;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.RowAccountingWithEstimators;
@@ -83,7 +84,6 @@ import io.crate.expression.RowFilter;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Routing;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.StreamerVisitor;
@@ -171,15 +171,13 @@ public class JobSetup extends AbstractComponent {
         );
     }
 
-    public List<CompletableFuture<StreamBucket>> prepareOnRemote(String userName,
-                                                                 String currentSchema,
+    public List<CompletableFuture<StreamBucket>> prepareOnRemote(SessionSettings sessionInfo,
                                                                  Collection<? extends NodeOperation> nodeOperations,
                                                                  RootTask.Builder contextBuilder,
                                                                  SharedShardContexts sharedShardContexts) {
         Context context = new Context(
             clusterService.localNode().getId(),
-            userName,
-            currentSchema,
+            sessionInfo,
             contextBuilder,
             logger,
             distributingConsumerFactory,
@@ -196,16 +194,14 @@ public class JobSetup extends AbstractComponent {
         return context.directResponseFutures;
     }
 
-    public List<CompletableFuture<StreamBucket>> prepareOnHandler(String userName,
-                                                                  String currentSchema,
+    public List<CompletableFuture<StreamBucket>> prepareOnHandler(SessionSettings sessionInfo,
                                                                   Collection<? extends NodeOperation> nodeOperations,
                                                                   RootTask.Builder taskBuilder,
                                                                   List<Tuple<ExecutionPhase, RowConsumer>> handlerPhases,
                                                                   SharedShardContexts sharedShardContexts) {
         Context context = new Context(
             clusterService.localNode().getId(),
-            userName,
-            currentSchema,
+            sessionInfo,
             taskBuilder,
             logger,
             distributingConsumerFactory,
@@ -439,8 +435,7 @@ public class JobSetup extends AbstractComponent {
         private TransactionContext transactionContext;
 
         Context(String localNodeId,
-                String userName,
-                String currentSchema,
+                SessionSettings sessionInfo,
                 RootTask.Builder taskBuilder,
                 Logger logger,
                 DistributingConsumerFactory distributingConsumerFactory,
@@ -451,7 +446,7 @@ public class JobSetup extends AbstractComponent {
             this.opCtx = new NodeOperationCtx(localNodeId, nodeOperations);
             this.distributingConsumerFactory = distributingConsumerFactory;
             this.sharedShardContexts = sharedShardContexts;
-            this.transactionContext = TransactionContext.of(userName, SearchPath.createSearchPathFrom(currentSchema));
+            this.transactionContext = TransactionContext.of(sessionInfo);
         }
 
         public UUID jobId() {
@@ -504,7 +499,7 @@ public class JobSetup extends AbstractComponent {
 
         /**
          * The rowReceiver for handlerPhases got passed into
-         * {@link #prepareOnHandler(String, String, Collection, RootTask.Builder, List, SharedShardContexts)}
+         * {@link #prepareOnHandler(SessionSettings, Collection, RootTask.Builder, List, SharedShardContexts)}
          * and is registered there.
          * <p>
          * Retrieve it

--- a/sql/src/main/java/io/crate/execution/jobs/transport/JobRequest.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/JobRequest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.jobs.transport;
 
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.execution.dsl.phases.NodeOperation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,8 +36,7 @@ import java.util.UUID;
 public class JobRequest extends TransportRequest {
 
     private UUID jobId;
-    private String userName;
-    private String currentSchema;
+    private SessionSettings sessionSettings;
     private String coordinatorNodeId;
     private Collection<? extends NodeOperation> nodeOperations;
     private boolean enableProfiling;
@@ -45,15 +45,13 @@ public class JobRequest extends TransportRequest {
     }
 
     public JobRequest(UUID jobId,
-                      String userName,
-                      String currentSchema,
+                      SessionSettings sessionSettings,
                       String coordinatorNodeId,
                       Collection<? extends NodeOperation> nodeOperations,
                       boolean enableProfiling) {
         this.jobId = jobId;
-        this.userName = userName;
-        this.currentSchema = currentSchema;
         this.coordinatorNodeId = coordinatorNodeId;
+        this.sessionSettings = sessionSettings;
         this.nodeOperations = nodeOperations;
         this.enableProfiling = enableProfiling;
     }
@@ -74,12 +72,8 @@ public class JobRequest extends TransportRequest {
         return enableProfiling;
     }
 
-    public String userName() {
-        return userName;
-    }
-
-    public String currentSchema() {
-        return currentSchema;
+    public SessionSettings sessionSettings() {
+        return sessionSettings;
     }
 
     @Override
@@ -97,8 +91,7 @@ public class JobRequest extends TransportRequest {
         this.nodeOperations = nodeOperations;
         enableProfiling = in.readBoolean();
 
-        userName = in.readString();
-        currentSchema = in.readString();
+        sessionSettings = new SessionSettings(in);
     }
 
     @Override
@@ -115,7 +108,7 @@ public class JobRequest extends TransportRequest {
         }
 
         out.writeBoolean(enableProfiling);
-        out.writeString(userName);
-        out.writeString(currentSchema);
+
+        sessionSettings.writeTo(out);
     }
 }

--- a/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -88,8 +88,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
         SharedShardContexts sharedShardContexts = maybeInstrumentProfiler(request.enableProfiling(), contextBuilder);
 
         List<CompletableFuture<StreamBucket>> directResponseFutures = jobSetup.prepareOnRemote(
-            request.userName(),
-            request.currentSchema(),
+            request.sessionSettings(),
             request.nodeOperations(),
             contextBuilder,
             sharedShardContexts

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -31,8 +31,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -61,7 +61,7 @@ public class CurrentSchemaFunction extends Scalar<String, Object> implements Fun
     @Override
     public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
-        return txnCtx.currentSchema();
+        return txnCtx.sessionSettings().currentSchema();
     }
 
     @Override
@@ -69,7 +69,7 @@ public class CurrentSchemaFunction extends Scalar<String, Object> implements Fun
         if (txnCtx == null) {
             return Literal.NULL;
         }
-        return Literal.of(txnCtx.currentSchema());
+        return Literal.of(txnCtx.sessionSettings().currentSchema());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -68,7 +68,7 @@ public class CurrentSchemasFunction extends Scalar<String[], Object> implements 
         }
 
         ArrayList<String> schemas = new ArrayList<>();
-        for (String schema : txnCtx.searchPath()) {
+        for (String schema : txnCtx.sessionSettings().searchPath()) {
             if (includeImplicitSchemas == false && schema.equals(PgCatalogSchemaInfo.NAME)) {
                 continue;
             }

--- a/sql/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/sql/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -23,6 +23,7 @@
 package io.crate.metadata;
 
 import io.crate.action.sql.SessionContext;
+import io.crate.metadata.settings.SessionSettings;
 import org.joda.time.DateTimeUtils;
 
 import java.util.Objects;
@@ -59,18 +60,11 @@ public final class CoordinatorTxnCtx implements TransactionContext {
     }
 
     @Override
-    public String userName() {
-        return sessionContext.user().name();
-    }
-
-    @Override
-    public String currentSchema() {
-        return sessionContext.searchPath().currentSchema();
-    }
-
-    @Override
-    public SearchPath searchPath() {
-        return sessionContext.searchPath();
+    public SessionSettings sessionSettings() {
+        return new SessionSettings(sessionContext.user().name(),
+                                   sessionContext.searchPath(),
+                                   sessionContext.getSemiJoinsRewriteEnabled(),
+                                   sessionContext.isHashJoinEnabled());
     }
 
     public SessionContext sessionContext() {

--- a/sql/src/main/java/io/crate/metadata/settings/SessionSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/SessionSettings.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.settings;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.metadata.SearchPath;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public final class SessionSettings implements Writeable {
+
+    private final String userName;
+    private final SearchPath searchPath;
+    private final boolean semiJoinsRewriteEnabled;
+    private final boolean hashJoinsEnabled;
+
+    public SessionSettings(StreamInput in) throws IOException {
+        this.userName = in.readString();
+        this.searchPath = SearchPath.createSearchPathFrom(in);
+        this.semiJoinsRewriteEnabled = in.readBoolean();
+        this.hashJoinsEnabled = in.readBoolean();
+    }
+
+    @VisibleForTesting
+    public SessionSettings(String userName, SearchPath searchPath) {
+        this(userName, searchPath, true, false);
+    }
+
+    public SessionSettings(String userName,
+                           SearchPath searchPath,
+                           boolean semiJoinsRewriteEnabled,
+                           boolean hashJoinsEnabled) {
+        this.userName = userName;
+        this.searchPath = searchPath;
+        this.semiJoinsRewriteEnabled = semiJoinsRewriteEnabled;
+        this.hashJoinsEnabled = hashJoinsEnabled;
+    }
+
+    public String userName() {
+        return userName;
+    }
+
+    public String currentSchema() {
+        return searchPath.currentSchema();
+    }
+
+    public SearchPath searchPath() {
+        return searchPath;
+    }
+
+    public boolean semiJoinsRewriteEnabled() {
+        return semiJoinsRewriteEnabled;
+    }
+
+    public boolean hashJoinsEnabled() {
+        return hashJoinsEnabled;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(userName);
+        searchPath.writeTo(out);
+        out.writeBoolean(semiJoinsRewriteEnabled);
+        out.writeBoolean(hashJoinsEnabled);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SessionSettings that = (SessionSettings) o;
+        return Objects.equals(userName, that.userName) &&
+               Objects.equals(searchPath, that.searchPath) &&
+               Objects.equals(semiJoinsRewriteEnabled, that.semiJoinsRewriteEnabled) &&
+               Objects.equals(hashJoinsEnabled, that.hashJoinsEnabled);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userName, searchPath, semiJoinsRewriteEnabled, hashJoinsEnabled);
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -33,7 +33,7 @@ import static io.crate.metadata.SearchPath.createSearchPathFrom;
 
 public class SessionSettingRegistry {
 
-    private static final String SEARCH_PATH_KEY = "search_path";
+    static final String SEARCH_PATH_KEY = "search_path";
     static final String SEMI_JOIN_KEY = "enable_semijoin";
     public static final String HASH_JOIN_KEY = "enable_hashjoin";
 

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -99,8 +99,7 @@ public final class UpdateById implements Plan {
         ClusterService clusterService = dependencies.clusterService();
         CoordinatorTxnCtx txnCtx = plannerContext.transactionContext();
         ShardUpsertRequest.Builder requestBuilder = new ShardUpsertRequest.Builder(
-            txnCtx.userName(),
-            txnCtx.currentSchema(),
+            txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(clusterService.state().metaData().settings()),
             ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
             true,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -22,6 +22,8 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -39,6 +41,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -59,8 +62,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         UUID jobId = UUID.randomUUID();
         Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            "dummyUser",
-            "dummySchema",
+            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
             TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -23,6 +23,8 @@
 package io.crate.execution.dml.upsert;
 
 import io.crate.Constants;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
@@ -36,6 +38,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.table.Operation;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
@@ -69,6 +72,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -91,6 +95,10 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     private final static String PARTITION_INDEX = new PartitionName(TABLE_IDENT, Arrays.asList("1395874800000")).asIndexName();
     private final static Reference ID_REF = new Reference(
         new ReferenceIdent(TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.SHORT, null);
+
+    private final static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
+        "dummyUser",
+        SearchPath.createSearchPathFrom("dummySchema"));
 
     private String charactersIndexUUID;
     private String partitionIndexUUID;
@@ -176,8 +184,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            "dummyUser",
-            "dummySchema",
+            DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
@@ -198,8 +205,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            "dummyUser",
-            "dummySchema",
+            DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
@@ -240,8 +246,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            "dummyUser",
-            "dummySchema",
+            DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
@@ -262,8 +267,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            "dummyUser",
-            "dummySchema",
+            DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
             DuplicateKeyAction.UPDATE_OR_FAIL,
             false,

--- a/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -22,15 +22,17 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.symbol.Assignments;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.elasticsearch.common.Strings;
@@ -47,6 +49,10 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.is;
 
 public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
+
+    private static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
+        "dummyUser",
+        SearchPath.createSearchPathFrom("dummySchema"));
 
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
@@ -163,7 +169,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen sourceGen = new UpdateSourceGen(
             e.functions(),
-            TransactionContext.of("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
+            TransactionContext.of(DUMMY_SESSION_INFO),
             table,
             assignments.targetNames()
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -244,8 +244,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             "remoteNode");
 
         List<CompletableFuture<StreamBucket>> results = jobSetup.prepareOnRemote(
-            "dummyUser",
-            "dummySchema",
+            DUMMY_SESSION_INFO,
             ImmutableList.of(nodeOperation),
             builder,
             sharedShardContexts

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -25,6 +25,8 @@ package io.crate.execution.engine.collect.collectors;
 import com.carrotsearch.hppc.IntArrayList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.exceptions.JobKilledException;
@@ -52,6 +54,7 @@ import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -109,8 +112,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         consumer = new TestingRowConsumer();
         remoteCollector = new RemoteCollector(
             jobId,
-            "dummyUser",
-            "dummySchema",
+            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
             "localNode",
             "remoteNode",
             transportJobAction,

--- a/sql/src/test/java/io/crate/execution/jobs/transport/JobRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/transport/JobRequestTest.java
@@ -22,6 +22,8 @@
 
 package io.crate.execution.jobs.transport;
 
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
@@ -35,7 +37,12 @@ public class JobRequestTest {
 
     @Test
     public void testJobRequestStreaming() throws Exception {
-        JobRequest r1 = new JobRequest(UUID.randomUUID(), "dummyUser", "dummySchema", "n1", Collections.emptyList(), true);
+        JobRequest r1 = new JobRequest(UUID.randomUUID(),
+                                       new SessionSettings("dummyUser",
+                                                           SearchPath.createSearchPathFrom("dummySchema")),
+                                       "n1",
+                                       Collections.emptyList(),
+                                       true);
 
         BytesStreamOutput out = new BytesStreamOutput();
         r1.writeTo(out);
@@ -45,6 +52,7 @@ public class JobRequestTest {
 
         assertThat(r1.coordinatorNodeId(), is(r2.coordinatorNodeId()));
         assertThat(r1.jobId(), is(r2.jobId()));
+        assertThat(r1.sessionSettings(), is(r2.sessionSettings()));
         assertThat(r1.nodeOperations().isEmpty(), is(true));
         assertThat(r1.enableProfiling(), is(r2.enableProfiling()));
     }

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.collections.Lists2;
@@ -44,6 +45,7 @@ import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.table.TestingTableInfo;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
@@ -75,6 +77,10 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
     protected Map<QualifiedName, AnalyzedRelation> tableSources;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private InputFactory inputFactory;
+
+    protected static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
+        "dummyUser",
+        SearchPath.createSearchPathFrom("dummySchema"));
 
     @Before
     public void prepareFunctions() throws Exception {

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -24,8 +24,8 @@ package io.crate.expression.scalar.arithmetic;
 import io.crate.data.Input;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     private RandomFunction random;
-    private TransactionContext txnCtx = TransactionContext.of("dummyUser", SearchPath.createSearchPathFrom("dummySchema"));
+    private TransactionContext txnCtx = TransactionContext.of(DUMMY_SESSION_INFO);
 
     @Before
     public void prepareRandom() {

--- a/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -25,10 +25,9 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.SearchPath;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.testing.SqlExpressions;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -59,7 +58,7 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
         FunctionIdent ident = function.info().ident();
         Scalar impl = (Scalar) functions.getQualified(ident);
         assertThat(
-            impl.evaluate(TransactionContext.of("dummyUser", SearchPath.createSearchPathFrom("dummySchema"))),
+            impl.evaluate(TransactionContext.of(DUMMY_SESSION_INFO)),
             Matchers.is("dummySchema"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -30,6 +30,7 @@ import io.crate.action.sql.Option;
 import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.Session;
 import io.crate.action.sql.SessionContext;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.analyze.Analyzer;
 import io.crate.analyze.ParameterContext;
 import io.crate.auth.user.User;
@@ -45,6 +46,7 @@ import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.KillableCallable;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
@@ -52,7 +54,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
@@ -142,6 +144,10 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
 
     private static final int ORIGINAL_PAGE_SIZE = Paging.PAGE_SIZE;
+
+    protected static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
+        "dummyUser",
+        SearchPath.createSearchPathFrom("dummySchema"));
 
     @Rule
     public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Bundled all session-related information together in ``SessionTransportableInfo`` 
and serialize them when needed in the relevant requests.

Currently, the state is that it always includes all 3 session settings.
Since `search_path` (schema seem to be  used in ``ShardUpsertRequest``, not sure if there is a way to control when to include this or not) needs to be always included, we will also inlcude the two other boolean settings (regardless if needed or not) as there is no real benefit to exclude them.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed