### PR TITLE
Migrate blackbox tests to cr8 CrateNode

### DIFF
--- a/blackbox/build.gradle
+++ b/blackbox/build.gradle
@@ -24,7 +24,6 @@ task unpackDistTar(dependsOn: [project(':app').installDist, deleteCrateDist]) {
             }
             into crateDist
         }
-        lessLogging()
         ignoreDiskThreshold()
     }
     outputs.dir crateDist
@@ -38,15 +37,9 @@ task unpackCommunityEditionDistTar(dependsOn: [project(':app').installCommunityE
             }
             into crateDist
         }
-        lessLogging()
         ignoreDiskThreshold()
     }
     outputs.dir crateDist
-}
-
-def lessLogging() {
-    def file = new File("$projectDir/tmp/crate/config/log4j2.properties")
-    file.write(file.text.replaceAll('rootLogger.level = info', 'rootLogger.level: warn'))
 }
 
 def ignoreDiskThreshold() {

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -47,11 +47,11 @@ Basic information about the CrateDB cluster can be retrieved from the
 The result has at most 1 row::
 
   cr> select name from sys.cluster;
-  +--------------+
-  | name         |
-  +--------------+
-  | Testing...   |
-  +--------------+
+  +-----------------+
+  | name            |
+  +-----------------+
+  | Testing-CrateDB |
+  +-----------------+
   SELECT 1 row in set (... sec)
 
 .. _sys-cluster-license:

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -4,6 +4,7 @@
 crash
 crate
 crate-docs-theme
+cr8>=0.15.1
 tqdm==4.24.0
 sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0

--- a/blackbox/test_ce_no_enterprise.py
+++ b/blackbox/test_ce_no_enterprise.py
@@ -25,15 +25,12 @@
 
 import os
 import unittest
-import logging
 from testutils.ports import bind_port
 from testutils.paths import crate_path
-from crate.testing.layer import CrateLayer
+from cr8.run_crate import CrateNode
 from test_jmx import JmxClient
 
 JMX_PORT = bind_port()
-CRATE_HTTP_PORT = bind_port()
-
 JMX_OPTS = '''
      -Dcom.sun.management.jmxremote
      -Dcom.sun.management.jmxremote.port={}
@@ -41,19 +38,16 @@ JMX_OPTS = '''
      -Dcom.sun.management.jmxremote.authenticate=false
 '''
 
-log = logging.getLogger('crate.testing.layer')
-ch = logging.StreamHandler()
-ch.setLevel(logging.ERROR)
-log.addHandler(ch)
-
 
 env = os.environ.copy()
 env['CRATE_JAVA_OPTS'] = JMX_OPTS.format(JMX_PORT)
-crate_layer = CrateLayer(
-    'crate-ce',
-    crate_home=crate_path(),
-    port=CRATE_HTTP_PORT,
-    transport_port=0,
+crate_layer = CrateNode(
+    crate_dir=crate_path(),
+    version=(4, 0, 0),
+    settings={
+        'transport.tcp.port': 0,
+        'node.name': 'crate-ce',
+    },
     env=env
 )
 
@@ -79,4 +73,3 @@ class CeHasNoEnterpriseModulesITest(unittest.TestCase):
             stderr,
             'MBean not found: io.crate.monitoring:type=QueryStats\n')
         self.assertEqual(stdout, '')
-


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We've occasional port binding errors in our blackbox tests. Switching to
`CrateNode` from `cr8` allows us to bind to port 0 and retrieve the
http_url by sniffing the logs.

This should resolve the port binding errors


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed