### PR TITLE
This fixes a few bugs on processing window functions over partitioned windows

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -172,6 +172,9 @@ Fixes
 - Fixed a ``ClassCastException`` which could occur when selecting
   ``pg_catalog.pg_type.typlen``.
 
+- Fixed an issue that would cause the window functions to yield incorrect
+  results if executed against partitioned windows (ordered or unordered).
+
 - Fixed an issue that could cause window functions to compute incorrect results
   if multiple window functions with different window definitions were used.
 

--- a/enterprise/functions/src/main/java/io/crate/window/NthValueFunctions.java
+++ b/enterprise/functions/src/main/java/io/crate/window/NthValueFunctions.java
@@ -62,7 +62,7 @@ public class NthValueFunctions implements WindowFunction {
                           WindowFrameState currentFrame,
                           List<? extends CollectExpression<Row, ?>> expressions,
                           Input... args) {
-        if (isNewFrame(seenFrameUpperBound, currentFrame)) {
+        if (rowIdx == 0 || currentFrame.upperBoundExclusive() > seenFrameUpperBound) {
             seenFrameUpperBound = currentFrame.upperBoundExclusive();
             Object[] nthRowCells = currentFrame.getRowAtIndexOrNull(frameIndexSupplier.apply(currentFrame, args));
             if (nthRowCells == null) {

--- a/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -163,4 +163,36 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
             new Object[] {2, 3}
         );
     }
+
+    @Test
+    public void testRowNthValueOverPartitionedWindow() {
+        Object[] expected = new Object[]{2, 2, 2, 4, 4, 4, null};
+        assertEvaluate("nth_value(x, 2) over(partition by x>2)",
+                       contains(expected),
+                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       null,
+                       new Object[]{1, 1},
+                       new Object[]{2, 2},
+                       new Object[]{2, 2},
+                       new Object[]{3, 3},
+                       new Object[]{4, 4},
+                       new Object[]{5, 5},
+                       new Object[]{null, null});
+    }
+
+    @Test
+    public void testNthValueOverPartitionedOrderedWindow() {
+        Object[] expected = new Object[]{null, 2, 2, null, 4, 4, null};
+        assertEvaluate("nth_value(x, 2) over(partition by x>2 order by x)",
+                       contains(expected),
+                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       new int[]{0},
+                       new Object[]{1, 1},
+                       new Object[]{2, 2},
+                       new Object[]{2, 2},
+                       new Object[]{3, 3},
+                       new Object[]{4, 4},
+                       new Object[]{5, 5},
+                       new Object[]{null, null});
+    }
 }

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowBatchIterator.java
@@ -99,7 +99,7 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
 
     private int sourceRowsConsumed;
     private int emittedRows;
-    private int windowRowPosition;
+    private int zeroIndexedRowNumber;
     private final List<Object[]> windowForCurrentRow = new ArrayList<>();
     /**
      * Represents the start index of the new rows that were added in the current frame (compared to the previous frame)
@@ -214,7 +214,7 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
         super.moveToStart();
         sourceRowsConsumed = 0;
         emittedRows = 0;
-        windowRowPosition = 0;
+        zeroIndexedRowNumber = 0;
         windowForCurrentRow.clear();
         newRowsInCurrentFrameStartIdx = -1;
         currentRowCells = null;
@@ -228,7 +228,6 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
         if (foundCurrentRowsLastPeer && emittedRows < sourceRowsConsumed - 1) {
             // emit the result of the window function as we computed the result and not yet emitted it for every row
             // in the window
-            windowRowPosition++;
             computeCurrentElement();
             return true;
         }
@@ -260,7 +259,7 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
                 windowForCurrentRow.add(currentRowCells);
                 newRowsInCurrentFrameStartIdx = 0;
                 previousPartitionKey = currentPartitionKey;
-                windowRowPosition = 0;
+                zeroIndexedRowNumber = 0;
                 computeCurrentElement();
                 return true;
             }
@@ -276,7 +275,6 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
                 currentRowCells = sourceRowCells;
                 windowForCurrentRow.add(currentRowCells);
                 newRowsInCurrentFrameStartIdx = windowForCurrentRow.size() - 1;
-                windowRowPosition++;
                 computeCurrentElement();
                 return true;
             }
@@ -292,7 +290,6 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
 
             if (emittedRows < sourceRowsConsumed) {
                 // we still need to emit rows
-                windowRowPosition++;
                 computeCurrentElement();
                 return true;
             }
@@ -326,23 +323,25 @@ public class WindowBatchIterator extends MappedForwardingBatchIterator<Row, Row>
     }
 
     private void executeWindowFunctions() {
-        int rowCountInCurrentFrame = windowForCurrentRow.size() - newRowsInCurrentFrameStartIdx;
+        int newRowsInCurrentFrameCount = windowForCurrentRow.size() - newRowsInCurrentFrameStartIdx;
         WindowFrameState currentFrame = new WindowFrameState(
             // lower bound is always 0 as we currently only support the UNBOUNDED_PRECEDING -> CURRENT_ROW frame definition.
             0,
-            windowRowPosition + rowCountInCurrentFrame,
+            windowForCurrentRow.size(),
             windowForCurrentRow
         );
 
-        Object[][] newRowsInCurrentFrameCells = new Object[rowCountInCurrentFrame][windowFunctionsCount];
+        Object[][] newRowsInCurrentFrameCells = new Object[newRowsInCurrentFrameCount][windowFunctionsCount];
 
-        for (int i = 0; i < rowCountInCurrentFrame; i++) {
+        int processedRowIndex = 0;
+        for (int i = newRowsInCurrentFrameStartIdx; i < windowForCurrentRow.size(); i++) {
             for (int funcIdx = 0; funcIdx < functions.size(); funcIdx++) {
                 WindowFunction function = functions.get(funcIdx);
                 Object result = function.execute(
-                    windowRowPosition + i, currentFrame, windowFuncArgsExpressions, windowFuncArgsInputs[funcIdx]);
-                newRowsInCurrentFrameCells[i][funcIdx] = result;
+                    zeroIndexedRowNumber++, currentFrame, windowFuncArgsExpressions, windowFuncArgsInputs[funcIdx]);
+                newRowsInCurrentFrameCells[processedRowIndex][funcIdx] = result;
             }
+            processedRowIndex++;
         }
 
         for (Object[] outgoingCells : newRowsInCurrentFrameCells) {

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFunction.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFunction.java
@@ -41,8 +41,4 @@ public interface WindowFunction extends FunctionImplementation {
      */
     Object execute(int rowIdx, WindowFrameState currentFrame, List<? extends CollectExpression<Row, ?>> expressions, Input... args);
 
-    default boolean isNewFrame(int lastSeenFramUpperBound, WindowFrameState frame) {
-        return frame.upperBoundExclusive() > lastSeenFramUpperBound;
-    }
-
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.contains;
 
-
 public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
     @Test
@@ -45,5 +44,37 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
             new Object[] {2},
             new Object[] {1}
             );
