### PR TITLE
Remove unused HDFS repository setting 'concurrent_streams'

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -88,6 +88,9 @@ The following settings are removed:
 Breaking Changes
 ----------------
 
+- Removed :ref:`HDFS repository setting<ref-create-repository-types-hdfs>`:
+  ``concurrent_streams`` as it is no longer supported.
+
 - Removed the implicit soft limit of 10000 that was applied for clients using
   ``HTTP``.
 

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -165,12 +165,6 @@ A repository that stores its snapshot inside an HDFS file-system.
 
   Dynamic config values added to the Hadoop configuration.
 
-**concurrent_streams**
-  | *Type:*    ``integer``
-  | *Default:* ``5``
-
-  The number of concurrent streams to use for backup and restore.
-
 **compress**
   | *Type:*    ``boolean``
   | *Default:* ``true``

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -71,7 +71,6 @@ public class RepositorySettingsModule extends AbstractModule {
             .put("security.principal", Setting.simpleString("security.principal", Setting.Property.NodeScope))
             .put("path", Setting.simpleString("path", Setting.Property.NodeScope))
             .put("load_defaults", Setting.boolSetting("load_defaults", true, Setting.Property.NodeScope))
-            .put("concurrent_streams", Setting.intSetting("concurrent_streams", 5, Setting.Property.NodeScope))
             .put("compress", Setting.boolSetting("compress", true, Setting.Property.NodeScope))
             // We cannot use a ByteSize setting as it doesn't support NULL and it must be NULL as default to indicate to
             // not override the default behaviour.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)