### PR TITLE
Add note about SET SESSION privilege limitation

### DIFF
--- a/blackbox/docs/admin/privileges.rst
+++ b/blackbox/docs/admin/privileges.rst
@@ -40,6 +40,11 @@ user is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH``, ``COPY TO``,
 and ``SET SESSION`` statements, as well as using the available user defined
 functions, on the object for which the privilege applies.
 
+.. NOTE::
+
+   :ref:`SET GLOBAL <ref-set-desc>` privileges cannot be granted because ``SET
+   GLOBAL`` statements can only be issued by the superuser.
+
 ``DML``
 .......
 

--- a/blackbox/docs/sql/statements/set.rst
+++ b/blackbox/docs/sql/statements/set.rst
@@ -25,6 +25,8 @@ Synopsis
 
     RESET GLOBAL setting_ident [, ...]
 
+.. _ref-set-desc:
+
 Description
 ===========
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change adds a note to the DQL privileges documentation about the `SET SESSION` limitation.

## Checklist

 - [ ] ~User relevant changes are recorded in ``CHANGES.txt``~
 - [ ] ~Touched code is covered by tests~
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes