### PR TITLE
Cleanup repository settings definitions - fs,url,s3

### DIFF
--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -32,13 +32,14 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 /**
  * A container for settings used to create an S3 client.
  */
-final class S3ClientSettings {
+public final class S3ClientSettings {
 
     private static final String DEFAULT = "default";
 
@@ -100,6 +101,13 @@ final class S3ClientSettings {
     static final Setting<Boolean> USE_THROTTLE_RETRIES_SETTING = Setting.boolSetting(DEFAULT_PREFIX + "use_throttle_retries",
                                                                                      ClientConfiguration.DEFAULT_THROTTLE_RETRIES,
                                                                                      Property.NodeScope);
+    public static List<Setting> optionalSettings() {
+        return List.of(ENDPOINT_SETTING,
+                       PROTOCOL_SETTING,
+                       MAX_RETRIES_SETTING,
+                       USE_THROTTLE_RETRIES_SETTING);
+    }
+
     /** Credentials to authenticate with s3. */
     final AWSCredentials credentials;
 

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -38,6 +38,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -53,7 +54,7 @@ import java.util.function.Function;
  * <dt>{@code compress}</dt><dd>If set to true metadata files will be stored compressed. Defaults to false.</dd>
  * </dl>
  */
-class S3Repository extends BlobStoreRepository {
+public class S3Repository extends BlobStoreRepository {
 
     private static final Logger LOGGER = LogManager.getLogger(S3Repository.class);
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(LOGGER);
@@ -142,6 +143,19 @@ class S3Repository extends BlobStoreRepository {
      * Specifies the path within bucket to repository data. Defaults to root directory.
      */
     static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path");
+
+    public static List<Setting> optionalSettings() {
+        return List.of(ACCESS_KEY_SETTING,
+                       SECRET_KEY_SETTING,
+                       BASE_PATH_SETTING,
+                       BUCKET_SETTING,
+                       CLIENT_NAME,
+                       BUFFER_SIZE_SETTING,
+                       CANNED_ACL_SETTING,
+                       CHUNK_SIZE_SETTING,
+                       COMPRESS_SETTING,
+                       SERVER_SIDE_ENCRYPTION_SETTING);
+    }
 
     private final S3Service service;
 

--- a/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -53,7 +53,7 @@ import java.util.function.Function;
  */
 public class URLRepository extends BlobStoreRepository {
 
-    private static final Logger logger = LogManager.getLogger(URLRepository.class);
+    private static final Logger LOGGER = LogManager.getLogger(URLRepository.class);
 
     public static final String TYPE = "url";
 
@@ -68,6 +68,10 @@ public class URLRepository extends BlobStoreRepository {
     public static final Setting<URL> REPOSITORIES_URL_SETTING =
         new Setting<>("repositories.url.url", (s) -> s.get("repositories.uri.url", "http:"), URLRepository::parseURL,
             Property.NodeScope);
+
+    public static List<Setting> mandatorySettings() {
+        return List.of(URL_SETTING);
+    }
 
     private final List<String> supportedProtocols;
 
@@ -136,7 +140,7 @@ public class URLRepository extends BlobStoreRepository {
                         return url;
                     }
                 } catch (URISyntaxException ex) {
-                    logger.warn("cannot parse the specified url [{}]", url);
+                    LOGGER.warn("cannot parse the specified url [{}]", url);
                     throw new RepositoryException(getMetadata().name(), "cannot parse the specified url [" + url + "]");
                 }
                 // We didn't match white list - try to resolve against path.repo
@@ -144,7 +148,7 @@ public class URLRepository extends BlobStoreRepository {
                 if (normalizedUrl == null) {
                     String logMessage = "The specified url [{}] doesn't start with any repository paths specified by the " +
                         "path.repo setting or by {} setting: [{}] ";
-                    logger.warn(logMessage, url, ALLOWED_URLS_SETTING.getKey(), environment.repoFiles());
+                    LOGGER.warn(logMessage, url, ALLOWED_URLS_SETTING.getKey(), environment.repoFiles());
                     String exceptionMessage = "file url [" + url + "] doesn't match any of the locations specified by path.repo or "
                         + ALLOWED_URLS_SETTING.getKey();
                     throw new RepositoryException(getMetadata().name(), exceptionMessage);

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -997,6 +998,16 @@ public class Setting<T> implements ToXContentObject {
             logSettingUpdate(Setting.this, current, previous, logger);
             consumer.accept(value);
         }
+    }
+
+    public Setting<T> copyAndRename(UnaryOperator<String> keyOperator) {
+        assert (isGroupSetting() == false) : "Can only be applied to concrete settings";
+        return new Setting<>(new SimpleKey(keyOperator.apply(getKey())),
+                             fallbackSetting,
+                             defaultValue,
+                             parser,
+                             validator,
+                             properties.toArray(new Property[0]));
     }
 
     public static Setting<Version> versionSetting(final String key, final Version defaultValue, Property... properties) {

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -34,6 +34,7 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -61,6 +62,14 @@ public class FsRepository extends BlobStoreRepository {
             new ByteSizeValue(Long.MAX_VALUE), new ByteSizeValue(5), new ByteSizeValue(Long.MAX_VALUE), Property.NodeScope);
     public static final Setting<ByteSizeValue> REPOSITORIES_CHUNK_SIZE_SETTING = Setting.byteSizeSetting("repositories.fs.chunk_size",
         new ByteSizeValue(Long.MAX_VALUE), new ByteSizeValue(5), new ByteSizeValue(Long.MAX_VALUE), Property.NodeScope);
+
+    public static List<Setting> mandatorySettings() {
+        return List.of(LOCATION_SETTING);
+    }
+
+    public static List<Setting> optionalSettings() {
+        return List.of(COMPRESS_SETTING, CHUNK_SIZE_SETTING);
+    }
 
     private final Environment environment;
 

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // They also need to be added in :app because :sql is declared non-transitive
     // in :app (=dependencies of :sql won't be included).
     compile project(":es:es-repository-url")
+    compile project(":es:es-repository-s3")
     compile project(":es:es-analysis-common")
 }
 //noinspection GroovyAssignabilityCheck

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -62,8 +62,9 @@ public class RepositorySettingsModule extends AbstractModule {
     );
 
     private static final TypeSettings URL_SETTINGS = new TypeSettings(
-        ImmutableMap.of("url", URLRepository.URL_SETTING),
-        Collections.emptyMap());
+        groupSettingsByKey(URLRepository.mandatorySettings()),
+        Map.of()
+    );
 
     private static final TypeSettings HDFS_SETTINGS = new TypeSettings(
         Collections.emptyMap(),

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -22,8 +22,8 @@
 
 package io.crate.analyze.repositories;
 
-import com.amazonaws.Protocol;
 import com.google.common.collect.ImmutableMap;
+import io.crate.common.collections.Maps;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GenericProperty;
@@ -34,13 +34,13 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.repositories.s3.S3ClientSettings;
+import org.elasticsearch.repositories.s3.S3Repository;
 import org.elasticsearch.repositories.url.URLRepository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -95,42 +95,13 @@ public class RepositorySettingsModule extends AbstractModule {
         }
     };
 
-    /**
-     * Default is to use 100MB (S3 defaults) for heaps above 2GB and 5% of
-     * the available memory for smaller heaps.
-     */
-    private static final ByteSizeValue S3_DEFAULT_BUFFER_SIZE = new ByteSizeValue(
-        Math.max(
-            ByteSizeUnit.MB.toBytes(5), // minimum value
-            Math.min(
-                ByteSizeUnit.MB.toBytes(100),
-                JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 20)),
-        ByteSizeUnit.BYTES);
-
-
     private static final TypeSettings S3_SETTINGS = new TypeSettings(
-        Collections.emptyMap(),
-        ImmutableMap.<String, Setting>builder()
-            .put("base_path", Setting.simpleString("base_path"))
-            .put("bucket", Setting.simpleString("bucket"))
-            .put("client", Setting.simpleString("client"))
-            .put("buffer_size", Setting.byteSizeSetting("buffer_size", S3_DEFAULT_BUFFER_SIZE,
-                new ByteSizeValue(5, ByteSizeUnit.MB), new ByteSizeValue(5, ByteSizeUnit.GB)))
-            .put("canned_acl", Setting.simpleString("canned_acl"))
-            .put("chunk_size", Setting.byteSizeSetting("chunk_size", new ByteSizeValue(1, ByteSizeUnit.GB),
-                new ByteSizeValue(5, ByteSizeUnit.MB), new ByteSizeValue(5, ByteSizeUnit.TB)))
-            .put("compress", Setting.boolSetting("compress", true)) // TODO: ES defaults to false!
-            .put("server_side_encryption",
-                Setting.boolSetting("server_side_encryption", false))
+        Map.of(),
+        Maps.concat(
+            groupSettingsByKey(S3Repository.optionalSettings()),
             // client related settings
-            .put("access_key", SecureSetting.insecureString("access_key"))
-            .put("secret_key", SecureSetting.insecureString("secret_key"))
-            .put("endpoint", Setting.simpleString("endpoint")
-            )
-            .put("protocol", new Setting<>("protocol", "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT))))
-            .put("max_retries", Setting.intSetting("max_retries", 3))
-            .put("use_throttle_retries", Setting.boolSetting("use_throttle_retries", true))
-            .build());
+            groupSettingsByKey(renameSettingsUsingSuffixAsKey(S3ClientSettings.optionalSettings()))
+        ));
 
     private static final TypeSettings AZURE_SETTINGS = new TypeSettings(
         Collections.emptyMap(),
@@ -174,5 +145,25 @@ public class RepositorySettingsModule extends AbstractModule {
 
     private static Map<String, Setting> groupSettingsByKey(List<Setting> settings) {
         return settings.stream().collect(Collectors.toMap(Setting::getKey, Function.identity()));
+    }
+
+    /**
+     * Copy and rename {@link Setting}s.
+     * For each Setting, a new Setting is created
+     * with it's key suffix acting as the new key
+     *
+     * eg. From Setting: s3.client.default.endpoint
+     * a new Setting will be created with same characteristics
+     * and new key name: endpoint
+     */
+    private static List<Setting> renameSettingsUsingSuffixAsKey(List<Setting> settings) {
+        return settings
+            .stream()
+            .map(s -> s.copyAndRename(k -> getSuffixOrInput((String) k)))
+            .collect(Collectors.toList());
+    }
+
+    private static String getSuffixOrInput(String str) {
+        return str.substring(str.lastIndexOf('.') + 1);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -39,8 +39,11 @@ import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.repositories.url.URLRepository;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
 
@@ -54,11 +57,9 @@ public class RepositorySettingsModule extends AbstractModule {
     private static final String AZURE = "azure";
 
     private static final TypeSettings FS_SETTINGS = new TypeSettings(
-        ImmutableMap.of("location", FsRepository.LOCATION_SETTING),
-        ImmutableMap.of(
-            "compress", FsRepository.COMPRESS_SETTING,
-            "chunk_size", FsRepository.CHUNK_SIZE_SETTING
-        ));
+        groupSettingsByKey(FsRepository.mandatorySettings()),
+        groupSettingsByKey(FsRepository.optionalSettings())
+    );
 
     private static final TypeSettings URL_SETTINGS = new TypeSettings(
         ImmutableMap.of("url", URLRepository.URL_SETTING),
@@ -168,5 +169,9 @@ public class RepositorySettingsModule extends AbstractModule {
         typeSettingsBinder.addBinding(HDFS).toInstance(HDFS_SETTINGS);
         typeSettingsBinder.addBinding(S3).toInstance(S3_SETTINGS);
         typeSettingsBinder.addBinding(AZURE).toInstance(AZURE_SETTINGS);
+    }
+
+    private static Map<String, Setting> groupSettingsByKey(List<Setting> settings) {
+        return settings.stream().collect(Collectors.toMap(Setting::getKey, Function.identity()));
     }
 }


### PR DESCRIPTION

Cleaning up the repo settings definitions to use existing definitions whenever possible.


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
