### PR TITLE
Make the attributes in QuerySpec final

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -240,16 +240,23 @@ class CopyAnalyzer {
             throw new UnsupportedFeatureException("Output format not supported without specifying columns.");
         }
 
-        QuerySpec querySpec = new QuerySpec()
-            .outputs(outputs)
-            .where(createWhereClause(
+        QuerySpec querySpec = new QuerySpec(
+            outputs,
+            createWhereClause(
                 node.whereClause(),
                 partitions,
                 normalizer,
                 expressionAnalyzer,
                 expressionAnalysisContext,
-                analysis.transactionContext())
-            );
+                analysis.transactionContext()
+            ),
+            List.of(),
+            null,
+            null,
+            null,
+            null,
+            false
+        );
         QueriedTable<DocTableRelation> subRelation = new QueriedTable<>(false, tableRelation, querySpec);
         return new CopyToAnalyzedStatement(
             subRelation, settings, uri, compressionType, outputFormat, outputNames, columnsDefined, overwrites);

--- a/sql/src/main/java/io/crate/analyze/HavingClause.java
+++ b/sql/src/main/java/io/crate/analyze/HavingClause.java
@@ -24,10 +24,19 @@ package io.crate.analyze;
 import io.crate.expression.symbol.Symbol;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 public class HavingClause extends QueryClause {
 
     public HavingClause(@Nullable Symbol query) {
         super(query);
+    }
+
+    public HavingClause map(Function<? super Symbol, ? extends Symbol> mapper) {
+        if (hasQuery()) {
+            return new HavingClause(mapper.apply(query));
+        } else {
+            return this;
+        }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -192,7 +192,7 @@ public class MultiSourceSelect implements AnalyzedRelation {
             isDistinct,
             mappedSources,
             transform(fields.asList(), Field::path),
-            querySpec.copyAndReplace(mapSymbol),
+            querySpec.map(mapSymbol),
             Lists2.map(joinPairs, joinPair -> joinPair.mapCondition(mapSymbol))
         );
     }

--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -173,7 +173,7 @@ public class OrderBy implements Writeable {
         }
     }
 
-    public OrderBy copyAndReplace(Function<? super Symbol, ? extends Symbol> replaceFunction) {
+    public OrderBy map(Function<? super Symbol, ? extends Symbol> replaceFunction) {
         return new OrderBy(Lists2.map(orderBySymbols, replaceFunction), reverseFlags, nullsFirst);
     }
 

--- a/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -153,7 +153,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
             isDistinct,
             newSubRelation,
             transform(fields.asList(), Field::path),
-            querySpec.copyAndReplace(mapFieldsToNewRelation)
+            querySpec.map(mapFieldsToNewRelation)
         );
     }
 }

--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -69,7 +69,7 @@ public final class QueriedTable<TR extends AbstractTableRelation> implements Ana
             isDistinct,
             tableRelation,
             transform(fields.asList(), Field::path),
-            querySpec.copyAndReplace(mapper)
+            querySpec.map(mapper)
         );
     }
 

