### PR TITLE
Fix timeout due to not enough replicas started

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
+++ b/sql/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
@@ -256,7 +256,7 @@ public class PrimaryAllocationIT extends SQLTransportIntegrationTest {
         final int numberOfReplicas = between(2, 3);
         final String oldPrimary = internalCluster().startDataOnlyNode();
         execute("create table t (x string) clustered into 1 shards " +
-                "with (number_of_replicas = " + numberOfReplicas + ")");
+                "with (number_of_replicas = " + numberOfReplicas + ", \"write.wait_for_active_shards\" = 1)");
         final ShardId shardId = new ShardId(clusterService().state().metaData().index(indexName).getIndex(), 0);
         final Set<String> replicaNodes = new HashSet<>(internalCluster().startDataOnlyNodes(numberOfReplicas));
         ensureGreen();


### PR DESCRIPTION
as it's just one data node when creating the table

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
