### PR TITLE
Add a rule based optimizer

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -42,6 +42,7 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * An optimized version for "select count(*) from t where ..."
@@ -102,6 +103,17 @@ public class Count extends ZeroInputPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of();
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        assert sources.isEmpty() : "Count has no sources, cannot replace them";
+        return this;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -248,6 +248,16 @@ class FetchOrEval extends OneInputPlan {
         return planWithEvalProjection(plannerContext, executionPlan, sourceOutputs, params, subQueryResults);
     }
 
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new FetchOrEval(Lists2.getOnlyElement(sources), outputs, fetchMode, doFetch);
+    }
+
     private ExecutionPlan planWithFetch(PlannerContext plannerContext,
                                         ExecutionPlan executionPlan,
                                         List<Symbol> sourceOutputs,

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -145,6 +145,17 @@ public class Get extends ZeroInputPlan {
     }
 
     @Override
+    public List<LogicalPlan> sources() {
+        return List.of();
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        assert sources.isEmpty() : "Get has no sources, cannot replace them";
+        return this;
+    }
+
+    @Override
     public long estimatedRowSize() {
         return estimatedSizePerRow;
     }

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -140,6 +140,16 @@ public class GroupHashAggregate extends OneInputPlan {
         );
     }
 
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new GroupHashAggregate(Lists2.getOnlyElement(sources), groupKeys, aggregates);
+    }
+
     private ExecutionPlan createMerge(PlannerContext plannerContext,
                                       ExecutionPlan executionPlan,
                                       List<Projection> projections,

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -23,6 +23,7 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
+import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.ExecutionPhases;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -149,6 +150,16 @@ public class HashAggregate extends OneInputPlan {
     @Override
     public List<Symbol> outputs() {
         return new ArrayList<>(aggregates);
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new HashAggregate(Lists2.getOnlyElement(sources), aggregates);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -198,6 +198,22 @@ class HashJoin extends TwoInputPlan {
         );
     }
 
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(lhs, rhs);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new HashJoin(
+            sources.get(0),
+            sources.get(1),
+            joinCondition,
+            concreteRelation,
+            tableStats
+        );
+    }
+
     private Tuple<List<Symbol>, List<Symbol>> extractHashJoinSymbolsFromJoinSymbolsAndSplitPerSide(boolean switchedTables) {
         Map<AnalyzedRelation, List<Symbol>> hashJoinSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
 

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
 import io.crate.execution.dsl.projection.EvalProjection;
@@ -100,6 +101,16 @@ public class Insert extends OneInputPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new Insert(Lists2.getOnlyElement(sources), writeToTable, applyCasts);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -23,6 +23,7 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
+import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.ExecutionPhases;
 import io.crate.execution.dsl.projection.TopNProjection;
@@ -111,6 +112,16 @@ class Limit extends OneInputPlan {
                 new TopNProjection(limit + offset, 0, sourceTypes), limit, offset, resultDescription.orderBy());
         }
         return executionPlan;
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new Limit(Lists2.getOnlyElement(sources), limit, offset);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -211,6 +211,10 @@ public interface LogicalPlan extends Plan {
 
     List<AbstractTableRelation> baseTables();
 
+    List<LogicalPlan> sources();
+
+    LogicalPlan replaceSources(List<LogicalPlan> sources);
+
     /**
      * SubQueries that this plan depends on to be able to execute it.
      *

--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
@@ -33,6 +34,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,6 +69,16 @@ public class MultiPhase extends OneInputPlan {
                                SubQueryResults subQueryResults) {
         return source.build(
             plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new MultiPhase(Lists2.getOnlyElement(sources), dependencies);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -212,6 +212,25 @@ class NestedLoopJoin extends TwoInputPlan {
         );
     }
 
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(lhs, rhs);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new NestedLoopJoin(
+            sources.get(0),
+            sources.get(1),
+            joinType,
+            joinCondition,
+            isFiltered,
+            noOuterJoin,
+            topMostLeftRelation,
+            orderByWasPushedDown
+        );
+    }
+
     private Tuple<Collection<String>, List<MergePhase>> configureExecution(ExecutionPlan left,
                                                                            ExecutionPlan right,
                                                                            PlannerContext plannerContext,

--- a/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
+++ b/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-final class OperatorUtils {
+public final class OperatorUtils {
 
     private OperatorUtils() {
     }
@@ -80,7 +80,7 @@ final class OperatorUtils {
     /**
      * @return a new list where all symbols are mapped using a mapping function created from {@code mapping}
      */
-    static List<Symbol> mappedSymbols(List<Symbol> sourceOutputs, Map<Symbol, Symbol> mapping) {
+    public static List<Symbol> mappedSymbols(List<Symbol> sourceOutputs, Map<Symbol, Symbol> mapping) {
         if (mapping.isEmpty()) {
             return sourceOutputs;
         }
@@ -102,7 +102,7 @@ final class OperatorUtils {
      *      f(xx)   -> f(add(x, x)
      * </pre>
      */
-    static Function<Symbol, Symbol> getMapper(Map<Symbol, Symbol> mapping) {
+    public static Function<Symbol, Symbol> getMapper(Map<Symbol, Symbol> mapping) {
         return s -> {
             Symbol mapped = mapping.get(s);
             if (mapped != null) {

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -104,6 +104,16 @@ class Order extends OneInputPlan {
         return executionPlan;
     }
 
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new Order(Lists2.getOnlyElement(sources), orderBy);
+    }
+
     private static void ensureOrderByColumnsArePresentInOutputs(List<Symbol> outputs, List<Symbol> orderBySymbols) {
         Set<Symbol> columnsInOutputs = extractColumns(outputs);
         for (Symbol columnInOrderBy : extractColumns(orderBySymbols)) {

--- a/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -118,6 +118,16 @@ public class ProjectSet extends OneInputPlan {
     }
 
     @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new ProjectSet(Lists2.getOnlyElement(sources), tableFunctions, standalone);
+    }
+
+    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitProjectSet(this, context);
     }

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -23,6 +23,7 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
+import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.ExecutionPlan;
@@ -30,6 +31,7 @@ import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * An operator with the primary purpose to ensure that the result is on the handler and no longer distributed.
@@ -59,6 +61,16 @@ public class RootRelationBoundary extends OneInputPlan {
             params,
             subQueryResults
         ), plannerContext);
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new RootRelationBoundary(Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -166,6 +166,16 @@ public class Union extends TwoInputPlan {
     }
 
     @Override
+    public List<LogicalPlan> sources() {
+        return List.of(lhs, rhs);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new Union(sources.get(0), sources.get(1), outputs);
+    }
+
+    @Override
     public LogicalPlan tryOptimize(@Nullable LogicalPlan ancestor, SymbolMapper mapper) {
         if (ancestor instanceof Order) {
             SymbolMapper symbolMapper = (newOutputs, x) -> {

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -216,6 +216,16 @@ public class WindowAgg extends OneInputPlan {
     }
 
     @Override
+    public List<LogicalPlan> sources() {
+        return List.of(source);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return new WindowAgg(Lists2.getOnlyElement(sources), windowDefinition, windowFunctions, standalone);
+    }
+
+    @Override
     public String toString() {
         return "WindowAgg{[" + ExplainLeaf.printList(windowFunctions) + "]}";
     }

--- a/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer;
+
+import io.crate.collections.Lists2;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+
+import java.util.List;
+
+public class Optimizer {
+
+    private List<Rule<?>> rules;
+
+    public Optimizer(List<Rule<?>> rules) {
+        this.rules = rules;
+    }
+
+    public LogicalPlan optimize(LogicalPlan plan) {
+        LogicalPlan optimizedRoot = tryApplyRules(plan);
+        return optimizedRoot.replaceSources(Lists2.map(optimizedRoot.sources(), this::optimize));
+    }
+
+    private LogicalPlan tryApplyRules(LogicalPlan plan) {
+        LogicalPlan node = plan;
+        for (Rule rule : rules) {
+            Match match = rule.pattern().accept(node, Captures.empty());
+            if (match.isPresent()) {
+                @SuppressWarnings("unchecked")
+                LogicalPlan transformedPlan = rule.apply(match.value(), match.captures());
+                if (transformedPlan != null) {
+                    node = transformedPlan;
+                }
+            }
+        }
+        return node;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer;
+
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+public interface Rule<T> {
+
+    Pattern<T> pattern();
+
+    LogicalPlan apply(T plan, Captures captures);
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Capture.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Capture.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+public class Capture<T> {
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+class CapturePattern<T> extends Pattern<T> {
+
+    private final Capture<T> capture;
+    private final Pattern<T> pattern;
+
+    CapturePattern(Capture<T> capture, Pattern<T> pattern) {
+        this.capture = capture;
+        this.pattern = pattern;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures) {
+        Match<T> match = pattern.accept(object, captures);
+        return match.flatMap(val -> Match.of(val, captures.add(Captures.of(capture, val))));
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Captures.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Captures.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import java.util.NoSuchElementException;
+
+public class Captures {
+
+    private static final Captures NIL = new Captures(null, null, null);
+
+    private final Capture<?> capture;
+    private final Object value;
+    private final Captures tail;
+
+    private Captures(Capture<?> capture, Object value, Captures tail) {
+        this.capture = capture;
+        this.value = value;
+        this.tail = tail;
+    }
+
+    public static Captures empty() {
+        return NIL;
+    }
+
+    public static <T> Captures of(Capture<T> capture, T value) {
+        return new Captures(capture, value, NIL);
+    }
+
+    public <T> T get(Capture<T> capture) {
+        if (this.equals(NIL)) {
+            throw new NoSuchElementException("Requested value for unknown Capture");
+        } else if (this.capture.equals(capture)) {
+            return (T) value;
+        } else {
+            return tail.get(capture);
+        }
+    }
+
+    public Captures add(Captures other) {
+        if (this.equals(NIL)) {
+            return other;
+        } else {
+            return new Captures(capture, value, tail.add(other));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Match.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Match.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+public abstract class Match<T> {
+
+    public static <T> Match<T> of(T value, Captures captures) {
+        return new Present<>(value, captures);
+    }
+
+    public static <T> Match<T> empty() {
+        //noinspection unchecked
+        return (Match<T>) Empty.INSTANCE;
+    }
+
+    public abstract Captures captures();
+
+    public abstract boolean isPresent();
+
+    public abstract T value();
+
+    public abstract <U> Match<U> map(Function<? super T, ? extends U> mapper);
+
+    public abstract <U> Match<U> flatMap(Function<? super T, Match<U>> mapper);
+
+    static class Present<T> extends Match<T> {
+
+        private final T value;
+        private final Captures captures;
+
+        Present(T value, Captures captures) {
+            this.value = value;
+            this.captures = captures;
+        }
+
+        @Override
+        public Captures captures() {
+            return captures;
+        }
+
+        @Override
+        public boolean isPresent() {
+            return true;
+        }
+
+        @Override
+        public T value() {
+            return value;
+        }
+
+        @Override
+        public <U> Match<U> map(Function<? super T, ? extends U> mapper) {
+            return Match.of(mapper.apply(value), captures);
+        }
+
+        @Override
+        public <U> Match<U> flatMap(Function<? super T, Match<U>> mapper) {
+            return mapper.apply(value);
+        }
+    }
+
+    static class Empty<T> extends Match<T> {
+
+        static final Empty INSTANCE = new Empty<>();
+
+        @Override
+        public Captures captures() {
+            return Captures.empty();
+        }
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+
+        @Override
+        public T value() {
+            throw new NoSuchElementException("Empty match contains no value");
+        }
+
+        @Override
+        public <U> Match<U> map(Function<? super T, ? extends U> mapper) {
+            return empty();
+        }
+
+        @Override
+        public <U> Match<U> flatMap(Function<? super T, Match<U>> mapper) {
+            return empty();
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public abstract class Pattern<T> {
+
+    public static <T> Pattern<T> typeOf(Class<T> expectedClass) {
+        return new TypeOfPattern<>(expectedClass);
+    }
+
+    public <U, V> Pattern<T> with(Function<? super T, Optional<U>> getProperty, Pattern<V> propertyPattern) {
+        return new WithPattern<>(this, getProperty, propertyPattern);
+    }
+
+    public Pattern<T> capturedAs(Capture<T> capture) {
+        return new CapturePattern<>(capture, this);
+    }
+
+    public abstract Match<T> accept(Object object, Captures captures);
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Patterns.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Patterns.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import io.crate.planner.operators.LogicalPlan;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class Patterns {
+
+    private Patterns() {
+    }
+
+    public static Function<LogicalPlan, Optional<LogicalPlan>> source() {
+        return plan -> plan.sources().size() == 1
+            ? Optional.of(plan.sources().get(0))
+            : Optional.empty();
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+class TypeOfPattern<T> extends Pattern<T> {
+
+    private Class<T> expectedClass;
+
+    TypeOfPattern(Class<T> expectedClass) {
+        this.expectedClass = expectedClass;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures) {
+        if (expectedClass.isInstance(object)) {
+            return Match.of(expectedClass.cast(object), captures);
+        } else {
+            return Match.empty();
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+class WithPattern<T, U, V> extends Pattern<T> {
+
+    private final Pattern<T> firstPattern;
+    private final Function<? super T, Optional<U>> getProperty;
+    private final Pattern<V> propertyPattern;
+
+    WithPattern(Pattern<T> firstPattern, Function<? super T, Optional<U>> getProperty, Pattern<V> propertyPattern) {
+        this.firstPattern = firstPattern;
+        this.getProperty = getProperty;
+        this.propertyPattern = propertyPattern;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures) {
+        Match<T> match = firstPattern.accept(object, captures);
+        return match.flatMap(matchedValue -> {
+            Optional<?> optProperty = getProperty.apply(matchedValue);
+            Match<V> propertyMatch = optProperty
+                .map(property -> propertyPattern.accept(property, match.captures()))
+                .orElse(Match.empty());
+            return propertyMatch.map(ignored -> match.value());
+        });
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+public class MergeFilterAndCollect implements Rule<Filter> {
+
+    private final Capture<Collect> collectCapture;
+    private final Pattern<Filter> pattern;
+
+    public MergeFilterAndCollect() {
+        this.collectCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Collect.class).capturedAs(collectCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter, Captures captures) {
+        Collect collect = captures.get(collectCapture);
+        return new Collect(
+            collect.relation(),
+            collect.outputs(),
+            collect.where().add(filter.query()),
+            collect.numExpectedRows(),
+            collect.estimatedRowSize()
+        );
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+/**
+ * Transforms
+ * <pre>
+ * - Filter
+ *   - Filter
+ *     - Source
+ * </pre>
+ * into
+ * <pre>
+ * - Filter
+ *   - Source
+ * </pre>
+ *
+ * By merging the conditions of both filters
+ */
+public class MergeFilters implements Rule<Filter> {
+
+    private final Capture<Filter> child;
+    private final Pattern<Filter> pattern;
+
+    public MergeFilters() {
+        child = new Capture<>();
+        pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Filter.class).capturedAs(child));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Filter apply(Filter plan, Captures captures) {
+        Filter childFilter = captures.get(child);
+        Symbol parentQuery = plan.query();
+        Symbol childQuery = childFilter.query();
+        return new Filter(childFilter.source(), AndOperator.of(parentQuery, childQuery));
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathBoundary.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathBoundary.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.OperatorUtils;
+import io.crate.planner.operators.RelationBoundary;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import java.util.List;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+public class MoveFilterBeneathBoundary implements Rule<Filter> {
+
+    private final Capture<RelationBoundary> boundary;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathBoundary() {
+        this.boundary = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(RelationBoundary.class).capturedAs(boundary));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter plan, Captures captures) {
+        RelationBoundary boundary = captures.get(this.boundary);
+        Filter newFilter = new Filter(
+            boundary.source(),
+            OperatorUtils.getMapper(boundary.expressionMapping()).apply(plan.query())
+        );
+        return boundary.replaceSources(List.of(newFilter));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -265,8 +265,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "HashJoin[\n" +
                                 "    Boundary[i, a]\n" +
                                 "    FetchOrEval[i, a]\n" +
-                                "    Filter[(a > '50')]\n" +
                                 "    Boundary[a, i]\n" +
+                                "    Filter[(a > '50')]\n" +
                                 "    Limit[5;0]\n" +
                                 "    OrderBy[a ASC]\n" +
                                 "    Collect[doc.t1 | [a, i] | All]\n" +

--- a/sql/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
+++ b/sql/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class CapturePatternTest {
+
+    @Test
+    public void testCapturePatternAddsToCaptureOnMatch() {
+        Filter filter = new Filter(mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
+
+        Capture<Filter> captureFilter = new Capture<>();
+        Pattern<Filter> filterPattern = Pattern.typeOf(Filter.class).capturedAs(captureFilter);
+        CapturePattern<Filter> pattern = new CapturePattern<>(captureFilter, filterPattern);
+
+        Match<Filter> match = pattern.accept(filter, Captures.empty());
+        Filter capturedFilter = match.captures().get(captureFilter);
+        assertThat(capturedFilter, Matchers.sameInstance(filter));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.analyze.QueriedTable;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.WhereClause;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MergeFiltersTest {
+
+    private SqlExpressions e;
+
+    @Before
+    public void setUp() throws Exception {
+        e = new SqlExpressions(T3.SOURCES);
+    }
+
+    @Test
+    public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
+        var table = new QueriedTable<>(false, T3.TR_1, new QuerySpec());
+        Collect source = new Collect(table, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
+        Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
+
+        MergeFilters mergeFilters = new MergeFilters();
+        Match<Filter> match = mergeFilters.pattern().accept(parentFilter, Captures.empty());
+
+        assertThat(match.isPresent(), Matchers.is(true));
+        assertThat(match.value(), Matchers.sameInstance(parentFilter));
+
+        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures());
+        assertThat(mergedFilter.query(), isSQL("((doc.t2.y > 10) AND (doc.t1.x > 10))"));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So far we have a couple of optimization rules as concrete implementation
within an operator (`LogicalPlan.tryOptimize`).

This is a first step to separate these rules from the operators
themselves.

The advantage of doing so is that we'll have more flexibility in regards
how we apply the rules and the implementation + testability of the rules
also becomes simpler. Each rule only needs to take care of one very
specific optimization, instead of having *all* possible optimizations
for an operator within the `tryOptimize` of that operator.

The `Rule`, `Pattern`, `Match`, `Captures` approach is heavily inspired
by Presto. (Except that I removed a lot of parts we don't need (yet))

The `Optimizer` itself is currently straight forward and can later on be
optimized further. (It only tries each rule after another, without any
re-iteration or other smarts)

As this is a first step it doesn't remove all `tryOptimize`
implementations and keeps some methods that will later on be removed
(E.g. the `updateSource` methods of `OneInputPlan` and `TwoInputPlan`)


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)