### PR TITLE
Remove querySpec property from AnalyzedRelation

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CopyFromReturnSummaryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CopyFromReturnSummaryAnalyzedStatement.java
@@ -95,8 +95,47 @@ public class CopyFromReturnSummaryAnalyzedStatement extends CopyFromAnalyzedStat
     }
 
     @Override
-    public QuerySpec querySpec() {
-        throw new UnsupportedOperationException("COPY FROM has no QuerySpec");
+    public List<Symbol> outputs() {
+        return List.copyOf(fields);
+    }
+
+    @Override
+    public WhereClause where() {
+        return WhereClause.MATCH_ALL;
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return List.of();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return null;
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return false;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
@@ -43,15 +44,14 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     final AnalyzedStatement statement;
     private final List<Field> fields;
     private final ProfilingContext context;
-    private final QuerySpec querySpec;
+    private final List<Symbol> outputs;
 
     ExplainAnalyzedStatement(String columnName, AnalyzedStatement statement, ProfilingContext context) {
         Field field = new Field(this, new OutputName(columnName), ObjectType.untyped());
         this.statement = statement;
         this.fields = Collections.singletonList(field);
         this.context = context;
-        this.querySpec = new QuerySpec()
-            .outputs(List.of(field));
+        this.outputs = List.of(field);
     }
 
     @Override
@@ -99,8 +99,47 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return querySpec;
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public WhereClause where() {
+        return WhereClause.MATCH_ALL;
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return List.of();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return null;
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return false;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -35,6 +35,9 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+
+import static com.google.common.collect.Lists.transform;
 
 public final class QueriedTable<TR extends AbstractTableRelation> implements AnalyzedRelation {
 
@@ -61,8 +64,13 @@ public final class QueriedTable<TR extends AbstractTableRelation> implements Ana
         this(isDistinct, tableRelation, Relations.namesFromOutputs(querySpec.outputs()), querySpec);
     }
 
-    public QuerySpec querySpec() {
-        return querySpec;
+    public QueriedTable<TR> map(Function<? super Symbol, ? extends Symbol> mapper) {
+        return new QueriedTable<>(
+            isDistinct,
+            tableRelation,
+            transform(fields.asList(), Field::path),
+            querySpec.copyAndReplace(mapper)
+        );
     }
 
     @Override
@@ -101,6 +109,50 @@ public final class QueriedTable<TR extends AbstractTableRelation> implements Ana
     @Override
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
         tableRelation.setQualifiedName(qualifiedName);
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return querySpec.outputs();
+    }
+
+    @Override
+    public WhereClause where() {
+        return querySpec.where();
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return querySpec.groupBy();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return querySpec.having();
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return querySpec.orderBy();
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return querySpec.limit();
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return querySpec.offset();
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return querySpec.hasAggregates();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
@@ -25,6 +25,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
 import io.crate.metadata.doc.DocTableInfo;
@@ -33,6 +34,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -41,13 +43,11 @@ public class ShowCreateTableAnalyzedStatement implements AnalyzedStatement, Anal
 
     private final DocTableInfo tableInfo;
     private final List<Field> fields;
-    private final QuerySpec querySpec;
 
     public ShowCreateTableAnalyzedStatement(DocTableInfo tableInfo) {
         String columnName = String.format(Locale.ENGLISH, "SHOW CREATE TABLE %s", tableInfo.ident().fqn());
         this.fields = Collections.singletonList(new Field(this, new OutputName(columnName), DataTypes.STRING));
         this.tableInfo = tableInfo;
-        this.querySpec = new QuerySpec();
     }
 
     public DocTableInfo tableInfo() {
@@ -90,8 +90,47 @@ public class ShowCreateTableAnalyzedStatement implements AnalyzedStatement, Anal
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return querySpec;
+    public List<Symbol> outputs() {
+        return List.copyOf(fields);
+    }
+
+    @Override
+    public WhereClause where() {
+        return WhereClause.MATCH_ALL;
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return List.of();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return null;
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return false;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
@@ -25,10 +25,9 @@ import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
-import io.crate.expression.symbol.Field;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
@@ -51,62 +50,40 @@ public interface AnalyzedRelation extends AnalyzedStatement {
 
     void setQualifiedName(@Nonnull QualifiedName qualifiedName);
 
-    /**
-     * The long-/midterm goal is to deprecate the QuerySpec;
-     *
-     * The other properties should be used instead.
-     */
-    QuerySpec querySpec();
 
     /** * @return The outputs of the relation */
-    default List<Symbol> outputs() {
-        return querySpec().outputs();
-    }
+    List<Symbol> outputs();
 
     /**
      * @return WHERE clause of the relation.
      *         This is {@link WhereClause#MATCH_ALL} if there was no WhereClause in the statement
      */
-    default WhereClause where() {
-        return querySpec().where();
-    }
+    WhereClause where();
 
     /**
      * @return The GROUP BY keys. Empty if there are none.
      */
-    default List<Symbol> groupBy() {
-        return querySpec().groupBy();
-    }
+    List<Symbol> groupBy();
 
     /**
      * @return The HAVING clause or null
      */
     @Nullable
-    default HavingClause having() {
-        return querySpec().having();
-    }
+    HavingClause having();
 
     /**
      * @return ORDER BY clause or null if not present
      */
     @Nullable
-    default OrderBy orderBy() {
-        return querySpec().orderBy();
-    }
+    OrderBy orderBy();
 
     @Nullable
-    default Symbol limit() {
-        return querySpec().limit();
-    }
+    Symbol limit();
 
     @Nullable
-    default Symbol offset() {
-        return querySpec().offset();
-    }
+    Symbol offset();
 
-    default boolean hasAggregates() {
-        return querySpec().hasAggregates();
-    }
+    boolean hasAggregates();
 
     /**
      * Calls the consumer for each top-level symbol in the relation

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -23,15 +23,20 @@
 package io.crate.analyze.relations;
 
 import io.crate.analyze.Fields;
+import io.crate.analyze.HavingClause;
+import io.crate.analyze.OrderBy;
 import io.crate.analyze.QuerySpec;
+import io.crate.analyze.WhereClause;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Path;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,11 +73,6 @@ public final class AnalyzedView implements AnalyzedRelation {
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return this.querySpec;
-    }
-
-    @Override
     public boolean isDistinct() {
         return false;
     }
@@ -103,5 +103,49 @@ public final class AnalyzedView implements AnalyzedRelation {
     @Override
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
         relation.setQualifiedName(qualifiedName);
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return querySpec.outputs();
+    }
+
+    @Override
+    public WhereClause where() {
+        return querySpec.where();
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return querySpec.groupBy();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return querySpec.having();
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return querySpec.orderBy();
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return querySpec.limit();
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return querySpec.offset();
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return querySpec.hasAggregates();
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
@@ -108,11 +108,6 @@ public class OrderedLimitedRelation implements AnalyzedRelation {
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return this.querySpec;
-    }
-
-    @Override
     public List<Symbol> outputs() {
         return childRelation.outputs();
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -25,23 +25,13 @@ package io.crate.analyze.relations;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QueriedTable;
-import io.crate.analyze.QuerySpec;
 import io.crate.analyze.where.WhereClauseValidator;
-import io.crate.collections.Lists2;
 import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
-import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.Operation;
-import io.crate.sql.tree.QualifiedName;
-
-import java.util.LinkedHashMap;
-import java.util.function.Function;
-
-import static com.google.common.collect.Lists.transform;
 
 /**
  * The RelationNormalizer tries to merge the tree of relations in a QueriedSelectRelation into a single AnalyzedRelation.
@@ -82,17 +72,7 @@ public final class RelationNormalizer {
             if (subRelation == normalizedSubRelation) {
                 return relation;
             }
-            return new QueriedSelectRelation(
-                relation.isDistinct(),
-                normalizedSubRelation,
-                transform(relation.fields(), Field::path),
-                relation.querySpec().copyAndReplace(FieldReplacer.bind(f -> {
-                    if (f.relation().equals(subRelation)) {
-                        return normalizedSubRelation.getField(f.path(), Operation.READ);
-                    }
-                    return f;
-                }))
-            );
+            return relation.replaceSubRelation(normalizedSubRelation);
         }
 
         @Override
@@ -110,38 +90,16 @@ public final class RelationNormalizer {
             AbstractTableRelation<?> tableRelation = queriedTable.tableRelation();
             EvaluatingNormalizer evalNormalizer = new EvaluatingNormalizer(
                 functions, RowGranularity.CLUSTER, null, tableRelation);
-
-            QueriedTable<? extends AbstractTableRelation<?>> table = new QueriedTable<>(
-                queriedTable.isDistinct(),
-                tableRelation,
-                transform(queriedTable.fields(), Field::path),
-                queriedTable.querySpec().copyAndReplace(s -> evalNormalizer.normalize(s, tnxCtx))
-            );
+            QueriedTable<?> table = queriedTable.map(s -> evalNormalizer.normalize(s, tnxCtx));
             WhereClauseValidator.validate(table.where().queryOrFallback());
             return table;
         }
 
         @Override
         public AnalyzedRelation visitMultiSourceSelect(MultiSourceSelect mss, CoordinatorTxnCtx context) {
-            LinkedHashMap<QualifiedName, AnalyzedRelation> normalizedSources = new LinkedHashMap<>();
-            for (var entry : mss.sources().entrySet()) {
-                normalizedSources.put(entry.getKey(), entry.getValue().accept(this, context));
-            }
-            Function<? super Symbol, ? extends Symbol> updateField = FieldReplacer.bind(f -> {
-                QualifiedName name = f.relation().getQualifiedName();
-                if (normalizedSources.containsKey(name)) {
-                    return normalizedSources.get(name).getField(f.path(), Operation.READ);
-                }
-                return f;
-            });
-            Function<Symbol, Symbol> updateSymbol = s -> updateField.apply(normalizer.normalize(s, context));
-            QuerySpec querySpec = mss.querySpec().copyAndReplace(updateSymbol);
-            return new MultiSourceSelect(
-                mss.isDistinct(),
-                normalizedSources,
-                transform(mss.fields(), Field::path),
-                querySpec,
-                Lists2.map(mss.joinPairs(), joinPair -> joinPair.mapCondition(updateSymbol))
+            return mss.mapSubRelations(
+                rel -> rel.accept(this, context),
+                s -> normalizer.normalize(s, context)
             );
         }
 

--- a/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -23,23 +23,26 @@
 package io.crate.analyze.relations;
 
 import io.crate.analyze.Fields;
-import io.crate.analyze.QuerySpec;
+import io.crate.analyze.HavingClause;
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.WhereClause;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class UnionSelect implements AnalyzedRelation {
 
-    private final QuerySpec querySpec = new QuerySpec();
     private final Fields fields;
     private final AnalyzedRelation left;
     private final AnalyzedRelation right;
+    private final List<Symbol> outputs;
     private QualifiedName name;
 
     public UnionSelect(AnalyzedRelation left, AnalyzedRelation right) {
@@ -52,7 +55,7 @@ public class UnionSelect implements AnalyzedRelation {
         for (Field field : fieldsFromLeft) {
             fields.add(field.path(), new Field(this, field.path(), field.valueType()));
         }
-        querySpec.outputs(new ArrayList<>(fields.asList()));
+        this.outputs = List.copyOf(fields.asList());
     }
 
     public AnalyzedRelation left() {
@@ -92,8 +95,47 @@ public class UnionSelect implements AnalyzedRelation {
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return querySpec;
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public WhereClause where() {
+        return WhereClause.MATCH_ALL;
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return List.of();
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return null;
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return false;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -374,7 +374,7 @@ public final class CopyStatementPlanner {
         }
 
         WriterProjection projection = ProjectionBuilder.writerProjection(
-            statement.subQueryRelation().querySpec().outputs(),
+            statement.subQueryRelation().outputs(),
             statement.uri(),
             statement.compressionType(),
             statement.overwrites(),

--- a/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -57,7 +57,7 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         CreateViewStmt createView = e.analyze("create view v1 as select * from t1");
 
         assertThat(createView.name(), is(new RelationName(e.getSessionContext().searchPath().currentSchema(), "v1")));
-        assertThat(createView.query(), isSQL("QueriedTable{DocTableRelation{doc.t1}}"));
+        assertThat(createView.query(), isSQL("SELECT doc.t1.x"));
         assertThat(createView.owner(), is(testUser));
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -76,7 +76,7 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
     }
 
     private void assertCompatibleColumns(InsertFromSubQueryAnalyzedStatement statement) {
-        List<Symbol> outputSymbols = statement.subQueryRelation().querySpec().outputs();
+        List<Symbol> outputSymbols = statement.subQueryRelation().outputs();
         assertThat(statement.columns().size(), is(outputSymbols.size()));
 
         for (int i = 0; i < statement.columns().size(); i++) {

--- a/sql/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
@@ -53,7 +53,7 @@ public class SelectFromViewAnalyzerTest extends CrateDummyClusterServiceUnitTest
         assertThat(query.outputs(), Matchers.contains(isField("name"), isField("count(*)")));
         assertThat(query.groupBy(), Matchers.empty());
         assertThat(query.subRelation(), instanceOf(AnalyzedView.class));
-        QueriedTable queriedDocTable = (QueriedTable) ((AnalyzedView) query.subRelation()).relation();
+        QueriedTable<?> queriedDocTable = (QueriedTable) ((AnalyzedView) query.subRelation()).relation();
         assertThat(queriedDocTable.groupBy(), Matchers.contains(isReference("name")));
         assertThat(queriedDocTable.tableRelation().tableInfo().ident(), is(new RelationName("doc", "t1")));
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -124,8 +124,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testIsNullQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where id is not null");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
-        Function query = (Function) relation.querySpec().where().query();
+        assertThat(relation.where().hasQuery(), is(true));
+        Function query = (Function) relation.where().query();
 
         assertThat(query.info().ident().name(), is(NotPredicate.NAME));
         assertThat(query.arguments().get(0), instanceOf(Function.class));
@@ -151,22 +151,22 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testOrderedSelect() throws Exception {
         QueriedTable table = (QueriedTable) analyze("select load['1'] from sys.nodes order by load['5'] desc");
-        assertThat(table.querySpec().limit(), nullValue());
+        assertThat(table.limit(), nullValue());
 
-        assertThat(table.querySpec().groupBy().isEmpty(), is(true));
-        assertThat(table.querySpec().orderBy(), notNullValue());
+        assertThat(table.groupBy().isEmpty(), is(true));
+        assertThat(table.orderBy(), notNullValue());
 
-        assertThat(table.querySpec().outputs().size(), is(1));
-        assertThat(table.querySpec().orderBy().orderBySymbols().size(), is(1));
-        assertThat(table.querySpec().orderBy().reverseFlags().length, is(1));
+        assertThat(table.outputs().size(), is(1));
+        assertThat(table.orderBy().orderBySymbols().size(), is(1));
+        assertThat(table.orderBy().reverseFlags().length, is(1));
 
-        assertThat(table.querySpec().orderBy().orderBySymbols().get(0), isReference("load['5']"));
+        assertThat(table.orderBy().orderBySymbols().get(0), isReference("load['5']"));
     }
 
     @Test
     public void testNegativeLiteral() throws Exception {
         AnalyzedRelation relation =  analyze("select * from sys.nodes where port['http'] = -400");
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         Symbol symbol = whereClause.arguments().get(1);
         assertThat(((Literal) symbol).value(), is(-400));
     }
@@ -174,19 +174,19 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSimpleSelect() throws Exception {
         AnalyzedRelation relation = analyze("select load['5'] from sys.nodes limit 2");
-        assertThat(relation.querySpec().limit(), is(Literal.of(2L)));
+        assertThat(relation.limit(), is(Literal.of(2L)));
 
-        assertThat(relation.querySpec().groupBy().isEmpty(), is(true));
-        assertThat(relation.querySpec().outputs().size(), is(1));
-        assertThat(relation.querySpec().outputs().get(0), isReference("load['5']"));
+        assertThat(relation.groupBy().isEmpty(), is(true));
+        assertThat(relation.outputs().size(), is(1));
+        assertThat(relation.outputs().get(0), isReference("load['5']"));
     }
 
     @Test
     public void testAggregationSelect() throws Exception {
         AnalyzedRelation relation = analyze("select avg(load['5']) from sys.nodes");
-        assertThat(relation.querySpec().groupBy().isEmpty(), is(true));
-        assertThat(relation.querySpec().outputs().size(), is(1));
-        Function col1 = (Function) relation.querySpec().outputs().get(0);
+        assertThat(relation.groupBy().isEmpty(), is(true));
+        assertThat(relation.outputs().size(), is(1));
+        Function col1 = (Function) relation.outputs().get(0);
         assertThat(col1.info().type(), is(FunctionInfo.Type.AGGREGATE));
         assertThat(col1.info().ident().name(), is(AverageAggregation.NAME));
     }
@@ -206,7 +206,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation relation = analyze("select * from sys.cluster");
         assertThat(relation.fields().size(), is(5));
         assertThat(outputNames(relation), containsInAnyOrder("id", "license", "master_node", "name", "settings"));
-        assertThat(relation.querySpec().outputs().size(), is(5));
+        assertThat(relation.outputs().size(), is(5));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "thread_pools",
             "version"
         ));
-        assertThat(relation.querySpec().outputs().size(), is(outputNames.size()));
+        assertThat(relation.outputs().size(), is(outputNames.size()));
     }
 
     @Test
@@ -241,9 +241,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation relation = analyze("select load from sys.nodes " +
                                             "where load['1'] = 1.2 or 1 >= load['5']");
 
-        assertThat(relation.querySpec().groupBy().isEmpty(), is(true));
+        assertThat(relation.groupBy().isEmpty(), is(true));
 
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
         assertThat(whereClause.info().type() == FunctionInfo.Type.AGGREGATE, is(false));
 
@@ -274,7 +274,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             new Short("1"),
             "node 1"
         });
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
         assertThat(whereClause.info().type() == FunctionInfo.Type.AGGREGATE, is(false));
 
@@ -318,9 +318,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(outputNames.size(), is(1));
         assertThat(outputNames.get(0), is("cluster_name"));
 
-        assertThat(relation.querySpec().orderBy(), notNullValue());
-        assertThat(relation.querySpec().orderBy().orderBySymbols().size(), is(1));
-        assertThat(relation.querySpec().orderBy().orderBySymbols().get(0), is(relation.querySpec().outputs().get(0)));
+        assertThat(relation.orderBy(), notNullValue());
+        assertThat(relation.orderBy().orderBySymbols().size(), is(1));
+        assertThat(relation.orderBy().orderBySymbols().get(0), is(relation.outputs().get(0)));
     }
 
     @Test
@@ -349,7 +349,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testOffsetSupportInAnalyzer() throws Exception {
         AnalyzedRelation relation = analyze("select * from sys.nodes limit 1 offset 3");
-        assertThat(relation.querySpec().offset(), is(Literal.of(3L)));
+        assertThat(relation.offset(), is(Literal.of(3L)));
     }
 
     @Test
@@ -359,16 +359,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "select id from sys.nodes where 1=0"
         )) {
             AnalyzedRelation relation = analyze(stmt);
-            assertThat(stmt, relation.querySpec().where().noMatch(), is(true));
-            assertThat(stmt, relation.querySpec().where().hasQuery(), is(false));
+            assertThat(stmt, relation.where().noMatch(), is(true));
+            assertThat(stmt, relation.where().hasQuery(), is(false));
         }
     }
 
     @Test
     public void testEvaluatingMatchAllStatement() throws Exception {
         AnalyzedRelation relation = analyze("select id from sys.nodes where 1 = 1");
-        assertThat(relation.querySpec().where().noMatch(), is(false));
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(false));
+        assertThat(relation.where().hasQuery(), is(false));
     }
 
     @Test
@@ -379,8 +379,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "select id from sys.nodes"
         )) {
             AnalyzedRelation relation = analyze(stmt);
-            assertThat(stmt, relation.querySpec().where().noMatch(), is(false));
-            assertThat(stmt, relation.querySpec().where().hasQuery(), is(false));
+            assertThat(stmt, relation.where().noMatch(), is(false));
+            assertThat(stmt, relation.where().hasQuery(), is(false));
         }
     }
 
@@ -394,7 +394,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         );
         for (String statement : statements) {
             AnalyzedRelation relation = analyze(statement);
-            WhereClause whereClause = relation.querySpec().where();
+            WhereClause whereClause = relation.where();
 
             Function notFunction = (Function) whereClause.query();
             assertThat(notFunction.info().ident().name(), is(NotPredicate.NAME));
@@ -413,7 +413,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testRewriteRegexpNoMatch() throws Exception {
         String statement = "select * from sys.nodes where sys.nodes.name !~ '[sS]omething'";
         AnalyzedRelation relation = analyze(statement);
-        WhereClause whereClause = relation.querySpec().where();
+        WhereClause whereClause = relation.where();
 
         Function notFunction = (Function) whereClause.query();
         assertThat(notFunction.info().ident().name(), is(NotPredicate.NAME));
@@ -438,7 +438,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRewriteCountStringLiteral() {
         AnalyzedRelation relation = analyze("select count('id') from sys.nodes");
-        List<Symbol> outputSymbols = relation.querySpec().outputs();
+        List<Symbol> outputSymbols = relation.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(Function.class));
         assertThat(((Function) outputSymbols.get(0)).arguments().size(), is(0));
@@ -447,7 +447,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRewriteCountNull() {
         AnalyzedRelation relation = analyze("select count(null) from sys.nodes");
-        List<Symbol> outputSymbols = relation.querySpec().outputs();
+        List<Symbol> outputSymbols = relation.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(Literal.class));
         assertThat(((Literal) outputSymbols.get(0)).value(), is(0L));
@@ -456,33 +456,33 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testWhereInSelect() throws Exception {
         AnalyzedRelation relation = analyze("select load from sys.nodes where load['1'] in (1.0, 2.0, 4.0, 8.0, 16.0)");
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         assertThat(whereClause.info().ident().name(), is(AnyOperators.Names.EQ));
     }
 
     @Test
     public void testWhereInSelectListWithNull() throws Exception {
         AnalyzedRelation relation = analyze("select 'found' from users where 1 in (3, 2, null)");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testWhereInSelectValueIsNull() throws Exception {
         AnalyzedRelation relation = analyze("select 'found' from users where null in (1, 2)");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testWhereInSelectDifferentDataTypeValue() throws Exception {
         AnalyzedRelation relation;
         relation = analyze("select 'found' from users where 1.2 in (1, 2)");
-        assertThat(relation.querySpec().where().hasQuery(), is(false)); // already normalized to 1.2 in (1.0, 2.0) --> false
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false)); // already normalized to 1.2 in (1.0, 2.0) --> false
+        assertThat(relation.where().noMatch(), is(true));
         relation = analyze("select 'found' from users where 1 in (1.2, 2)");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
@@ -496,8 +496,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAggregationDistinct() {
         AnalyzedRelation relation = analyze("select count(distinct load['1']) from sys.nodes");
 
-        assertThat(relation.querySpec().hasAggregates(), is(true));
-        Symbol output = relation.querySpec().outputs().get(0);
+        assertThat(relation.hasAggregates(), is(true));
+        Symbol output = relation.outputs().get(0);
         assertThat(output, isFunction("collection_count"));
 
         Function collectionCount = (Function) output;
@@ -516,23 +516,21 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectDistinctWithFunction() {
         AnalyzedRelation relation = analyze("select distinct id + 1 from users");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec().outputs(), isSQL("add(doc.users.id, 1)"));
+        assertThat(relation.outputs(), isSQL("add(doc.users.id, 1)"));
     }
 
     @Test
     public void testSelectDistinctWithGroupBySameFieldsSameOrder() {
         AnalyzedRelation distinctRelation = analyze("select distinct id, name from users group by id, name");
         AnalyzedRelation groupByRelation = analyze("select id, name from users group by id, name");
-        assertThat(distinctRelation.querySpec().groupBy(),
-                   equalTo(groupByRelation.querySpec().groupBy()));
-        assertThat(distinctRelation.querySpec().outputs(),
-                   equalTo(groupByRelation.querySpec().outputs()));
+        assertThat(distinctRelation.groupBy(), equalTo(groupByRelation.groupBy()));
+        assertThat(distinctRelation.outputs(), equalTo(groupByRelation.outputs()));
     }
 
     @Test
     public void testSelectDistinctWithGroupBySameFieldsDifferentOrder() {
         AnalyzedRelation relation = analyze("select distinct name, id from users group by id, name");
-        assertThat(relation.querySpec(),
+        assertThat(relation,
                    isSQL("SELECT doc.users.name, doc.users.id GROUP BY doc.users.id, doc.users.name"));
     }
 
@@ -540,27 +538,27 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testDistinctOnLiteral() {
         AnalyzedRelation relation = analyze("select distinct [1,2,3] from users");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec().outputs(), isSQL("[1, 2, 3]"));
+        assertThat(relation.outputs(), isSQL("[1, 2, 3]"));
     }
 
     @Test
     public void testDistinctOnNullLiteral() {
         AnalyzedRelation relation = analyze("select distinct null from users");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec().outputs(), isSQL("NULL"));
+        assertThat(relation.outputs(), isSQL("NULL"));
     }
 
     @Test
     public void testSelectGlobalDistinctAggregate() {
         AnalyzedRelation relation = analyze("select distinct count(*) from users");
-        assertThat(relation.querySpec().groupBy().isEmpty(), is(true));
+        assertThat(relation.groupBy().isEmpty(), is(true));
     }
 
     @Test
     public void testSelectGlobalDistinctRewriteAggregationGroupBy() {
         AnalyzedRelation distinctRelation = analyze("select distinct name, count(id) from users group by name");
         AnalyzedRelation groupByRelation = analyze("select name, count(id) from users group by name");
-        assertEquals(groupByRelation.querySpec().groupBy(), distinctRelation.querySpec().groupBy());
+        assertEquals(groupByRelation.groupBy(), distinctRelation.groupBy());
     }
 
     @Test
@@ -571,7 +569,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         map.put("15", 8.0);
         AnalyzedRelation relation = analyze("select id from sys.nodes where load=?",
             new Object[]{map});
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         assertThat(whereClause.arguments().get(1), instanceOf(Literal.class));
         assertThat(((Literal) whereClause.arguments().get(1)).value().equals(map), is(true));
     }
@@ -580,8 +578,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testLikeInWhereQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where name like 'foo'");
 
-        assertNotNull(relation.querySpec().where());
-        Function whereClause = (Function) relation.querySpec().where().query();
+        assertNotNull(relation.where());
+        Function whereClause = (Function) relation.where().query();
         assertThat(whereClause.info().ident().name(), is(LikeOperator.NAME));
         ImmutableList<DataType> argumentTypes = ImmutableList.of(DataTypes.STRING, DataTypes.STRING);
         assertEquals(argumentTypes, whereClause.info().ident().argumentTypes());
@@ -604,7 +602,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         // check if the implicit cast of the pattern worked
         ImmutableList<DataType> argumentTypes = ImmutableList.of(DataTypes.STRING, DataTypes.STRING);
-        Function whereClause = (Function) relation.querySpec().where().query();
+        Function whereClause = (Function) relation.where().query();
         assertEquals(argumentTypes, whereClause.info().ident().argumentTypes());
         assertThat(whereClause.arguments().get(1), IsInstanceOf.instanceOf(Literal.class));
         Literal stringLiteral = (Literal) whereClause.arguments().get(1);
@@ -614,42 +612,42 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testLikeLongDataTypeInWhereQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where 1 like 2");
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testIsNullInWhereQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where name is null");
-        Function isNullFunction = (Function) relation.querySpec().where().query();
+        Function isNullFunction = (Function) relation.where().query();
 
         assertThat(isNullFunction.info().ident().name(), is(IsNullPredicate.NAME));
         assertThat(isNullFunction.arguments().size(), is(1));
         assertThat(isNullFunction.arguments().get(0), isReference("name"));
-        assertNotNull(relation.querySpec().where());
+        assertNotNull(relation.where());
     }
 
     @Test
     public void testNullIsNullInWhereQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where null is null");
-        assertThat(relation.querySpec().where(), is(WhereClause.MATCH_ALL));
+        assertThat(relation.where(), is(WhereClause.MATCH_ALL));
     }
 
     @Test
     public void testLongIsNullInWhereQuery() {
         AnalyzedRelation relation = analyze("select * from sys.nodes where 1 is null");
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testNotPredicate() {
         AnalyzedRelation relation = analyze("select * from users where name not like 'foo%'");
-        assertThat(((Function) relation.querySpec().where().query()).info().ident().name(), is(NotPredicate.NAME));
+        assertThat(((Function) relation.where().query()).info().ident().name(), is(NotPredicate.NAME));
     }
 
     @Test
     public void testFilterByLiteralBoolean() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where awesome=TRUE");
-        assertThat(((Function) relation.querySpec().where().query()).arguments().get(1).symbolType(),
+        assertThat(((Function) relation.where().query()).arguments().get(1).symbolType(),
             is(SymbolType.LITERAL));
     }
 
@@ -697,7 +695,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testInnerJoinSyntaxDoesNotExtendsWhereClause() throws Exception {
         MultiSourceSelect mss = (MultiSourceSelect) analyze(
             "select * from users inner join users_multi_pk on users.id = users_multi_pk.id");
-        assertThat(mss.querySpec().where().query(), isSQL("null"));
+        assertThat(mss.where().query(), isSQL("null"));
         assertThat(mss.joinPairs().get(0).condition(),
             isSQL("(doc.users.id = doc.users_multi_pk.id)"));
     }
@@ -707,7 +705,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         MultiSourceSelect relation = (MultiSourceSelect) analyze("select * from users u1 " +
                                                                  "join users_multi_pk u2 on u1.id = u2.id " +
                                                                  "join users_clustered_by_only u3 on u2.id = u3.id ");
-        assertThat(relation.querySpec().where().query(), isSQL("null"));
+        assertThat(relation.where().query(), isSQL("null"));
 
         assertThat(relation.joinPairs().get(0).condition(),
             isSQL("(doc.users.id = doc.users_multi_pk.id)"));
@@ -742,7 +740,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.joinPairs().get(0).condition(),
             isSQL("(doc.users.id = doc.users_multi_pk.id)"));
 
-        assertThat(relation.querySpec().where().query(), isSQL("(doc.users.name = 'Arthur')"));
+        assertThat(relation.where().query(), isSQL("(doc.users.name = 'Arthur')"));
         AnalyzedRelation users = relation.sources().get(QualifiedName.of("doc", "users"));
         assertThat(users.where(), is(WhereClause.MATCH_ALL));
     }
@@ -769,10 +767,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         MultiSourceSelect mss = (MultiSourceSelect) relation;
 
-        assertThat(mss.querySpec().orderBy(), isSQL("doc.users.id"));
+        assertThat(mss.orderBy(), isSQL("doc.users.id"));
         Iterator<Map.Entry<QualifiedName, AnalyzedRelation>> it = mss.sources().entrySet().iterator();
         AnalyzedRelation usersRel = it.next().getValue();
-        assertThat(usersRel.querySpec().orderBy(), nullValue());
+        assertThat(usersRel.orderBy(), nullValue());
     }
 
     @Test
@@ -780,7 +778,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation relation = analyze("select count(*) from users u1, users_multi_pk u2 " +
                                             "order by 1");
         MultiSourceSelect mss = (MultiSourceSelect) relation;
-        assertThat(mss.querySpec().orderBy(), isSQL("count()"));
+        assertThat(mss.orderBy(), isSQL("count()"));
     }
 
     @Test
@@ -791,7 +789,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         MultiSourceSelect mss = (MultiSourceSelect) relation;
         AnalyzedRelation u1 = mss.sources().values().iterator().next();
-        assertThat(u1.querySpec().outputs(), allOf(
+        assertThat(u1.outputs(), allOf(
             hasItem(isReference("name")),
             hasItem(isReference("id")))
         );
@@ -801,8 +799,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testJoinConditionIsNotPartOfOutputs() throws Exception {
         AnalyzedRelation rel = analyze(
             "select u1.name from users u1 inner join users u2 on u1.id = u2.id order by u2.date");
-        MultiSourceSelect mss = (MultiSourceSelect) rel;
-        assertThat(rel.querySpec().outputs(), contains(isField("name")));
+        assertThat(rel.outputs(), contains(isField("name")));
     }
 
     @Test
@@ -844,15 +841,15 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArrayCompareAny() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where 0 = ANY (counters)");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
+        assertThat(relation.where().hasQuery(), is(true));
 
-        FunctionInfo anyInfo = ((Function) relation.querySpec().where().query()).info();
+        FunctionInfo anyInfo = ((Function) relation.where().query()).info();
         assertThat(anyInfo.ident().name(), is("any_="));
 
         relation = analyze("select * from users where 0 = ANY (counters)");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
+        assertThat(relation.where().hasQuery(), is(true));
 
-        anyInfo = ((Function) relation.querySpec().where().query()).info();
+        anyInfo = ((Function) relation.where().query()).info();
         assertThat(anyInfo.ident().name(), is("any_="));
     }
 
@@ -860,9 +857,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testArrayCompareAnyNeq() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where ? != ANY (counters)",
             new Object[]{4.3F});
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
+        assertThat(relation.where().hasQuery(), is(true));
 
-        FunctionInfo anyInfo = ((Function) relation.querySpec().where().query()).info();
+        FunctionInfo anyInfo = ((Function) relation.where().query()).info();
         assertThat(anyInfo.ident().name(), is("any_<>"));
     }
 
@@ -887,8 +884,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAnyOnObjectArrayField() throws Exception {
         AnalyzedRelation relation = analyze(
             "select * from users where 5 = ANY (friends['id'])");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
-        Function anyFunction = (Function) relation.querySpec().where().query();
+        assertThat(relation.where().hasQuery(), is(true));
+        Function anyFunction = (Function) relation.where().query();
         assertThat(anyFunction.info().ident().name(), is(AnyOperators.Names.EQ));
         assertThat(anyFunction.arguments().get(1), isReference("friends['id']", new ArrayType(DataTypes.LONG)));
         assertThat(anyFunction.arguments().get(0), isLiteral(5L));
@@ -930,8 +927,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAliasSubscript() throws Exception {
         AnalyzedRelation relation = analyze(
             "select u.friends['id'] from users as u");
-        assertThat(relation.querySpec().outputs().size(), is(1));
-        Symbol s = relation.querySpec().outputs().get(0);
+        assertThat(relation.outputs().size(), is(1));
+        Symbol s = relation.outputs().get(0);
         assertThat(s, notNullValue());
         assertThat(s, isReference("friends['id']"));
     }
@@ -940,7 +937,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testOrderByWithOrdinal() throws Exception {
         AnalyzedRelation relation = analyze(
             "select name from users u order by 1");
-        assertEquals(relation.querySpec().outputs().get(0), relation.querySpec().orderBy().orderBySymbols().get(0));
+        assertEquals(relation.outputs().get(0), relation.orderBy().orderBySymbols().get(0));
     }
 
     @Test
@@ -960,29 +957,29 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArithmeticPlus() throws Exception {
         AnalyzedRelation relation = analyze("select load['1'] + load['5'] from sys.nodes");
-        assertThat(((Function) relation.querySpec().outputs().get(0)).info().ident().name(), is(ArithmeticFunctions.Names.ADD));
+        assertThat(((Function) relation.outputs().get(0)).info().ident().name(), is(ArithmeticFunctions.Names.ADD));
     }
 
     @Test
     public void testPrefixedNumericLiterals() throws Exception {
         AnalyzedRelation relation = analyze("select - - - 10");
-        List<Symbol> outputs = relation.querySpec().outputs();
+        List<Symbol> outputs = relation.outputs();
         assertThat(outputs.get(0), is(Literal.of(-10L)));
 
         relation = analyze("select - + - 10");
-        outputs = relation.querySpec().outputs();
+        outputs = relation.outputs();
         assertThat(outputs.get(0), is(Literal.of(10L)));
 
         relation = analyze("select - (- 10 - + 10) * - (+ 10 + - 10)");
-        outputs = relation.querySpec().outputs();
+        outputs = relation.outputs();
         assertThat(outputs.get(0), is(Literal.of(0L)));
     }
 
     @Test
     public void testAnyLike() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where 'awesome' LIKE ANY (tags)");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
-        Function query = (Function) relation.querySpec().where().query();
+        assertThat(relation.where().hasQuery(), is(true));
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is("any_like"));
         assertThat(query.arguments().size(), is(2));
         assertThat(query.arguments().get(0), instanceOf(Literal.class));
@@ -993,22 +990,22 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAnyLikeLiteralMatchAll() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where 'awesome' LIKE ANY (['a', 'b', 'awesome'])");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(false));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(false));
     }
 
     @Test
     public void testAnyLikeLiteralNoMatch() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where 'awesome' LIKE ANY (['a', 'b'])");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testAnyNotLike() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where 'awesome' NOT LIKE ANY (tags)");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
-        Function query = (Function) relation.querySpec().where().query();
+        assertThat(relation.where().hasQuery(), is(true));
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is("any_not_like"));
 
         assertThat(query.arguments().size(), is(2));
@@ -1065,15 +1062,15 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     private void testDistanceOrderBy(String stmt) throws Exception {
         AnalyzedRelation relation = analyze(stmt);
-        assertThat(relation.querySpec().orderBy(), notNullValue());
-        assertThat(((Function) relation.querySpec().orderBy().orderBySymbols().get(0)).info().ident().name(),
+        assertThat(relation.orderBy(), notNullValue());
+        assertThat(((Function) relation.orderBy().orderBySymbols().get(0)).info().ident().name(),
                    is(DistanceFunction.NAME));
     }
 
     @Test
     public void testWhereMatchOnColumn() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where match(name, 'Arthur Dent')");
-        Function query = (Function) relation.querySpec().where().query();
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is("match"));
         assertThat(query.arguments().size(), is(4));
         assertThat(query.arguments().get(0), Matchers.instanceOf(Literal.class));
@@ -1096,7 +1093,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchOnIndex() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where match(name_text_ft, 'Arthur Dent')");
-        Function query = (Function) relation.querySpec().where().query();
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is("match"));
         assertThat(query.arguments().size(), is(4));
         assertThat(query.arguments().get(0), Matchers.instanceOf(Literal.class));
@@ -1154,9 +1151,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectWhereSimpleMatchPredicate() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where match (text, 'awesome')");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
+        assertThat(relation.where().hasQuery(), is(true));
 
-        Function query = (Function) relation.querySpec().where().query();
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is(MatchPredicate.NAME));
         assertThat(query.arguments().size(), is(4));
         assertThat(query.arguments().get(0), Matchers.instanceOf(Literal.class));
@@ -1174,9 +1171,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectWhereFullMatchPredicate() throws Exception {
         AnalyzedRelation relation = analyze("select * from users " +
                                             "where match ((name 1.2, text), 'awesome') using best_fields with (analyzer='german')");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
+        assertThat(relation.where().hasQuery(), is(true));
 
-        Function query = (Function) relation.querySpec().where().query();
+        Function query = (Function) relation.where().query();
         assertThat(query.info().ident().name(), is(MatchPredicate.NAME));
         assertThat(query.arguments().size(), is(4));
         assertThat(query.arguments().get(0), Matchers.instanceOf(Literal.class));
@@ -1237,11 +1234,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation phrase_prefix_relation = analyze("select * from users " +
                                                           "where match ((name 1.2, text), 'awesome') using phrase_prefix");
 
-        assertThat(getMatchType((Function) best_fields_relation.querySpec().where().query()), is("best_fields"));
-        assertThat(getMatchType((Function) most_fields_relation.querySpec().where().query()), is("most_fields"));
-        assertThat(getMatchType((Function) cross_fields_relation.querySpec().where().query()), is("cross_fields"));
-        assertThat(getMatchType((Function) phrase_relation.querySpec().where().query()), is("phrase"));
-        assertThat(getMatchType((Function) phrase_prefix_relation.querySpec().where().query()), is("phrase_prefix"));
+        assertThat(getMatchType((Function) best_fields_relation.where().query()), is("best_fields"));
+        assertThat(getMatchType((Function) most_fields_relation.where().query()), is("most_fields"));
+        assertThat(getMatchType((Function) cross_fields_relation.where().query()), is("cross_fields"));
+        assertThat(getMatchType((Function) phrase_relation.where().query()), is("phrase"));
+        assertThat(getMatchType((Function) phrase_prefix_relation.where().query()), is("phrase_prefix"));
     }
 
     @Test
@@ -1263,7 +1260,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
                                             "  cutoff_frequency=5," +
                                             "  slop=3" +
                                             ")");
-        Function match = (Function) relation.querySpec().where().query();
+        Function match = (Function) relation.where().query();
         //noinspection unchecked
         Map<String, Object> options = ((Literal<Map<String, Object>>) match.arguments().get(3)).value();
         replaceBytesRefWithString(options);
@@ -1293,7 +1290,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testGlobalAggregateHaving() throws Exception {
         AnalyzedRelation relation = analyze("select sum(floats) from users having sum(bytes) in (42, 43, 44)");
-        Function havingFunction = (Function) relation.querySpec().having().query();
+        Function havingFunction = (Function) relation.having().query();
 
         // assert that the in was converted to or
         assertThat(havingFunction.info().ident().name(), is(AnyOperators.Names.EQ));
@@ -1360,22 +1357,22 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRegexpMatchNull() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where name ~ null");
-        assertThat(relation.querySpec().where().hasQuery(), is(false));
-        assertThat(relation.querySpec().where().noMatch(), is(true));
+        assertThat(relation.where().hasQuery(), is(false));
+        assertThat(relation.where().noMatch(), is(true));
     }
 
     @Test
     public void testRegexpMatch() throws Exception {
         AnalyzedRelation relation = analyze("select * from users where name ~ '.*foo(bar)?'");
-        assertThat(relation.querySpec().where().hasQuery(), is(true));
-        assertThat(((Function) relation.querySpec().where().query()).info().ident().name(), is("op_~"));
+        assertThat(relation.where().hasQuery(), is(true));
+        assertThat(((Function) relation.where().query()).info().ident().name(), is("op_~"));
     }
 
     @Test
     public void testSubscriptArray() throws Exception {
         AnalyzedRelation relation = analyze("select tags[1] from users");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(SubscriptFunction.NAME));
-        List<Symbol> arguments = ((Function) relation.querySpec().outputs().get(0)).arguments();
+        assertThat(relation.outputs().get(0), isFunction(SubscriptFunction.NAME));
+        List<Symbol> arguments = ((Function) relation.outputs().get(0)).arguments();
         assertThat(arguments.size(), is(2));
         assertThat(arguments.get(0), isReference("tags"));
         assertThat(arguments.get(1), isLiteral(1));
@@ -1398,8 +1395,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSubscriptArrayNested() throws Exception {
         AnalyzedRelation relation = analyze("select tags[1]['name'] from deeply_nested");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(SubscriptFunction.NAME));
-        List<Symbol> arguments = ((Function) relation.querySpec().outputs().get(0)).arguments();
+        assertThat(relation.outputs().get(0), isFunction(SubscriptFunction.NAME));
+        List<Symbol> arguments = ((Function) relation.outputs().get(0)).arguments();
         assertThat(arguments.size(), is(2));
         assertThat(arguments.get(0), isReference("tags['name']"));
         assertThat(arguments.get(1), isLiteral(1));
@@ -1415,8 +1412,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSubscriptArrayAsAlias() throws Exception {
         AnalyzedRelation relation = analyze("select tags[1] as t_alias from users");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(SubscriptFunction.NAME));
-        List<Symbol> arguments = ((Function) relation.querySpec().outputs().get(0)).arguments();
+        assertThat(relation.outputs().get(0), isFunction(SubscriptFunction.NAME));
+        List<Symbol> arguments = ((Function) relation.outputs().get(0)).arguments();
         assertThat(arguments.size(), is(2));
         assertThat(arguments.get(0), isReference("tags"));
         assertThat(arguments.get(1), isLiteral(1));
@@ -1425,9 +1422,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSubscriptArrayOnScalarResult() throws Exception {
         AnalyzedRelation relation = analyze("select regexp_matches(name, '.*')[1] as t_alias from users order by t_alias");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(SubscriptFunction.NAME));
-        assertThat(relation.querySpec().orderBy().orderBySymbols().get(0), is(relation.querySpec().outputs().get(0)));
-        List<Symbol> arguments = ((Function) relation.querySpec().outputs().get(0)).arguments();
+        assertThat(relation.outputs().get(0), isFunction(SubscriptFunction.NAME));
+        assertThat(relation.orderBy().orderBySymbols().get(0), is(relation.outputs().get(0)));
+        List<Symbol> arguments = ((Function) relation.outputs().get(0)).arguments();
         assertThat(arguments.size(), is(2));
 
         assertThat(arguments.get(0), isFunction(MatchesFunction.NAME));
@@ -1458,7 +1455,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArraySubqueryExpression() throws Exception {
         AnalyzedRelation relation = analyze("select array(select id from sys.shards) as shards_id_array from sys.shards");
-        SelectSymbol arrayProjection = (SelectSymbol) relation.querySpec().outputs().get(0);
+        SelectSymbol arrayProjection = (SelectSymbol) relation.outputs().get(0);
         assertThat(arrayProjection.getResultType(), is(SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES));
         assertThat(arrayProjection.valueType().id(), is(ArrayType.ID));
     }
@@ -1473,31 +1470,31 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testCastExpression() {
         AnalyzedRelation relation = analyze("select cast(other_id as text) from users");
-        assertThat(relation.querySpec().outputs().get(0),
+        assertThat(relation.outputs().get(0),
             isFunction("to_text", singletonList(DataTypes.LONG)));
 
         relation = analyze("select cast(1+1 as string) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral("2", DataTypes.STRING));
+        assertThat(relation.outputs().get(0), isLiteral("2", DataTypes.STRING));
 
         relation = analyze("select cast(friends['id'] as array(text)) from users");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(
+        assertThat(relation.outputs().get(0), isFunction(
             "to_text_array", singletonList(new ArrayType(DataTypes.LONG))));
     }
 
     @Test
     public void testTryCastExpression() {
         AnalyzedRelation relation = analyze("select try_cast(other_id as text) from users");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(
+        assertThat(relation.outputs().get(0), isFunction(
             "try_to_text", singletonList(DataTypes.LONG)));
 
         relation = analyze("select try_cast(1+1 as string) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral("2", DataTypes.STRING));
+        assertThat(relation.outputs().get(0), isLiteral("2", DataTypes.STRING));
 
         relation = analyze("select try_cast(null as string) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral(null, DataTypes.STRING));
+        assertThat(relation.outputs().get(0), isLiteral(null, DataTypes.STRING));
 
         relation = analyze("select try_cast(counters as array(boolean)) from users");
-        assertThat(relation.querySpec().outputs().get(0), isFunction(
+        assertThat(relation.outputs().get(0), isFunction(
             "try_to_boolean_array",
             singletonList(new ArrayType(DataTypes.LONG))));
     }
@@ -1505,13 +1502,13 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testTryCastReturnNullWhenCastFailsOnLiterals() {
         AnalyzedRelation relation = analyze("select try_cast('124123asdf' as integer) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral(null));
+        assertThat(relation.outputs().get(0), isLiteral(null));
 
         relation = analyze("select try_cast(['fd', '3', '5'] as array(integer)) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral(null));
+        assertThat(relation.outputs().get(0), isLiteral(null));
 
         relation = analyze("select try_cast('1' as boolean) from users");
-        assertThat(relation.querySpec().outputs().get(0), isLiteral(null));
+        assertThat(relation.outputs().get(0), isLiteral(null));
     }
 
     @Test
@@ -1532,8 +1529,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectWithAliasRenaming() throws Exception {
         AnalyzedRelation relation = analyze("select text as name, name as n from users");
 
-        Symbol text = relation.querySpec().outputs().get(0);
-        Symbol name = relation.querySpec().outputs().get(1);
+        Symbol text = relation.outputs().get(0);
+        Symbol name = relation.outputs().get(1);
 
         assertThat(text, isReference("text"));
         assertThat(name, isReference("name"));
@@ -1556,8 +1553,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testCanSelectColumnWithAndWithoutSubscript() throws Exception {
         AnalyzedRelation relation = analyze("select counters, counters[1] from users");
-        Symbol counters = relation.querySpec().outputs().get(0);
-        Symbol countersSubscript = relation.querySpec().outputs().get(1);
+        Symbol counters = relation.outputs().get(0);
+        Symbol countersSubscript = relation.outputs().get(1);
 
         assertThat(counters, isReference("counters"));
         assertThat(countersSubscript, isFunction("subscript"));
@@ -1567,8 +1564,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testOrderByOnAliasWithSameColumnNameInSchema() throws Exception {
         // name exists in the table but isn't selected so not ambiguous
         AnalyzedRelation relation = analyze("select other_id as name from users order by name");
-        assertThat(relation.querySpec().outputs().get(0), isReference("other_id"));
-        List<Symbol> sortSymbols = relation.querySpec().orderBy().orderBySymbols();
+        assertThat(relation.outputs().get(0), isReference("other_id"));
+        List<Symbol> sortSymbols = relation.orderBy().orderBySymbols();
         assert sortSymbols != null;
         assertThat(sortSymbols.get(0), isReference("other_id"));
     }
@@ -1577,7 +1574,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectPartitionedTableOrderBy() throws Exception {
         AnalyzedRelation relation = analyze(
             "select id from multi_parted order by id, abs(num)");
-        List<Symbol> symbols = relation.querySpec().orderBy().orderBySymbols();
+        List<Symbol> symbols = relation.orderBy().orderBySymbols();
         assert symbols != null;
         assertThat(symbols.size(), is(2));
         assertThat(symbols.get(0), isReference("id"));
@@ -1587,7 +1584,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testExtractFunctionWithLiteral() {
         AnalyzedRelation relation = analyze("select extract('day' from '2012-03-24') from users");
-        Symbol symbol = relation.querySpec().outputs().get(0);
+        Symbol symbol = relation.outputs().get(0);
         assertThat(symbol, isLiteral(24));
     }
 
@@ -1595,7 +1592,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testExtractFunctionWithWrongType() {
         AnalyzedRelation relation = analyze(
             "select extract(day from name::timestamp with time zone) from users");
-        Symbol symbol = relation.querySpec().outputs().get(0);
+        Symbol symbol = relation.outputs().get(0);
         assertThat(symbol, isFunction("extract_DAY_OF_MONTH"));
 
         Symbol argument = ((Function) symbol).arguments().get(0);
@@ -1606,7 +1603,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testExtractFunctionWithCorrectType() {
         AnalyzedRelation relation = analyze("select extract(day from timestamp) from transactions");
 
-        Symbol symbol = relation.querySpec().outputs().get(0);
+        Symbol symbol = relation.outputs().get(0);
         assertThat(symbol, isFunction("extract_DAY_OF_MONTH"));
 
         Symbol argument = ((Function) symbol).arguments().get(0);
@@ -1616,7 +1613,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void selectCurrentTimeStamp() {
         AnalyzedRelation relation = analyze("select CURRENT_TIMESTAMP from sys.cluster");
-        Symbol currentTime = relation.querySpec().outputs().get(0);
+        Symbol currentTime = relation.outputs().get(0);
         assertThat(currentTime, instanceOf(Literal.class));
         assertThat(currentTime.valueType(), is(DataTypes.TIMESTAMPZ));
     }
@@ -1624,7 +1621,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAnyRightLiteral() throws Exception {
         AnalyzedRelation relation = analyze("select id from sys.shards where id = any ([1,2])");
-        WhereClause whereClause = relation.querySpec().where();
+        WhereClause whereClause = relation.where();
         assertThat(whereClause.hasQuery(), is(true));
         assertThat(whereClause.query(),
                    isFunction("any_=", ImmutableList.of(DataTypes.INTEGER, new ArrayType(DataTypes.INTEGER))));
@@ -1637,8 +1634,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "from transactions " +
             "where random() = 13.2 " +
             "order by 1, random(), random()");
-        List<Symbol> outputs = relation.querySpec().outputs();
-        List<Symbol> orderBySymbols = relation.querySpec().orderBy().orderBySymbols();
+        List<Symbol> outputs = relation.outputs();
+        List<Symbol> orderBySymbols = relation.orderBy().orderBySymbols();
 
         // non deterministic, all equal
         assertThat(outputs.get(0),
@@ -1661,7 +1658,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(orderBySymbols.get(0), is(equalTo(orderBySymbols.get(1))));
 
         // check where clause
-        WhereClause whereClause = relation.querySpec().where();
+        WhereClause whereClause = relation.where();
         Function eqFunction = (Function) whereClause.query();
         Symbol whereClauseSleepFn = eqFunction.arguments().get(0);
         assertThat(outputs.get(0), is(equalTo(whereClauseSleepFn)));
@@ -1692,10 +1689,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testStarToFieldsInMultiSelect() throws Exception {
         AnalyzedRelation relation = analyze(
             "select jobs.stmt, operations.* from sys.jobs, sys.operations where jobs.id = operations.job_id");
-        List<Symbol> joinOutputs = relation.querySpec().outputs();
+        List<Symbol> joinOutputs = relation.outputs();
 
         AnalyzedRelation operations = analyze("select * from sys.operations");
-        List<Symbol> operationOutputs = operations.querySpec().outputs();
+        List<Symbol> operationOutputs = operations.outputs();
         assertThat(joinOutputs.size(), is(operationOutputs.size() + 1));
     }
 
@@ -1709,7 +1706,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testFullQualifiedStarPrefix() throws Exception {
         AnalyzedRelation relation = analyze("select sys.jobs.* from sys.jobs");
-        List<Symbol> outputs = relation.querySpec().outputs();
+        List<Symbol> outputs = relation.outputs();
         assertThat(outputs.size(), is(5));
         //noinspection unchecked
         assertThat(outputs, Matchers.contains(isReference("id"),
@@ -1730,7 +1727,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarWithTableAliasAsPrefix() throws Exception {
         AnalyzedRelation relation = analyze("select t1.* from sys.jobs t1");
-        List<Symbol> outputs = relation.querySpec().outputs();
+        List<Symbol> outputs = relation.outputs();
         assertThat(outputs.size(), is(5));
         //noinspection unchecked
         assertThat(outputs, Matchers.contains(isReference("id"),
@@ -1752,14 +1749,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectMatchOnGeoShape() throws Exception {
         AnalyzedRelation relation = analyze(
             "select * from users where match(shape, 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))')");
-        assertThat(relation.querySpec().where().query(), isFunction("match"));
+        assertThat(relation.where().query(), isFunction("match"));
     }
 
     @Test
     public void testSelectMatchOnGeoShapeObjectLiteral() throws Exception {
         AnalyzedRelation relation = analyze(
             "select * from users where match(shape, {type='Polygon', coordinates=[[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]]})");
-        assertThat(relation.querySpec().where().query(), isFunction("match"));
+        assertThat(relation.where().query(), isFunction("match"));
     }
 
     @Test
@@ -1773,7 +1770,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectStarFromUnnest() throws Exception {
         AnalyzedRelation relation = analyze("select * from unnest([1, 2], ['Marvin', 'Trillian'])");
         //noinspection generics
-        assertThat(relation.querySpec().outputs(), contains(isReference("col1"), isReference("col2")));
+        assertThat(relation.outputs(), contains(isReference("col1"), isReference("col2")));
     }
 
     @Test
@@ -1786,7 +1783,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectCol1FromUnnest() throws Exception {
         AnalyzedRelation relation = analyze("select col1 from unnest([1, 2], ['Marvin', 'Trillian'])");
-        assertThat(relation.querySpec().outputs(), contains(isReference("col1")));
+        assertThat(relation.outputs(), contains(isReference("col1")));
     }
 
     @Test
@@ -1797,8 +1794,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "group by 2, 3 " +
             "having collect_set(recovery['size']['percent']) != [100.0] " +
             "order by 2, 3");
-        assertThat(relation.querySpec().having(), notNullValue());
-        assertThat(relation.querySpec().having().query(),
+        assertThat(relation.having(), notNullValue());
+        assertThat(relation.having().query(),
             isSQL("(NOT (collect_set(sys.shards.recovery['size']['percent']) = [100.0]))"));
     }
 
@@ -1823,7 +1820,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         String sqlFields = "col1, col2, col3, col4, " +
                            "col5, col6, col7, col8, " +
                            "col9, col10, col11";
-        assertThat(relation.querySpec().outputs(), isSQL(sqlFields));
+        assertThat(relation.outputs(), isSQL(sqlFields));
         assertThat(relation.fields(), isSQL(sqlFields));
     }
 
@@ -1837,7 +1834,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testScalarCanBeUsedInFromClause() {
         AnalyzedRelation relation = analyze("select * from abs(1)");
-        assertThat(relation.querySpec().outputs(), isSQL("abs"));
+        assertThat(relation.outputs(), isSQL("abs"));
         assertThat(relation.fields(), isSQL("abs"));
         assertThat(((QueriedTable) relation).tableRelation(), instanceOf(TableFunctionRelation.class));
     }

--- a/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
@@ -52,9 +52,9 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testEmptyOverClause() {
-        QueriedTable analysis = e.analyze("select avg(x) OVER () from t");
+        QueriedTable<?> analysis = e.analyze("select avg(x) OVER () from t");
 
-        List<Symbol> outputSymbols = analysis.querySpec().outputs();
+        List<Symbol> outputSymbols = analysis.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(WindowFunction.class));
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
@@ -67,9 +67,9 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testOverWithPartitionByClause() {
-        QueriedTable analysis = e.analyze("select avg(x) OVER (PARTITION BY x) from t");
+        QueriedTable<?> analysis = e.analyze("select avg(x) OVER (PARTITION BY x) from t");
 
-        List<Symbol> outputSymbols = analysis.querySpec().outputs();
+        List<Symbol> outputSymbols = analysis.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(WindowFunction.class));
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
@@ -101,9 +101,9 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testOverWithOrderByClause() {
-        QueriedTable analysis = e.analyze("select avg(x) OVER (ORDER BY x) from t");
+        QueriedTable<?> analysis = e.analyze("select avg(x) OVER (ORDER BY x) from t");
 
-        List<Symbol> outputSymbols = analysis.querySpec().outputs();
+        List<Symbol> outputSymbols = analysis.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(WindowFunction.class));
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
@@ -114,9 +114,9 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testOverWithPartitionAndOrderByClauses() {
-        QueriedTable analysis = e.analyze("select avg(x) OVER (PARTITION BY x ORDER BY x) from t");
+        QueriedTable<?> analysis = e.analyze("select avg(x) OVER (PARTITION BY x ORDER BY x) from t");
 
-        List<Symbol> outputSymbols = analysis.querySpec().outputs();
+        List<Symbol> outputSymbols = analysis.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(WindowFunction.class));
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
@@ -128,10 +128,10 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testOverWithFrameDefinition() {
-        QueriedTable analysis = e.analyze("select avg(x) OVER (PARTITION BY x ORDER BY x " +
-                                          "RANGE BETWEEN 5 PRECEDING AND 6 FOLLOWING) from t");
+        QueriedTable<?> analysis = e.analyze("select avg(x) OVER (PARTITION BY x ORDER BY x " +
+                                             "RANGE BETWEEN 5 PRECEDING AND 6 FOLLOWING) from t");
 
-        List<Symbol> outputSymbols = analysis.querySpec().outputs();
+        List<Symbol> outputSymbols = analysis.outputs();
         assertThat(outputSymbols.size(), is(1));
         assertThat(outputSymbols.get(0), instanceOf(WindowFunction.class));
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);

--- a/sql/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
@@ -52,14 +52,14 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
         AnalyzedRelation relation = analyze("show tables in QNAME");
 
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE ((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
             "ORDER BY information_schema.tables.table_name"));
 
         relation = analyze("show tables");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE ((information_schema.tables.table_type = 'BASE TABLE') " +
             "AND (NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
@@ -71,7 +71,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
         AnalyzedRelation relation = analyze("show tables in QNAME like 'likePattern'");
 
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
             "AND (information_schema.tables.table_name LIKE 'likePattern')) " +
@@ -79,7 +79,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
 
         relation = analyze("show tables like '%'");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND " +
             "(NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
@@ -92,7 +92,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
         AnalyzedRelation relation =
             analyze("show tables in QNAME where table_name = 'foo' or table_name like '%bar%'");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') AND (information_schema.tables.table_schema = 'qname')) " +
             "AND ((information_schema.tables.table_name = 'foo') OR (information_schema.tables.table_name LIKE '%bar%'))) " +
@@ -100,7 +100,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
 
         relation = analyze("show tables where table_name like '%'");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.querySpec(), isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.tables.table_name " +
             "WHERE (((information_schema.tables.table_type = 'BASE TABLE') " +
             "AND (NOT (information_schema.tables.table_schema = ANY(['information_schema', 'sys', 'pg_catalog'])))) " +
@@ -111,9 +111,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testShowSchemasLike() throws Exception {
         AnalyzedRelation relation = analyze("show schemas like '%'");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL("SELECT information_schema.schemata.schema_name " +
+        assertThat(relation, isSQL("SELECT information_schema.schemata.schema_name " +
                                     "WHERE (information_schema.schemata.schema_name LIKE '%') " +
                                     "ORDER BY information_schema.schemata.schema_name"));
     }
@@ -121,9 +119,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testShowSchemasWhere() throws Exception {
         AnalyzedRelation relation = analyze("show schemas where schema_name = 'doc'");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL("SELECT information_schema.schemata.schema_name " +
+        assertThat(relation, isSQL("SELECT information_schema.schemata.schema_name " +
                                     "WHERE (information_schema.schemata.schema_name = 'doc') " +
                                     "ORDER BY information_schema.schemata.schema_name"));
     }
@@ -131,17 +127,14 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testShowSchemas() throws Exception {
         AnalyzedRelation relation = analyze("show schemas");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL("SELECT information_schema.schemata.schema_name " +
+        assertThat(relation, isSQL("SELECT information_schema.schemata.schema_name " +
                                     "ORDER BY information_schema.schemata.schema_name"));
     }
 
     @Test
     public void testShowColumnsLike() throws Exception {
         AnalyzedRelation relation = analyze("show columns from schemata in information_schema like '%'");
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.columns.column_name, information_schema.columns.data_type" +
             " WHERE (((information_schema.columns.table_name = 'schemata')" +
             " AND (information_schema.columns.table_schema = 'information_schema'))" +
@@ -153,9 +146,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     public void testShowColumnsWhere() throws Exception {
         AnalyzedRelation relation = analyze("show columns in schemata from information_schema"
                                             + " where column_name = 'id'");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.columns.column_name, information_schema.columns.data_type" +
             " WHERE (((information_schema.columns.table_name = 'schemata')" +
             " AND (information_schema.columns.table_schema = 'information_schema'))" +
@@ -166,9 +157,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testShowColumnsLikeWithoutSpecifiedSchema() throws Exception {
         AnalyzedRelation relation = analyze("show columns in schemata like '%'");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.columns.column_name, information_schema.columns.data_type" +
             " WHERE (((information_schema.columns.table_name = 'schemata')" +
             " AND (information_schema.columns.table_schema = 'doc'))" +
@@ -179,9 +168,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testShowColumnsFromOneTable() throws Exception {
         AnalyzedRelation relation = analyze("show columns in schemata");
-
-        QuerySpec querySpec = relation.querySpec();
-        assertThat(querySpec, isSQL(
+        assertThat(relation, isSQL(
             "SELECT information_schema.columns.column_name, information_schema.columns.data_type" +
             " WHERE ((information_schema.columns.table_name = 'schemata')" +
             " AND (information_schema.columns.table_schema = 'doc'))" +
@@ -190,7 +177,7 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
 
     @Test
     public void testRewriteOfTransactionIsolation() {
-        QueriedTable stmt = analyze("show transaction isolation level");
+        QueriedTable<?> stmt = analyze("show transaction isolation level");
         assertThat(stmt.tableRelation().tableInfo().ident(), is(SysClusterTableInfo.IDENT));
         assertThat(stmt.outputs(), contains(isLiteral("read uncommitted")));
 

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -135,13 +135,13 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                              " (select b, i from t2 where b > 10) t2 " +
                                              "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
                                              "limit 10");
-        assertThat(relation.querySpec(),
+        assertThat(relation,
                    isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) LIMIT 10"));
         assertThat(relation.joinPairs().get(0).condition(),
                    isSQL("(t1.i = t2.i)"));
-        assertThat(relation.sources().get(new QualifiedName("t1")).querySpec(),
+        assertThat(relation.sources().get(new QualifiedName("t1")),
                    isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
-        assertThat(relation.sources().get(new QualifiedName("t2")).querySpec(),
+        assertThat(relation.sources().get(new QualifiedName("t2")),
                    isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '10')"));
     }
 
@@ -153,13 +153,13 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                              " (select b, i from t2 where b > 10) t2 " +
                                              "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
                                              "order by 2 limit 10");
-        assertThat(relation.querySpec(),
+        assertThat(relation,
             isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) ORDER BY t1.i LIMIT 10"));
         assertThat(relation.joinPairs().get(0).condition(),
             isSQL("(t1.i = t2.i)"));
-        assertThat(relation.sources().get(new QualifiedName("t1")).querySpec(),
+        assertThat(relation.sources().get(new QualifiedName("t1")),
             isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
-        assertThat(relation.sources().get(new QualifiedName("t2")).querySpec(),
+        assertThat(relation.sources().get(new QualifiedName("t2")),
             isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '10')"));
     }
 

--- a/sql/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
@@ -70,10 +70,9 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         UnionSelect tableUnion = (UnionSelect) orderedLimitedRelation.childRelation();
         assertThat(tableUnion.left(), instanceOf(QueriedTable.class));
         assertThat(tableUnion.right(), instanceOf(QueriedTable.class));
-        assertThat(tableUnion.querySpec(),
-            isSQL("SELECT doc.users.id, doc.users.text"));
-        assertThat(tableUnion.left().querySpec(), isSQL("SELECT doc.users.id, doc.users.text"));
-        assertThat(tableUnion.right().querySpec(), isSQL("SELECT doc.users_multi_pk.id, doc.users_multi_pk.name"));
+        assertThat(tableUnion, isSQL("SELECT doc.users.id, doc.users.text"));
+        assertThat(tableUnion.left(), isSQL("SELECT doc.users.id, doc.users.text"));
+        assertThat(tableUnion.right(), isSQL("SELECT doc.users_multi_pk.id, doc.users_multi_pk.name"));
     }
 
     @Test
@@ -95,17 +94,15 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         UnionSelect tableUnion1 = (UnionSelect) orderedLimitedRelation.childRelation();
         assertThat(tableUnion1.left(), instanceOf(UnionSelect.class));
         assertThat(tableUnion1.right(), instanceOf(QueriedTable.class));
-        assertThat(tableUnion1.querySpec(),
-            isSQL("SELECT u1.id, u1.text"));
-        assertThat(tableUnion1.right().querySpec(), isSQL("SELECT doc.users.id, doc.users.name"));
+        assertThat(tableUnion1, isSQL("SELECT u1.id, u1.text"));
+        assertThat(tableUnion1.right(), isSQL("SELECT doc.users.id, doc.users.name"));
 
         UnionSelect tableUnion2 = (UnionSelect) tableUnion1.left();
-        assertThat(tableUnion2.querySpec(),
-            isSQL("SELECT u1.id, u1.text"));
+        assertThat(tableUnion2, isSQL("SELECT u1.id, u1.text"));
         assertThat(tableUnion2.left(), instanceOf(QueriedTable.class));
         assertThat(tableUnion2.right(), instanceOf(QueriedTable.class));
-        assertThat(tableUnion2.left().querySpec(), isSQL("SELECT doc.users.id, doc.users.text"));
-        assertThat(tableUnion2.right().querySpec(), isSQL("SELECT doc.users_multi_pk.id, doc.users_multi_pk.name"));
+        assertThat(tableUnion2.left(), isSQL("SELECT doc.users.id, doc.users.text"));
+        assertThat(tableUnion2.right(), isSQL("SELECT doc.users_multi_pk.id, doc.users_multi_pk.name"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/DummyRelation.java
+++ b/sql/src/test/java/io/crate/testing/DummyRelation.java
@@ -22,10 +22,13 @@
 
 package io.crate.testing;
 
-import io.crate.analyze.QuerySpec;
+import io.crate.analyze.HavingClause;
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
@@ -33,6 +36,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,8 +84,47 @@ public class DummyRelation implements AnalyzedRelation {
     }
 
     @Override
-    public QuerySpec querySpec() {
-        return new QuerySpec();
+    public List<Symbol> outputs() {
+        return null;
+    }
+
+    @Override
+    public WhereClause where() {
+        return null;
+    }
+
+    @Override
+    public List<Symbol> groupBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public HavingClause having() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public OrderBy orderBy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol limit() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Symbol offset() {
+        return null;
+    }
+
+    @Override
+    public boolean hasAggregates() {
+        return false;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/testing/SQLPrinter.java
+++ b/sql/src/test/java/io/crate/testing/SQLPrinter.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Ordering;
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
-import io.crate.analyze.QuerySpec;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolPrinter;
 
@@ -38,8 +38,8 @@ public class SQLPrinter {
     private static final TestingSymbolPrinter TESTING_SYMBOL_PRINTER = new TestingSymbolPrinter();
 
     public static String print(Object o) {
-        if (o instanceof QuerySpec) {
-            return print((QuerySpec) o);
+        if (o instanceof AnalyzedRelation) {
+            return print((AnalyzedRelation) o);
         } else if (o instanceof OrderBy) {
             return print((OrderBy) o);
         } else if (o instanceof Symbol) {
@@ -81,42 +81,43 @@ public class SQLPrinter {
         return sb.toString();
     }
 
-    public static String print(QuerySpec spec) {
+    public static String print(AnalyzedRelation relation) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("SELECT ");
-        TESTING_SYMBOL_PRINTER.process(spec.outputs(), sb);
+        TESTING_SYMBOL_PRINTER.process(relation.outputs(), sb);
 
-        if (spec.where().hasQuery()) {
+        if (relation.where().hasQuery()) {
             sb.append(" WHERE ");
-            TESTING_SYMBOL_PRINTER.process(spec.where().query(), sb);
+            TESTING_SYMBOL_PRINTER.process(relation.where().query(), sb);
         }
-        if (!spec.groupBy().isEmpty()) {
+        if (!relation.groupBy().isEmpty()) {
             sb.append(" GROUP BY ");
-            TESTING_SYMBOL_PRINTER.process(spec.groupBy(), sb);
+            TESTING_SYMBOL_PRINTER.process(relation.groupBy(), sb);
         }
-        HavingClause having = spec.having();
+        HavingClause having = relation.having();
         if (having != null) {
             sb.append(" HAVING ");
             TESTING_SYMBOL_PRINTER.process(having.query(), sb);
         }
-        OrderBy orderBy = spec.orderBy();
+        OrderBy orderBy = relation.orderBy();
         if (orderBy != null) {
             sb.append(" ORDER BY ");
             TESTING_SYMBOL_PRINTER.process(orderBy, sb);
         }
-        Symbol limit = spec.limit();
+        Symbol limit = relation.limit();
         if (limit != null) {
             sb.append(" LIMIT ");
             sb.append(print(limit));
         }
-        Symbol offset = spec.offset();
+        Symbol offset = relation.offset();
         if (offset != null) {
             sb.append(" OFFSET ");
             sb.append(print(offset));
         }
         return sb.toString();
     }
+
 
     /**
      * produces same results as with {@link SymbolPrinter#printQualified(Symbol)} but is

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -62,7 +62,7 @@ public class SymbolMatchers {
     }
 
     private static Matcher<Symbol> hasValue(Object expectedValue) {
-        return new FeatureMatcher<Symbol, Object>(equalTo(expectedValue), "value", "value") {
+        return new FeatureMatcher<>(equalTo(expectedValue), "value", "value") {
             @Override
             protected Object featureValueOf(Symbol actual) {
                 return ((Input) actual).value();
@@ -149,8 +149,8 @@ public class SymbolMatchers {
     }
 
     @SafeVarargs
-    public static Matcher<Symbol> isFunction(final String name, Matcher<Symbol>... argMatchers) {
-        FeatureMatcher<Symbol, Collection<Symbol>> ma = new FeatureMatcher<Symbol, Collection<Symbol>>(
+    public static Matcher<Symbol> isFunction(final String name, Matcher<? super Symbol>... argMatchers) {
+        FeatureMatcher<Symbol, Collection<Symbol>> ma = new FeatureMatcher<>(
             contains(argMatchers), "args", "args") {
             @Override
             protected Collection<Symbol> featureValueOf(Symbol actual) {

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -294,7 +294,7 @@ public class TestingHelpers {
     }
 
     public static <T> Matcher<T> isSQL(final String stmt) {
-        return new BaseMatcher<T>() {
+        return new BaseMatcher<>() {
             @Override
             public boolean matches(Object item) {
                 return SQLPrinter.print(item).equals(stmt);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This makes it harder to mutate relations and removes the redundancy we
had since we introduced the outputs/where/... properties on the
AnalyzedRelation

It will also enable us to further tune the AnalyzedRelation classes.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)