### PR TITLE
Replace Ordering/Comparator chaining with a specific implementation

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorBenchmark.java
@@ -59,7 +59,7 @@ public class SortedPagingIteratorBenchmark {
     @Setup
     public void prepareData() {
         rnd = new Random(42);
-        compareOnFirstColumn = OrderingByPosition.rowOrdering(0, false, null);
+        compareOnFirstColumn = OrderingByPosition.rowOrdering(0, false, false);
 
         unsortedFirst = IntStream.range(0, 1_000_000).mapToObj(Row1::new).collect(Collectors.toList());
         unsortedSecond = IntStream.range(500_000, 1_500_00).mapToObj(Row1::new).collect(Collectors.toList());

--- a/sql/src/main/java/io/crate/execution/engine/collect/RowsTransformer.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RowsTransformer.java
@@ -24,7 +24,6 @@ package io.crate.execution.engine.collect;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.data.Buckets;
@@ -40,6 +39,7 @@ import io.crate.types.DataTypes;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 
 public final class RowsTransformer {
 
@@ -85,8 +85,8 @@ public final class RowsTransformer {
 
     public static Iterable<Row> sortRows(Iterable<Object[]> rows, RoutedCollectPhase collectPhase) {
         ArrayList<Object[]> objects = Lists.newArrayList(rows);
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(collectPhase);
-        objects.sort(ordering.reverse());
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(collectPhase);
+        objects.sort(ordering);
         return Iterables.transform(objects, Buckets.arrayToSharedRow()::apply);
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/sort/BoundedSortingTopNCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/BoundedSortingTopNCollector.java
@@ -92,7 +92,7 @@ public class BoundedSortingTopNCollector implements Collector<Row, RowPriorityQu
 
     @Override
     public Supplier<RowPriorityQueue<Object[]>> supplier() {
-        return () -> new RowPriorityQueue<>(maxSize, comparator);
+        return () -> new RowPriorityQueue<>(maxSize, comparator.reversed());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/sort/NullAwareComparator.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/NullAwareComparator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.sort;
+
+import java.util.Comparator;
+import java.util.function.Function;
+
+/**
+ * Specialized comparator implementation that directly handles reverse/nullsFirst.
+ * (`Comparator.comparing()` doesn't handle nulls)
+ *
+ * We favour this over chaining Comparator.nullsFirst/nullsLast + .reversed()
+ * Because sorting is often one of the main bottlenecks and we want to have a small call stack for that.
+ */
+class NullAwareComparator<T> implements Comparator<T> {
+
+    private final int mod;
+    private final Function<T, Comparable<Object>> keyExtractor;
+    private final int leftNull;
+    private final int rightNull;
+
+    NullAwareComparator(Function<T, Comparable<Object>> keyExtractor, boolean reverse, boolean nullsFirst) {
+        this.keyExtractor = keyExtractor;
+        this.mod = reverse ? -1 : 1;
+        this.leftNull = nullsFirst ? -1 : 1;
+        this.rightNull = nullsFirst ? 1 : -1;
+    }
+
+    @Override
+    public int compare(T o1, T o2) {
+        var val1 = keyExtractor.apply(o1);
+        var val2 = keyExtractor.apply(o2);
+        if (val1 == val2) {
+            return 0;
+        }
+        if (val1 == null) {
+            return leftNull;
+        }
+        if (val2 == null) {
+            return rightNull;
+        }
+        int cmp = val1.compareTo(val2);
+        return cmp * mod;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortingProjector.java
@@ -100,7 +100,7 @@ public class SortingProjector implements Projector {
     }
 
     private Bucket sortAndCreateBucket(List<Object[]> rows) {
-        rows.sort(comparator.reversed());
+        rows.sort(comparator);
         if (offset == 0) {
             return new CollectionBucket(rows, numOutputs);
         }

--- a/sql/src/main/java/io/crate/execution/engine/sort/UnboundedSortingTopNCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/UnboundedSortingTopNCollector.java
@@ -97,7 +97,7 @@ public class UnboundedSortingTopNCollector implements Collector<Row, PriorityQue
 
     @Override
     public Supplier<PriorityQueue<Object[]>> supplier() {
-        return () -> new PriorityQueue<>(initialCapacity, comparator);
+        return () -> new PriorityQueue<>(initialCapacity, comparator.reversed());
     }
 
     @Override
@@ -135,7 +135,7 @@ public class UnboundedSortingTopNCollector implements Collector<Row, PriorityQue
 
         if (pq.size() == maxNumberOfRowsInQueue) {
             Object[] highestElementInOrder = pq.peek();
-            if (highestElementInOrder == null || comparator.compare(rowCells, highestElementInOrder) > 0) {
+            if (highestElementInOrder == null || comparator.compare(rowCells, highestElementInOrder) < 0) {
                 pq.poll();
                 pq.add(rowCells);
             }

--- a/sql/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
@@ -28,69 +28,65 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 import static org.hamcrest.core.Is.is;
 
-/**
- * NOTE: The given <p>reverse</p> boolean is always reversed by the {@link OrderingByPosition} so the comparator is
- * working correctly while used on queue implementations where elements are popped from the end of the queue
- * while iterating. So all tests should also be read reversed ;).
- */
 public class OrderingByPositionTest extends CrateUnitTest {
 
     @Test
     public void testOrderByAscNullsFirst() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, true);
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, true);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(-1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
     }
 
     @Test
     public void testOrderByAscNullsLast() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, false);
-
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
-    }
-
-    @Test
-    public void testOrderByDescNullsLast() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, false);
-
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{2}), is(-1));
-    }
-
-    @Test
-    public void testOrderByDescNullsFirst() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, true);
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, false);
 
         assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(-1));
     }
 
     @Test
