### PR TITLE
Fix handling of multiple window definitions

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -169,6 +169,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause window functions to compute incorrect results
+  if multiple window functions with different window definitions were used.
+
 - Fixed an issue that could cause a query with window functions and limit to
   return too few rows or have the window functions compute wrong results.
 

--- a/sql/src/main/java/io/crate/expression/symbol/WindowFunction.java
+++ b/sql/src/main/java/io/crate/expression/symbol/WindowFunction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import static io.crate.metadata.FunctionInfo.Type.AGGREGATE;
 import static io.crate.metadata.FunctionInfo.Type.WINDOW;
@@ -72,5 +73,25 @@ public class WindowFunction extends Function {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         windowDefinition.writeTo(out);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        WindowFunction that = (WindowFunction) o;
+        return windowDefinition.equals(that.windowDefinition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), windowDefinition);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -59,7 +59,7 @@ import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
 public class WindowAgg extends OneInputPlan {
 
-    private final WindowDefinition windowDefinition;
+    final WindowDefinition windowDefinition;
     private final List<WindowFunction> windowFunctions;
     private final List<Symbol> standalone;
 

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -25,7 +25,6 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -519,6 +518,15 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 WindowAgg windowAgg = (WindowAgg) plan;
                 startLine("WindowAgg[");
                 addSymbolsList(windowAgg.windowFunctions());
+                if (!windowAgg.windowDefinition.partitions().isEmpty()) {
+                    sb.append(" | PARTITION BY ");
+                    addSymbolsList(windowAgg.windowDefinition.partitions());
+                }
+                OrderBy orderBy = windowAgg.windowDefinition.orderBy();
+                if (orderBy != null) {
+                    sb.append(" | ORDER BY ");
+                    OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst());
+                }
                 sb.append("]\n");
                 plan = windowAgg.source;
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The missing `equals` and `hashCode` implementation from `WindowFunction`
caused window functions with the same function and column name but
different window definitions to be merged.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed