### PR TITLE
Remove unused deprecated index.ttl.disable_purge setting

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -51,7 +51,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
     // this allows analysis settings to be passed
     public static final Set<Setting<?>> BUILT_IN_INDEX_SETTINGS = Set.of(
         MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,
-        IndexSettings.INDEX_TTL_DISABLE_PURGE_SETTING,
         MergeSchedulerConfig.AUTO_THROTTLE_SETTING,
         MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
         MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,

--- a/es/es-server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -68,22 +68,18 @@ public final class IndexSettings {
             (value) -> Translog.Durability.valueOf(value.toUpperCase(Locale.ROOT)), Property.Dynamic, Property.IndexScope);
     public static final Setting<Boolean> INDEX_WARMER_ENABLED_SETTING =
         Setting.boolSetting("index.warmer.enabled", true, Property.Dynamic, Property.IndexScope);
-    @Deprecated
-    public static final Setting<Boolean> INDEX_TTL_DISABLE_PURGE_SETTING =
-        Setting.boolSetting("index.ttl.disable_purge", false, Property.Dynamic, Property.IndexScope, Property.Deprecated);
 
-    public static final Setting<String> INDEX_CHECK_ON_STARTUP =
-        new Setting<>("index.shard.check_on_startup", "false", (s) -> {
-            switch (s) {
-                case "false":
-                case "true":
-                case "checksum":
-                    return s;
-                default:
-                    throw new IllegalArgumentException("unknown value for [index.shard.check_on_startup] must be one of " +
-                                                       "[true, false, checksum] but was: " + s);
-            }
-        }, Property.IndexScope);
+    public static final Setting<String> INDEX_CHECK_ON_STARTUP = new Setting<>("index.shard.check_on_startup", "false", (s) -> {
+        switch(s) {
+            case "false":
+            case "true":
+            case "fix":
+            case "checksum":
+                return s;
+            default:
+                throw new IllegalArgumentException("unknown value for [index.shard.check_on_startup] must be one of [true, false, fix, checksum] but was: " + s);
+        }
+    }, Property.IndexScope);
 
     /**
      * Index setting describing for NGramTokenizer and NGramTokenFilter


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
