### PR TITLE
Remove index() from Field

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchRowInputSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchRowInputSymbolVisitor.java
@@ -28,11 +28,11 @@ import io.crate.expression.BaseImplementationSymbolVisitor;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.InputColumn;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.fetch.FetchSource;
 
 import java.util.Map;
@@ -197,7 +197,8 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
 
     @Override
     public Input<?> visitField(Field field, Context context) {
-        return context.allocateInput(field.index());
+        throw new UnsupportedOperationException(
+            "Encountered " + field + " but Fields should have been changed to InputColumns already");
     }
 
     @Override
@@ -208,6 +209,5 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
         assert fetchReference.ref().granularity() == RowGranularity.PARTITION :
             "fetchReference.ref().granularity() must be " + RowGranularity.PARTITION;
         return context.allocatePartitionedInput(fetchReference);
-
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/Field.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Field.java
@@ -70,6 +70,10 @@ public class Field extends Symbol {
         this.pointer = pointer;
     }
 
+    public Symbol pointer() {
+        return pointer;
+    }
+
     public Path path() {
         return path;
     }
@@ -130,14 +134,5 @@ public class Field extends Symbol {
         result = 31 * result + path.hashCode();
         result = 31 * result + pointer.hashCode();
         return result;
-    }
-
-    /**
-     * @return the position of the field in its relation
-     */
-    public int index() {
-        int idx = relation.fields().indexOf(this);
-        assert idx >= 0 : "idx must be >= 0";
-        return idx;
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -319,7 +319,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
         }
         FieldsVisitor.visitFields(symbol, f -> {
             if (f.relation().getQualifiedName().equals(rel.getQualifiedName())) {
-                consumer.accept(rel.outputs().get(f.index()));
+                consumer.accept(f.pointer());
             }
         });
     }

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -59,10 +59,12 @@ public class RelationBoundary extends ForwardingLogicalPlan {
         return (tableStats, usedBeforeNextFetch) -> {
             HashMap<Symbol, Symbol> expressionMapping = new HashMap<>();
             HashMap<Symbol, Symbol> reverseMapping = new HashMap<>();
-            for (Field field : relation.fields()) {
-                Symbol value = field.relation().outputs().get(field.index());
-                expressionMapping.put(field, value);
-                reverseMapping.put(value, field);
+            List<Field> fields = relation.fields();
+            for (int i = 0; i < fields.size(); i++) {
+                Field field = fields.get(i);
+                Symbol outputAtSamePosition = relation.outputs().get(i);
+                expressionMapping.put(field, outputAtSamePosition);
+                reverseMapping.put(outputAtSamePosition, field);
             }
             Function<Symbol, Symbol> mapper = OperatorUtils.getMapper(expressionMapping);
             HashSet<Symbol> mappedUsedColumns = new LinkedHashSet<>();

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -114,7 +114,7 @@ public class Union implements LogicalPlan {
         }
         FieldsVisitor.visitFields(symbol, f -> {
             if (f.relation().getQualifiedName().equals(rel.getQualifiedName())) {
-                consumer.accept(rel.outputs().get(f.index()));
+                consumer.accept(f.pointer());
             }
         });
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To favour `pointer`

- In two cases `pointer()` can be used instead
- One case was dead code and shouldn't be supported
- One case can be changed easily


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)