### PR TITLE
Register udfs against the pg_catalog schema.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -150,6 +150,9 @@ Deprecations
 Changes
 =======
 
+- Allow :ref:`sql_administration_udf` to be registered against the
+  ``pg_catalog`` schema.
+
 - Added the :ref:`string_agg` aggregation function.
 
 - Improved resiliency of the :ref:`ref-create-snapshot` operation.

--- a/blackbox/docs/general/user-defined-functions.rst
+++ b/blackbox/docs/general/user-defined-functions.rst
@@ -89,6 +89,13 @@ You can explicitly assign a schema like this::
     ...  AS 'function log10(a) { return Math.log(a)/Math.log(10); }';
     CREATE OK, 1 row affected  (... sec)
 
+.. NOTE::
+
+   In order to improve the PostgreSQL server compatibility CrateDB allows the
+   creation of user defined functions against the :ref:`postgres_pg_catalog`
+   schema. However, the creation of user defined functions against the
+   read-only :ref:`system-information` and :ref:`information_schema` schemas is
+   prohibited.
 
 .. WARNING::
 

--- a/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -151,6 +151,15 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
     }
 
     @Test
+    public void testFunctionIsCreatedInThePgCatalogSchema() throws Exception {
+        execute("create function pg_catalog.udf(integer) returns string language dummy_lang as '42'");
+        assertFunctionIsCreatedOnAll("pg_catalog", "udf", ImmutableList.of(DataTypes.INTEGER));
+
+        execute("select udf(1::integer)");
+        assertThat(response.rows()[0][0], is("DUMMY EATS integer"));
+    }
+
+    @Test
     public void testDropFunction() throws Exception {
         execute("create function custom(string) returns string language dummy_lang as 'DUMMY DUMMY DUMMY'");
         assertFunctionIsCreatedOnAll(sqlExecutor.getCurrentSchema(), "custom", ImmutableList.of(DataTypes.STRING));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
