### PR TITLE
Change collect operator to depend on table instead of queried-table

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -432,6 +432,9 @@ public class FetchOrEval implements LogicalPlan {
                 } else {
                     relation = field.relation();
                 }
+                if (relation instanceof DocTableRelation) {
+                    return (DocTableRelation) relation;
+                }
                 if (relation instanceof QueriedTable
                     && ((QueriedTable) relation).tableRelation() instanceof DocTableRelation) {
                     return ((DocTableRelation) ((QueriedTable) relation).tableRelation());

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -154,9 +154,6 @@ public class FetchOrEval implements LogicalPlan {
                     source = sourceBuilder.build(tableStats, usedBeforeNextFetch);
                 }
             }
-            if (source.outputs().equals(outputs)) {
-                return source;
-            }
             if (!doFetch && Symbols.containsColumn(source.outputs(), DocSysColumns.FETCHID)) {
                 if (usedBeforeNextFetch.isEmpty()) {
                     return new FetchOrEval(source, source.outputs(), fetchMode, false);
@@ -246,10 +243,6 @@ public class FetchOrEval implements LogicalPlan {
         ExecutionPlan executionPlan = source.build(
             plannerContext, projectionBuilder, limit, offset, null, pageSizeHint, params, subQueryResults);
         List<Symbol> sourceOutputs = source.outputs();
-        if (sourceOutputs.equals(outputs)) {
-            return executionPlan;
-        }
-
         if (doFetch && Symbols.containsColumn(sourceOutputs, DocSysColumns.FETCHID)) {
             return planWithFetch(plannerContext, executionPlan, sourceOutputs, params, subQueryResults);
         }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -302,13 +302,13 @@ public class LogicalPlanner {
                     return (tableStats, usedBeforeNextFetch) ->
                         new Get(queriedTable, docKeys.get(), toCollect, tableStats);
                 }
-                return Collect.create(queriedTable, toCollect, new WhereClause(
+                return Collect.create(queriedTable.tableRelation(), toCollect, new WhereClause(
                     detailedQuery.query(),
                     where.partitions(),
                     detailedQuery.clusteredBy()
                 ));
             }
-            return Collect.create(queriedTable, toCollect, where);
+            return Collect.create(queriedTable.tableRelation(), toCollect, where);
         }
         if (analyzedRelation instanceof MultiSourceSelect) {
             return JoinPlanBuilder.createNodes((MultiSourceSelect) analyzedRelation, where, subqueryPlanner, functions, txnCtx);

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -76,6 +76,7 @@ import io.crate.planner.optimizer.rule.MoveOrderBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
+import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -96,6 +97,7 @@ public class LogicalPlanner {
 
     public static final int NO_LIMIT = -1;
     private static final Optimizer OPTIMIZER = new Optimizer(List.of(
+        new RemoveRedundantFetchOrEval(),
         new MergeAggregateAndCollectToCount(),
         new MergeFilters(),
         new MoveFilterBeneathBoundary(),

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -45,7 +45,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
         this.collectCapture = new Capture<>();
         this.pattern = typeOf(HashAggregate.class)
             .with(source(), typeOf(Collect.class).capturedAs(collectCapture)
-                .with(collect -> collect.relation().tableRelation().tableInfo() instanceof DocTableInfo))
+                .with(collect -> collect.relation().tableInfo() instanceof DocTableInfo))
             .with(aggregate ->
                 aggregate.aggregates().size() == 1
                 && aggregate.aggregates().get(0).info().equals(CountAggregation.COUNT_STAR_FUNCTION));
@@ -59,10 +59,6 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     @Override
     public Count apply(HashAggregate aggregate, Captures captures) {
         Collect collect = captures.get(collectCapture);
-        return new Count(
-            Lists2.getOnlyElement(aggregate.aggregates()),
-            collect.relation().tableRelation(),
-            collect.where()
-        );
+        return new Count(Lists2.getOnlyElement(aggregate.aggregates()), collect.relation(), collect.where());
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.planner.operators.FetchOrEval;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+/**
+ * Eliminates any FetchOrEval nodes that have the same output as their source
+ */
+public final class RemoveRedundantFetchOrEval implements Rule<FetchOrEval> {
+
+    private final Pattern<FetchOrEval> pattern;
+
+    public RemoveRedundantFetchOrEval() {
+        this.pattern = typeOf(FetchOrEval.class)
+            .with(fetchOrEval -> fetchOrEval.outputs().equals(fetchOrEval.source().outputs()));
+    }
+
+    @Override
+    public Pattern<FetchOrEval> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(FetchOrEval plan, Captures captures) {
+        return plan.source();
+    }
+}

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -860,11 +860,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[id, name, date, obj]\n" +
             "FetchOrEval[id, name, date, obj]\n" +
             "Boundary[_fetchid, date]\n" +
-            "FetchOrEval[_fetchid, date]\n" +
             "Collect[doc.parted | [_fetchid, date] | date IS NULL]\n"
         ));
         QueryThenFetch qtf = e.plan(statement);
-        Collect collect = ((Collect) qtf.subPlan());
+        ExecutionPlan subPlan = qtf.subPlan();
+        Collect collect = subPlan instanceof Collect ? (Collect) subPlan : (Collect) ((Merge) subPlan).subPlan();
         RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collect.collectPhase();
 
         int numShards = 0;

--- a/sql/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -53,7 +53,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan plan = Limit.create(
             Limit.create(
-                Collect.create(queriedDocTable, queriedDocTable.outputs(), queriedDocTable.where()),
+                Collect.create(queriedDocTable.tableRelation(), queriedDocTable.outputs(), queriedDocTable.where()),
                 Literal.of(10L),
                 Literal.of(5L)
             ),

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -203,7 +203,6 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "OrderBy[x ASC]\n" +
                                 "HashJoin[\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Collect[doc.t1 | [_fetchid, x] | All]\n" +
                                 "    --- INNER ---\n" +
                                 "    Boundary[y]\n" +
@@ -288,19 +287,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan("FetchOrEval[x, a, x, a]\n" +
                                 "HashJoin[\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Collect[doc.t1 | [_fetchid, x] | All]\n" +
                                 "    --- INNER ---\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Boundary[_fetchid, x]\n" +
-                                "    FetchOrEval[_fetchid, x]\n" +
                                 "    Collect[doc.t1 | [_fetchid, x] | All]\n" +
                                 "]\n"));
     }

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -133,12 +133,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan(sqlExecutor.functions(), "FetchOrEval[y, b, i]\n" +
                                                          "NestedLoopJoin[\n" +
                                                          "    Boundary[_fetchid, a, x]\n" +
-                                                         "    FetchOrEval[_fetchid, a, x]\n" +
                                                          "    OrderBy[x DESC]\n" +
                                                          "    Collect[doc.t1 | [_fetchid, a, x] | All]\n" +
                                                          "    --- INNER ---\n" +
                                                          "    Boundary[_fetchid, b]\n" +
-                                                         "    FetchOrEval[_fetchid, b]\n" +
                                                          "    Collect[doc.t2 | [_fetchid, b] | All]\n]" +
                                                          "\n"));
     }
@@ -231,9 +229,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                 "    Collect[doc.t2 | [_fetchid, y, b] | All]\n" +
                 "    --- INNER ---\n" +
                 "    Boundary[_fetchid, x]\n" +
-                "    FetchOrEval[_fetchid, x]\n" +
                 "    Boundary[_fetchid, x]\n" +
-                "    FetchOrEval[_fetchid, x]\n" +
                 "    Collect[doc.t1 | [_fetchid, x] | All]\n" +
                 "]\n")
         );

--- a/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -22,8 +22,6 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.analyze.QueriedTable;
-import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
@@ -51,8 +49,7 @@ public class MergeFiltersTest {
 
     @Test
     public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
-        var table = new QueriedTable<>(false, T3.TR_1, new QuerySpec());
-        Collect source = new Collect(table, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Collect source = new Collect(T3.TR_1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
         Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
         Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

First commit will be required to move the predicate push downs from the
analyzer to the new rule based optimizer.

Second commit is mostly a cosmetic change (see commit message for
details)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)