### PR TITLE
Ignore new trial license if a license exists.

### DIFF
--- a/enterprise/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
+++ b/enterprise/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
@@ -18,7 +18,6 @@
 
 package io.crate.license;
 
-import io.crate.exceptions.LicenseViolationException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -69,7 +68,9 @@ public class TransportSetLicenseAction extends TransportMasterNodeAction<SetLice
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     MetaData currentMetaData = currentState.metaData();
-                    validateTrialLicenseDoNotOverrideExistingLicense(metaData, currentMetaData);
+                    if (ignoreNewTrialLicense(metaData, currentMetaData)) {
+                        return currentState;
+                    }
                     MetaData.Builder mdBuilder = MetaData.builder(currentMetaData);
                     mdBuilder.putCustom(LicenseKey.WRITEABLE_TYPE, metaData);
                     return ClusterState.builder(currentState).metaData(mdBuilder).build();
@@ -97,14 +98,13 @@ public class TransportSetLicenseAction extends TransportMasterNodeAction<SetLice
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
-    static void validateTrialLicenseDoNotOverrideExistingLicense(LicenseKey newLicenseKey,
-                                                                 MetaData currentMetaData) throws Exception {
+    static boolean ignoreNewTrialLicense(LicenseKey newLicenseKey,
+                                         MetaData currentMetaData) throws Exception {
         LicenseKey previousLicenseKey = currentMetaData.custom(LicenseKey.WRITEABLE_TYPE);
         if (previousLicenseKey != null) {
             License newLicense = decode(newLicenseKey);
-            if (newLicense.type() == License.Type.TRIAL) {
-                throw new LicenseViolationException("Cannot set a trial license if a license already exists");
-            }
+            return newLicense.type() == License.Type.TRIAL;
         }
+        return false;
     }
 }

--- a/enterprise/licensing/src/test/java/io/crate/license/TransportSetLicenseActionTest.java
+++ b/enterprise/licensing/src/test/java/io/crate/license/TransportSetLicenseActionTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.license;
 
-import io.crate.exceptions.LicenseViolationException;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.junit.Test;
@@ -45,7 +44,6 @@ public class TransportSetLicenseActionTest extends CrateUnitTest {
         );
         LicenseKey trialLicenseKey = TrialLicense.createLicenseKey(LicenseKey.VERSION, licenseData);
 
-        expectedException.expect(LicenseViolationException.class);
-        TransportSetLicenseAction.validateTrialLicenseDoNotOverrideExistingLicense(trialLicenseKey, currentMetaData);
+        assertTrue(TransportSetLicenseAction.ignoreNewTrialLicense(trialLicenseKey, currentMetaData));
     }
 }


### PR DESCRIPTION
Follow up of https://github.com/crate/crate/commit/0df95b92f89041a02ebb8b230afe3813b3c816b0.
Trial licenses are always self-generated by the cluster and thus should
not result in an error/exception if another license already exist.
