### PR TITLE
3.2 - manual backport of #8515

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -47,6 +47,9 @@ None
 Fixes
 =====
 
+- Fixed a ``ClassCastException`` which could occur when selecting
+  ``pg_catalog.pg_type.typlen``.
+
 - Fixed an issue that could cause window functions to compute incorrect results
   if multiple window functions with different window definitions were used.
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -108,7 +108,7 @@ public class PgAttributeTable extends StaticTableInfo {
                 .register(Columns.ATTNAME.name(), DataTypes.STRING, null)
                 .register(Columns.ATTTYPID.name(), DataTypes.INTEGER, null)
                 .register(Columns.ATTSTATTARGET.name(), DataTypes.INTEGER, null)
-                .register(Columns.ATTLEN.name(), DataTypes.INTEGER, null)
+                .register(Columns.ATTLEN.name(), DataTypes.SHORT, null)
                 .register(Columns.ATTNUM.name(), DataTypes.SHORT, null)
                 .register(Columns.ATTNDIMS.name(), DataTypes.INTEGER, null)
                 .register(Columns.ATTCACHEOFF.name(), DataTypes.INTEGER, null)

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -50,8 +50,8 @@ public abstract class PGType {
         return oid;
     }
 
-    public int typeLen() {
-        return typeLen;
+    public short typeLen() {
+        return (short) typeLen;
     }
 
     public int typeMod() {

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -241,7 +241,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readInt(), is(0));
                 assertThat(response.readShort(), is((short) 0));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.BOOLEAN).oid()));
-                assertThat(response.readShort(), is((short) PGTypes.get(DataTypes.BOOLEAN).typeLen()));
+                assertThat(response.readShort(), is(PGTypes.get(DataTypes.BOOLEAN).typeLen()));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).typeMod()));
                 assertThat(response.readShort(), is((short) 0));
             } finally {
@@ -301,7 +301,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readInt(), is(0));
                 assertThat(response.readShort(), is((short) 0));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.BOOLEAN).oid()));
-                assertThat(response.readShort(), is((short) PGTypes.get(DataTypes.BOOLEAN).typeLen()));
+                assertThat(response.readShort(), is(PGTypes.get(DataTypes.BOOLEAN).typeLen()));
                 assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).typeMod()));
                 assertThat(response.readShort(), is((short) 0));
             } finally {


### PR DESCRIPTION
…rotocol

(cherry picked from commit a1b08bce4a2a3d85036271bf72066ad2ba948dbb)

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
