### PR TITLE
Support host names as `initial_master_nodes` entries.

### DIFF
--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -344,10 +344,10 @@ new master node is elected.
    | *Default:* ``not set``
    | *Runtime:* ``no``
 
-   Contains a list of names or IP addresses of the master-eligible nodes which
-   will vote in the very first election of a cluster that's bootstrapping for
-   the first time. By default this is not set, meaning it expects this node to
-   join an already formed cluster.
+   Contains a list of node names, full-qualified hostnames or IP addresses of
+   the master-eligible nodes which will vote in the very first election of a
+   cluster that's bootstrapping for the first time. By default this is not set,
+   meaning it expects this node to join an already formed cluster.
    In development mode, with no discovery settings configured, this step is
    performed by the nodes themselves, but this auto-bootstrapping is designed
    to aim development and is not safe for production. In production you must

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -214,6 +214,7 @@ public class ClusterBootstrapService {
 
     private static boolean matchesRequirement(DiscoveryNode discoveryNode, String requirement) {
         return discoveryNode.getName().equals(requirement)
+            || discoveryNode.getHostName().equals(requirement)
             || discoveryNode.getAddress().toString().equals(requirement)
             || discoveryNode.getAddress().getAddress().equals(requirement);
     }

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -411,6 +411,18 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
         assertTrue(bootstrapped.get());
     }
 
+    public void testMatchesOnHostName() {
+        final AtomicBoolean bootstrapped = new AtomicBoolean();
+        ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(
+            Settings.builder().putList(INITIAL_MASTER_NODES_SETTING.getKey(), localNode.getHostName()).build(), transportService,
+            Collections::emptyList, () -> false, vc -> assertTrue(bootstrapped.compareAndSet(false, true)));
+
+        transportService.start();
+        clusterBootstrapService.onFoundPeersUpdated();
+        deterministicTaskQueue.runAllTasks();
+        assertTrue(bootstrapped.get());
+    }
+
     public void testMatchesOnNodeAddress() {
         final AtomicBoolean bootstrapped = new AtomicBoolean();
         ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(


### PR DESCRIPTION
Adds support for using the `hostname` of each node in addition to
`node.name` or `<IP-Address>`, so same values used for
`discovery.seed_hosts` can be used.