### PR TITLE
Add support for handling scalar functions as table functions

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -132,6 +132,9 @@ Deprecations
 Changes
 =======
 
+- Enabled Scalar function evaluation when used :ref:`in the query FROM
+  clause <table-functions-scalar>`.
+
 - Show the session setting description in the output of the ``SHOW ALL``
   statement.
 

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -5,7 +5,7 @@
 Scalar Functions
 ================
 
-Scalar functions return a single value (not a table).
+Scalar functions return a single value.
 
 .. rubric:: Table of Contents
 

--- a/blackbox/docs/general/builtins/table-functions.rst
+++ b/blackbox/docs/general/builtins/table-functions.rst
@@ -34,6 +34,11 @@ values will be returned for the functions that are exhausted. An example::
     around is not allowed, unless sub queries are utilized.
     (SELECT aggregate_func(col) FROM (SELECT table_func(...) as col) ...)
 
+.. NOTE::
+
+  In addition to the pure table functions listed below, :ref:`scalar`
+  can also be used :ref:`in the context of the FROM clause
+  <table-functions-scalar>`.
 
 .. rubric:: Table of Contents
 
@@ -104,3 +109,24 @@ value will match the argument types.
     |    4 |
     +------+
     SELECT 4 rows in set (... sec)
+
+.. _table-functions-scalar:
+
+Scalar functions
+================
+
+:ref:`scalar` can also return a set of rows when used in the ``FROM`` clause
+of a query as a table or subquery. The result set of such functions is always
+a relation of one row and one column which contains the value returned from
+the scalar function.
+
+::
+
+    cr> SELECT * FROM abs(-5), initcap('hello world');
+    +-----+-------------+
+    | abs | initcap     |
+    +-----+-------------+
+    |   5 | Hello World |
+    +-----+-------------+
+    SELECT 1 row in set (... sec)
+

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -38,6 +38,7 @@ public class ExpressionAnalysisContext {
     private final Map<SubqueryExpression, Object> arrayExpressionsChildren = new IdentityHashMap<>();
 
     private boolean hasAggregates;
+    private boolean allowEagerNormalize = true;
 
     void indicateAggregates() {
         hasAggregates = true;
@@ -45,6 +46,14 @@ public class ExpressionAnalysisContext {
 
     public boolean hasAggregates() {
         return hasAggregates;
+    }
+
+    public boolean isEagerNormalizationAllowed() {
+        return allowEagerNormalize;
+    }
+
+    public void allowEagerNormalize(boolean value) {
+        this.allowEagerNormalize = value;
     }
 
     /**

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1057,7 +1057,7 @@ public class ExpressionAnalyzer {
             }
             newFunction = new WindowFunction(functionInfo, castArguments, windowDefinition);
         }
-        if (functionInfo.isDeterministic() && Symbols.allLiterals(newFunction)) {
+        if (context.isEagerNormalizationAllowed() && functionInfo.isDeterministic() && Symbols.allLiterals(newFunction)) {
             return funcImpl.normalizeSymbol(newFunction, coordinatorTxnCtx);
         }
         return newFunction;

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.tablefunctions;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.data.ArrayBucket;
+import io.crate.data.Bucket;
+import io.crate.data.Input;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.metadata.tablefunctions.TableFunctionImplementation;
+import org.elasticsearch.cluster.ClusterState;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class TableFunctionFactory {
+
+    public static TableFunctionImplementation from(FunctionImplementation functionImplementation) {
+
+        TableFunctionImplementation tableFunction;
+        switch (functionImplementation.info().type()) {
+            case TABLE:
+                tableFunction = (TableFunctionImplementation) functionImplementation;
+                break;
+            case SCALAR:
+                tableFunction = new ScalarTableFunctionImplementation<>((Scalar<?, ?>) functionImplementation);
+                break;
+            case WINDOW:
+            case AGGREGATE:
+                throw new UnsupportedOperationException(
+                    String.format(
+                        Locale.ENGLISH,
+                        "Window or Aggregate function: '%s' is not allowed in function in FROM clause",
+                        functionImplementation.info().ident().name()));
+            default:
+                throw new UnsupportedOperationException(
+                    String.format(
+                        Locale.ENGLISH,
+                        "Unknown type function: '%s' is not allowed in function in FROM clause",
+                        functionImplementation.info().ident().name()));
+        }
+        return tableFunction;
+    }
+
+    /**
+     * Evaluates the {@link Scalar} function and emits scalar result as a 1x1 table
+     */
+    private static class ScalarTableFunctionImplementation<T> extends TableFunctionImplementation<T> {
+
+        private final RelationName TABLE_IDENT = new RelationName("", "scalar_table");
+
+        private final Scalar<?, T> functionImplementation;
+
+        private ScalarTableFunctionImplementation(Scalar<?, T> functionImplementation) {
+            this.functionImplementation = functionImplementation;
+        }
+
+        @Override
+        public FunctionInfo info() {
+            return functionImplementation.info();
+        }
+
+        @Override
+        public Bucket evaluate(TransactionContext txnCtx, Input<T>[] args) {
+            return new ArrayBucket(new Object[][] {new Object[] {functionImplementation.evaluate(txnCtx,args)}});
+        }
+
+        @Override
+        public TableInfo createTableInfo() {
+            String functionName = info().ident().name();
+            ColumnIdent col = new ColumnIdent(functionName);
+            Reference reference = new Reference(new ReferenceIdent(TABLE_IDENT, col),
+                                                RowGranularity.DOC,
+                                                info().returnType(),
+                                                1);
+            Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col, reference);
+            return new StaticTableInfo(TABLE_IDENT, referenceByColumn, List.of(reference), List.of()) {
+                @Override
+                public Routing getRouting(ClusterState state,
+                                          RoutingProvider routingProvider,
+                                          WhereClause whereClause,
+                                          RoutingProvider.ShardSelection shardSelection,
+                                          SessionContext sessionContext) {
+                    return Routing.forTableOnSingleNode(TABLE_IDENT, state.getNodes().getLocalNodeId());
+                }
+
+                @Override
+                public RowGranularity rowGranularity() {
+                    return RowGranularity.DOC;
+                }
+            };
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.RelationUnknown;
@@ -1845,13 +1846,6 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testSelectFromNonTableFunction() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Non table function 'abs' is not supported in from clause");
-        analyze("select * from abs(1)");
-    }
-
-    @Test
     public void testMatchInExplicitJoinConditionIsProhibited() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot use MATCH predicates on columns of 2 different relations");
@@ -1875,6 +1869,35 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expect(ColumnUnknownException.class);
         expectedException.expectMessage("Column col1['x'] unknown");
         analyze("select col1['x'] from unnest([{x=1}])");
+    }
+
+    @Test
+    public void testScalarCanBeUsedInFromClause() {
+        QueriedRelation relation = analyze("select * from abs(1)");
+        assertThat(relation.querySpec().outputs(), isSQL("abs"));
+        assertThat(relation.fields(), isSQL("abs"));
+        assertThat(((QueriedTable) relation).tableRelation(), instanceOf(TableFunctionRelation.class));
+    }
+
+    @Test
+    public void testCannotUseSameTableNameMoreThanOnce() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("\"abs\" specified more than once in the FROM clause");
+        analyze("select * from abs(1), abs(5)");
+    }
+
+    @Test
+    public void testWindowFunctionCannotBeUsedInFromClause() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Window or Aggregate function: 'row_number' is not allowed in function in FROM clause");
+        analyze("select * from row_number()");
+    }
+
+    @Test
+    public void testAggregateCannotBeUsedInFromClause() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Window or Aggregate function: 'count' is not allowed in function in FROM clause");
+        analyze("select * from count()");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -79,7 +79,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testSubSelectWithoutAlias() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("subquery in FROM must have an alias");
+        expectedException.expectMessage("subquery in FROM clause must have an alias");
         analyze("select id from (select a as id from t1)");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -136,4 +136,11 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
             is("1| 1\n" +
                "2| 1\n"));
     }
+
+    @Test
+    public void testScalarCanBeUsedInFromClause() {
+        execute("select * from substr('foo',1,2), array_cat([1], [2, 3])");
+        assertThat(printedTable(response.rows()),
+            is("fo| [1, 2, 3]\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add support for handling scalar functions as table functions

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)