### PR TITLE
Optimize filters on views or subqueries

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -150,6 +150,9 @@ Deprecations
 Changes
 =======
 
+- Added a new optimization that allows to run predicates on top of views or
+  sub-queries more efficiently in some cases.
+
 - Allow :ref:`sql_administration_udf` to be registered against the
   ``pg_catalog`` schema.
 

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.FetchOrEval;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import java.util.List;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
+
+    private final Capture<FetchOrEval> fetchOrEvalCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathFetchOrEval() {
+        this.fetchOrEvalCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(FetchOrEval.class).capturedAs(fetchOrEvalCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter plan, Captures captures) {
+        FetchOrEval fetchOrEval = captures.get(fetchOrEvalCapture);
+        List<Symbol> outputsOfFetchSource = fetchOrEval.source().outputs();
+        if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {
+            return transpose(plan, fetchOrEval);
+        }
+        return null;
+    }
+}

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -125,16 +125,16 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections, Matchers.contains(
             instanceOf(TopNProjection.class),
-            instanceOf(EvalProjection.class),
             instanceOf(FilterProjection.class),
+            instanceOf(EvalProjection.class),
             instanceOf(OrderedTopNProjection.class),
             instanceOf(TopNProjection.class),
             instanceOf(FetchProjection.class)
         ));
-        assertThat(projections.get(1).outputs(), isSQL("INPUT(0), add(INPUT(1), INPUT(1))"));
-        FilterProjection filterProjection = (FilterProjection) projections.get(2);
+        assertThat(projections.get(2).outputs(), isSQL("INPUT(0), add(INPUT(1), INPUT(1))"));
+        FilterProjection filterProjection = (FilterProjection) projections.get(1);
         // filter is before fetch; preFetchOutputs: [_fetchId, add(x, x)]
-        assertThat(filterProjection.query(), isSQL("(INPUT(1) = 10)"));
+        assertThat(filterProjection.query(), isSQL("(add(INPUT(1), INPUT(1)) = 10)"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -686,7 +686,7 @@ public class SQLExecutor {
             // because the subRelations are not yet AnalyzedRelations.
             // we eventually should integrate normalize into unboundAnalyze.
             // But then we have to remove the whereClauseAnalyzer calls because they depend on all values being available
-            stmt = (AnalyzedStatement) new RelationNormalizer(functions)
+            stmt = new RelationNormalizer(functions)
                 .normalize((AnalyzedRelation) stmt, coordinatorTxnCtx);
         }
         return (T) planner.plan(stmt, getPlannerContext(planner.currentClusterState()));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a new optimization rule `MoveFilterBeneathFetchOrEval` to
optimize `Filter -> FetchOrEval -> X` to `FetchOrEval -> Filter -> X`

This in turn enables other already existing rules, most importantly
`MergeFilterAndCollect` which enables us to utilize Lucene indices to
run the filters efficiently and also runs an optimization to narrow the
partitions being searched to those that can match the filter.

This optimization is particularly important to work efficiently with
views.


I'm also thinking about having some column pruning rules and maybe even handle the _fetch optimizations as rules. But that is a bit farther down in the agenda (I want to first get the join rules in place)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)