### PR TITLE
Fix watermark sys checks

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -291,6 +291,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue with the disk watermark sys checks which would incorrectly
+  report all of them as failed if
+  :ref:`cluster.routing.allocation.disk.threshold_enabled
+  <cluster.routing.allocation.disk.threshold_enabled>` was set to false.
+
 - Fixed an issue were a query on a sub-query with ambiguous columns would
   return the same values for all of the ambiguous columns. An example is
   ``SELECT * FROM (SELECT * FROM t1, t2) AS tjoin`` where both ``t1`` and

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
@@ -55,7 +55,9 @@ abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
     @Override
     public boolean validate() {
         try {
-            if (!diskThresholdSettings.isEnabled()) return false;
+            if (!diskThresholdSettings.isEnabled()) {
+                return true;
+            }
 
             FsInfo.Path leastAvailablePath = getLeastAvailablePath();
             return validate(

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -177,6 +177,16 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testLowDiskWatermarkSucceedsIfThresholdCheckIsDisabled() {
+        LowDiskWatermarkNodesSysCheck check = new LowDiskWatermarkNodesSysCheck(
+            clusterService,
+            Settings.builder().put("cluster.routing.allocation.disk.threshold_enabled", false).build(),
+            mock(NodeService.class, Answers.RETURNS_MOCKS)
+        );
+        assertThat(check.validate(), is(true));
+    }
+
+    @Test
     public void testValidationHighDiskWatermarkCheck() {
         DiskWatermarkNodesSysCheck high = new HighDiskWatermarkNodesSysCheck(
             clusterService,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

All watermark sys node checks failed if
`cluster.routing.allocation.disk.threshold_enabled` was set to false.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)