### PR TITLE
class cast exception fix 

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -169,6 +169,9 @@ Changes
 Fixes
 =====
 
+- Fixed a ``ClassCastException`` which could occur when selecting
+  ``pg_catalog.pg_type.typlen``.
+
 - Fixed an issue that could cause window functions to compute incorrect results
   if multiple window functions with different window definitions were used.
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -110,7 +110,7 @@ public class PgAttributeTable extends StaticTableInfo {
                 .register(Columns.ATTNAME.name(), DataTypes.STRING)
                 .register(Columns.ATTTYPID.name(), DataTypes.INTEGER)
                 .register(Columns.ATTSTATTARGET.name(), DataTypes.INTEGER)
-                .register(Columns.ATTLEN.name(), DataTypes.INTEGER)
+                .register(Columns.ATTLEN.name(), DataTypes.SHORT)
                 .register(Columns.ATTNUM.name(), DataTypes.INTEGER)
                 .register(Columns.ATTNDIMS.name(), DataTypes.INTEGER)
                 .register(Columns.ATTCACHEOFF.name(), DataTypes.INTEGER)

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -50,8 +50,8 @@ public abstract class PGType {
         return oid;
     }
 
-    public int typeLen() {
-        return typeLen;
+    public short typeLen() {
+        return (short) typeLen;
     }
 
     public abstract int typArray();

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -241,7 +241,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readInt(), is(0));
                 assertThat(response.readShort(), is((short) 0));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.BOOLEAN).oid()));
-                assertThat(response.readShort(), is((short) PGTypes.get(DataTypes.BOOLEAN).typeLen()));
+                assertThat(response.readShort(), is(PGTypes.get(DataTypes.BOOLEAN).typeLen()));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).typeMod()));
                 assertThat(response.readShort(), is((short) 0));
             } finally {
@@ -301,7 +301,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readInt(), is(0));
                 assertThat(response.readShort(), is((short) 0));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.BOOLEAN).oid()));
-                assertThat(response.readShort(), is((short) PGTypes.get(DataTypes.BOOLEAN).typeLen()));
+                assertThat(response.readShort(), is(PGTypes.get(DataTypes.BOOLEAN).typeLen()));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).typeMod()));
                 assertThat(response.readShort(), is((short) 0));
             } finally {


### PR DESCRIPTION
...when accessing `pgtype.typlen` over wire protocol

## Summary of the changes / Why this improves CrateDB

`pgtype.typlen` is registered as a `short` but the expression 
used for it's evaluation (`PGType::typeLen`) returns an integer.

This resulted in a class cast exception when serialising the result
(see e.g.`SmallIntType::encodeAsUTF8Text`)

Before the fix:
```
crate=> SELECT typlen FROM pg_catalog.pg_type WHERE typname = 'char';
ERROR:  ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Short (java.lang.Integer and java.lang.Short are in module java.base of loader 'bootstrap')
```
After the fix:
```
crate=> SELECT typlen FROM pg_catalog.pg_type WHERE typname = 'char';
 typlen 
--------
      1
(1 row)
```

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)