+    public void testOrderByDescNullsLast() throws Exception {
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, false);
+
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(-1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{2}), is(1));
+    }
+
+    @Test
+    public void testOrderByDescNullsFirst() throws Exception {
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, true);
+
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
+    }
+
+    @Test
     public void testOrderByAsc() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, null);
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, true);
 
         assertThat(ordering.compare(new Object[]{1}, new Object[]{2}), is(-1));
     }
 
     @Test
     public void testMultipleOrderBy() throws Exception {
-        Ordering<Object[]> ordering = Ordering.compound(Arrays.asList(
-            OrderingByPosition.arrayOrdering(1, false, null),
-            OrderingByPosition.arrayOrdering(0, false, null)
+        Comparator<Object[]> ordering = Ordering.compound(Arrays.asList(
+            OrderingByPosition.arrayOrdering(1, false, false),
+            OrderingByPosition.arrayOrdering(0, false, false)
         ));
 
-        assertThat(ordering.compare(new Object[]{0, 0}, new Object[]{4, 0}), is(1));
-        assertThat(ordering.compare(new Object[]{4, 0}, new Object[]{1, 1}), is(1));
-        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(1));
-        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(1));
+        assertThat(ordering.compare(new Object[]{0, 0}, new Object[]{4, 0}), is(-1));
+        assertThat(ordering.compare(new Object[]{4, 0}, new Object[]{1, 1}), is(-1));
+        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(-1));
+        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(-1));
     }
 
     @Test
     public void testSingleOrderByPositionResultsInNonCompoundOrdering() throws Exception {
-        Ordering<Object[]> ordering = OrderingByPosition.arrayOrdering(
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(
             new int[]{0}, new boolean[]{false}, new boolean[]{false});
-        assertThat(ordering, Matchers.instanceOf(OrderingByPosition.class));
+        assertThat(ordering, Matchers.instanceOf(NullAwareComparator.class));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -23,12 +23,12 @@
 package io.crate.execution.engine.sort;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.expression.symbol.Literal;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.Literal;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
@@ -47,7 +47,7 @@ public class SortingProjectorTest extends CrateUnitTest {
             ImmutableList.of(input, Literal.of(true)),
             ImmutableList.<CollectExpression<Row, ?>>of(input),
             numOutputs,
-            OrderingByPosition.arrayOrdering(0, false, null),
+            OrderingByPosition.arrayOrdering(0, false, false),
             offset
         );
     }

--- a/sql/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
@@ -23,7 +23,6 @@
 package io.crate.execution.engine.sort;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Ordering;
 import io.crate.data.Bucket;
 import io.crate.data.Input;
 import io.crate.data.Projector;
@@ -37,6 +36,7 @@ import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
 import org.junit.Test;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static io.crate.testing.TestingHelpers.isRow;
@@ -48,11 +48,11 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
     private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
     private static final List<Input<?>> INPUT_LITERAL_LIST = ImmutableList.of(INPUT, TRUE_LITERAL);
     private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = ImmutableList.<CollectExpression<Row, ?>>of(INPUT);
-    private static final Ordering<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, null);
+    private static final Comparator<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, false);
 
     private TestingRowConsumer consumer = new TestingRowConsumer();
 
