### PR TITLE
Add a rule to move filters beneath GROUP BY

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -71,6 +71,7 @@ import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathBoundary;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathHashJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
@@ -118,6 +119,7 @@ public class LogicalPlanner {
             new MoveFilterBeneathHashJoin(),
             new MoveFilterBeneathNestedLoop(),
             new MoveFilterBeneathUnion(),
+            new MoveFilterBeneathGroupBy(),
             new MergeFilterAndCollect(),
             new RewriteFilterOnOuterJoinToInnerJoin(functions),
             new MoveOrderBeneathUnion(),

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.metadata.FunctionInfo;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+/**
+ * Transforms queries like
+ *
+ * <pre>
+ *     SELECT x, count(*) FROM t GROUP BY x HAVING x > 10
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ *     SELECT x, count(*) FROM t WHERE x > 10 GROUP BY x
+ * </pre>
+ */
+public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
+
+    private final Pattern<Filter> pattern;
+    private final Capture<GroupHashAggregate> groupByCapture;
+
+    public MoveFilterBeneathGroupBy() {
+        this.groupByCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(GroupHashAggregate.class).capturedAs(groupByCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter, Captures captures) {
+        // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
+        // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
+        Symbol predicate = filter.query();
+        List<Symbol> parts = AndOperator.split(predicate);
+        ArrayList<Symbol> withAggregates = new ArrayList<>();
+        ArrayList<Symbol> withoutAggregates = new ArrayList<>();
+        for (Symbol part : parts) {
+            if (SymbolVisitors.any(MoveFilterBeneathGroupBy::isAggregate, part)) {
+                withAggregates.add(part);
+            } else {
+                withoutAggregates.add(part);
+            }
+        }
+        if (withoutAggregates.isEmpty()) {
+            return null;
+        }
+        GroupHashAggregate groupBy = captures.get(groupByCapture);
+        if (withoutAggregates.size() == parts.size()) {
+            return transpose(filter, groupBy);
+        }
+
+        /* HAVING `count(*) > 1 AND x = 10`
+         * withAggregates:    [count(*) > 1]
+         * withoutAggregates: [x = 10]
+         *
+         * Filter
+         *  |
+         * GroupBy
+         *
+         * transforms to
+         *
+         * Filter (count(*) > 1)
+         *  |
+         * GroupBy
+         *  |
+         * Filter (x = 10)
+         */
+        LogicalPlan newGroupBy = groupBy.replaceSources(
+            List.of(new Filter(groupBy.source(), AndOperator.join(withoutAggregates))));
+
+        return new Filter(newGroupBy, AndOperator.join(withAggregates));
+    }
+
+    private static boolean isAggregate(Symbol s) {
+        return s instanceof Function && ((Function) s).info().type() == FunctionInfo.Type.AGGREGATE;
+    }
+}

--- a/sql/src/test/java/io/crate/expression/operator/AndOperatorTest.java
+++ b/sql/src/test/java/io/crate/expression/operator/AndOperatorTest.java
@@ -1,10 +1,16 @@
 package io.crate.expression.operator;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Symbol;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isLiteral;
+import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.contains;
 
 public class AndOperatorTest extends AbstractScalarFunctionsTest {
 
@@ -39,5 +45,25 @@ public class AndOperatorTest extends AbstractScalarFunctionsTest {
         assertEvaluate("false and null", false);
         assertEvaluate("null and false", false);
         assertEvaluate("null and null", null);
+    }
+
+    @Test
+    public void test_get_conjunctions_of_predicate_with_2_ands() {
+        Symbol query = sqlExpressions.asSymbol("(a = 1 or a = 2) AND x = 2 AND name = 'foo'");
+        List<Symbol> split = AndOperator.split(query);
+        assertThat(split, contains(
+            isSQL("((doc.users.a = 1) OR (doc.users.a = 2))"),
+            isSQL("(doc.users.x = 2)"),
+            isSQL("(doc.users.name = 'foo')")
+        ));
+    }
+
+    @Test
+    public void test_get_conjunctions_of_predicate_without_any_ands() {
+        Symbol query = sqlExpressions.asSymbol("a = 1");
+        List<Symbol> split = AndOperator.split(query);
+        assertThat(split, contains(
+            isSQL("(doc.users.a = 1)")
+        ));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Views (and WITH clauses in the future) make simple optimizations like
these more important as it is less likely for users to be able to
manually optimize it.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)