### PR TITLE
Fix limit processing in queries of insert into statements

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -203,6 +203,14 @@ Changes
 Fixes
 =====
 
+- Fixed the processing of ``LIMIT`` clauses within queries in the :ref:`INSERT
+  INTO <ref-insert>` statement. A query like ``INSERT INTO target (SELECT *
+  FROM (SELECT * FROM source LIMIT 10) t)`` could insert more than 10 rows if
+  there is more than 1 node in the cluster.
+  In addition, using ``LIMIT`` in the top level query of the ``INSERT INTO``
+  statement is now no longer prohibited. So the query can be written as
+  follows: ``INSERT INTO target (SELECT * FROM source LIMIT 10)``.
+
 - Fixed an issue that would cause the wrong evaluation of nested sub-queries
   in cases where the inner sub-query returns a multi-value and the outer returns
   a single value result. For instance, the assignment sub-query expression in

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -25,6 +25,8 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.data.Row;
+import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
+import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
@@ -34,17 +36,22 @@ import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class Insert extends OneInputPlan {
 
-    private final List<Projection> projections;
+    private final ColumnIndexWriterProjection writeToTable;
 
-    public Insert(LogicalPlan source, List<Projection> projections) {
+    @Nullable
+    private final EvalProjection applyCasts;
+
+    public Insert(LogicalPlan source, ColumnIndexWriterProjection writeToTable, @Nullable EvalProjection applyCasts) {
         super(source);
-        this.projections = projections;
+        this.writeToTable = writeToTable;
+        this.applyCasts = applyCasts;
     }
 
     @Override
@@ -56,22 +63,28 @@ public class Insert extends OneInputPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        ExecutionPlan executionSubPlan = source.build(
+        ExecutionPlan sourcePlan = source.build(
             plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
-        for (Projection projection : projections) {
-            executionSubPlan.addProjection(projection);
+        if (applyCasts != null) {
+            sourcePlan.addProjection(applyCasts);
         }
-        ExecutionPlan executionPlan = Merge.ensureOnHandler(executionSubPlan, plannerContext);
-        if (executionPlan == executionSubPlan) {
-            return executionPlan;
+        if (sourcePlan.resultDescription().hasRemainingLimitOrOffset()) {
+            ExecutionPlan localMerge = Merge.ensureOnHandler(sourcePlan, plannerContext);
+            localMerge.addProjection(writeToTable);
+            return localMerge;
+        } else {
+            sourcePlan.addProjection(writeToTable);
+            ExecutionPlan localMerge = Merge.ensureOnHandler(sourcePlan, plannerContext);
+            if (sourcePlan != localMerge) {
+                localMerge.addProjection(MergeCountProjection.INSTANCE);
+            }
+            return localMerge;
         }
-        executionPlan.addProjection(MergeCountProjection.INSTANCE);
-        return executionPlan;
     }
 
     @Override
     protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
-        return new Insert(newSource, projections);
+        return new Insert(newSource, writeToTable, applyCasts);
     }
 
     @Override
@@ -99,12 +112,16 @@ public class Insert extends OneInputPlan {
         return visitor.visitInsert(this, context);
     }
 
-    public List<Projection> projections() {
-        return projections;
-    }
-
     @Override
     public StatementType type() {
         return StatementType.INSERT;
+    }
+
+    public Collection<Projection> projections() {
+        if (applyCasts == null) {
+            return List.of(writeToTable);
+        } else {
+            return List.of(applyCasts, writeToTable);
+        }
     }
 }

--- a/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -23,7 +23,6 @@
 package io.crate.planner;
 
 import io.crate.analyze.TableDefinitions;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.PKLookupPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
@@ -33,7 +32,9 @@ import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.FilterProjection;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.MergeCountProjection;
+import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.PartitionName;
@@ -169,10 +170,30 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testInsertFromSubQueryDistributedGroupByWithLimit() {
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("Using limit, offset or order by is not supported on insert using a sub-query");
+        Merge localMerge = e.plan("insert into users (id, name) " +
+                             "(select name, count(*) from users group by name order by name limit 10)");
 
-        e.plan("insert into users (id, name) (select name, count(*) from users group by name order by name limit 10)");
+        Merge distMerge = (Merge) localMerge.subPlan();
+        Collect collect = (Collect) distMerge.subPlan();
+        assertThat(
+            collect.collectPhase().projections(),
+            contains(instanceOf(GroupProjection.class))
+        );
+        assertThat(
+            distMerge.mergePhase().projections(),
+            contains(
+                instanceOf(GroupProjection.class),
+                instanceOf(OrderedTopNProjection.class),
+                instanceOf(EvalProjection.class)
+            )
+        );
+        assertThat(
+            localMerge.mergePhase().projections(),
+            contains(
+                instanceOf(TopNProjection.class),
+                instanceOf(ColumnIndexWriterProjection.class)
+            )
+        );
     }
 
     @Test
@@ -305,26 +326,33 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testInsertFromSubQueryWithLimit() {
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("Using limit, offset or order by is not supported on insert using a sub-query");
-
-        e.plan("insert into users (date, id, name) (select date, id, name from users limit 10)");
+        Merge merge = e.plan("insert into users (date, id, name) (select date, id, name from users limit 10)");
+        Collect collect = (Collect) merge.subPlan();
+        assertThat(collect.collectPhase().projections(), contains(instanceOf(TopNProjection.class)));
+        assertThat(
+            merge.mergePhase().projections(),
+            contains(
+                instanceOf(TopNProjection.class),
+                instanceOf(ColumnIndexWriterProjection.class)
+            )
+        );
     }
 
     @Test
-    public void testInsertFromSubQueryWithOffset() {
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("Using limit, offset or order by is not supported on insert using a sub-query");
-
-        e.plan("insert into users (id, name) (select id, name from users offset 10)");
+    public void testInsertFromSubQueryWithOffsetDoesTableWriteOnCollect() {
+        Merge merge = e.plan("insert into users (id, name) (select id, name from users offset 10)");
+        // We can ignore the offset since SQL semantics don't promise a deterministic order without explicit order by clause
+        Collect collect = (Collect) merge.subPlan();
+        assertThat(collect.collectPhase().projections(), contains(instanceOf(ColumnIndexWriterProjection.class)));
+        assertThat(merge.mergePhase().projections(), contains(instanceOf(MergeCountProjection.class)));
     }
 
     @Test
     public void testInsertFromSubQueryWithOrderBy() {
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("Using limit, offset or order by is not supported on insert using a sub-query");
-
-        e.plan("insert into users (date, id, name) (select date, id, name from users order by id)");
+        Merge merge = e.plan("insert into users (date, id, name) (select date, id, name from users order by id)");
+        Collect collect = (Collect) merge.subPlan();
+        assertThat(collect.collectPhase().projections(), contains(instanceOf(ColumnIndexWriterProjection.class)));
+        assertThat(merge.mergePhase().projections(), contains(instanceOf(MergeCountProjection.class)));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We prohibited the use of ORDER BY, OFFSET and LIMIT in the top level
query of INSERT INTO statements, but it was still possible to wrap the
ORDER BY, OFFSET and LIMIT within another sub-query within the query to
avoid this restriction - but in that case the clauses weren't being
processed correctly as we applied the write projection too early.

This removes the restriction (as it is mostly a artificial limitation,
coming from a time when our execution plan building was less modular)
and fixes the handling.


Fixes https://github.com/crate/crate/issues/8550

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)