### PR TITLE
Fix limit application in nested window agg operators

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -219,6 +219,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause a query with window functions and limit to
+  return too few rows or have the window functions compute wrong results.
+
 - Fixed an issue that would cause a ``ClassCastException`` for queries ordered
   by a window function.
 

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -31,6 +31,7 @@ import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.WindowAggProjection;
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
@@ -124,9 +125,9 @@ public class WindowAgg extends OneInputPlan {
         ExecutionPlan sourcePlan = source.build(
             plannerContext,
             projectionBuilder,
-            limit,
-            offset,
-            order,
+            TopN.NO_LIMIT,
+            0,
+            null,
             pageSizeHint,
             params,
             subQueryResults
@@ -183,19 +184,14 @@ public class WindowAgg extends OneInputPlan {
                 reverseFlagsArray[i] = reverseFlags.get(i);
             }
             OrderedTopNProjection topNProjection = new OrderedTopNProjection(
-                Limit.limitAndOffset(limit, offset),
+                TopN.NO_LIMIT,
                 0,
                 outputs,
                 orderByICs,
                 reverseFlagsArray,
                 nullsFirst.toArray(new Boolean[0])
             );
-            sourcePlan.addProjection(
-                topNProjection,
-                limit,
-                offset,
-                null
-            );
+            sourcePlan.addProjection(topNProjection);
         }
 
         int[] orderByIndexes = new int[orderByICs.size()];

--- a/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
@@ -157,4 +157,23 @@ public class WindowFunctionsIntegrationTest extends SQLTransportIntegrationTest 
                                                      "1| 2\n" +
                                                      "1| 3\n"));
     }
+
+    @Test
+    public void testLimitAndOffsetIsAppliedCorrectlyWith2DifferentWindowDefinitions() {
+        execute("SELECT\n" +
+                "    col2,\n" +
+                "    avg(col1) OVER (ORDER BY col1),\n" +
+                "    avg(col2) OVER ()\n" +
+                "FROM\n" +
+                "    unnest([1, 2, 3, 4, 5, 6, 7],[10, 20, 30, 40, 50, 60, 70])\n" +
+                "ORDER BY\n" +
+                "    col2\n" +
+                "LIMIT 3 offset 2\n");
+        assertThat(
+            printedTable(response.rows()),
+            is("30| 2.0| 40.0\n" +
+               "40| 2.5| 40.0\n" +
+               "50| 3.0| 40.0\n")
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If there are multiple window definitions we cannot eagerly apply the
limit, as the calculations within the window functions might be based on
all rows.

Furthermore, if a offset was present the result was also cut off. The
following query returned only 3 instead of 5 rows for example:

    SELECT
        col2,
        avg(col1) OVER (ORDER BY col1),
        avg(col2) OVER ()
    FROM
        unnest(array[1, 2, 3, 4, 5, 6, 7], array[10, 20, 30, 40, 50, 60, 70]) as t (x, y)
    ORDER BY
        col2
    LIMIT 5 offset 2


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed