### PR TITLE
Use Netty ByteBuf Bulk Operations for Faster Deserialization backport…

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -20,6 +20,7 @@ package org.elasticsearch.common.io.stream;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 public class ByteBufferStreamInput extends StreamInput {
@@ -77,7 +78,39 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    @SuppressWarnings("sync-override")
+    public short readShort() throws IOException {
+        try {
+            return buffer.getShort();
+        } catch (BufferUnderflowException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        try {
+            return buffer.getInt();
+        } catch (BufferUnderflowException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        try {
+            return buffer.getLong();
+        } catch (BufferUnderflowException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+    @Override
     public void reset() throws IOException {
         buffer.reset();
     }

--- a/es/es-server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -405,7 +405,6 @@ public abstract class StreamInput extends InputStream {
         return spare.toString();
     }
 
-
     public final float readFloat() throws IOException {
         return Float.intBitsToFloat(readInt());
     }

--- a/es/es-transport/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/es/es-transport/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -28,7 +28,7 @@ import java.io.EOFException;
 import java.io.IOException;
 
 /**
- * A Netty {@link io.netty.buffer.ByteBuf} based {@link org.elasticsearch.common.io.stream.StreamInput}.
+ * A Netty {@link ByteBuf} based {@link StreamInput}.
  */
 class ByteBufStreamInput extends StreamInput {
 
@@ -111,7 +111,39 @@ class ByteBufStreamInput extends StreamInput {
     }
 
     @Override
-    @SuppressWarnings("sync-override")
+    public short readShort() throws IOException {
+        try {
+            return buffer.readShort();
+        } catch (IndexOutOfBoundsException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        try {
+            return buffer.readInt();
+        } catch (IndexOutOfBoundsException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        try {
+            return buffer.readLong();
+        } catch (IndexOutOfBoundsException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
+    }
+
+
     public void reset() throws IOException {
         buffer.resetReaderIndex();
     }
@@ -134,7 +166,13 @@ class ByteBufStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        return buffer.readByte();
+        try {
+            return buffer.readByte();
+        } catch (IndexOutOfBoundsException ex) {
+            EOFException eofException = new EOFException();
+            eofException.initCause(ex);
+            throw eofException;
+        }
     }
 
     @Override


### PR DESCRIPTION
… from https://github.com/elastic/elasticsearch/pull/40158

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
