### PR TITLE
Make the `show all` statement display session description.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -132,6 +132,9 @@ Deprecations
 Changes
 =======
 
+- Show the session setting description in the output of the ``SHOW ALL``
+  statement.
+
 - Exposed the :ref:`_seq_no <sql_administration_system_columns_seq_no>` and
   :ref:`_primary_term <sql_administration_system_columns_primary_term>` system
   columns.

--- a/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -98,7 +98,7 @@ class ShowStatementAnalyzer {
         if (sessionSetting != null) {
             sb.append("setting ");
         } else {
-            sb.append("name, setting ");
+            sb.append("name, setting, short_desc as description ");
         }
         sb.append("FROM pg_catalog.pg_settings ");
         if (sessionSetting != null) {

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -59,7 +59,7 @@ public class SessionSettingRegistry {
                     SessionContext::setSemiJoinsRewriteEnabled,
                     s -> Boolean.toString(s.semiJoinsRewriteEnabled()),
                     () -> String.valueOf(false),
-                    "Consider rewriting a SemiJoin query into a conventional join query.",
+                    "Considers rewriting a SemiJoin query into a conventional join query.",
                     DataTypes.BOOLEAN.getName()))
             .put(HASH_JOIN_KEY,
                 new SessionSetting<>(

--- a/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -103,7 +103,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select * from pg_catalog.pg_settings");
         assertThat(printedTable(response.rows()), is(
             "pg_catalog, doc| NULL| NULL| NULL| NULL| NULL| NULL| search_path| NULL| pg_catalog, doc| pg_catalog, doc| Sets the schema search order.| NULL| NULL| NULL| NULL| text\n" +
-            "false| NULL| NULL| NULL| NULL| NULL| NULL| enable_semijoin| NULL| false| true| Consider rewriting a SemiJoin query into a conventional join query.| NULL| NULL| NULL| NULL| boolean\n" +
+            "false| NULL| NULL| NULL| NULL| NULL| NULL| enable_semijoin| NULL| false| true| Considers rewriting a SemiJoin query into a conventional join query.| NULL| NULL| NULL| NULL| boolean\n" +
             "true| NULL| NULL| NULL| NULL| NULL| NULL| enable_hashjoin| NULL| true| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL| NULL| NULL| boolean\n")
         );
     }

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -401,8 +401,10 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testShowAll() {
         execute("show all");
-        assertThat(printedTable(response.rows()), is("search_path| pg_catalog, doc\n" +
-                                                     "enable_semijoin| false\n" +
-                                                     "enable_hashjoin| true\n"));
+        assertThat(printedTable(response.rows()), is(
+            "search_path| pg_catalog, doc| Sets the schema search order.\n" +
+            "enable_semijoin| false| Considers rewriting a SemiJoin query into a conventional join query.\n" +
+            "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n")
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
