### PR TITLE
Make nested subqueries ignore the limit of outer subqueries.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -203,4 +203,9 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that would cause the wrong evaluation of nested sub-queries
+  in cases where the inner sub-query returns a multi-value and the outer returns
+  a single value result. For instance, the assignment sub-query expression in
+  the following update statement
+  ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN (SELECT x FROM t3))")``
+  might have produced an incorrect result.

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.MultiPhaseExecutor;
@@ -46,9 +47,11 @@ import java.util.Map;
  */
 public class MultiPhasePlan implements Plan {
 
-    private final Plan rootPlan;
+    @VisibleForTesting
+    protected final Plan rootPlan;
 
-    private final Map<LogicalPlan, SelectSymbol> dependencies;
+    @VisibleForTesting
+    protected final Map<LogicalPlan, SelectSymbol> dependencies;
 
     public static Plan createIfNeeded(Plan rootPlan, Map<LogicalPlan, SelectSymbol> dependencies) {
         if (dependencies.isEmpty()) {

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -107,10 +107,12 @@ public class LogicalPlanner {
     public LogicalPlan planSubSelect(SelectSymbol selectSymbol, PlannerContext plannerContext) {
         final int softLimit, fetchSize;
         if (selectSymbol.getResultType() == SINGLE_COLUMN_SINGLE_VALUE) {
+            // The reason why the soft limit equals 2 is because single value
+            // sub-queries need to have a validation that it only returns 1 row.
             softLimit = fetchSize = 2;
         } else {
-            softLimit = plannerContext.softLimit();
-            fetchSize = plannerContext.fetchSize();
+            softLimit = NO_LIMIT;
+            fetchSize = 0;
         }
         QueriedRelation relation = (QueriedRelation) relationNormalizer.normalize(
             selectSymbol.relation(), plannerContext.transactionContext());

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -31,6 +31,7 @@ import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.UpdateProjection;
 import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.TransactionContext;
@@ -38,6 +39,7 @@ import io.crate.metadata.Reference;
 import io.crate.planner.consumer.UpdatePlanner;
 import io.crate.planner.node.dml.UpdateById;
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -47,7 +49,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES;
+import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
@@ -140,5 +145,24 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         UpdatePlanner.Update plan = e.plan("update users set name = 'should not update' where _seq_no = 11 and _primary_term = 1");
         plan.createExecutionPlan.create(
             e.getPlannerContext(clusterService.state()), Row.EMPTY, SubQueryResults.EMPTY);
+    }
+
+    @Test
+    public void testMultiValueSubQueryWithinSingleValueSubQueryDoesNotInheritSoftLimit() {
+        MultiPhasePlan plan = e.plan(
+            "update users set ints = (" +
+                "   select count(id) from users where id in (select unnest([1, 2, 3, 4])))");
+        assertThat(plan.rootPlan, instanceOf(UpdatePlanner.Update.class));
+
+        Map<LogicalPlan, SelectSymbol> rootPlanDependencies = plan.dependencies;
+        LogicalPlan outerSubSelectPlan = rootPlanDependencies.keySet().iterator().next();
+        SelectSymbol outerSubSelectSymbol = rootPlanDependencies.values().iterator().next();
+        assertThat(outerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_SINGLE_VALUE));
+        assertThat(outerSubSelectPlan.numExpectedRows(), is(2L));
+
+        LogicalPlan innerSubSelectPlan = outerSubSelectPlan.dependencies().keySet().iterator().next();
+        SelectSymbol innerSubSelectSymbol = outerSubSelectPlan.dependencies().values().iterator().next();
+        assertThat(innerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_MULTIPLE_VALUES));
+        assertThat(innerSubSelectPlan.numExpectedRows(), is(-1L));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
