### PR TITLE
Disables the coordinator unit tests as they introduces flakiness.

### DIFF
--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -73,12 +73,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.disruption.DisruptableMockTransport;
 import org.elasticsearch.test.disruption.DisruptableMockTransport.ConnectionStatus;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -143,6 +143,10 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 
+/**
+ * TODO: Fix flakiness of the test suite
+ */
+@Ignore("Flaky test suite, fix asap")
 public class CoordinatorTests extends ESTestCase {
 
     private final List<NodeEnvironment> nodeEnvironments = new ArrayList<>();


### PR DESCRIPTION
Flakiness should be tackled in a dedicated branch to not break all master test runs.