+    }
+
+    @Test
+    public void testRowNumberOverPartitionedWindow() {
+        Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
+        assertEvaluate("row_number() over(partition by x>2)",
+                       contains(expected),
+                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       null,
+                       new Object[]{1},
+                       new Object[]{2},
+                       new Object[]{2},
+                       new Object[]{3},
+                       new Object[]{4},
+                       new Object[]{5},
+                       new Object[]{null});
+    }
+
+    @Test
+    public void testRowNumberOverPartitionedOrderedWindow() {
+        Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
+        assertEvaluate("row_number() over(partition by x>2 order by x)",
+                       contains(expected),
+                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       new int[]{0},
+                       new Object[]{1, 1},
+                       new Object[]{2, 2},
+                       new Object[]{2, 2},
+                       new Object[]{3, 3},
+                       new Object[]{4, 4},
+                       new Object[]{5, 5},
+                       new Object[]{null, null});
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -29,8 +29,11 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.Row1;
+import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.FunctionExpression;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
@@ -108,7 +111,7 @@ public class WindowBatchIteratorTest {
     }
 
     @Test
-    public void testFrameBounds() throws Exception {
+    public void testFrameBoundsEmptyWindow() throws Exception {
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(new WindowBatchIterator(
             emptyWindow(),
@@ -126,6 +129,89 @@ public class WindowBatchIteratorTest {
         List<Object[]> result = consumer.getResult();
 
         IntStream.range(0, 10).forEach(i -> assertThat(result.get(i), is(expectedBounds)));
+    }
+
+    @Test
+    public void testFrameBoundsForPartitionedWindow() throws Exception {
+        InputCollectExpression partitionKey = new InputCollectExpression(0);
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(new WindowBatchIterator(
+            new WindowDefinition(List.of(new InputColumn(0)), null, null),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            InMemoryBatchIterator.of(
+                List.of(
+                    new Row1(-1), new Row1(1), new Row1(1), new Row1(2), new Row1(2),
+                    new Row1(3), new Row1(4), new Row1(5), new Row1(null), new Row1(null)
+                ),
+                SENTINEL
+            ),
+            List.of(frameBoundsWindowFunction()),
+            List.of(),
+            List.of(partitionKey),
+            List.of(partitionKey),
+            List.of(DataTypes.INTEGER),
+            ramAccountingContext,
+            null,
+            new Input[0]), null);
+
+        Object[] expectedBounds = {
+            tuple(0, 1), // partition: -1
+            tuple(0, 2), tuple(0, 2), // partition: 1, 1
+            tuple(0, 2), tuple(0, 2), // partition: 2, 2
+            tuple(0, 1), // partition: 3
+            tuple(0, 1), // partition: 4
+            tuple(0, 1), // partition: 5
+            tuple(0, 2), tuple(0, 2) // partition: null, null
+        };
+        List<Object[]> result = consumer.getResult();
+
+        IntStream.range(0, 10).forEach(i -> assertThat(result.get(i)[0], is(expectedBounds[i])));
+    }
+
+    @Test
+    public void testFrameBoundsForPartitionedOrderedWindow() throws Exception {
+        // window: partition by IC0, order by IC1
+
+        InputCollectExpression partitionKey = new InputCollectExpression(0);
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(new WindowBatchIterator(
+            new WindowDefinition(List.of(new InputColumn(0)), new OrderBy(List.of(new InputColumn(1))), null),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            InMemoryBatchIterator.of(
+                List.of(
+                    new RowN(new Object[]{-1, -1}),
+                    new RowN(new Object[]{1, 0}), new RowN(new Object[]{1, 1}),
+                    new RowN(new Object[]{2, 2}), new RowN(new Object[]{2, -1}),
+                    new RowN(new Object[]{3, 3}),
+                    new RowN(new Object[]{4, 4}),
+                    new RowN(new Object[]{5, 5}),
+                    new RowN(new Object[]{null, null}), new RowN(new Object[]{null, null})
+                ),
+                SENTINEL
+            ),
+            List.of(frameBoundsWindowFunction()),
+            List.of(),
+            List.of(partitionKey),
+            List.of(partitionKey),
+            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
+            ramAccountingContext,
+            new int[]{1},
+            new Input[0]), null);
+
+        Object[] expectedBounds = {
+            tuple(0, 1), // partition: -1 -1
+            tuple(0, 1), tuple(0, 2), // partition: 1 0, 1 1 (rows are not peers)
+            tuple(0, 1), tuple(0, 2), // partition: 2 2, 2 -1 (rows are not peers)
+            tuple(0, 1), // partition: 3 3
+            tuple(0, 1), // partition: 4 4
+            tuple(0, 1), // partition: 5 5
+            tuple(0, 2), tuple(0, 2) // partition: null null, null null (rows are peers)
+        };
+        List<Object[]> result = consumer.getResult();
+
+        IntStream.range(0, 10).forEach(i -> assertThat(result.get(i)[0], is(expectedBounds[i])));
     }
 
     @Test
@@ -176,7 +262,7 @@ public class WindowBatchIteratorTest {
         Supplier<WindowBatchIterator> batchIterator = () -> {
             InputCollectExpression partitionByCollectExpression = new InputCollectExpression(0);
             return new WindowBatchIterator(
-                emptyWindow(),
+                new WindowDefinition(List.of(new InputColumn(0)), null, null),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 InMemoryBatchIterator.of(

--- a/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
@@ -86,6 +86,25 @@ public class WindowFunctionsIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
+    public void testPartitionedWindowResultSetUnordered() {
+        execute("select col1, sum(col1) over(partition by col1>2 order by col1) from unnest([1, 2, 2, 3, 4, 5])");
+        assertThat(printedTable(response.rows()), is("1| 1\n" +
+                                                     "2| 5\n" +
+                                                     "2| 5\n" +
+                                                     "3| 3\n" +
+                                                     "4| 7\n" +
+                                                     "5| 12\n"));
+
+        execute("select col1, col2, sum(col1) over(partition by col1 order by col2) FROM unnest([1, 2, 1, 1, 1, 4], [6, 6, 9, 6, 7, 8])");
+        assertThat(printedTable(response.rows()), is("1| 6| 2\n" +
+                                                     "1| 6| 2\n" +
+                                                     "1| 7| 3\n" +
+                                                     "1| 9| 4\n" +
+                                                     "2| 6| 2\n" +
+                                                     "4| 8| 4\n"));
+    }
+
+    @Test
     public void testPartitionByMultipleColumns() {
         execute("select col1, col2, row_number() over(partition by col1, col2) FROM " +
                 "unnest([1, 2, 1, 1, 1, 4], [6, 6, 9, 6, 7, 8]) order by 1, 2, 3");


### PR DESCRIPTION
Namely, due to the fact that window functions are executed for every row in
the window set we previously introduced a caching of a result mechanism (as with
each window func call the entire window frame is passed so the result for the entire
frame is calculated on the first window func call). With partitioned windows, we have
to re-iterate (start on row 0 again) with every partition so we now take that into
account when deciding if we should recompute the window function. This fixes an issue
where aggreates/nth_value functions would include results from previous frames in the
computation by now resetting the internal state of the window funcs.

The row number functions for partitioned windows was also broken due to the
fact that the row number resets with every partition. Renamed
windowRowPosition -> zeroIndexedRowNumber in the WindowBatchIterator and simplify
how it's computed to fix this - the initial intention was for the windowRowPosition
to also represent the number of emitted rows, but we have a dedicated field for that
so its computation is now much simpler.

Fix the window frame boundaries.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
