### PR TITLE
Remove null checks for list ctor parameters in Node classes.

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/SearchedCaseExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SearchedCaseExpression.java
@@ -21,9 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-
+import java.util.Collections;
 import java.util.List;
 
 public class SearchedCaseExpression
@@ -32,8 +30,7 @@ public class SearchedCaseExpression
     private final Expression defaultValue;
 
     public SearchedCaseExpression(List<WhenClause> whenClauses, Expression defaultValue) {
-        Preconditions.checkNotNull(whenClauses, "whenClauses is null");
-        this.whenClauses = ImmutableList.copyOf(whenClauses);
+        this.whenClauses = Collections.unmodifiableList(whenClauses);
         this.defaultValue = defaultValue;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Select.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Select.java
@@ -22,11 +22,9 @@
 package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Select
     extends Node {
@@ -35,7 +33,7 @@ public class Select
 
     public Select(boolean distinct, List<SelectItem> selectItems) {
         this.distinct = distinct;
-        this.selectItems = ImmutableList.copyOf(checkNotNull(selectItems, "selectItems"));
+        this.selectItems = Collections.unmodifiableList(selectItems);
     }
 
     public boolean isDistinct() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/SimpleCaseExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SimpleCaseExpression.java
@@ -22,8 +22,8 @@
 package io.crate.sql.tree;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
 
 public class SimpleCaseExpression
@@ -34,10 +34,8 @@ public class SimpleCaseExpression
 
     public SimpleCaseExpression(Expression operand, List<WhenClause> whenClauses, Expression defaultValue) {
         Preconditions.checkNotNull(operand, "operand is null");
-        Preconditions.checkNotNull(whenClauses, "whenClauses is null");
-
         this.operand = operand;
-        this.whenClauses = ImmutableList.copyOf(whenClauses);
+        this.whenClauses = Collections.unmodifiableList(whenClauses);
         this.defaultValue = defaultValue;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

AstBuilder uses visitCollection that returns an empty list
if a visitable object is null.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
