### PR TITLE
Tweak authentication failure logging

### DIFF
--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -116,6 +116,10 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
                 authorizedUser = username;
                 ctx.fireChannelRead(request);
             } catch (Exception e) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("Password authentication failed for user={} from connection={}",
+                                username, connectionProperties.address());
+                }
                 sendUnauthorized(ctx.channel(), e.getMessage());
             }
         }
@@ -133,7 +137,6 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
 
     @VisibleForTesting
     static void sendUnauthorized(Channel channel, @Nullable String body) {
-        LOGGER.warn(body == null ? "unauthorized http chunk" : body);
         HttpResponse response;
         if (body != null) {
             if (!body.endsWith("\n")) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We usually see a pair of logs like this:

```
[2019-05-05T17:16:04,447][WARN ][i.c.p.h.HttpAuthUpstreamHandler] password authentication failed for user "crate"
[2019-05-05T17:16:04,447][WARN ][i.c.p.h.HttpAuthUpstreamHandler] unauthorized http chunk
```

This removes the "unauthorized http chunk" as it usually follows the
first log entry, and extends the first log entry to include connection
details.

It also changes the log level to info as this usually doesn't require
any intervention from an administrator.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)