### PR TITLE
Add zen2/discovery related upgrade notes.

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -26,7 +26,6 @@
 # Clustering: To avoid split-brain situations and data loss on recovery
 #gateway.expected_nodes: 5              # Total amount of nodes
 #gateway.recover_after_nodes: 3         # More than half of the nodes
-#discovery.zen.minimum_master_nodes: 3  # More than half of the nodes
 
 # Networking: Bind to an IP address or interface other than localhost.
 # Be careful! Never expose an unprotected node to the internet.
@@ -34,10 +33,18 @@
 #network.host: _site_
 
 # Cluster discovery: Specify the hosts which will form the CrateDB cluster
-#discovery.zen.ping:
-#  unicast.hosts:
-#    - host1:4300
-#    - host2:4300
+#discovery.seed_hosts:
+#    - host1
+#    - host2
+
+# Bootstrap the cluster using an initial set of master-eligible nodes. All
+# master-eligible nodes must be set here for new (or upgraded from CrateDB < 4.x)
+# production (non loop-back bound) clusters otherwise the cluster is not able to
+# initially vote an initial master node:
+#
+#cluster.initial_master_nodes:
+#    - host1
+#    - host2
 
 
 ################################# Full Settings ##############################
@@ -451,35 +458,19 @@ auth:
 #
 # Unicast discovery allows to explicitly control which nodes will be used
 # to discover the cluster by pinging them.
-#discovery.zen.ping.unicast.hosts:
+#discovery.seed_hosts:
 #  - host1:port
 #  - host2:port
 #
 # If you want to debug the discovery process, you can set a logger in
 # 'config/log4j2.properties' to help you doing so.
 
-# Set to ensure a node sees M other master eligible nodes to be considered
-# operational within the cluster. It's recommended to set it to a higher value
-# than 1 when running more than 2 nodes in the cluster.
+# Bootstrap the cluster using an initial set of master-eligible nodes. All
+# master-eligible nodes must be set here for new (or upgraded from CrateDB < 4.x)
+# production (non loop-back bound) clusters otherwise the cluster is not able to
+# initially vote an initial master node:
 #
-# We highly recommend to set the minimum master nodes as follows:
-#   minimum_master_nodes: (N / 2) + 1 where N is the cluster size
-# That will ensure a full recovery of the cluster state.
-#discovery.zen.minimum_master_nodes: 1
-
-# Set the time to wait for ping responses from other nodes when discovering.
-# Set this option to a higher value on a slow or congested network to minimize
-# discovery failures:
-#discovery.zen.ping.timeout: 3s
-
-# Time a node is waiting for responses from other nodes to a published
-# cluster state.
-#discovery.zen.publish_timeout: 30s
-
-# Ping configuration
-#discovery.zen.fd.ping_timeout: 30s
-#discovery.zen.fd.ping_retries: 3
-#discovery.zen.fd.ping_interval: 1s
+#cluster.initial_master_nodes: ["host1", "host2"]
 
 #/////////////////////////// Discovery via DNS ///////////////////////////////
 
@@ -487,7 +478,7 @@ auth:
 # SRV DNS records.
 
 # To enable SRV discovery you need to set the discovery type to 'srv'.
-#discovery.zen.hosts_provider: srv
+#discovery.seed_providers: srv
 
 # Service discovery requires a query that is used to look up SRV records,
 # this is usually in the format _service._protocol.fqdn
@@ -499,7 +490,7 @@ auth:
 # AWS EC2 API.
 
 # To enable EC2 discovery you need to set the discovery type to 'ec2'.
-#discovery.zen.hosts_provider: ec2
+#discovery.seed_providers: ec2
 
 # There are multiple ways to filter EC2 instances:
 #
@@ -542,7 +533,7 @@ auth:
 # the Azure API.
 
 # To enable Azure discovery you need to set the discovery type to 'azure'.
-#discovery.zen.hosts_provider: azure
+#discovery.seed_providers: azure
 
 # You should provide resource group name of your instances
 #cloud.azure.management.resourcegroup.name: myrg

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -38,8 +38,49 @@ Unreleased Changes
 .. contents::
    :local:
 
