### PR TITLE
Remove deprecation logging fro index.shard.check_on_startup

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -71,17 +71,19 @@ public final class IndexSettings {
     @Deprecated
     public static final Setting<Boolean> INDEX_TTL_DISABLE_PURGE_SETTING =
         Setting.boolSetting("index.ttl.disable_purge", false, Property.Dynamic, Property.IndexScope, Property.Deprecated);
-    public static final Setting<String> INDEX_CHECK_ON_STARTUP = new Setting<>("index.shard.check_on_startup", "false", (s) -> {
-        switch(s) {
-            case "false":
-            case "true":
-            case "fix":
-            case "checksum":
-                return s;
-            default:
-                throw new IllegalArgumentException("unknown value for [index.shard.check_on_startup] must be one of [true, false, fix, checksum] but was: " + s);
-        }
-    }, Property.IndexScope);
+
+    public static final Setting<String> INDEX_CHECK_ON_STARTUP =
+        new Setting<>("index.shard.check_on_startup", "false", (s) -> {
+            switch (s) {
+                case "false":
+                case "true":
+                case "checksum":
+                    return s;
+                default:
+                    throw new IllegalArgumentException("unknown value for [index.shard.check_on_startup] must be one of " +
+                                                       "[true, false, checksum] but was: " + s);
+            }
+        }, Property.IndexScope);
 
     /**
      * Index setting describing for NGramTokenizer and NGramTokenFilter

--- a/es/es-server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -246,10 +246,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         logger.debug("state: [CREATED]");
 
         this.checkIndexOnStartup = indexSettings.getValue(IndexSettings.INDEX_CHECK_ON_STARTUP);
-        if ("fix".equals(checkIndexOnStartup)) {
-            deprecationLogger.deprecated("Setting [index.shard.check_on_startup] is set to deprecated value [fix], "
-                + "which has no effect and will not be accepted in future");
-        }
         this.translogConfig = new TranslogConfig(shardId, shardPath().resolveTranslog(), indexSettings, bigArrays);
         final String aId = shardRouting.allocationId().getId();
         this.globalCheckpointListeners =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We never exposed the setting, so we don't need deprecation logging for a
possible value removal.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)