-    private Projector getProjector(int numOutputs, int limit, int offset, Ordering<Object[]> ordering) {
+    private Projector getProjector(int numOutputs, int limit, int offset, Comparator<Object[]> ordering) {
         int unboundedCollectorThreshold = 10_000;
         if (random().nextFloat() >= 0.5f) {
             unboundedCollectorThreshold = 1;

--- a/sql/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
@@ -163,7 +163,8 @@ public class JoinGroupByIntegrationTests extends SQLTransportIntegrationTest {
 
         assertThat(
             TestingHelpers.printedTable(response.rows()),
-            is("apple| 2| 1.9\nbanana| 2| 0.8\n")
+            is("apple| 2| 1.9\n" +
+               "banana| 2| 0.8\n")
         );
     }
 
@@ -213,7 +214,7 @@ public class JoinGroupByIntegrationTests extends SQLTransportIntegrationTest {
         );
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        rows.sort(OrderingByPosition.arrayOrdering(1, true, null));
+        rows.sort(OrderingByPosition.arrayOrdering(1, false, false));
         assertThat(
             TestingHelpers.printedTable(new CollectionBucket(rows)),
             is("yellow| 5.0\n" +
@@ -231,7 +232,7 @@ public class JoinGroupByIntegrationTests extends SQLTransportIntegrationTest {
         );
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        rows.sort(OrderingByPosition.arrayOrdering(1, true, null));
+        rows.sort(OrderingByPosition.arrayOrdering(1, false, false));
 
         assertThat(
             TestingHelpers.printedTable(new CollectionBucket(rows)),

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -192,7 +192,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, false}, new boolean[]{false, false}).reverse());
+            new int[]{0, 1}, new boolean[]{false, false}, new boolean[]{false, false}));
         assertThat(printRows(rows), is(
             "blue| large\n" +
             "blue| small\n" +
@@ -276,7 +276,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, true}, new boolean[]{false, true}).reverse());
+            new int[]{0, 1}, new boolean[]{false, true}, new boolean[]{false, true}));
 
         assertThat(printedTable(new CollectionBucket(rows)),
             is("" +

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -149,7 +149,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "  select min(age) as minAge from characters group by gender) as ch " +
                 "group by minAge");
         List<Object[]> rows = Arrays.asList(response.rows());
-        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, true, null));
+        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, true, true));
         assertThat(TestingHelpers.printedTable(rows.toArray(new Object[0][])),
             is("1\n1\n"));
     }
@@ -163,7 +163,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "group by race");
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, true, null));
+        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, false, true));
         assertThat(printedTable(rows.toArray(new Object[0][])),
             is("Android| NULL\n" +
                "Human| 73.0\n" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This replaces the ordering chaining using `nullsFirst` / `reversed` with
an implementation that handles both reverse and nullsFirst flag
directly.

In addition, it removes the implicit `reversed` that we had in place for
priority queues. This sometimes resulted in double reversing which is
confusing and overhead.

Main motivation is to reduce the call stack for ordering operations and
to have a better basis to integrate expression evaluation into ordering
later on.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)