### PR TITLE
 Fix flaky testArrayLengthWithAllSupportedTypes & testWhereRefEqNullWithDifferentTypes.

### DIFF
--- a/sql/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/sql/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -27,7 +27,6 @@ import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.Version;
 import org.junit.After;
@@ -280,12 +279,16 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             Object[] values = new Object[] {
                 arr
             };
+
+            // ensure the test is operating on a fresh, empty cluster state (no tables)
+            resetClusterService();
+
             try (QueryTester tester = new QueryTester.Builder(
                 createTempDir(),
                 THREAD_POOL,
                 clusterService,
                 Version.CURRENT,
-                "create table t (xs array(\"" + type.getName() + "\"))"
+                "create table \"t_"+ type.getName() + "\" (xs array(\"" + type.getName() + "\"))"
             ).indexValues("xs", values).build()) {
                 System.out.println(type);
                 List<Object> result = tester.runQuery("xs", "array_length(xs, 1) >= 2");

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -71,6 +71,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testWhereRefEqNullWithDifferentTypes() throws Exception {
         for (DataType type : DataTypes.PRIMITIVE_TYPES) {
+            // ensure the test is operating on a fresh, empty cluster state (no existing tables)
+            resetClusterService();
+
             DocTableInfo tableInfo = SQLExecutor.tableInfo(
                 new RelationName(DocSchemaInfo.NAME, "test_primitive"),
                 "create table doc.test_primitive (" +


### PR DESCRIPTION
Both tests were re-creating the same table with a different definition on the same cluster state.
By resetting the cluster state before re-creating a possible existing table, it can be ensured that the test is working on the correct table definition.