### PR TITLE
Cleaned up repository loggers

### DIFF
--- a/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -134,7 +134,7 @@ public final class HdfsRepository extends BlobStoreRepository {
             }
         });
 
-        logger.debug("Using file-system [{}] for URI [{}], path [{}]", fileContext.getDefaultFileSystem(),
+        LOGGER.debug("Using file-system [{}] for URI [{}], path [{}]", fileContext.getDefaultFileSystem(),
                 fileContext.getDefaultFileSystem().getUri(), path);
 
         try {

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -55,8 +55,8 @@ import java.util.function.Function;
  */
 class S3Repository extends BlobStoreRepository {
 
-    private static final Logger logger = LogManager.getLogger(S3Repository.class);
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+    private static final Logger LOGGER = LogManager.getLogger(S3Repository.class);
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(LOGGER);
 
     static final String TYPE = "s3";
 
@@ -212,7 +212,7 @@ class S3Repository extends BlobStoreRepository {
         this.clientName = CLIENT_NAME.get(metadata.settings());
 
         if (CLIENT_NAME.exists(metadata.settings()) && S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
-            logger.warn(
+            LOGGER.warn(
                     "ignoring use of named client [{}] for repository [{}] as insecure credentials were specified",
                     clientName,
                     metadata.name());
@@ -220,7 +220,7 @@ class S3Repository extends BlobStoreRepository {
 
         if (S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
             // provided repository settings
-            deprecationLogger.deprecated("Using s3 access/secret key from repository settings. Instead "
+            DEPRECATION_LOGGER.deprecated("Using s3 access/secret key from repository settings. Instead "
                     + "store these in named clients and the CrateDB keystore for secure settings.");
             final BasicAWSCredentials insecureCredentials = S3ClientSettings.loadDeprecatedCredentials(metadata.settings());
             final S3ClientSettings s3ClientSettings = S3ClientSettings.getClientSettings(metadata, insecureCredentials);
@@ -229,7 +229,7 @@ class S3Repository extends BlobStoreRepository {
             reference = null;
         }
 
-        logger.debug(
+        LOGGER.debug(
                 "using bucket [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], cannedACL [{}], storageClass [{}]",
                 bucket,
                 chunkSize,

--- a/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.repositories.url;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -50,6 +52,8 @@ import java.util.function.Function;
  * </dl>
  */
 public class URLRepository extends BlobStoreRepository {
+
+    private static final Logger logger = LogManager.getLogger(URLRepository.class);
 
     public static final String TYPE = "url";
 

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.repositories.fs;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -46,6 +48,8 @@ import java.util.function.Function;
  * </dl>
  */
 public class FsRepository extends BlobStoreRepository {
+
+    private static final Logger LOGGER = LogManager.getLogger(FsRepository.class);
 
     public static final String TYPE = "fs";
 
@@ -77,19 +81,19 @@ public class FsRepository extends BlobStoreRepository {
         this.environment = environment;
         String location = REPOSITORIES_LOCATION_SETTING.get(metadata.settings());
         if (location.isEmpty()) {
-            logger.warn("the repository location is missing, it should point to a shared file system location"
+            LOGGER.warn("the repository location is missing, it should point to a shared file system location"
                 + " that is available on all master and data nodes");
             throw new RepositoryException(metadata.name(), "missing location");
         }
         Path locationFile = environment.resolveRepoFile(location);
         if (locationFile == null) {
             if (environment.repoFiles().length > 0) {
-                logger.warn("The specified location [{}] doesn't start with any "
+                LOGGER.warn("The specified location [{}] doesn't start with any "
                     + "repository paths specified by the path.repo setting: [{}] ", location, environment.repoFiles());
                 throw new RepositoryException(metadata.name(), "location [" + location
                     + "] doesn't match any of the locations specified by path.repo");
             } else {
-                logger.warn("The specified location [{}] should start with a repository path specified by"
+                LOGGER.warn("The specified location [{}] should start with a repository path specified by"
                     + " the path.repo setting, but the path.repo setting was not set on this node", location);
                 throw new RepositoryException(metadata.name(), "location [" + location
                     + "] doesn't match any of the locations specified by path.repo because this setting is empty");


### PR DESCRIPTION
Each repo should use its own logger.
In the case of 'HdfsRepository', it was using both its own logger and also the one inherited from its base class.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
