### PR TITLE
Add a rule to move filters beneath hash joins

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
 
 import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
-class HashJoin implements LogicalPlan {
+public class HashJoin implements LogicalPlan {
 
     private final Symbol joinCondition;
     private final TableStats tableStats;
@@ -71,11 +71,11 @@ class HashJoin implements LogicalPlan {
     final LogicalPlan lhs;
     private final Map<Symbol, Symbol> expressionMapping;
 
-    HashJoin(LogicalPlan lhs,
-             LogicalPlan rhs,
-             Symbol joinCondition,
-             AnalyzedRelation concreteRelation,
-             TableStats tableStats) {
+    public HashJoin(LogicalPlan lhs,
+                    LogicalPlan rhs,
+                    Symbol joinCondition,
+                    AnalyzedRelation concreteRelation,
+                    TableStats tableStats) {
         this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         this.lhs = lhs;
         this.rhs = rhs;
@@ -85,12 +85,20 @@ class HashJoin implements LogicalPlan {
         this.expressionMapping = Maps.concat(lhs.expressionMapping(), rhs.expressionMapping());
     }
 
-    JoinType joinType() {
+    public JoinType joinType() {
         return JoinType.INNER;
     }
 
-    Symbol joinCondition() {
+    public Symbol joinCondition() {
         return joinCondition;
+    }
+
+    public LogicalPlan lhs() {
+        return lhs;
+    }
+
+    public LogicalPlan rhs() {
+        return rhs;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -72,6 +72,7 @@ import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathHashJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
@@ -109,7 +110,8 @@ public class LogicalPlanner {
         new MoveOrderBeneathNestedLoop(),
         new MoveOrderBeneathBoundary(),
         new MoveOrderBeneathFetchOrEval(),
-        new DeduplicateOrder()
+        new DeduplicateOrder(),
+        new MoveFilterBeneathHashJoin()
     ));
 
     private final OptimizingRewriter optimizingRewriter;

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -73,6 +73,7 @@ import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathHashJoin;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
@@ -105,13 +106,14 @@ public class LogicalPlanner {
         new MoveFilterBeneathBoundary(),
         new MoveFilterBeneathFetchOrEval(),
         new MoveFilterBeneathOrder(),
+        new MoveFilterBeneathHashJoin(),
+        new MoveFilterBeneathNestedLoop(),
         new MergeFilterAndCollect(),
         new MoveOrderBeneathUnion(),
         new MoveOrderBeneathNestedLoop(),
         new MoveOrderBeneathBoundary(),
         new MoveOrderBeneathFetchOrEval(),
-        new DeduplicateOrder(),
-        new MoveFilterBeneathHashJoin()
+        new DeduplicateOrder()
     ));
 
     private final OptimizingRewriter optimizingRewriter;

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.sql.tree.QualifiedName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class FilterOnJoinsUtil {
+
+    private FilterOnJoinsUtil() {
+    }
+
+    private static Set<QualifiedName> getRelationNames(LogicalPlan plan) {
+        return plan.baseTables().stream().map(AnalyzedRelation::getQualifiedName).collect(Collectors.toSet());
+    }
+
+    private static LogicalPlan getNewSource(Symbol splitQuery, LogicalPlan source) {
+        return splitQuery == null ? source : new Filter(source, splitQuery);
+    }
+
+    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join) {
+        Map<Set<QualifiedName>, Symbol> splitQuery = QuerySplitter.split(query);
+        if (splitQuery.size() == 1 && splitQuery.keySet().iterator().next().size() > 1) {
+            return null;
+        }
+        assert join.sources().size() == 2 : "Join operator must only have 2 children, LHS and RHS";
+        LogicalPlan lhs = join.sources().get(0);
+        LogicalPlan rhs = join.sources().get(1);
+        Set<QualifiedName> leftName = getRelationNames(lhs);
+        Set<QualifiedName> rightName = getRelationNames(rhs);
+        Symbol queryForLhs = splitQuery.remove(leftName);
+        Symbol queryForRhs = splitQuery.remove(rightName);
+        LogicalPlan newLhs = getNewSource(queryForLhs, lhs);
+        LogicalPlan newRhs = getNewSource(queryForRhs, rhs);
+        LogicalPlan newJoin = join.replaceSources(List.of(newLhs, newRhs));
+        if (splitQuery.isEmpty()) {
+            return newJoin;
+        } else {
+            return new Filter(newJoin, AndOperator.join(splitQuery.values()));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.QualifiedName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
+
+    private final Capture<HashJoin> joinCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathHashJoin() {
+        this.joinCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(HashJoin.class).capturedAs(joinCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter, Captures captures) {
+        HashJoin hashJoin = captures.get(joinCapture);
+        Symbol query = filter.query();
+        Map<Set<QualifiedName>, Symbol> splitQuery = QuerySplitter.split(query);
+        if (splitQuery.size() == 1 && splitQuery.keySet().iterator().next().size() > 1) {
+            return null;
+        }
+        Set<QualifiedName> leftName = getName(hashJoin.lhs());
+        Set<QualifiedName> rightName = getName(hashJoin.rhs());
+        Symbol queryForLhs = splitQuery.remove(leftName);
+        Symbol queryForRhs = splitQuery.remove(rightName);
+        LogicalPlan newLhs = getNewSource(queryForLhs, hashJoin.lhs());
+        LogicalPlan newRhs = getNewSource(queryForRhs, hashJoin.rhs());
+        LogicalPlan newJoin = hashJoin.replaceSources(List.of(newLhs, newRhs));
+        if (splitQuery.isEmpty()) {
+            return newJoin;
+        } else {
+            return new Filter(newJoin, AndOperator.join(splitQuery.values()));
+        }
+    }
+
+    private static Set<QualifiedName> getName(LogicalPlan plan) {
+        return plan.baseTables().stream().map(AnalyzedRelation::getQualifiedName).collect(Collectors.toSet());
+    }
+
+    private static LogicalPlan getNewSource(Symbol splitQuery, LogicalPlan source) {
+        return splitQuery == null ? source : new Filter(source, splitQuery);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently we do an eager predicate push-down in the
`RelationNormalizer`. (`MultiSourceSelect.createWithPushDown`)

This commit adds the same logic based on the optimization rule
framework. This has the advantage that it also works for more complex
queries that involve sub-queries.

This doesn't yet remove the logic from the `RelationNormalizer` as it is
still required for the outer-to-inner-join rewrite to work.

Once we've the outer-to-inner-join rewrite also done as part of an
optimization rule, we can remove the push-down logic from the
`RelationNormalizer`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)