### PR TITLE
Add the `max_index_keys` session setting.

### DIFF
--- a/blackbox/docs/config/session.rst
+++ b/blackbox/docs/config/session.rst
@@ -14,7 +14,8 @@ Session settings only apply to the currently connected client session.
 Usage
 =====
 
-To configure a session setting, use :ref:`SET <ref-set>` eg:
+To configure a modifiable session setting, use :ref:`SET <ref-set>`,
+for example:
 
 .. code-block:: sql
 
@@ -36,7 +37,10 @@ Supported Session Settings
 
 .. _conf-session-search-path:
 
-``search_path``: *schema names* (default: ``doc``)
+**search_path**
+  | *Default:* ``pg_catalog, doc``
+  | *Modifiable:* ``yes``
+
   The list of schemas to be searched when a relation is referenced without a
   schema.
 
@@ -57,7 +61,10 @@ Supported Session Settings
      includes it in the ``search_path`` *before* the configured schemas, unless
      it is already explicitly in the schema configuration.
 
-``enable_semijoin``: *enabled* (default: ``false``)
+**enable_semijoin**
+  | *Default:* ``false``
+  | *Modifiable:* ``yes``
+
   An :ref:`experimental <experimental-warning>` setting which enables CrateDB
   to consider rewriting a ``SemiJoin`` query into a conventional join query,
   if possible. For instance, a query in the form of:
@@ -73,7 +80,10 @@ Supported Session Settings
 
 .. _conf-session-enable-hashjoin:
 
-``enable_hashjoin``: *enabled* (default: ``true``)
+**enable_hashjoin**
+  | *Default:* ``true``
+  | *Modifiable:* ``yes``
+
   An :ref:`experimental <experimental-warning>` setting which enables CrateDB
   to consider whether a Join operation should be evaluated using the
   ``HashJoin`` implementation instead of the ``Nested-Loops`` implementation.
@@ -85,6 +95,19 @@ Supported Session Settings
      option of considering it, it will not guaranty it.
      See also the :ref:`available join algorithms
      <available-join-algo>` for more insights on this topic.
+
+.. _conf-session-max_index_keys:
+
+**max_index_keys**
+  | *Default:* ``32``
+  | *Modifiable:* ``no``
+
+  Shows the maximum number of index keys.
+
+  .. NOTE::
+
+     The session setting has not effect on CrateDB and was added to enhance
+     compatibility with ``PostgreSQL``.
 
 .. _experimental-warning:
 

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -29,6 +29,7 @@ import io.crate.types.DataTypes;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.crate.metadata.SearchPath.createSearchPathFrom;
 
@@ -37,6 +38,7 @@ public class SessionSettingRegistry {
     private static final String SEARCH_PATH_KEY = "search_path";
     static final String SEMI_JOIN_KEY = "enable_semijoin";
     static final String HASH_JOIN_KEY = "enable_hashjoin";
+    static final String MAX_INDEX_KEYS = "max_index_keys";
 
     public static final Map<String, SessionSetting<?>> SETTINGS = ImmutableMap.<String, SessionSetting<?>>builder()
             .put(SEARCH_PATH_KEY,
@@ -74,6 +76,17 @@ public class SessionSettingRegistry {
                     () -> String.valueOf(true),
                     "Considers using the Hash Join instead of the Nested Loop Join implementation.",
                     DataTypes.BOOLEAN.getName()))
+            .put(MAX_INDEX_KEYS,
+                new SessionSetting<>(
+                    objects -> {},
+                    Function.identity(),
+                    (s, v) -> {
+                        throw new UnsupportedOperationException("\"" + MAX_INDEX_KEYS + "\" cannot be changed.");
+                    },
+                    s -> String.valueOf(32),
+                    () -> String.valueOf(32),
+                    "Shows the maximum number of index keys.",
+                    DataTypes.INTEGER.getName()))
             .build();
 
     private static String[] objectsToStringArray(Object[] objects) {

--- a/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -104,7 +104,8 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is(
             "pg_catalog, doc| NULL| NULL| NULL| NULL| NULL| NULL| search_path| NULL| pg_catalog, doc| pg_catalog, doc| Sets the schema search order.| NULL| NULL| NULL| NULL| text\n" +
             "false| NULL| NULL| NULL| NULL| NULL| NULL| enable_semijoin| NULL| false| true| Considers rewriting a SemiJoin query into a conventional join query.| NULL| NULL| NULL| NULL| boolean\n" +
-            "true| NULL| NULL| NULL| NULL| NULL| NULL| enable_hashjoin| NULL| true| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL| NULL| NULL| boolean\n")
+            "true| NULL| NULL| NULL| NULL| NULL| NULL| enable_hashjoin| NULL| true| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL| NULL| NULL| boolean\n" +
+            "32| NULL| NULL| NULL| NULL| NULL| NULL| max_index_keys| NULL| 32| 32| Shows the maximum number of index keys.| NULL| NULL| NULL| NULL| integer\n")
         );
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -404,7 +404,8 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is(
             "search_path| pg_catalog, doc| Sets the schema search order.\n" +
             "enable_semijoin| false| Considers rewriting a SemiJoin query into a conventional join query.\n" +
-            "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n")
+            "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n" +
+            "max_index_keys| 32| Shows the maximum number of index keys.\n")
         );
     }
 }

--- a/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -26,7 +26,9 @@ import io.crate.action.sql.SessionContext;
 import io.crate.data.Row;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.StringLiteral;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,12 +40,23 @@ import static org.junit.Assert.fail;
 
 public class SessionSettingRegistryTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     private SessionContext sessionContext = SessionContext.systemSessionContext();
 
     @Test
     public void testSemiJoinSessionSetting() {
         SessionSetting<?> setting = SessionSettingRegistry.SETTINGS.get(SessionSettingRegistry.SEMI_JOIN_KEY);
         assertBooleanNonEmptySetting(sessionContext::getSemiJoinsRewriteEnabled, setting, false);
+    }
+
+    @Test
+    public void testMaxIndexKeysSessionSettingCannotBeChanged() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("\"max_index_keys\" cannot be changed.");
+        SessionSetting<?> setting = SessionSettingRegistry.SETTINGS.get(SessionSettingRegistry.MAX_INDEX_KEYS);
+        setting.apply(Row.EMPTY, generateInput("32"), sessionContext);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The session setting has no effect on CrateDB and add to enhance
compatibility with PostgreSQL.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
