### PR TITLE
Resolve parameters in view definitions when the view is created

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -291,6 +291,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented parameter placeholders from being resolved when
+  creating a view. A view definition like ``CREATE VIEW v1 AS SELECT ?`` would
+  get stored without the ``?`` being resolved to the actual parameter value,
+  causing queries on the view to fail and also breaking
+  ``information_schema.views``.
+
 - Fixed an issue that will prevent CrateDB from bootstrapping when running on
   java 8 and a javaagent is specificed using ``JAVA_OPTS`` or
   ``CRATE_JAVA_OPTS``.

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -454,7 +454,7 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 createViewStmt.name().schema(),
                 user,
                 defaultSchema);
-            visitRelation(createViewStmt.query(), user, Privilege.Type.DQL);
+            visitRelation(createViewStmt.analyzedQuery(), user, Privilege.Type.DQL);
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -76,6 +76,7 @@ import io.crate.sql.tree.WhenClause;
 import io.crate.sql.tree.Window;
 import io.crate.sql.tree.WindowFrame;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -103,12 +104,18 @@ public final class ExpressionFormatter {
      * be enclosed in parenthesis, as that is a requirement for correctness, but the outer most expression will not be
      * surrounded by parenthesis)
      */
-    public static String formatStandaloneExpression(Expression expression) {
-        return formatStandaloneExpression(expression, DEFAULT_FORMATTER);
+    public static String formatStandaloneExpression(Expression expression, @Nullable List<Expression> parameters) {
+        return formatStandaloneExpression(expression, parameters, DEFAULT_FORMATTER);
     }
 
-    public static <T extends Formatter> String formatStandaloneExpression(Expression expression, T formatter) {
-        String formattedExpression = formatter.process(expression, null);
+    public static String formatStandaloneExpression(Expression expression) {
+        return formatStandaloneExpression(expression, null, DEFAULT_FORMATTER);
+    }
+
+    public static <T extends Formatter> String formatStandaloneExpression(Expression expression,
+                                                                          @Nullable List<Expression> parameters,
+                                                                          T formatter) {
+        String formattedExpression = formatter.process(expression, parameters);
         if (formattedExpression.startsWith("(") && formattedExpression.endsWith(")")) {
             return formattedExpression.substring(1, formattedExpression.length() - 1);
         } else {
@@ -117,28 +124,24 @@ public final class ExpressionFormatter {
     }
 
     public static String formatExpression(Expression expression) {
-        return formatExpression(expression, DEFAULT_FORMATTER);
+        return expression.accept(DEFAULT_FORMATTER, null);
     }
 
-    private static <T extends Formatter> String formatExpression(Expression expression, T formatter) {
-        return formatter.process(expression, null);
-    }
-
-    public static class Formatter extends AstVisitor<String, Void> {
+    public static class Formatter extends AstVisitor<String, List<Expression>> {
 
         @Override
-        protected String visitNode(Node node, Void context) {
+        protected String visitNode(Node node, @Nullable List<Expression> parameters) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "cannot handle node '%s'", node.toString()));
         }
 
         @Override
-        protected String visitExpression(Expression node, Void context) {
+        protected String visitExpression(Expression node, @Nullable List<Expression> parameters) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
                 "not yet implemented: %s.visit%s", getClass().getName(), node.getClass().getSimpleName()));
         }
 
         @Override
-        public String visitArrayComparisonExpression(ArrayComparisonExpression node, Void context) {
+        public String visitArrayComparisonExpression(ArrayComparisonExpression node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
 
             String array = node.getRight().toString();
@@ -150,7 +153,7 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitArraySubQueryExpression(ArraySubQueryExpression node, Void context) {
+        protected String visitArraySubQueryExpression(ArraySubQueryExpression node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
             String subqueryExpression = node.subqueryExpression().toString();
 
@@ -158,7 +161,7 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitCurrentTime(CurrentTime node, Void context) {
+        protected String visitCurrentTime(CurrentTime node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
             switch (node.getType()) {
                 case TIME:
@@ -184,52 +187,62 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitExtract(Extract node, Void context) {
-            return "EXTRACT(" + node.getField() + " FROM " + process(node.getExpression(), context) + ")";
+        protected String visitExtract(Extract node, @Nullable List<Expression> parameters) {
+            return "EXTRACT(" + node.getField() + " FROM " + process(node.getExpression(), parameters) + ")";
         }
 
         @Override
-        protected String visitBooleanLiteral(BooleanLiteral node, Void context) {
+        protected String visitBooleanLiteral(BooleanLiteral node, @Nullable List<Expression> parameters) {
             return String.valueOf(node.getValue());
         }
 
         @Override
-        protected String visitSubscriptExpression(SubscriptExpression node, Void context) {
+        protected String visitSubscriptExpression(SubscriptExpression node, @Nullable List<Expression> parameters) {
             return node.name() + "[" + node.index() + "]";
         }
 
         @Override
-        public String visitParameterExpression(ParameterExpression node, Void context) {
-            return "$" + node.position();
+        public String visitParameterExpression(ParameterExpression node, @Nullable List<Expression> parameters) {
+            if (parameters == null) {
+                return "$" + node.position();
+            } else {
+                int index = node.index();
+                if (index >= parameters.size()) {
+                    throw new IllegalArgumentException(
+                        "Invalid parameter number " + node.position() +
+                        ". Only " + parameters.size() + " parameters are available");
+                }
+                return parameters.get(index).accept(this, parameters);
+            }
         }
 
         @Override
-        protected String visitStringLiteral(StringLiteral node, Void context) {
+        protected String visitStringLiteral(StringLiteral node, @Nullable List<Expression> parameters) {
             return Literals.quoteStringLiteral(node.getValue());
         }
 
         @Override
-        protected String visitEscapedCharStringLiteral(EscapedCharStringLiteral node, Void context) {
+        protected String visitEscapedCharStringLiteral(EscapedCharStringLiteral node, @Nullable List<Expression> parameters) {
             return Literals.quoteEscapedStringLiteral(node.getRawValue());
         }
 
         @Override
-        protected String visitLongLiteral(LongLiteral node, Void context) {
+        protected String visitLongLiteral(LongLiteral node, @Nullable List<Expression> parameters) {
             return Long.toString(node.getValue());
         }
 
         @Override
-        protected String visitDoubleLiteral(DoubleLiteral node, Void context) {
+        protected String visitDoubleLiteral(DoubleLiteral node, @Nullable List<Expression> parameters) {
             return Double.toString(node.getValue());
         }
 
         @Override
-        protected String visitNullLiteral(NullLiteral node, Void context) {
+        protected String visitNullLiteral(NullLiteral node, @Nullable List<Expression> parameters) {
             return "NULL";
         }
 
         @Override
-        public String visitArrayLiteral(ArrayLiteral node, Void context) {
+        public String visitArrayLiteral(ArrayLiteral node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder("[");
             boolean first = true;
             for (Expression element : node.values()) {
@@ -238,14 +251,14 @@ public final class ExpressionFormatter {
                 } else {
                     first = false;
                 }
-                builder.append(element.accept(this, context));
+                builder.append(element.accept(this, parameters));
 
             }
             return builder.append("]").toString();
         }
 
         @Override
-        public String visitObjectLiteral(ObjectLiteral node, Void context) {
+        public String visitObjectLiteral(ObjectLiteral node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder("{");
             boolean first = true;
             TreeMultimap<String, Expression> sorted = TreeMultimap.create(
@@ -261,31 +274,31 @@ public final class ExpressionFormatter {
                 }
                 builder.append(formatIdentifier(entry.getKey()))
                     .append("= ")
-                    .append(entry.getValue().accept(this, context));
+                    .append(entry.getValue().accept(this, parameters));
 
             }
             return builder.append("}").toString();
         }
 
         @Override
-        protected String visitSubqueryExpression(SubqueryExpression node, Void context) {
+        protected String visitSubqueryExpression(SubqueryExpression node, @Nullable List<Expression> parameters) {
             return "(" + formatSql(node.getQuery()) + ")";
         }
 
         @Override
-        protected String visitExists(ExistsPredicate node, Void context) {
+        protected String visitExists(ExistsPredicate node, @Nullable List<Expression> parameters) {
             return "EXISTS (" + formatSql(node.getSubquery()) + ")";
         }
 
         @Override
-        protected String visitQualifiedNameReference(QualifiedNameReference node, Void context) {
+        protected String visitQualifiedNameReference(QualifiedNameReference node, @Nullable List<Expression> parameters) {
             return node.getName().getParts().stream()
                 .map(Formatter::formatIdentifier)
                 .collect(Collectors.joining("."));
         }
 
         @Override
-        protected String visitFunctionCall(FunctionCall node, Void context) {
+        protected String visitFunctionCall(FunctionCall node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
 
             String arguments = joinExpressions(node.getArguments());
@@ -302,13 +315,13 @@ public final class ExpressionFormatter {
             }
 
             if (node.getWindow().isPresent()) {
-                builder.append(" OVER ").append(visitWindow(node.getWindow().get(), context));
+                builder.append(" OVER ").append(visitWindow(node.getWindow().get(), parameters));
             }
             return builder.toString();
         }
 
         @Override
-        public String visitWindow(Window node, Void context) {
+        public String visitWindow(Window node, @Nullable List<Expression> parameters) {
             StringBuilder sb = new StringBuilder("(");
             if (!node.getPartitions().isEmpty()) {
                 sb.append("PARTITION BY ");
@@ -316,10 +329,10 @@ public final class ExpressionFormatter {
                 sb.append(" ");
             }
             if (!node.getOrderBy().isEmpty()) {
-                sb.append(formatOrderBy(node.getOrderBy()));
+                sb.append(formatOrderBy(node.getOrderBy(), parameters));
             }
             if (node.getWindowFrame().isPresent()) {
-                sb.append(process(node.getWindowFrame().get(), context));
+                sb.append(process(node.getWindowFrame().get(), parameters));
             }
             if (Character.isWhitespace(sb.charAt(sb.length() - 1))) {
                 sb.setLength(sb.length() - 1);
@@ -328,40 +341,40 @@ public final class ExpressionFormatter {
             return sb.toString();
         }
 
-        private static String formatOrderBy(List<SortItem> orderBy) {
+        private static String formatOrderBy(List<SortItem> orderBy, @Nullable List<Expression> parameters) {
             return "ORDER BY " + orderBy.stream()
-                .map(SqlFormatter::formatSortItem)
+                .map(e -> SqlFormatter.formatSortItem(e, parameters))
                 .collect(Collectors.joining(", "));
         }
 
         @Override
-        public String visitWindowFrame(WindowFrame node, Void context) {
+        public String visitWindowFrame(WindowFrame node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
 
             builder.append(node.getType().toString()).append(' ');
 
             if (node.getEnd().isPresent()) {
                 builder.append("BETWEEN ")
-                    .append(process(node.getStart(), context))
+                    .append(process(node.getStart(), parameters))
                     .append(" AND ")
-                    .append(process(node.getEnd().get(), context));
+                    .append(process(node.getEnd().get(), parameters));
             } else {
-                builder.append(process(node.getStart(), context));
+                builder.append(process(node.getStart(), parameters));
             }
             return builder.toString();
         }
 
         @Override
-        public String visitFrameBound(FrameBound node, Void context) {
+        public String visitFrameBound(FrameBound node, @Nullable List<Expression> parameters) {
             switch (node.getType()) {
                 case UNBOUNDED_PRECEDING:
                     return "UNBOUNDED PRECEDING";
                 case PRECEDING:
-                    return process(node.getValue(), context) + " PRECEDING";
+                    return process(node.getValue(), parameters) + " PRECEDING";
                 case CURRENT_ROW:
                     return "CURRENT ROW";
                 case FOLLOWING:
-                    return process(node.getValue(), context) + " FOLLOWING";
+                    return process(node.getValue(), parameters) + " FOLLOWING";
                 case UNBOUNDED_FOLLOWING:
                     return "UNBOUNDED FOLLOWING";
                 default:
@@ -370,67 +383,81 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context) {
-            return formatBinaryExpression(node.getType().toString(), node.getLeft(), node.getRight());
+        protected String visitLogicalBinaryExpression(LogicalBinaryExpression node, @Nullable List<Expression> parameters) {
+            return formatBinaryExpression(
+                node.getType().toString(),
+                node.getLeft(),
+                node.getRight(),
+                parameters
+            );
         }
 
         @Override
-        protected String visitNotExpression(NotExpression node, Void context) {
-            return "(NOT " + process(node.getValue(), null) + ")";
+        protected String visitNotExpression(NotExpression node, @Nullable List<Expression> parameters) {
+            return "(NOT " + process(node.getValue(), parameters) + ")";
         }
 
         @Override
-        protected String visitComparisonExpression(ComparisonExpression node, Void context) {
-            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight());
+        protected String visitComparisonExpression(ComparisonExpression node, @Nullable List<Expression> parameters) {
+            return formatBinaryExpression(
+                node.getType().getValue(),
+                node.getLeft(),
+                node.getRight(),
+                parameters
+            );
         }
 
         @Override
-        protected String visitIsNullPredicate(IsNullPredicate node, Void context) {
-            return "(" + process(node.getValue(), null) + " IS NULL)";
+        protected String visitIsNullPredicate(IsNullPredicate node, @Nullable List<Expression> parameters) {
+            return "(" + process(node.getValue(), parameters) + " IS NULL)";
         }
 
         @Override
-        protected String visitIsNotNullPredicate(IsNotNullPredicate node, Void context) {
-            return "(" + process(node.getValue(), null) + " IS NOT NULL)";
+        protected String visitIsNotNullPredicate(IsNotNullPredicate node, @Nullable List<Expression> parameters) {
+            return "(" + process(node.getValue(), parameters) + " IS NOT NULL)";
         }
 
         @Override
-        protected String visitIfExpression(IfExpression node, Void context) {
+        protected String visitIfExpression(IfExpression node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
             builder.append("IF(")
-                .append(process(node.getCondition(), context))
+                .append(process(node.getCondition(), parameters))
                 .append(", ")
-                .append(process(node.getTrueValue(), context));
+                .append(process(node.getTrueValue(), parameters));
             if (node.getFalseValue().isPresent()) {
                 builder.append(", ")
-                    .append(process(node.getFalseValue().get(), context));
+                    .append(process(node.getFalseValue().get(), parameters));
             }
             builder.append(")");
             return builder.toString();
         }
 
         @Override
-        protected String visitNegativeExpression(NegativeExpression node, Void context) {
-            return "- " + process(node.getValue(), null);
+        protected String visitNegativeExpression(NegativeExpression node, @Nullable List<Expression> parameters) {
+            return "- " + process(node.getValue(), parameters);
         }
 
         @Override
-        protected String visitArithmeticExpression(ArithmeticExpression node, Void context) {
-            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight());
+        protected String visitArithmeticExpression(ArithmeticExpression node, @Nullable List<Expression> parameters) {
+            return formatBinaryExpression(
+                node.getType().getValue(),
+                node.getLeft(),
+                node.getRight(),
+                parameters);
         }
 
         @Override
-        protected String visitLikePredicate(LikePredicate node, Void context) {
+        protected String visitLikePredicate(LikePredicate node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
 
             builder.append('(')
-                .append(process(node.getValue(), null))
+                .append(process(node.getValue(), parameters))
                 .append(" LIKE ")
-                .append(process(node.getPattern(), null));
+                .append(process(node.getPattern(), parameters));
 
             if (node.getEscape() != null) {
                 builder.append(" ESCAPE ")
-                    .append(process(node.getEscape(), null));
+                    .append(process(node.getEscape(), parameters));
             }
 
             builder.append(')');
@@ -439,55 +466,55 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        public String visitArrayLikePredicate(ArrayLikePredicate node, Void context) {
+        public String visitArrayLikePredicate(ArrayLikePredicate node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
             builder.append('(')
-                .append(process(node.getPattern(), null))
+                .append(process(node.getPattern(), parameters))
                 .append(node.inverse() ? " NOT" : "")
                 .append(" LIKE ")
                 .append(node.quantifier().name())
                 .append(" (")
-                .append(process(node.getValue(), null))
+                .append(process(node.getValue(), parameters))
                 .append(") ");
             if (node.getEscape() != null) {
                 builder.append("ESCAPE ")
-                    .append(process(node.getEscape(), null));
+                    .append(process(node.getEscape(), parameters));
             }
             builder.append(')');
             return builder.toString();
         }
 
         @Override
-        public String visitMatchPredicate(MatchPredicate node, Void context) {
+        public String visitMatchPredicate(MatchPredicate node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
             builder.append("MATCH (");
             if (node.idents().size() == 1) {
-                builder.append(process(node.idents().get(0).columnIdent(), context));
+                builder.append(process(node.idents().get(0).columnIdent(), parameters));
             } else {
                 builder.append("(");
                 List<MatchPredicateColumnIdent> idents = node.idents();
                 for (int i = 0, identsSize = idents.size(); i < identsSize; i++) {
                     MatchPredicateColumnIdent ident = idents.get(i);
-                    builder.append(ident.accept(this, null));
+                    builder.append(ident.accept(this, parameters));
                     if (i < (identsSize - 1)) {
                         builder.append(", ");
                     }
                 }
                 builder.append(")");
             }
-            builder.append(", ").append(process(node.value(), context));
+            builder.append(", ").append(process(node.value(), parameters));
             builder.append(")");
             if (node.matchType() != null) {
                 builder.append(" USING ").append(node.matchType()).append(" ");
                 if (node.properties().properties().size() > 0) {
-                    builder.append(process(node.properties(), context));
+                    builder.append(process(node.properties(), parameters));
                 }
             }
             return builder.toString();
         }
 
         @Override
-        public String visitMatchPredicateColumnIdent(MatchPredicateColumnIdent node, Void context) {
+        public String visitMatchPredicateColumnIdent(MatchPredicateColumnIdent node, @Nullable List<Expression> parameters) {
             String column = process(node.columnIdent(), null);
             if (!(node.boost() instanceof NullLiteral)) {
                 column = column + " " + node.boost().toString();
@@ -496,7 +523,7 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        public String visitGenericProperties(GenericProperties node, Void context) {
+        public String visitGenericProperties(GenericProperties node, @Nullable List<Expression> parameters) {
             return " WITH (" +
                 node.properties().entrySet().stream()
                     .map(prop -> prop.getKey() + "=" + process(prop.getValue(), null))
@@ -505,7 +532,7 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitAllColumns(AllColumns node, Void context) {
+        protected String visitAllColumns(AllColumns node, @Nullable List<Expression> parameters) {
             if (node.getPrefix().isPresent()) {
                 return node.getPrefix().get() + ".*";
             }
@@ -514,26 +541,26 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        public String visitCast(Cast node, Void context) {
-            return "CAST(" + process(node.getExpression(), context) + " AS " + process(node.getType(), context) + ")";
+        public String visitCast(Cast node, @Nullable List<Expression> parameters) {
+            return "CAST(" + process(node.getExpression(), parameters) + " AS " + process(node.getType(), parameters) + ")";
         }
 
         @Override
-        protected String visitTryCast(TryCast node, Void context) {
-            return "TRY_CAST(" + process(node.getExpression(), context) + " AS " + process(node.getType(), context) +
+        protected String visitTryCast(TryCast node, @Nullable List<Expression> parameters) {
+            return "TRY_CAST(" + process(node.getExpression(), parameters) + " AS " + process(node.getType(), parameters) +
                 ")";
         }
 
         @Override
-        protected String visitSearchedCaseExpression(SearchedCaseExpression node, Void context) {
+        protected String visitSearchedCaseExpression(SearchedCaseExpression node, @Nullable List<Expression> parameters) {
             ImmutableList.Builder<String> parts = ImmutableList.builder();
             parts.add("CASE");
             for (WhenClause whenClause : node.getWhenClauses()) {
-                parts.add(process(whenClause, context));
+                parts.add(process(whenClause, parameters));
             }
             if (node.getDefaultValue() != null) {
                 parts.add("ELSE")
-                    .add(process(node.getDefaultValue(), context));
+                    .add(process(node.getDefaultValue(), parameters));
             }
             parts.add("END");
 
@@ -541,16 +568,16 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitSimpleCaseExpression(SimpleCaseExpression node, Void context) {
+        protected String visitSimpleCaseExpression(SimpleCaseExpression node, @Nullable List<Expression> parameters) {
             ImmutableList.Builder<String> parts = ImmutableList.builder();
             parts.add("CASE")
-                .add(process(node.getOperand(), context));
+                .add(process(node.getOperand(), parameters));
             for (WhenClause whenClause : node.getWhenClauses()) {
-                parts.add(process(whenClause, context));
+                parts.add(process(whenClause, parameters));
             }
             if (node.getDefaultValue() != null) {
                 parts.add("ELSE")
-                    .add(process(node.getDefaultValue(), context));
+                    .add(process(node.getDefaultValue(), parameters));
             }
             parts.add("END");
 
@@ -558,43 +585,46 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        protected String visitWhenClause(WhenClause node, Void context) {
-            return "WHEN " + process(node.getOperand(), context) + " THEN " + process(node.getResult(), context);
+        protected String visitWhenClause(WhenClause node, @Nullable List<Expression> parameters) {
+            return "WHEN " + process(node.getOperand(), parameters) + " THEN " + process(node.getResult(), parameters);
         }
 
         @Override
-        protected String visitBetweenPredicate(BetweenPredicate node, Void context) {
-            return "(" + process(node.getValue(), context) + " BETWEEN " +
-                process(node.getMin(), context) + " AND " + process(node.getMax(), context) + ")";
+        protected String visitBetweenPredicate(BetweenPredicate node, @Nullable List<Expression> parameters) {
+            return "(" + process(node.getValue(), parameters) + " BETWEEN " +
+                process(node.getMin(), parameters) + " AND " + process(node.getMax(), parameters) + ")";
         }
 
         @Override
-        protected String visitInPredicate(InPredicate node, Void context) {
-            return "(" + process(node.getValue(), context) + " IN " + process(node.getValueList(), context) + ")";
+        protected String visitInPredicate(InPredicate node, @Nullable List<Expression> parameters) {
+            return "(" + process(node.getValue(), parameters) + " IN " + process(node.getValueList(), parameters) + ")";
         }
 
         @Override
-        protected String visitInListExpression(InListExpression node, Void context) {
+        protected String visitInListExpression(InListExpression node, @Nullable List<Expression> parameters) {
             return "(" + joinExpressions(node.getValues()) + ")";
         }
 
         @Override
-        public String visitColumnType(ColumnType node, Void context) {
+        public String visitColumnType(ColumnType node, @Nullable List<Expression> parameters) {
             return node.name();
         }
 
         @Override
-        public String visitCollectionColumnType(CollectionColumnType node, Void context) {
-            return node.name() + "(" + process(node.innerType(), context) + ")";
+        public String visitCollectionColumnType(CollectionColumnType node, @Nullable List<Expression> parameters) {
+            return node.name() + "(" + process(node.innerType(), parameters) + ")";
         }
 
         @Override
-        public String visitObjectColumnType(ObjectColumnType node, Void context) {
+        public String visitObjectColumnType(ObjectColumnType node, @Nullable List<Expression> parameters) {
             return node.name();
         }
 
-        private String formatBinaryExpression(String operator, Expression left, Expression right) {
-            return '(' + process(left, null) + ' ' + operator + ' ' + process(right, null) + ')';
+        private String formatBinaryExpression(String operator,
+                                              Expression left,
+                                              Expression right,
+                                              @Nullable List<Expression> parameters) {
+            return '(' + process(left, parameters) + ' ' + operator + ' ' + process(right, parameters) + ')';
         }
 
         private String joinExpressions(List<Expression> expressions) {

--- a/sql/src/main/java/io/crate/analyze/CreateViewAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateViewAnalyzer.java
@@ -24,8 +24,8 @@ package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.parser.SqlParser;
@@ -46,15 +46,11 @@ public final class CreateViewAnalyzer {
         if (BlobSchemaInfo.NAME.equals(name.schema())) {
             throw new UnsupportedOperationException("Creating a view in the \"blob\" schema is not supported");
         }
-        AnalyzedRelation query = relationAnalyzer.analyzeUnbound(
-            createView.query(), txnCtx, ParamTypeHints.EMPTY);
-
-        // sqlPrinter isn't feature complete yet; so restrict CREATE VIEW to only support queries where the
-        // format->analyze round-trip works.
-        String formattedQuery;
+        AnalyzedRelation query;
         try {
-            formattedQuery = SqlFormatter.formatSql(createView.query());
-            relationAnalyzer.analyzeUnbound((Query) SqlParser.createStatement(formattedQuery), txnCtx, ParamTypeHints.EMPTY);
+            String formattedQuery = SqlFormatter.formatSql(createView.query());
+            // Analyze the formatted Query to make sure the formatting didn't mess it up in any way.
+            query = relationAnalyzer.analyzeUnbound((Query) SqlParser.createStatement(formattedQuery), txnCtx, ParamTypeHints.EMPTY);
         } catch (Exception e) {
             throw new UnsupportedOperationException("Query cannot be used in a VIEW: " + createView.query());
         }
@@ -66,6 +62,12 @@ public final class CreateViewAnalyzer {
         if (query.fields().stream().map(f -> f.path().outputName()).distinct().count() != query.fields().size()) {
             throw new IllegalArgumentException("Query in CREATE VIEW must not have duplicate column names");
         }
-        return new CreateViewStmt(name, query, formattedQuery, createView.replaceExisting(), txnCtx.sessionContext().user());
+        return new CreateViewStmt(
+            name,
+            query,
+            createView.query(),
+            createView.replaceExisting(),
+            txnCtx.sessionContext().user()
+        );
     }
 }

--- a/sql/src/main/java/io/crate/analyze/CreateViewStmt.java
+++ b/sql/src/main/java/io/crate/analyze/CreateViewStmt.java
@@ -24,26 +24,35 @@ package io.crate.analyze;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.metadata.RelationName;
 import io.crate.auth.user.User;
+import io.crate.metadata.RelationName;
+import io.crate.sql.tree.Query;
 
 import javax.annotation.Nullable;
 
 public final class CreateViewStmt implements AnalyzedStatement {
 
     private final RelationName name;
-    private final AnalyzedRelation query;
-    private final String formattedQuery;
+    private final AnalyzedRelation analyzedQuery;
+    private final Query query;
     private final boolean replaceExisting;
     @Nullable
     private final User owner;
 
-    CreateViewStmt(RelationName name, AnalyzedRelation query, String formattedQuery, boolean replaceExisting, @Nullable User owner) {
+    CreateViewStmt(RelationName name,
+                   AnalyzedRelation analyzedQuery,
+                   Query query,
+                   boolean replaceExisting,
+                   @Nullable User owner) {
         this.name = name;
+        this.analyzedQuery = analyzedQuery;
         this.query = query;
-        this.formattedQuery = formattedQuery;
         this.replaceExisting = replaceExisting;
         this.owner = owner;
+    }
+
+    public Query query() {
+        return query;
     }
 
     public RelationName name() {
@@ -51,12 +60,8 @@ public final class CreateViewStmt implements AnalyzedStatement {
     }
 
     @VisibleForTesting
-    public AnalyzedRelation query() {
-        return query;
-    }
-
-    public String formattedQuery() {
-        return formattedQuery;
+    public AnalyzedRelation analyzedQuery() {
+        return analyzedQuery;
     }
 
     public boolean replaceExisting() {

--- a/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
+++ b/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
@@ -41,7 +41,7 @@ public class OutputNameFormatter {
 
     private static class InnerOutputNameFormatter extends ExpressionFormatter.Formatter {
         @Override
-        protected String visitQualifiedNameReference(QualifiedNameReference node, Void context) {
+        protected String visitQualifiedNameReference(QualifiedNameReference node, List<Expression> parameters) {
             List<String> parts = node.getName().getParts();
             if (parts.isEmpty()) {
                 throw new NoSuchElementException("Parts of QualifiedNameReference are empty: " + node.getName());
@@ -50,12 +50,12 @@ public class OutputNameFormatter {
         }
 
         @Override
-        protected String visitSubscriptExpression(SubscriptExpression node, Void context) {
+        protected String visitSubscriptExpression(SubscriptExpression node, List<Expression> parameters) {
             return process(node.name(), null) + '[' + process(node.index(), null) + ']';
         }
 
         @Override
-        public String visitArrayComparisonExpression(ArrayComparisonExpression node, Void context) {
+        public String visitArrayComparisonExpression(ArrayComparisonExpression node, List<Expression> parameters) {
             return process(node.getLeft(), null) + ' ' +
                    node.getType().getValue() + ' ' +
                    node.quantifier().name() + '(' +
@@ -63,8 +63,8 @@ public class OutputNameFormatter {
         }
 
         @Override
-        protected String visitSubqueryExpression(SubqueryExpression node, Void context) {
-            return super.visitSubqueryExpression(node, context).replace("\n", "");
+        protected String visitSubqueryExpression(SubqueryExpression node, List<Expression> parameters) {
+            return super.visitSubqueryExpression(node, parameters).replace("\n", "");
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -623,9 +623,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             ViewMetaData view = viewMetaData.v1();
             relationName = viewMetaData.v2();
             AnalyzedRelation resolvedView = process(SqlParser.createStatement(view.stmt()), context);
-            if (!(resolvedView instanceof AnalyzedRelation)) {
-                throw new IllegalArgumentException("View must be a top-level SELECT statement, got: " + view.stmt());
-            }
             relation = new AnalyzedView(relationName, view.owner(), resolvedView);
         }
 

--- a/sql/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -23,6 +23,8 @@
 package io.crate.planner;
 
 import io.crate.analyze.CreateViewStmt;
+import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -30,7 +32,21 @@ import io.crate.data.RowConsumer;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.execution.ddl.views.CreateViewRequest;
 import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Schemas;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.SqlFormatter;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.Literal;
+import io.crate.sql.tree.ParameterExpression;
+import io.crate.sql.tree.Query;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class CreateViewPlan implements Plan {
 
@@ -53,9 +69,12 @@ public final class CreateViewPlan implements Plan {
                               SubQueryResults subQueryResults) {
 
         User owner = createViewStmt.owner();
+        String formattedQuery = SqlFormatter.formatSql(createViewStmt.query(), makeExpressions(params));
+        ensureFormattedQueryCanStillBeAnalyzed(
+            dependencies.functions(), dependencies.schemas(), plannerContext.transactionContext(), formattedQuery);
         CreateViewRequest request = new CreateViewRequest(
             createViewStmt.name(),
-            createViewStmt.formattedQuery(),
+            formattedQuery,
             createViewStmt.replaceExisting(),
             owner == null ? null : owner.name()
         );
@@ -65,5 +84,30 @@ public final class CreateViewPlan implements Plan {
             }
             return new Row1(1L);
         }));
+    }
+
+    private static void ensureFormattedQueryCanStillBeAnalyzed(Functions functions,
+                                                               Schemas schemas,
+                                                               CoordinatorTxnCtx txnCtx,
+                                                               String formattedQuery) {
+        RelationAnalyzer analyzer = new RelationAnalyzer(functions, schemas);
+        Query query = (Query) SqlParser.createStatement(formattedQuery);
+        analyzer.analyzeUnbound(query, txnCtx, new ParamTypeHints(List.of()) {
+
+                @Override
+                public Symbol apply(@Nullable ParameterExpression input) {
+                    throw new UnsupportedOperationException(
+                        "View definition must not contain any parameter placeholders");
+                }
+            }
+        );
+    }
+
+    private static List<Expression> makeExpressions(Row params) {
+        ArrayList<Expression> result = new ArrayList<>(params.numColumns());
+        for (int i = 0; i < params.numColumns(); i++) {
+            result.add(Literal.fromObject(params.get(i)));
+        }
+        return result;
     }
 }

--- a/sql/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/sql/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -33,6 +33,7 @@ import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.PhasesTaskFactory;
 import io.crate.license.LicenseService;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Schemas;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -51,6 +52,7 @@ public class DependencyCarrier {
     private final TransportActionProvider transportActionProvider;
     private final PhasesTaskFactory phasesTaskFactory;
     private final ThreadPool threadPool;
+    private final Schemas schemas;
     private final Functions functions;
     private final DDLStatementDispatcher ddlAnalysisDispatcherProvider;
     private final ClusterService clusterService;
@@ -67,6 +69,7 @@ public class DependencyCarrier {
                              TransportActionProvider transportActionProvider,
                              PhasesTaskFactory phasesTaskFactory,
                              ThreadPool threadPool,
+                             Schemas schemas,
                              Functions functions,
                              DDLStatementDispatcher ddlAnalysisDispatcherProvider,
                              ClusterService clusterService,
@@ -80,6 +83,7 @@ public class DependencyCarrier {
         this.transportActionProvider = transportActionProvider;
         this.phasesTaskFactory = phasesTaskFactory;
         this.threadPool = threadPool;
+        this.schemas = schemas;
         this.functions = functions;
         this.ddlAnalysisDispatcherProvider = ddlAnalysisDispatcherProvider;
         this.clusterService = clusterService;
@@ -90,6 +94,10 @@ public class DependencyCarrier {
         this.createViewAction = createViewAction;
         this.dropViewAction = dropViewAction;
         this.swapRelationsAction = swapRelationsAction;
+    }
+
+    public Schemas schemas() {
+        return schemas;
     }
 
     public TransportSwapRelationsAction swapRelationsAction() {

--- a/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -57,8 +57,14 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         CreateViewStmt createView = e.analyze("create view v1 as select * from t1");
 
         assertThat(createView.name(), is(new RelationName(e.getSessionContext().searchPath().currentSchema(), "v1")));
-        assertThat(createView.query(), isSQL("SELECT doc.t1.x"));
+        assertThat(createView.analyzedQuery(), isSQL("SELECT doc.t1.x"));
         assertThat(createView.owner(), is(testUser));
+    }
+
+    @Test
+    public void testCreateViewIncludingParamPlaceholder() {
+        CreateViewStmt createView = e.analyze("create view v1 as select * from t1 where x = ?");
+        assertThat(createView.analyzedQuery(), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = $1)"));
     }
 
     @Test
@@ -93,7 +99,7 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAliasCanBeUsedToAvoidDuplicateColumnNamesInQuery() {
         CreateViewStmt createView = e.analyze("create view v1 as select x, x as y from t1");
-        assertThat(createView.query().fields(), contains(isField("x"), isField("y")));
+        assertThat(createView.analyzedQuery().fields(), contains(isField("x"), isField("y")));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Creating a view like

    CREATE VIEW v1 AS SELECT ?

Didn't resolve the parameter, which broke queries on the view and the
`information_schema.views` table.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)