### PR TITLE
Ensure a trial license won’t override any existing license

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -234,7 +234,9 @@ Changes
 Fixes
 =====
 
+- Fixed a race condition when setting an enterprise license very early on node
+  startup while a trial license is generated concurrently and such may used
+  instead of the user given license.
+
 - Improve error message for the unsupported :ref:`window-definition` ordered or
   partitioned by an array column type in the context of :ref:`window-functions`
-
-None

--- a/enterprise/licensing/src/test/java/io/crate/integrationtests/LicenseITest.java
+++ b/enterprise/licensing/src/test/java/io/crate/integrationtests/LicenseITest.java
@@ -24,20 +24,22 @@ import io.crate.testing.SQLResponse;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import static org.elasticsearch.common.settings.Settings.builder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
 public class LicenseITest extends SQLTransportIntegrationTest {
 
-    private static final String LICENSE_KEY = "AAAAAAAAAAEAAABAFs4j1KCBd7oXN4ep073eHrdvIO8mbMadmNLFbvxK4F3kj9Cfc2HEYzmCWtLVoQ6I7ocn4g10q90QiFm/w2hm6g==";
+    public static final String ENTERPRISE_LICENSE_KEY =
+        "AAAAAQAAAAIAAAEAGzjeQvokJp4ND3h8T/9/JFij7Jey2wGs4qHTR4kFXBf0dDki61pypEM7Or5p4Vb7e9t4ZErvNwwbMd9O4w" +
+        "TW1ykfbJDWOul71C8pkb8VXkCNnCFHAs2Z71hY88iORn9FzB7gkJyHekv59Dpn9PH42EI52+qbi3oBprtUfbsdudx8Rwnq8ev8" +
+        "4zRF57e5KVUwRvvpBlE7lqYKBLp7BrjYOWMFFKE0liNH7rUff6KBtkK0pmCYcWWp+b7TW8O3mhQoCk1GcRyyDwwhjTKuutWC+w" +
+        "lBj7eoTRqinJ3aK8jr0Yi3q58Zx6Q31MYKsNjn84xwW900v3X1+XjuLJIRYJ+9uA==";
 
     @Test
     public void testLicenseIsAvailableInClusterStateAfterSetLicense() {
-        execute("set license '" + LICENSE_KEY + "'");
+        execute("set license '" + ENTERPRISE_LICENSE_KEY + "'");
 
         LicenseKey licenseKey = clusterService().state().metaData().custom(LicenseKey.WRITEABLE_TYPE);
-        assertThat(licenseKey, is(new LicenseKey(LICENSE_KEY)));
+        assertThat(licenseKey, is(new LicenseKey(ENTERPRISE_LICENSE_KEY)));
     }
 
     @Test

--- a/enterprise/licensing/src/test/java/io/crate/license/TransportSetLicenseActionTest.java
+++ b/enterprise/licensing/src/test/java/io/crate/license/TransportSetLicenseActionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.exceptions.LicenseViolationException;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.junit.Test;
+
+import static io.crate.integrationtests.LicenseITest.ENTERPRISE_LICENSE_KEY;
+import static io.crate.license.EnterpriseLicenseService.UNLIMITED_EXPIRY_DATE_IN_MS;
+
+public class TransportSetLicenseActionTest extends CrateUnitTest {
+
+    @Test
+    public void testTrialLicenseCannotOverrideExistingLicense() throws Exception {
+        MetaData currentMetaData = MetaData.builder()
+            .putCustom(LicenseKey.WRITEABLE_TYPE, new LicenseKey(ENTERPRISE_LICENSE_KEY))
+            .build();
+
+        LicenseData licenseData = new LicenseData(
+            UNLIMITED_EXPIRY_DATE_IN_MS,
+            "Trial-Dummy",
+            3
+        );
+        LicenseKey trialLicenseKey = TrialLicense.createLicenseKey(LicenseKey.VERSION, licenseData);
+
+        expectedException.expect(LicenseViolationException.class);
+        TransportSetLicenseAction.validateTrialLicenseDoNotOverrideExistingLicense(trialLicenseKey, currentMetaData);
+    }
+}


### PR DESCRIPTION
This fixes a race condition which could occur when a `SET LICENSE` stmt
is issued while a trial license is registered concurrently.