+Upgrade Notes
+=============
+
+Discovery Changes
+-----------------
+
+This version of CrateDB uses a new cluster coordination (discovery)
+implementation known as `zen2` which improves resiliency and master election
+times.
+Due to this some discovery settings are renamed, removed and added.
+
+Added Settings
+~~~~~~~~~~~~~~
+
+ - Added :ref:`cluster.initial_master_nodes <cluster_initial_master_nodes>`.
+
+.. CAUTION::
+
+   This setting is required to be set at production (non loopback bound)
+   clusters on upgrade, see
+   :ref:`cluster.initial_master_nodes <cluster_initial_master_nodes>` for
+   details.
+
+Renamed Settings
+~~~~~~~~~~~~~~~~
+
+ - Renamed ``discovery.zen.ping.unicast.hosts`` to ``discovery.seed_hosts``.
+
+ - Renamed ``discovery.zen.hosts_provider`` to ``discovery.seed_providers``.
+
+Removed Settings
+~~~~~~~~~~~~~~~~
+
+The following settings are removed:
+
+ - ``discovery.zen.minimum_master_nodes``
+ - ``discovery.zen.ping_interval``
+ - ``discovery.zen.ping_timeout``
+ - ``discovery.zen.ping_retries``
+ - ``discovery.zen.publish_timeout``
+
 Breaking Changes
-================
+----------------
 
 - Removed the implicit soft limit of 10000 that was applied for clients using
   ``HTTP``.

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -335,10 +335,12 @@ new master node is elected.
    without any configuration.
    Each value should be in the form of host:port or host (where port defaults
    to the setting ``transport.tcp.port``).
- 
+
 .. NOTE::
 
    IPv6 hosts must be bracketed.
+
+.. _cluster_initial_master_nodes:
 
 **cluster.initial_master_nodes**
    | *Default:* ``not set``

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -163,7 +163,7 @@ public class ClusterFormationFailureHelper {
 
                 return String.format(Locale.ROOT,
                     "master not discovered yet, this node has not previously joined a bootstrapped (v%d+) cluster, and %s: %s",
-                    Version.V_4_0_0.major, bootstrappingDescription, discoveryStateIgnoringQuorum);
+                    ((Version.V_4_0_0.externalId / 1000_000) % 100), bootstrappingDescription, discoveryStateIgnoringQuorum);
             }
 
             assert clusterState.getLastCommittedConfiguration().isEmpty() == false;

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -162,28 +162,28 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId())).build();
 
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 1L).getDescription(),
-            is("master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and " +
+            is("master not discovered yet, this node has not previously joined a bootstrapped (v4+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered []; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 1, last-accepted version 7 in term 4"));
 
         final TransportAddress otherAddress = buildNewFakeTransportAddress();
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 2L).getDescription(),
-            is("master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and " +
+            is("master not discovered yet, this node has not previously joined a bootstrapped (v4+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered []; " +
                 "discovery will continue using [" + otherAddress + "] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 2, last-accepted version 7 in term 4"));
 
         final DiscoveryNode otherNode = new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT);
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 3L).getDescription(),
-            is("master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and " +
+            is("master not discovered yet, this node has not previously joined a bootstrapped (v4+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered [" + otherNode + "]; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 3, last-accepted version 7 in term 4"));
 
         assertThat(new ClusterFormationState(Settings.builder().putList(INITIAL_MASTER_NODES_SETTING.getKey(), "other").build(),
                 clusterState, emptyList(), emptyList(), 4L).getDescription(),
-            is("master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and " +
+            is("master not discovered yet, this node has not previously joined a bootstrapped (v4+) cluster, and " +
                 "this node must discover master-eligible nodes [other] to bootstrap a cluster: have discovered []; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 4, last-accepted version 7 in term 4"));


### PR DESCRIPTION
Beside some removed and renamed discovery settings, the new zen2 implementation requires some additional setting `cluster.initial_master_nodes` to be set on update.