### PR TITLE
Add a rule to push filters beneath order operators

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -72,6 +72,7 @@ import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
@@ -102,6 +103,7 @@ public class LogicalPlanner {
         new MergeFilters(),
         new MoveFilterBeneathBoundary(),
         new MoveFilterBeneathFetchOrEval(),
+        new MoveFilterBeneathOrder(),
         new MergeFilterAndCollect(),
         new MoveOrderBeneathUnion(),
         new MoveOrderBeneathNestedLoop(),

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+/**
+ * Transforms
+ *
+ * <pre>
+ *     Filter
+ *     |
+ *     Order
+ *     |
+ *     X
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ *     Order
+ *     |
+ *     Filter
+ *     |
+ *     X
+ * </pre>
+ *
+ * Which is always safe to do as Order doesn't produce new outputs and the order operation becomes cheaper if we can
+ * remove data up-front.
+ */
+public final class MoveFilterBeneathOrder implements Rule<Filter> {
+
+    private final Capture<Order> orderCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathOrder() {
+        this.orderCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Order.class).capturedAs(orderCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter, Captures captures) {
+        return transpose(filter, captures.get(orderCapture));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.TableDefinitions;
 import io.crate.exceptions.UnsupportedFeatureException;

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -169,6 +169,17 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testFilterIsMovedBeneathOrder() {
+        LogicalPlan plan = plan("select * from (select * from t1 order by a) tt where a > 10");
+        assertThat(plan, isPlan(sqlExecutor.functions(),
+            "FetchOrEval[a, x, i]\n" +
+            "Boundary[_fetchid, a]\n" +
+            "OrderBy[a ASC]\n" +
+            "Collect[doc.t1 | [_fetchid, a] | (a > '10')]\n"
+        ));
+    }
+
+    @Test
     public void testOrderByOnJoinOuterJoinInvolvedNotPushedDown() {
         LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
                                 "inner join t2 on t1.a = t2.b " +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This optimizes queries like

    select * from (select * from t1 order by a) tt where a > 10

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)