### PR TITLE
Fix incorrent field de-duplication

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -234,6 +234,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue were a query on a sub-query with ambiguous columns would
+  return the same values for all of the ambiguous columns. An example is
+  ``SELECT * FROM (SELECT * FROM t1, t2) AS tjoin`` where both ``t1`` and
+  ``t2`` have a column named ``x``. In this case the value for ``t1.x`` would
+  be output twice.
+
 - Fixed a race condition when setting an enterprise license very early on node
   startup while a trial license is generated concurrently and such may used
   instead of the user given license.

--- a/sql/src/main/java/io/crate/analyze/CopyFromReturnSummaryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CopyFromReturnSummaryAnalyzedStatement.java
@@ -28,6 +28,7 @@ import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
@@ -47,14 +48,14 @@ import java.util.function.Predicate;
 public class CopyFromReturnSummaryAnalyzedStatement extends CopyFromAnalyzedStatement implements AnalyzedRelation {
 
     private final List<Field> fields = ImmutableList.of(
-        new Field(this, new ColumnIdent("node"), ObjectType.builder()
+        new Field(this, new ColumnIdent("node"), new InputColumn(0, ObjectType.builder()
             .setInnerType("id", DataTypes.STRING)
             .setInnerType("name", DataTypes.STRING)
-            .build()),
-        new Field(this, new ColumnIdent("uri"), DataTypes.STRING),
-        new Field(this, new ColumnIdent("success_count"), DataTypes.LONG),
-        new Field(this, new ColumnIdent("error_count"), DataTypes.LONG),
-        new Field(this, new ColumnIdent("errors"), ObjectType.untyped())
+            .build())),
+        new Field(this, new ColumnIdent("uri"), new InputColumn(1, DataTypes.STRING)),
+        new Field(this, new ColumnIdent("success_count"), new InputColumn(2, DataTypes.LONG)),
+        new Field(this, new ColumnIdent("error_count"), new InputColumn(3, DataTypes.LONG)),
+        new Field(this, new ColumnIdent("errors"), new InputColumn(4, ObjectType.untyped()))
     );
 
     private QualifiedName qualifiedName;

--- a/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
@@ -47,7 +48,7 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     private final List<Symbol> outputs;
 
     ExplainAnalyzedStatement(String columnName, AnalyzedStatement statement, ProfilingContext context) {
-        Field field = new Field(this, new OutputName(columnName), ObjectType.untyped());
+        Field field = new Field(this, new OutputName(columnName), new InputColumn(0, ObjectType.untyped()));
         this.statement = statement;
         this.fields = Collections.singletonList(field);
         this.context = context;

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -71,7 +71,7 @@ public class MultiSourceSelect implements AnalyzedRelation {
         fields = new Fields(outputNames.size());
         Iterator<Symbol> outputsIterator = querySpec.outputs().iterator();
         for (Path path : outputNames) {
-            fields.add(path, new Field(this, path, outputsIterator.next().valueType()));
+            fields.add(path, new Field(this, path, outputsIterator.next()));
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -56,7 +56,7 @@ public final class QueriedTable<TR extends AbstractTableRelation> implements Ana
         this.fields = new Fields(outputNames.size());
         Iterator<Symbol> outputsIterator = querySpec.outputs().iterator();
         for (Path path : outputNames) {
-            fields.add(path, new Field(this, path, outputsIterator.next().valueType()));
+            fields.add(path, new Field(this, path, outputsIterator.next()));
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
@@ -25,6 +25,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
@@ -46,7 +47,7 @@ public class ShowCreateTableAnalyzedStatement implements AnalyzedStatement, Anal
 
     public ShowCreateTableAnalyzedStatement(DocTableInfo tableInfo) {
         String columnName = String.format(Locale.ENGLISH, "SHOW CREATE TABLE %s", tableInfo.ident().fqn());
-        this.fields = Collections.singletonList(new Field(this, new OutputName(columnName), DataTypes.STRING));
+        this.fields = Collections.singletonList(new Field(this, new OutputName(columnName), new InputColumn(0, DataTypes.STRING)));
         this.tableInfo = tableInfo;
     }
 

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -179,7 +179,7 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
 
     protected Field allocate(Path path, Reference reference) {
         allocatedFields.put(path, reference);
-        return new Field(this, path, reference.valueType());
+        return new Field(this, path, reference);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -52,7 +52,7 @@ public final class AnalyzedView implements AnalyzedRelation {
         this.fields = new Fields(relation.fields().size());
         this.relation = relation;
         for (Field field : relation.fields()) {
-            fields.add(field.path(), new Field(this, field.path(), field.valueType()));
+            fields.add(field.path(), new Field(this, field.path(), field));
         }
         this.outputSymbols = List.copyOf(relation.fields());
     }

--- a/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -53,7 +53,12 @@ public class UnionSelect implements AnalyzedRelation {
         List<Field> fieldsFromLeft = left.fields();
         fields = new Fields(fieldsFromLeft.size());
         for (Field field : fieldsFromLeft) {
-            fields.add(field.path(), new Field(this, field.path(), field.valueType()));
+            // Creating a field that points to the field of the left relation isn't 100% accurate.
+            // We're pointing to *two* symbols (both left AND right).
+            // We could either use a `InputColumn` to do that (by pointing to a position) - (but might be confusing to have InputColumns in the analysis already)
+            // Or introduce a `UnionSymbol` or `UnionField` which would take two symbols it is pointing to
+            // Since this currently has no effect we go with the left symbol until there is a good reason to change it.
+            fields.add(field.path(), new Field(this, field.path(), field));
         }
         this.outputs = List.copyOf(fields.asList());
     }

--- a/sql/src/main/java/io/crate/expression/symbol/Field.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Field.java
@@ -60,15 +60,14 @@ public class Field extends Symbol {
 
     private final AnalyzedRelation relation;
     private final Path path;
-    private final DataType valueType;
+    private final Symbol pointer;
 
-    public Field(AnalyzedRelation relation, Path path, DataType valueType) {
+    public Field(AnalyzedRelation relation, Path path, Symbol pointer) {
         assert path != null : "path must not be null";
         assert relation != null : "relation must not be null";
-
         this.relation = relation;
         this.path = path;
-        this.valueType = valueType;
+        this.pointer = pointer;
     }
 
     public Path path() {
@@ -91,7 +90,7 @@ public class Field extends Symbol {
 
     @Override
     public DataType valueType() {
-        return valueType;
+        return pointer.valueType();
     }
 
     @Override
@@ -107,7 +106,7 @@ public class Field extends Symbol {
     @Override
     public String representation() {
         return "Field{" + relation + "." + path +
-               ", type=" + valueType +
+               ", pointer=" + pointer +
                '}';
     }
 
@@ -120,7 +119,7 @@ public class Field extends Symbol {
 
         if (!relation.equals(that.relation)) return false;
         if (!path.equals(that.path)) return false;
-        if (!valueType.equals(that.valueType)) return false;
+        if (!pointer.equals(that.pointer)) return false;
 
         return true;
     }
@@ -129,7 +128,7 @@ public class Field extends Symbol {
     public int hashCode() {
         int result = Objects.hashCode(relation.getQualifiedName());
         result = 31 * result + path.hashCode();
-        result = 31 * result + valueType.hashCode();
+        result = 31 * result + pointer.hashCode();
         return result;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -78,7 +78,7 @@ public class RelationBoundary implements LogicalPlan {
             LogicalPlan source = sourceBuilder.build(tableStats, mappedUsedColumns);
             for (Symbol symbol : source.outputs()) {
                 RefVisitor.visitRefs(symbol, r -> {
-                    Field field = new Field(relation, r.column(), r.valueType());
+                    Field field = new Field(relation, r.column(), r);
                     if (reverseMapping.putIfAbsent(r, field) == null) {
                         expressionMapping.put(field, r);
                     }

--- a/sql/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze.relations;
 
 import io.crate.analyze.ValuesResolver;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
@@ -45,7 +46,7 @@ public class ExcludedFieldProviderTest {
         QualifiedName excludedName = QualifiedName.of("excluded", "field3");
 
         FieldProvider fieldProvider = (qualifiedName, path, operation) -> {
-            return new Field(Mockito.mock(AnalyzedRelation.class), qualifiedName::toString, DataTypes.INTEGER);
+            return new Field(Mockito.mock(AnalyzedRelation.class), qualifiedName::toString, new InputColumn(0, DataTypes.INTEGER));
         };
         ValuesResolver valuesResolver = argumentColumn -> {
             assertThat(argumentColumn.path().outputName(), is("field3"));

--- a/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FuncArg;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
@@ -143,7 +144,7 @@ public class FuncParamsTest extends CrateUnitTest {
     @Test
     public void testFieldsAreNotCastable() {
         Path path = new ColumnIdent("test");
-        Field field = new Field(Mockito.mock(AnalyzedRelation.class), path, DataTypes.INTEGER);
+        Field field = new Field(Mockito.mock(AnalyzedRelation.class), path, new InputColumn(0, DataTypes.INTEGER));
         FuncParams params = FuncParams.builder(Param.LONG).build();
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("Cannot cast test to type bigint");

--- a/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -29,6 +29,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.test.integration.CrateUnitTest;
@@ -52,9 +53,9 @@ public class RestActionReceiversTest extends CrateUnitTest {
         new RowN(new Object[]{"foobar", 3, null})
     );
     private final List<Field> fields = ImmutableList.of(
-        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_a"), DataTypes.STRING),
-        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_b"), DataTypes.INTEGER),
-        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_c"), DataTypes.BOOLEAN)
+        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_a"), new InputColumn(0, DataTypes.STRING)),
+        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_b"), new InputColumn(1, DataTypes.INTEGER)),
+        new Field(new DummyRelation(), ColumnIdent.fromPath("doc.col_c"), new InputColumn(2, DataTypes.BOOLEAN))
     );
     private final Row row = new Row1(1L);
 

--- a/sql/src/test/java/io/crate/testing/DummyRelation.java
+++ b/sql/src/test/java/io/crate/testing/DummyRelation.java
@@ -28,6 +28,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
@@ -63,7 +64,7 @@ public class DummyRelation implements AnalyzedRelation {
     @Override
     public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
         if (columnReferences.contains(path)) {
-            return new Field(this, path, DataTypes.STRING);
+            return new Field(this, path, new InputColumn(0, DataTypes.STRING));
         }
         return null;
     }

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -39,7 +39,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -47,6 +46,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class SymbolMatchers {
 
@@ -55,21 +55,11 @@ public class SymbolMatchers {
     }
 
     private static Matcher<Symbol> hasDataType(DataType type) {
-        return new FeatureMatcher<>(equalTo(type), "valueType", "valueType") {
-            @Override
-            protected DataType featureValueOf(Symbol actual) {
-                return actual.valueType();
-            }
-        };
+        return withFeature(Symbol::valueType, "valueType", equalTo(type));
     }
 
     private static Matcher<Symbol> hasValue(Object expectedValue) {
-        return new FeatureMatcher<>(equalTo(expectedValue), "value", "value") {
-            @Override
-            protected Object featureValueOf(Symbol actual) {
-                return ((Input) actual).value();
-            }
-        };
+        return withFeature(s -> ((Input) s).value(), "value", equalTo(expectedValue));
     }
 
     public static Matcher<Symbol> isLiteral(Object expectedValue, @Nullable final DataType type) {
@@ -80,13 +70,8 @@ public class SymbolMatchers {
     }
 
     public static Matcher<Symbol> isInputColumn(final Integer index) {
-        return both(Matchers.<Symbol>instanceOf(InputColumn.class)).and(
-            new FeatureMatcher<Symbol, Integer>(equalTo(index), "index", "index") {
-                @Override
-                protected Integer featureValueOf(Symbol actual) {
-                    return ((InputColumn) actual).index();
-                }
-            });
+        return both(Matchers.<Symbol>instanceOf(InputColumn.class))
+            .and(withFeature(s -> ((InputColumn) s).index(), "index", equalTo(index)));
     }
 
     public static Matcher<Symbol> isField(final String expectedName) {
@@ -94,43 +79,23 @@ public class SymbolMatchers {
     }
 
     public static Matcher<Symbol> isField(final String expectedName, @Nullable final DataType dataType) {
-        FeatureMatcher<Symbol, String> fm = new FeatureMatcher<Symbol, String>(equalTo(expectedName), "path", "path") {
-            @Override
-            protected String featureValueOf(Symbol actual) {
-                return ((Field) actual).path().outputName();
-            }
-        };
+        var hasExpectedName = withFeature(s -> ((Field) s).path().outputName(), "name", equalTo(expectedName));
         if (dataType == null) {
-            return fm;
+            return both(Matchers.<Symbol>instanceOf(Field.class)).and(hasExpectedName);
         }
-        return both(fm).and(hasDataType(dataType));
+        return allOf(instanceOf(Field.class), hasExpectedName, hasDataType(dataType));
     }
 
     public static Matcher<Symbol> isFetchRef(int docIdIdx, String ref) {
         return isFetchRef(isInputColumn(docIdIdx), isReference(ref));
     }
 
-    public static Matcher<Symbol> isFetchRef(Matcher<Symbol> docIdMatcher, Matcher<Symbol> refMatcher) {
-
-        FeatureMatcher<Symbol, Symbol> m1 = new FeatureMatcher<Symbol, Symbol>(
-            docIdMatcher, "docId", "docId"
-        ) {
-            @Override
-            protected Symbol featureValueOf(Symbol actual) {
-                return ((FetchReference) actual).fetchId();
-            }
-        };
-
-        FeatureMatcher<Symbol, Symbol> m2 = new FeatureMatcher<Symbol, Symbol>(
-            refMatcher, "ref", "ref"
-        ) {
-            @Override
-            protected Symbol featureValueOf(Symbol actual) {
-                return ((FetchReference) actual).ref();
-            }
-        };
-        return allOf(Matchers.<Symbol>instanceOf(FetchReference.class), m1, m2);
-
+    public static Matcher<Symbol> isFetchRef(Matcher<Symbol> fetchIdMatcher, Matcher<Symbol> refMatcher) {
+        return allOf(
+            Matchers.instanceOf(FetchReference.class),
+            withFeature(s -> ((FetchReference) s).fetchId(), "fetchId", fetchIdMatcher),
+            withFeature(s -> ((FetchReference) s).ref(), "ref", refMatcher)
+        );
     }
 
     public static Matcher<Symbol> isReference(String expectedName) {
@@ -148,7 +113,7 @@ public class SymbolMatchers {
         );
     }
 
-    private static <T> Matcher<Symbol> withFeature(java.util.function.Function<? super Symbol, T> getFeature,
+    private static <T> FeatureMatcher<Symbol, T> withFeature(java.util.function.Function<? super Symbol, T> getFeature,
                                                    String featureName,
                                                    Matcher<T> featureMatcher) {
         return new FeatureMatcher<>(featureMatcher, featureName, featureName) {
@@ -161,12 +126,7 @@ public class SymbolMatchers {
     }
 
     public static Matcher<Symbol> isReference(final String expectedName, @Nullable final DataType dataType) {
-        FeatureMatcher<Symbol, String> fm = new FeatureMatcher<>(equalTo(expectedName), "name", "name") {
-            @Override
-            protected String featureValueOf(Symbol actual) {
-                return ((Reference) actual).column().outputName();
-            }
-        };
+        Matcher<Symbol> fm = withFeature(s -> ((Reference) s).column().outputName(), "name", equalTo(expectedName));
         if (dataType == null) {
             return allOf(Matchers.instanceOf(Reference.class), fm);
         }
@@ -175,25 +135,13 @@ public class SymbolMatchers {
 
     @SafeVarargs
     public static Matcher<Symbol> isFunction(final String name, Matcher<? super Symbol>... argMatchers) {
-        FeatureMatcher<Symbol, Collection<Symbol>> ma = new FeatureMatcher<>(
-            contains(argMatchers), "args", "args") {
-            @Override
-            protected Collection<Symbol> featureValueOf(Symbol actual) {
-                return ((Function) actual).arguments();
-            }
-        };
-        return both(isFunction(name)).and(ma);
+        return both(isFunction(name))
+            .and(withFeature(s -> ((Function) s).arguments(), "args", contains(argMatchers)));
     }
 
     public static Matcher<Symbol> isFunction(String name) {
-        FeatureMatcher<Symbol, String> mn = new FeatureMatcher<Symbol, String>(
-            equalTo(name), "name", "name") {
-            @Override
-            protected String featureValueOf(Symbol actual) {
-                return ((Function) actual).info().ident().name();
-            }
-        };
-        return both(Matchers.<Symbol>instanceOf(Function.class)).and(mn);
+        return both(Matchers.<Symbol>instanceOf(Function.class))
+            .and(withFeature(s -> ((Function) s).info().ident().name(), "name", equalTo(name)));
     }
 
     public static Matcher<Symbol> isFunction(final String name, @Nullable final List<DataType> argumentTypes) {
@@ -212,12 +160,7 @@ public class SymbolMatchers {
     }
 
     public static Matcher<Symbol> isAggregation(String name) {
-        FeatureMatcher<Symbol, String> fm = new FeatureMatcher<Symbol, String>(equalTo(name), "name", "name") {
-            @Override
-            protected String featureValueOf(Symbol actual) {
-                return ((Aggregation) actual).functionIdent().name();
-            }
-        };
-        return both(Matchers.<Symbol>instanceOf(Aggregation.class)).and(fm);
+        return both(Matchers.<Symbol>instanceOf(Aggregation.class))
+            .and(withFeature(s -> ((Aggregation) s).functionIdent().name(), "name", equalTo(name)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In a scenario like so:

    create table t1 (x int);
    create table t2 (x int);
    insert into t1 (x) values (1), (2), (3);
    insert into t2 (x) values (2), (3), (4);
    refresh table t1, t2;
    select * from (select * from t1 left join t2 on t1.x = t2.x) tjoin;

The query returned the value for `t1.x` twice because it got
de-duplicated due to the fields looking identical. Both had
`relation=tjoin` and `path=x`.

To address this, this changes the Field to contain the symbol the field
is pointing to. This way it includes a reference to the underlying
`t1.x` or `t2.x` `Reference` symbols and it correctly detects that the
fields on the upper level are different.

This should also make it easier to later on de-duplicate `fields()` and
`outputs()` on `AnalyzedRelation`


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)