### PR TITLE
Fix startup script conditional for older shells.

### DIFF
--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -10,7 +10,7 @@ EOF
 fi
 
 for libname in $CRATE_HOME/lib/*.jar; do
-    if [[ -n $CRATE_CLASSPATH ]]; then
+    if [ "x$CRATE_CLASSPATH" != "x" ]; then
         CRATE_CLASSPATH=$CRATE_CLASSPATH:$libname
     else
         CRATE_CLASSPATH=$libname


### PR DESCRIPTION
Follow up of https://github.com/crate/crate/commit/e544a27ddd2997172c31c650bce899fa6b742a95.

Using `[[` is not supported on all (mostly older) shell implementation and thus using it will fail, see e.g. https://travis-ci.org/crate/crate-java-testing/builds/534670215#L779.