### PR TITLE
Build the crate classpath manually

### DIFF
--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -9,7 +9,13 @@ EOF
     exit 1
 fi
 
-CRATE_CLASSPATH=$CRATE_HOME/lib/*:
+for libname in $CRATE_HOME/lib/*.jar; do
+    if [[ -n $CRATE_CLASSPATH ]]; then
+        CRATE_CLASSPATH=$CRATE_CLASSPATH:$libname
+    else
+        CRATE_CLASSPATH=$libname
+    fi
+done
 
 if [ "x$CRATE_MIN_MEM" = "x" ]; then
     CRATE_MIN_MEM=256m

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -291,6 +291,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that will prevent CrateDB from bootstrapping when running on
+  java 8 and a javaagent is specificed using ``JAVA_OPTS`` or
+  ``CRATE_JAVA_OPTS``.
+
 - Increased the precedence of the double colon cast operator, so that a
   statement like ``x::double / y::double`` applies both casts before the
   division.


### PR DESCRIPTION
Fixes an issue where the classpath is not correctly built when running on
java 8 and a javaagent is specified (namely an empty classpath entry `::`
is included in the classpath).

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
