### PR TITLE
Eagerly resolve the default for nullsFirst in OrderBy

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -81,7 +81,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
     private String columnName;
     private IndexSearcher indexSearcher;
     private boolean[] reverseFlags = new boolean[]{true};
-    private Boolean[] nullsFirst = new Boolean[]{null};
+    private boolean[] nullsFirst = new boolean[]{true};
     private Reference reference;
     private OrderBy orderBy;
     private CollectorContext collectorContext;

--- a/sql/src/main/java/io/crate/analyze/relations/OrderyByAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/OrderyByAnalyzer.java
@@ -43,7 +43,7 @@ public class OrderyByAnalyzer {
         }
         List<Symbol> symbols = new ArrayList<>(size);
         boolean[] reverseFlags = new boolean[size];
-        Boolean[] nullsFirst = new Boolean[size];
+        boolean[] nullsFirst = new boolean[size];
 
         for (int i = 0; i < size; i++) {
             SortItem sortItem = sortItems.get(i);
@@ -58,7 +58,7 @@ public class OrderyByAnalyzer {
                     nullsFirst[i] = false;
                     break;
                 case UNDEFINED:
-                    nullsFirst[i] = null;
+                    nullsFirst[i] = sortItem.getOrdering() == SortItem.Ordering.DESCENDING;
                     break;
                 default:
             }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/OrderedTopNProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/OrderedTopNProjection.java
@@ -46,14 +46,14 @@ public class OrderedTopNProjection extends Projection {
     private final List<Symbol> outputs;
     private final List<Symbol> orderBy;
     private final boolean[] reverseFlags;
-    private final Boolean[] nullsFirst;
+    private final boolean[] nullsFirst;
 
     public OrderedTopNProjection(int limit,
                                  int offset,
                                  List<Symbol> outputs,
                                  List<Symbol> orderBy,
                                  boolean[] reverseFlags,
-                                 Boolean[] nullsFirst) {
+                                 boolean[] nullsFirst) {
         assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
             : "OrderedTopNProjection outputs cannot contain Field, Reference or SelectSymbol symbols: " + outputs;
         assert orderBy.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
@@ -77,15 +77,15 @@ public class OrderedTopNProjection extends Projection {
         if (numOrderBy == 0) {
             orderBy = Collections.emptyList();
             reverseFlags = new boolean[0];
-            nullsFirst = new Boolean[0];
+            nullsFirst = new boolean[0];
         } else {
             orderBy = new ArrayList<>(numOrderBy);
             reverseFlags = new boolean[numOrderBy];
-            nullsFirst = new Boolean[numOrderBy];
+            nullsFirst = new boolean[numOrderBy];
             for (int i = 0; i < numOrderBy; i++) {
                 orderBy.add(Symbols.fromStream(in));
                 reverseFlags[i] = in.readBoolean();
-                nullsFirst[i] = in.readOptionalBoolean();
+                nullsFirst[i] = in.readBoolean();
             }
         }
     }
@@ -106,7 +106,7 @@ public class OrderedTopNProjection extends Projection {
         return reverseFlags;
     }
 
-    public Boolean[] nullsFirst() {
+    public boolean[] nullsFirst() {
         return nullsFirst;
     }
 
@@ -134,7 +134,7 @@ public class OrderedTopNProjection extends Projection {
         for (int i = 0; i < orderBy.size(); i++) {
             Symbols.toStream(orderBy.get(i), out);
             out.writeBoolean(reverseFlags[i]);
-            out.writeOptionalBoolean(nullsFirst[i]);
+            out.writeBoolean(nullsFirst[i]);
         }
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -72,7 +72,7 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     // must not contain system columns.
                     return null;
                 }
-                boolean nullsFirst = orderBy.nullsFirst()[i] == null ? false : orderBy.nullsFirst()[i];
+                boolean nullsFirst = orderBy.nullsFirst()[i];
                 value = value == null || value.equals(missingValues[i]) ? null : value;
                 if (nullsFirst && value == null) {
                     // no filter needed

--- a/sql/src/main/java/io/crate/execution/engine/sort/OrderingByPosition.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/OrderingByPosition.java
@@ -50,7 +50,7 @@ public abstract class OrderingByPosition<T> extends Ordering<T> {
         return rowOrdering(orderBy.indices(), orderBy.reverseFlags(), orderBy.nullsFirst());
     }
 
-    public static Ordering<Row> rowOrdering(int[] positions, boolean[] reverseFlags, Boolean[] nullsFirst) {
+    public static Ordering<Row> rowOrdering(int[] positions, boolean[] reverseFlags, boolean[] nullsFirst) {
         List<Comparator<Row>> comparators = new ArrayList<>(positions.length);
         for (int i = 0; i < positions.length; i++) {
             OrderingByPosition<Row> rowOrdering = OrderingByPosition.rowOrdering(
@@ -78,7 +78,7 @@ public abstract class OrderingByPosition<T> extends Ordering<T> {
         }
     }
 
-    public static Ordering<Object[]> arrayOrdering(int[] position, boolean[] reverse, Boolean[] nullsFirst) {
+    public static Ordering<Object[]> arrayOrdering(int[] position, boolean[] reverse, boolean[] nullsFirst) {
         if (position.length == 1) {
             return arrayOrdering(position[0], reverse[0], nullsFirst[0]);
         }

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -81,12 +81,12 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
         private final boolean reverseFlag;
         private final CollectorContext context;
         private final TransactionContext txnCtx;
-        private final Boolean nullFirst;
+        private final boolean nullFirst;
 
         SortSymbolContext(TransactionContext txnCtx,
                           CollectorContext collectorContext,
                           boolean reverseFlag,
-                          Boolean nullFirst) {
+                          boolean nullFirst) {
             this.txnCtx = txnCtx;
             this.nullFirst = nullFirst;
             this.context = collectorContext;
@@ -107,7 +107,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                                    TransactionContext txnCtx,
                                    CollectorContext collectorContext,
                                    boolean[] reverseFlags,
-                                   Boolean[] nullsFirst) {
+                                   boolean[] nullsFirst) {
         SortField[] sortFields = new SortField[sortSymbols.size()];
         for (int i = 0; i < sortSymbols.size(); i++) {
             Symbol sortSymbol = sortSymbols.get(i);

--- a/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
+++ b/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
@@ -37,9 +37,9 @@ public class PositionalOrderBy {
 
     private final int[] indices;
     private final boolean[] reverseFlags;
-    private final Boolean[] nullsFirst;
+    private final boolean[] nullsFirst;
 
-    public PositionalOrderBy(int[] indices, boolean[] reverseFlags, Boolean[] nullsFirst) {
+    public PositionalOrderBy(int[] indices, boolean[] reverseFlags, boolean[] nullsFirst) {
         assert indices.length == reverseFlags.length && reverseFlags.length == nullsFirst.length
             : "all parameters to OrderByPositions must have the same length";
         // PositionalOrderBy should be null if there is no order by
@@ -58,7 +58,7 @@ public class PositionalOrderBy {
         return reverseFlags;
     }
 
-    public Boolean[] nullsFirst() {
+    public boolean[] nullsFirst() {
         return nullsFirst;
     }
 
@@ -116,11 +116,11 @@ public class PositionalOrderBy {
         }
         int[] indices = new int[size];
         boolean[] reverseFlags = new boolean[size];
-        Boolean[] nullsFirst = new Boolean[size];
+        boolean[] nullsFirst = new boolean[size];
         for (int i = 0; i < size; i++) {
             indices[i] = in.readVInt();
             reverseFlags[i] = in.readBoolean();
-            nullsFirst[i] = in.readOptionalBoolean();
+            nullsFirst[i] = in.readBoolean();
         }
         return new PositionalOrderBy(indices, reverseFlags, nullsFirst);
     }
@@ -134,7 +134,7 @@ public class PositionalOrderBy {
         for (int i = 0; i < orderBy.indices.length; i++) {
             out.writeVInt(orderBy.indices[i]);
             out.writeBoolean(orderBy.reverseFlags[i]);
-            out.writeOptionalBoolean(orderBy.nullsFirst[i]);
+            out.writeBoolean(orderBy.nullsFirst[i]);
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -50,9 +50,9 @@ import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
@@ -141,9 +141,7 @@ public class LogicalPlanner {
             OrderBy relationOrderBy = relation.orderBy();
             if (relationOrderBy == null ||
                 relationOrderBy.orderBySymbols().get(0).equals(relation.outputs().get(0)) == false) {
-                return Order.create(
-                    planBuilder,
-                    new OrderBy(relation.outputs(), new boolean[]{false}, new Boolean[]{false}));
+                return Order.create(planBuilder, new OrderBy(relation.outputs()));
             }
         }
         return planBuilder;

--- a/sql/src/test/java/io/crate/analyze/OrderByTest.java
+++ b/sql/src/test/java/io/crate/analyze/OrderByTest.java
@@ -45,7 +45,7 @@ public class OrderByTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
-        OrderBy orderBy = new OrderBy(ImmutableList.<Symbol>of(ref("name")), new boolean[]{true}, new Boolean[]{true});
+        OrderBy orderBy = new OrderBy(ImmutableList.<Symbol>of(ref("name")), new boolean[]{true}, new boolean[]{true});
         BytesStreamOutput out = new BytesStreamOutput();
         orderBy.writeTo(out);
 

--- a/sql/src/test/java/io/crate/analyze/WindowDefinitionSerialisationTest.java
+++ b/sql/src/test/java/io/crate/analyze/WindowDefinitionSerialisationTest.java
@@ -59,7 +59,7 @@ public class WindowDefinitionSerialisationTest {
         FrameBoundDefinition start = new FrameBoundDefinition(FrameBound.Type.UNBOUNDED_PRECEDING, Literal.of(5L));
         FrameBoundDefinition end = new FrameBoundDefinition(FrameBound.Type.FOLLOWING, Literal.of(3L));
         WindowFrameDefinition frameDefinition = new WindowFrameDefinition(WindowFrame.Type.RANGE, start, end);
-        OrderBy orderBy = new OrderBy(singletonList(Literal.of(1L)), new boolean[]{true}, new Boolean[]{true});
+        OrderBy orderBy = new OrderBy(singletonList(Literal.of(1L)), new boolean[]{true}, new boolean[]{true});
         WindowDefinition windowDefinition = new WindowDefinition(singletonList(Literal.of(2L)), orderBy, frameDefinition);
 
         BytesStreamOutput output = new BytesStreamOutput();

--- a/sql/src/test/java/io/crate/analyze/relations/OrderByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/OrderByAnalyzerTest.java
@@ -73,7 +73,7 @@ public class OrderByAnalyzerTest {
         assertThat(reverseFlags[0], is(false));
         assertThat(reverseFlags[1], is(true));
 
-        Boolean[] nullsFirst = orderBy.nullsFirst();
+        boolean[] nullsFirst = orderBy.nullsFirst();
         assertThat(nullsFirst.length, is(2));
         assertThat(nullsFirst[0], is(true));
         assertThat(nullsFirst[1], is(false));

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -153,7 +153,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         // select a from t1, t2 order by a, b + x desc
 
         List<Symbol> orderBySymbols = Arrays.asList(asSymbol("a"), asSymbol("x + y"));
-        OrderBy orderBy = new OrderBy(orderBySymbols, new boolean[]{true, false}, new Boolean[]{null, null});
+        OrderBy orderBy = new OrderBy(orderBySymbols, new boolean[]{true, false}, new boolean[]{true, false});
 
         QuerySpec querySpec = new QuerySpec()
             .outputs(singleTrue())
@@ -171,7 +171,7 @@ public class RelationSplitterTest extends CrateUnitTest {
     public void testSplitOrderByWith3RelationsButOutputsOnly2Relations() throws Exception {
         QuerySpec querySpec = fromQuery("x = 1 and y = 2 and z = 3").limit(Literal.of(30));
         List<Symbol> orderBySymbols = Arrays.asList(asSymbol("x"), asSymbol("y"), asSymbol("z"));
-        OrderBy orderBy = new OrderBy(orderBySymbols, new boolean[]{false, false, false}, new Boolean[]{null, null, null});
+        OrderBy orderBy = new OrderBy(orderBySymbols);
         querySpec.orderBy(orderBy).limit(Literal.of(20)).outputs(Arrays.asList(asSymbol("x"), asSymbol("y")));
 
         RelationSplitter splitter = split(querySpec);
@@ -191,9 +191,7 @@ public class RelationSplitterTest extends CrateUnitTest {
             asSymbol("x - y + z"),
             asSymbol("y"),
             asSymbol("x+y"));
-        OrderBy orderBy = new OrderBy(orderBySymbols,
-            new boolean[]{false, false, false, false},
-            new Boolean[]{null, null, null, null});
+        OrderBy orderBy = new OrderBy(orderBySymbols);
         querySpec.orderBy(orderBy);
 
         RelationSplitter splitter = split(querySpec);

--- a/sql/src/test/java/io/crate/execution/dsl/projection/OrderedTopNProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/OrderedTopNProjectionTest.java
@@ -44,7 +44,7 @@ public class OrderedTopNProjectionTest extends CrateUnitTest {
             Collections.singletonList(Literal.of("foobar")),
             Collections.singletonList(new InputColumn(0, DataTypes.STRING)),
             new boolean[] { true },
-            new Boolean[] { null }
+            new boolean[] { true }
         );
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -100,7 +100,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         StandardAnalyzer analyzer = new StandardAnalyzer();
         IndexWriterConfig cfg = new IndexWriterConfig(analyzer);
         IndexWriter w = new IndexWriter(index, cfg);
-        for (Long i = 0L; i < 4; i++) {
+        for (long i = 0L; i < 4; i++) {
             if (i < 2) {
                 addDocToLucene(w, i + 1);
             } else {
@@ -137,10 +137,10 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         return docs;
     }
 
-    private Long[] nextPageQuery(IndexReader reader, FieldDoc lastCollected, boolean reverseFlag, @Nullable Boolean nullFirst) throws IOException {
+    private Long[] nextPageQuery(IndexReader reader, FieldDoc lastCollected, boolean reverseFlag, boolean nullFirst) throws IOException {
         OrderBy orderBy = new OrderBy(ImmutableList.of(REFERENCE),
             new boolean[]{reverseFlag},
-            new Boolean[]{nullFirst});
+            new boolean[]{nullFirst});
 
         SortField sortField = new SortedNumericSortField("value", SortField.Type.LONG, reverseFlag);
         Long missingValue = (Long) LuceneMissingValue.missingValue(orderBy, 0);
@@ -168,7 +168,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
     @Test
     public void testNextPageQueryWithLastCollectedNullValue() {
         FieldDoc fieldDoc = new FieldDoc(1, 0, new Object[]{null});
-        OrderBy orderBy = new OrderBy(Collections.singletonList(REFERENCE), new boolean[]{false}, new Boolean[]{null});
+        OrderBy orderBy = new OrderBy(Collections.singletonList(REFERENCE), new boolean[]{false}, new boolean[]{false});
 
         OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(
             orderBy, mock(QueryShardContext.class), name -> valueFieldType);
@@ -187,14 +187,14 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         //    ^  (lastCollected = 2)
 
         FieldDoc afterDoc = new FieldDoc(0, 0, new Object[]{2L});
-        Long[] result = nextPageQuery(reader, afterDoc, false, null);
+        Long[] result = nextPageQuery(reader, afterDoc, false, false);
         assertThat(result, is(new Long[]{2L, null, null}));
 
         // reverseOrdering = false, nulls First = false
         // 1  2  null null
         //       ^
         afterDoc = new FieldDoc(0, 0, new Object[]{LuceneMissingValue.missingValue(false, null, SortField.Type.LONG)});
-        result = nextPageQuery(reader, afterDoc, false, null);
+        result = nextPageQuery(reader, afterDoc, false, false);
         assertThat(result, is(new Long[]{null, null}));
 
         // reverseOrdering = true, nulls First = false
@@ -263,7 +263,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
         OrderBy orderBy = new OrderBy(ImmutableList.of(sysColReference, REFERENCE),
             new boolean[]{false, false},
-            new Boolean[]{false, false});
+            new boolean[]{false, false});
 
         FieldDoc lastCollected = new FieldDoc(0, 0, new Object[]{2L});
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -31,10 +31,10 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.BatchIteratorTester;
@@ -170,8 +170,7 @@ public class NodeStatsTest extends CrateUnitTest {
         toCollect.add(idRef);
         when(collectPhase.toCollect()).thenReturn(toCollect);
         when(collectPhase.where()).thenReturn(Literal.BOOLEAN_TRUE);
-        when(collectPhase.orderBy()).thenReturn(new OrderBy(Collections.singletonList(idRef),
-            new boolean[]{false}, new Boolean[]{true}));
+        when(collectPhase.orderBy()).thenReturn(new OrderBy(Collections.singletonList(idRef)));
 
         List<Object[]> expectedResult = Arrays.asList(
             new Object[]{"nodeOne"},

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -85,7 +85,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
     private OrderBy orderBy;
     private List<Object[]> expectedResult;
     private boolean[] reverseFlags = new boolean[]{true};
-    private Boolean[] nullsFirst = new Boolean[]{null};
+    private boolean[] nullsFirst = new boolean[]{true};
 
     @Before
     public void prepareSearchers() throws Exception {

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -76,7 +76,7 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
-        collectPhase.orderBy(new OrderBy(Collections.singletonList(shardId), new boolean[]{false}, new Boolean[]{null}));
+        collectPhase.orderBy(new OrderBy(Collections.singletonList(shardId), new boolean[]{false}, new boolean[]{false}));
 
         Iterable<? extends Row> rows = systemCollectSource.toRowsIterableTransformation(
             collectPhase,

--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -96,7 +96,7 @@ public class RamAccountingPageIteratorTest extends CrateUnitTest {
     @Test
     public void testRamAccountingWrappingAppliedForOrderedIterators() {
         PositionalOrderBy orderBy = PositionalOrderBy.of(
-            new OrderBy(Collections.singletonList(Literal.of(1)), new boolean[]{false}, new Boolean[]{false}),
+            new OrderBy(Collections.singletonList(Literal.of(1)), new boolean[]{false}, new boolean[]{false}),
             Collections.singletonList(Literal.of(1)));
 
         PagingIterator<Integer, Row> repeatingSortedPagingIterator = PagingIterator.create(

--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.core.Is.is;
 public class SortedPagingIteratorTest extends CrateUnitTest {
 
     public static final Ordering<Row> ORDERING =
-        OrderingByPosition.rowOrdering(new int[]{0}, new boolean[]{false}, new Boolean[]{null});
+        OrderingByPosition.rowOrdering(new int[]{0}, new boolean[]{false}, new boolean[]{false});
 
     @Test
     public void testTwoBucketsAndTwoPagesAreSortedCorrectly() throws Exception {

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -55,10 +55,10 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
@@ -158,7 +158,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         OrderedTopNProjection projection = new OrderedTopNProjection(10, 0, outputs,
             Arrays.asList(new InputColumn(0), new InputColumn(1)),
             new boolean[]{false, false},
-            new Boolean[]{null, null}
+            new boolean[]{false, false}
         );
         Projector projector = visitor.create(projection, txnCtx, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         assertThat(projector, instanceOf(SortingTopNProjector.class));
@@ -170,7 +170,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         OrderedTopNProjection projection = new OrderedTopNProjection(TopN.NO_LIMIT, TopN.NO_OFFSET, outputs,
             Arrays.asList(new InputColumn(0), new InputColumn(1)),
             new boolean[]{false, false},
-            new Boolean[]{null, null}
+            new boolean[]{false, false}
         );
         Projector projector = visitor.create(projection, txnCtx, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         assertThat(projector, instanceOf(SortingProjector.class));
@@ -235,7 +235,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         OrderedTopNProjection topNProjection = new OrderedTopNProjection(10, 0, outputs,
             ImmutableList.of(new InputColumn(2, DataTypes.DOUBLE)),
             new boolean[]{false},
-            new Boolean[]{null});
+            new boolean[]{false});
         Projector topNProjector = visitor.create(topNProjection, txnCtx, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
 
         String human = "human";

--- a/sql/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
@@ -90,7 +90,7 @@ public class OrderingByPositionTest extends CrateUnitTest {
     @Test
     public void testSingleOrderByPositionResultsInNonCompoundOrdering() throws Exception {
         Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(
-            new int[]{0}, new boolean[]{false}, new Boolean[]{null});
+            new int[]{0}, new boolean[]{false}, new boolean[]{false});
         assertThat(ordering, Matchers.instanceOf(OrderingByPosition.class));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -32,7 +32,6 @@ import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
-import io.crate.expression.FunctionExpression;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
@@ -236,7 +235,7 @@ public class WindowBatchIteratorTest {
 
     @Test
     public void testWindowBatchIteratorWithOrderedWindowOverNullValues() throws Exception {
-        OrderBy orderBy = new OrderBy(singletonList(Literal.of(1L)), new boolean[]{true}, new Boolean[]{true});
+        OrderBy orderBy = new OrderBy(singletonList(Literal.of(1L)), new boolean[]{true}, new boolean[]{true});
         WindowDefinition windowDefinition = new WindowDefinition(Collections.emptyList(), orderBy, null);
 
         WindowBatchIterator windowBatchIterator = new WindowBatchIterator(

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -192,7 +192,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, false}, new Boolean[]{null, null}).reverse());
+            new int[]{0, 1}, new boolean[]{false, false}, new boolean[]{false, false}).reverse());
         assertThat(printRows(rows), is(
             "blue| large\n" +
             "blue| small\n" +
@@ -276,7 +276,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, true}, new Boolean[]{null, null}).reverse());
+            new int[]{0, 1}, new boolean[]{false, true}, new boolean[]{false, true}).reverse());
 
         assertThat(printedTable(new CollectionBucket(rows)),
             is("" +

--- a/sql/src/test/java/io/crate/planner/PositionalOrderByTest.java
+++ b/sql/src/test/java/io/crate/planner/PositionalOrderByTest.java
@@ -46,7 +46,7 @@ public class PositionalOrderByTest {
         OrderBy orderBy = new OrderBy(
             Arrays.asList(ref("a"), ref("c"), ref("b")),
             new boolean[]{true, false, true},
-            new Boolean[]{true, null, null}
+            new boolean[]{true, false, false}
         );
         PositionalOrderBy positionalOrderBy = PositionalOrderBy.of(orderBy, oldOutputs);
         PositionalOrderBy newOrderBy = positionalOrderBy.tryMapToNewOutputs(oldOutputs, newOutputs);

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -193,7 +193,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Collect left = (Collect) join.left();
         assertThat("1 node, otherwise mergePhases would be required", left.nodeIds().size(), is(1));
-        assertThat(left.orderBy(), isSQL("OrderByPositions{indices=[1], reverseFlags=[false], nullsFirst=[null]}"));
+        assertThat(left.orderBy(), isSQL("OrderByPositions{indices=[1], reverseFlags=[false], nullsFirst=[false]}"));
         assertThat(left.collectPhase().projections(), contains(
             isTopN(10, 2)
         ));

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -74,7 +74,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -282,7 +281,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(positionalOrderBy.indices().length, is(1));
         assertThat(positionalOrderBy.indices()[0], is(0));
         assertThat(positionalOrderBy.reverseFlags()[0], is(false));
-        assertThat(positionalOrderBy.nullsFirst()[0], nullValue());
+        assertThat(positionalOrderBy.nullsFirst()[0], is(false));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -148,7 +148,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
             "MultiPhase[\n" +
             "    subQueries[\n" +
             "        RootBoundary['foo']\n" +
-            "        OrderBy['foo' ASC NULLS LAST]\n" +
+            "        OrderBy['foo' ASC]\n" +
             "        Collect[.empty_row | ['foo'] | All]\n" +
             "    ]\n" +
             "    FetchOrEval[a, x, i]\n" +

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -98,7 +98,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_SAME_NODE
         );
-        collect.orderBy(new OrderBy(Collections.singletonList(toInt10), new boolean[]{false}, new Boolean[]{null}));
+        collect.orderBy(new OrderBy(Collections.singletonList(toInt10)));
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
         RoutedCollectPhase normalizedCollect = collect.normalize(
             normalizer, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -224,7 +224,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan.dependencies().entrySet().size(), is(1));
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
         assertThat(subPlan, isPlan("RootBoundary[x]\n" +
-                                   "OrderBy[x ASC NULLS LAST]\n" +
+                                   "OrderBy[x ASC]\n" +
                                    "Collect[doc.t1 | [x] | All]\n"));
     }
 
@@ -245,7 +245,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan.dependencies().entrySet().size(), is(1));
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
         assertThat(subPlan, isPlan("RootBoundary[x]\n" +
-                                   "OrderBy[x ASC NULLS LAST]\n" +
+                                   "OrderBy[x ASC]\n" +
                                    "FetchOrEval[x]\n" +
                                    "Limit[10;0]\n" +
                                    "OrderBy[a DESC]\n" +

--- a/sql/src/test/java/io/crate/testing/SQLPrinter.java
+++ b/sql/src/test/java/io/crate/testing/SQLPrinter.java
@@ -149,8 +149,8 @@ public class SQLPrinter {
                 if (orderBy.reverseFlags()[i]) {
                     sb.append(" DESC");
                 }
-                Boolean nullsFirst = orderBy.nullsFirst()[i];
-                if (nullsFirst != null) {
+                boolean nullsFirst = orderBy.nullsFirst()[i];
+                if (orderBy.reverseFlags()[i] != nullsFirst) {
                     sb.append(" NULLS");
                     if (nullsFirst) {
                         sb.append(" FIRST");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We kept a `null` value for `nullsFirst` and resolved it very late in the
execution layer. This PR removes this `null` case by eagerly resolving
it to `true` or `false` depending on if the ordering is ASC or DESC.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)