### PR TITLE
Create default template in a dedicated service

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -92,8 +92,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
     private final Map<String, SchemaInfo> schemas = new ConcurrentHashMap<>();
     private final Map<String, SchemaInfo> builtInSchemas;
 
-    private final DefaultTemplateService defaultTemplateService;
-
     @Inject
     public Schemas(Map<String, SchemaInfo> builtInSchemas,
                    ClusterService clusterService,
@@ -102,7 +100,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         this.docSchemaInfoFactory = docSchemaInfoFactory;
         schemas.putAll(builtInSchemas);
         this.builtInSchemas = builtInSchemas;
-        this.defaultTemplateService = new DefaultTemplateService(clusterService);
     }
 
     public TableInfo resolveTableInfo(QualifiedName ident, Operation operation, SearchPath searchPath) {
@@ -260,7 +257,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         if (!event.metaDataChanged()) {
             return;
         }
-        defaultTemplateService.createIfNotExists(event.state());
 
         Set<String> newCurrentSchemas = getNewCurrentSchemas(event.state().metaData());
         synchronized (schemas) {

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -48,6 +48,7 @@ import io.crate.license.CeLicenseModule;
 import io.crate.license.LicenseExtension;
 import io.crate.lucene.ArrayMapperService;
 import io.crate.metadata.DanglingArtifactsService;
+import io.crate.metadata.DefaultTemplateService;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.MetaDataBlobModule;
@@ -152,6 +153,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             .add(PostgresNetty.class)
             .add(TasksService.class)
             .add(Schemas.class)
+            .add(DefaultTemplateService.class)
             .add(ArrayMapperService.class)
             .add(DanglingArtifactsService.class);
         if (licenseExtension != null) {


### PR DESCRIPTION
The Schemas class is heavily used in unit tests where most test rely on
synchronous cluster state publishing. The default template state
change was triggered asynchronously by the Schemas event listeners
which may caused an existing (synchronous) state change to be
overwritten resulting in test failures.