### PR TITLE
WIP: Fix flaky remote collector test.

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollectorTest.java
@@ -113,7 +113,7 @@ public class ShardStateAwareRemoteCollectorTest extends CrateDummyClusterService
 
         // add 2 nodes and the table to the cluster state
         SQLExecutor.builder(clusterService, 2, Randomness.get())
-            .addTable("create table t (id long primary key)")
+            .addTable("create table t (id long primary key) clustered into 1 shards with (number_of_replicas=0)")
             .build();
     }
 


### PR DESCRIPTION
The used table was build with 4 shards and 1 replica while the tests
are overriding this with 1 shard only.