--- a/sql/src/main/java/io/crate/analyze/QueryClause.java
+++ b/sql/src/main/java/io/crate/analyze/QueryClause.java
@@ -34,9 +34,6 @@ public abstract class QueryClause {
     protected Symbol query;
     protected boolean noMatch = false;
 
-    protected QueryClause() {
-    }
-
     protected QueryClause(@Nullable Symbol normalizedQuery) {
         if (normalizedQuery == null) {
             return;

--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -155,7 +155,7 @@ public class WhereClause extends QueryClause {
         return this;
     }
 
-    WhereClause copyAndReplace(Function<? super Symbol, ? extends Symbol> replaceFunction) {
+    WhereClause map(Function<? super Symbol, ? extends Symbol> replaceFunction) {
         if (!hasQuery()) {
             return this;
         }

--- a/sql/src/main/java/io/crate/analyze/WindowDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowDefinition.java
@@ -79,7 +79,7 @@ public class WindowDefinition implements Writeable {
         if (!partitions.isEmpty() || orderBy != null) {
             return new WindowDefinition(
                 Lists2.map(partitions, mapSymbolsFunction),
-                orderBy != null ? orderBy.copyAndReplace(mapSymbolsFunction) : null,
+                orderBy != null ? orderBy.map(mapSymbolsFunction) : null,
                 windowFrameDefinition
             );
         } else {

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -25,7 +25,6 @@ package io.crate.analyze.relations;
 import io.crate.analyze.Fields;
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
@@ -37,7 +36,6 @@ import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
 public final class AnalyzedView implements AnalyzedRelation {
@@ -46,7 +44,7 @@ public final class AnalyzedView implements AnalyzedRelation {
     private final String owner;
     private final AnalyzedRelation relation;
     private final Fields fields;
-    private final QuerySpec querySpec;
+    private final List<Symbol> outputSymbols;
 
     public AnalyzedView(RelationName name, String owner, AnalyzedRelation relation) {
         this.name = name;
@@ -56,8 +54,7 @@ public final class AnalyzedView implements AnalyzedRelation {
         for (Field field : relation.fields()) {
             fields.add(field.path(), new Field(this, field.path(), field.valueType()));
         }
-        querySpec = new QuerySpec()
-            .outputs(new ArrayList<>(relation.fields()));
+        this.outputSymbols = List.copyOf(relation.fields());
     }
 
     public String owner() {
@@ -107,45 +104,45 @@ public final class AnalyzedView implements AnalyzedRelation {
 
     @Override
     public List<Symbol> outputs() {
-        return querySpec.outputs();
+        return outputSymbols;
     }
 
     @Override
     public WhereClause where() {
-        return querySpec.where();
+        return WhereClause.MATCH_ALL;
     }
 
     @Override
     public List<Symbol> groupBy() {
-        return querySpec.groupBy();
+        return List.of();
     }
 
     @Nullable
     @Override
     public HavingClause having() {
-        return querySpec.having();
+        return null;
     }
 
     @Nullable
     @Override
     public OrderBy orderBy() {
-        return querySpec.orderBy();
+        return null;
     }
 
     @Nullable
     @Override
     public Symbol limit() {
-        return querySpec.limit();
+        return null;
     }
 
     @Nullable
     @Override
     public Symbol offset() {
-        return querySpec.offset();
+        return null;
     }
 
     @Override
     public boolean hasAggregates() {
-        return querySpec.hasAggregates();
+        return false;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/OrderedLimitedRelation.java
@@ -24,7 +24,6 @@ package io.crate.analyze.relations;
 
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
@@ -65,17 +64,20 @@ import java.util.function.Function;
 public class OrderedLimitedRelation implements AnalyzedRelation {
 
     private final AnalyzedRelation childRelation;
-    private final QuerySpec querySpec;
+    private final OrderBy orderBy;
+    @Nullable
+    private final Symbol limit;
+    @Nullable
+    private final Symbol offset;
 
     public OrderedLimitedRelation(AnalyzedRelation childRelation,
                                   OrderBy orderBy,
                                   @Nullable Symbol limit,
                                   @Nullable Symbol offset) {
         this.childRelation = childRelation;
-        this.querySpec = new QuerySpec();
-        querySpec.limit(limit);
-        querySpec.orderBy(orderBy);
-        querySpec.offset(offset);
+        this.orderBy = orderBy;
+        this.limit = limit;
+        this.offset = offset;
     }
 
     @Override
@@ -129,17 +131,17 @@ public class OrderedLimitedRelation implements AnalyzedRelation {
     }
 
     public OrderBy orderBy() {
-        return querySpec.orderBy();
+        return orderBy;
     }
 
     @Nullable
     public Symbol limit() {
-        return querySpec.limit();
+        return limit;
     }
 
     @Nullable
     public Symbol offset() {
-        return querySpec.offset();
+        return offset;
     }
 
     @Override
@@ -163,7 +165,7 @@ public class OrderedLimitedRelation implements AnalyzedRelation {
         Symbol offset = offset();
         return new OrderedLimitedRelation(
             newChild,
-            orderBy == null ? null : orderBy.copyAndReplace(mapper),
+            orderBy == null ? null : orderBy.map(mapper),
             limit == null ? null : mapper.apply(limit),
             offset == null ? null : mapper.apply(offset)
         );

--- a/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -247,7 +247,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         Symbol newWhereClause = normalizer.normalize(where, coordinatorTxnCtx);
         OrderBy orderBy = this.orderBy;
         if (orderBy != null) {
-            orderBy = orderBy.copyAndReplace(normalize);
+            orderBy = orderBy.map(normalize);
         }
         changed = changed || newWhereClause != where;
         if (changed) {

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -200,7 +200,7 @@ public class Collect implements LogicalPlan {
         RoutedCollectPhase collectPhase = createPhase(plannerContext, params, subQueryResults);
         PositionalOrderBy positionalOrderBy = getPositionalOrderBy(order, outputs);
         if (positionalOrderBy != null) {
-            collectPhase.orderBy(order.copyAndReplace(s -> SubQueryAndParamBinder.convert(s, params, subQueryResults)));
+            collectPhase.orderBy(order.map(s -> SubQueryAndParamBinder.convert(s, params, subQueryResults)));
         }
         int limitAndOffset = limitAndOffset(limit, offset);
         maybeApplyPageSize(limitAndOffset, pageSizeHint, collectPhase);

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathBoundary.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathBoundary.java
@@ -58,7 +58,7 @@ public final class MoveOrderBeneathBoundary implements Rule<Order> {
     public LogicalPlan apply(Order plan, Captures captures) {
         RelationBoundary relationBoundary = captures.get(boundary);
         Function<Symbol, Symbol> mapper = OperatorUtils.getMapper(relationBoundary.expressionMapping());
-        Order newOrder = new Order(relationBoundary.source(), plan.orderBy().copyAndReplace(mapper));
+        Order newOrder = new Order(relationBoundary.source(), plan.orderBy().map(mapper));
         return relationBoundary.replaceSources(List.of(newOrder));
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -64,7 +64,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
 
     private static Order updateSources(Order order, LogicalPlan rhs) {
         List<Symbol> sourceOutputs = order.source().outputs();
-        return new Order(rhs, order.orderBy().copyAndReplace(s -> {
+        return new Order(rhs, order.orderBy().map(s -> {
             int idx = sourceOutputs.indexOf(s);
             if (idx < 0) {
                 throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To make sure we don't start mutating the QuerySpec again.

We could even remove it completely if we inlined all attributes into the
corresponding AnalyzedRelation instances, but before looking into that,
we could first look into merging some of the instances as some have a
similar shape.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)