### PR TITLE
Utilize `getLeastDiskEstimate` in DiskWatermarkNodesSysCheck

### DIFF
--- a/enterprise/licensing/src/main/java/io/crate/expression/reference/sys/check/cluster/LicenseCheck.java
+++ b/enterprise/licensing/src/main/java/io/crate/expression/reference/sys/check/cluster/LicenseCheck.java
@@ -54,7 +54,7 @@ public class LicenseCheck implements SysCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         LicenseData currentLicense = licenseService.currentLicense();
         if (currentLicense == null) {
             // node might've not have received the license cluster state

--- a/enterprise/licensing/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseCheckTest.java
+++ b/enterprise/licensing/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseCheckTest.java
@@ -56,7 +56,7 @@ public class LicenseCheckTest extends CrateDummyClusterServiceUnitTest {
         when(licenseService.currentLicense()).thenReturn(thirtyDaysLicense);
 
         assertThat(licenseCheck.severity(), is(SysCheck.Severity.LOW));
-        assertThat(licenseCheck.validate(), is(true));
+        assertThat(licenseCheck.isValid(), is(true));
         assertThat(licenseCheck.description(), is(
             "Your CrateDB license is valid. Enjoy CrateDB!"));
     }
@@ -69,7 +69,7 @@ public class LicenseCheckTest extends CrateDummyClusterServiceUnitTest {
         when(licenseService.getLicenseState()).thenReturn(LicenseService.LicenseState.VALID);
         when(licenseService.currentLicense()).thenReturn(license);
 
-        assertThat(licenseCheck.validate(), is(false));
+        assertThat(licenseCheck.isValid(), is(false));
         assertThat(licenseCheck.severity(), is(SysCheck.Severity.MEDIUM));
         // Verify the description only partly as the LicenseData.millisToExpiration() can vary
         assertThat(licenseCheck.description(), containsString("Your CrateDB license will expire in"));
@@ -82,7 +82,7 @@ public class LicenseCheckTest extends CrateDummyClusterServiceUnitTest {
         when(licenseService.getLicenseState()).thenReturn(LicenseService.LicenseState.VALID);
         when(licenseService.currentLicense()).thenReturn(license);
 
-        assertThat(licenseCheck.validate(), is(false));
+        assertThat(licenseCheck.isValid(), is(false));
         assertThat(licenseCheck.severity(), is(SysCheck.Severity.HIGH));
         // Verify the description only partly as the LicenseData.millisToExpiration() can vary
         assertThat(licenseCheck.description(), containsString("Your CrateDB license will expire in"));
@@ -95,7 +95,7 @@ public class LicenseCheckTest extends CrateDummyClusterServiceUnitTest {
         when(licenseService.currentLicense()).thenReturn(license);
         when(licenseService.getLicenseState()).thenReturn(LicenseService.LicenseState.MAX_NODES_VIOLATED);
 
-        assertThat(licenseCheck.validate(), is(false));
+        assertThat(licenseCheck.isValid(), is(false));
         assertThat(licenseCheck.severity(), is(SysCheck.Severity.HIGH));
         assertThat(licenseCheck.description(), is(
             "The license is limited to 2 nodes, but there are 1 nodes in the cluster." +
@@ -110,7 +110,7 @@ public class LicenseCheckTest extends CrateDummyClusterServiceUnitTest {
         when(licenseService.getLicenseState()).thenReturn(LicenseService.LicenseState.EXPIRED);
         when(licenseService.currentLicense()).thenReturn(license);
 
-        assertThat(licenseCheck.validate(), is(false));
+        assertThat(licenseCheck.isValid(), is(false));
         assertThat(licenseCheck.severity(), is(SysCheck.Severity.HIGH));
         assertThat(licenseCheck.description(), is(
             "Your CrateDB license has expired. For more information on " +

--- a/enterprise/licensing/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseCheckTest.java
+++ b/enterprise/licensing/src/test/java/io/crate/expression/reference/sys/check/cluster/LicenseCheckTest.java
@@ -22,7 +22,6 @@ import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.license.LicenseData;
 import io.crate.license.LicenseService;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/AbstractSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/AbstractSysCheck.java
@@ -59,7 +59,7 @@ public abstract class AbstractSysCheck implements SysCheck {
         return severity;
     }
 
-    public abstract boolean validate();
+    public abstract boolean isValid();
 
     @Override
     public CompletableFuture<?> computeResult() {

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/SysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/SysCheck.java
@@ -71,7 +71,7 @@ public interface SysCheck {
      *
      * @return true if validation is passed.
      */
-    boolean validate();
+    boolean isValid();
 
     /**
      * Start the checks in an async manner and returns a future

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
@@ -49,7 +49,7 @@ public class NumberOfPartitionsSysCheck extends AbstractSysCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         for (SchemaInfo schemaInfo : schemas) {
             if (schemaInfo instanceof DocSchemaInfo && !validateDocTablesPartitioning(schemaInfo)) {
                 return false;

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -99,7 +99,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         return tablesNeedUpgrade == null || tablesNeedUpgrade.isEmpty();
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
@@ -22,21 +22,14 @@
 
 package io.crate.expression.reference.sys.check.node;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.fs.FsService;
-
-import java.io.IOException;
 
 
 abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
-
-    private static final Logger LOGGER = LogManager.getLogger(DiskWatermarkNodesSysCheck.class);
 
     private final FsService fsService;
     final DiskThresholdSettings diskThresholdSettings;
@@ -54,41 +47,20 @@ abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
 
     @Override
     public boolean validate() {
-        try {
-            if (!diskThresholdSettings.isEnabled()) {
-                return true;
-            }
-
-            FsInfo.Path leastAvailablePath = getLeastAvailablePath();
-            return validate(
-                leastAvailablePath.getAvailable().getBytes(),
-                leastAvailablePath.getTotal().getBytes()
-            );
-        } catch (IOException e) {
-            LOGGER.error("Unable to determine the node disk usage while validating high/low disk watermark check: ", e);
-            return false;
+        if (!diskThresholdSettings.isEnabled()) {
+            return true;
         }
+        DiskUsage leastDiskEstimate = fsService.stats().getLeastDiskEstimate();
+        if (leastDiskEstimate == null) {
+            // DiskUsage can be unavailable during cluster start-up
+            return true;
+        }
+        return validate(leastDiskEstimate.getFreeBytes(), leastDiskEstimate.getTotalBytes());
     }
 
     protected abstract boolean validate(long free, long total);
 
-    // if the path with least available disk space violates the check,
-    // then there is no reason to run a check against other paths
-    @VisibleForTesting
-    FsInfo.Path getLeastAvailablePath() throws IOException {
-        FsInfo.Path leastAvailablePath = null;
-        for (FsInfo.Path info : fsService.stats()) {
-            if (leastAvailablePath == null) {
-                leastAvailablePath = info;
-            } else if (leastAvailablePath.getAvailable().getBytes() > info.getAvailable().getBytes()) {
-                leastAvailablePath = info;
-            }
-        }
-        assert leastAvailablePath != null : "must be at least one path";
-        return leastAvailablePath;
-    }
-
-    double getFreeDiskAsPercentage(long free, long total) {
+    static double getFreeDiskAsPercentage(long free, long total) {
         if (total == 0) {
             return 100.0;
         }

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
@@ -46,7 +46,7 @@ abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         if (!diskThresholdSettings.isEnabled()) {
             return true;
         }
@@ -55,10 +55,10 @@ abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
             // DiskUsage can be unavailable during cluster start-up
             return true;
         }
-        return validate(leastDiskEstimate.getFreeBytes(), leastDiskEstimate.getTotalBytes());
+        return isValid(leastDiskEstimate.getFreeBytes(), leastDiskEstimate.getTotalBytes());
     }
 
-    protected abstract boolean validate(long free, long total);
+    protected abstract boolean isValid(long free, long total);
 
     static double getFreeDiskAsPercentage(long free, long total) {
         if (total == 0) {

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/FloodStageDiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/FloodStageDiskWatermarkNodesSysCheck.java
@@ -44,7 +44,7 @@ public class FloodStageDiskWatermarkNodesSysCheck extends DiskWatermarkNodesSysC
     }
 
     @Override
-    protected boolean validate(long free, long total) {
+    protected boolean isValid(long free, long total) {
         return !(free < diskThresholdSettings.getFreeBytesThresholdFloodStage().getBytes() ||
                  getFreeDiskAsPercentage(free, total) < diskThresholdSettings.getFreeDiskThresholdFloodStage());
     }

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/HighDiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/HighDiskWatermarkNodesSysCheck.java
@@ -43,7 +43,7 @@ public class HighDiskWatermarkNodesSysCheck extends DiskWatermarkNodesSysCheck {
     }
 
     @Override
-    protected boolean validate(long free, long total) {
+    protected boolean isValid(long free, long total) {
         return !(free < diskThresholdSettings.getFreeBytesThresholdHigh().getBytes() ||
             getFreeDiskAsPercentage(free, total) < diskThresholdSettings.getFreeDiskThresholdHigh());
     }

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
@@ -46,7 +46,7 @@ public final class JvmVersionNodeCheck extends AbstractSysNodeCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         try {
             return isOnOrAfter11(Constants.JAVA_VERSION);
         } catch (Exception e) {

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/LowDiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/LowDiskWatermarkNodesSysCheck.java
@@ -43,7 +43,7 @@ public class LowDiskWatermarkNodesSysCheck extends DiskWatermarkNodesSysCheck {
     }
 
     @Override
-    protected boolean validate(long free, long total) {
+    protected boolean isValid(long free, long total) {
         return !(free < diskThresholdSettings.getFreeBytesThresholdLow().getBytes()
             || getFreeDiskAsPercentage(free, total) < diskThresholdSettings.getFreeDiskThresholdLow());
     }

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterNodesSysCheck.java
@@ -47,7 +47,7 @@ public class RecoveryAfterNodesSysCheck extends AbstractSysNodeCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         return validate(
             GatewayService.RECOVER_AFTER_NODES_SETTING.get(settings),
             GatewayService.EXPECTED_NODES_SETTING.get(settings)

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterTimeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterTimeSysCheck.java
@@ -44,7 +44,7 @@ public class RecoveryAfterTimeSysCheck extends AbstractSysNodeCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         return validate(
             GatewayService.RECOVER_AFTER_TIME_SETTING.get(settings),
             GatewayService.RECOVER_AFTER_NODES_SETTING.get(settings),

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
@@ -46,7 +46,7 @@ public class RecoveryExpectedNodesSysCheck extends AbstractSysNodeCheck {
     }
 
     @Override
-    public boolean validate() {
+    public boolean isValid() {
         return validate(clusterService.state().nodes().getMasterAndDataNodes().size(),
             GatewayService.EXPECTED_NODES_SETTING.get(settings)
         );

--- a/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
@@ -60,7 +60,7 @@ public class SysChecksTableInfo extends StaticTableInfo {
             .put(SysChecksTableInfo.Columns.SEVERITY,
                 () -> NestableCollectExpression.forFunction((SysCheck r) -> r.severity().value()))
             .put(SysChecksTableInfo.Columns.PASSED,
-                () -> NestableCollectExpression.forFunction(SysCheck::validate))
+                () -> NestableCollectExpression.forFunction(SysCheck::isValid))
             .build();
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
@@ -72,7 +72,7 @@ public class SysNodeChecksTableInfo extends StaticTableInfo {
             .put(SysNodeChecksTableInfo.Columns.SEVERITY,
                 () -> NestableCollectExpression.forFunction((SysNodeCheck x) -> x.severity().value()))
             .put(SysNodeChecksTableInfo.Columns.PASSED,
-                () -> NestableCollectExpression.forFunction(SysNodeCheck::validate))
+                () -> NestableCollectExpression.forFunction(SysNodeCheck::isValid))
             .put(SysNodeChecksTableInfo.Columns.ACKNOWLEDGED,
                 () -> NestableCollectExpression.forFunction(SysNodeCheck::acknowledged))
             .put(DocSysColumns.ID,

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -131,7 +131,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
-        assertThat(recoveryAfterNodesCheck.validate(), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
 
-        assertThat(recoveryAfterNodesCheck.validate(), is(false));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
     }
 
     @Test
@@ -172,8 +172,8 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         assertThat(low.severity(), is(SysCheck.Severity.HIGH));
 
         // default threshold is: 85% used
-        assertThat(low.validate(15, 100), is(true));
-        assertThat(low.validate(14, 100), is(false));
+        assertThat(low.isValid(15, 100), is(true));
+        assertThat(low.isValid(14, 100), is(false));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder().put("cluster.routing.allocation.disk.threshold_enabled", false).build(),
             mock(NodeService.class, Answers.RETURNS_MOCKS)
         );
-        assertThat(check.validate(), is(true));
+        assertThat(check.isValid(), is(true));
     }
 
     @Test
@@ -198,8 +198,8 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         assertThat(high.severity(), is(SysCheck.Severity.HIGH));
 
         // default threshold is: 90% used
-        assertThat(high.validate(10, 100), is(true));
-        assertThat(high.validate(9, 100), is(false));
+        assertThat(high.isValid(10, 100), is(true));
+        assertThat(high.isValid(9, 100), is(false));
     }
 
     @Test
@@ -214,7 +214,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         assertThat(floodStage.severity(), is(SysCheck.Severity.HIGH));
 
         // default threshold is: 95% used
-        assertThat(floodStage.validate(5, 100), is(true));
-        assertThat(floodStage.validate(4, 100), is(false));
+        assertThat(floodStage.isValid(5, 100), is(true));
+        assertThat(floodStage.isValid(4, 100), is(false));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commit messages


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)