### PR TITLE
Fix jobs logs expiration interference with cluster coordination

### DIFF
--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -32,6 +32,7 @@ import io.crate.execution.TransportExecutorModule;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.collect.CollectOperationModule;
 import io.crate.execution.engine.collect.files.FileCollectModule;
+import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.window.WindowFunctionModule;
 import io.crate.execution.jobs.JobModule;
 import io.crate.execution.jobs.TasksService;
@@ -150,6 +151,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             ImmutableList.<Class<? extends LifecycleComponent>>builder()
             .add(DecommissioningService.class)
             .add(NodeDisconnectJobMonitorService.class)
+            .add(JobsLogService.class)
             .add(PostgresNetty.class)
             .add(TasksService.class)
             .add(Schemas.class)

--- a/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -53,6 +53,7 @@ public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {
         Settings.Builder builder = Settings.builder();
         return builder.put(super.nodeSettings(nodeOrdinal))
             .put("psql.port", "4244-4299")
+            .put("stats.jobs_log_expiration", "30m")
             .put("network.host", "127.0.0.1").build();
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If the `jobs_log_expiration` setting was set the cluster discovery
didn't work as the scheduled task which cleans up entries from the jobs
log conflicted with the cluster coordination tasks as they were using
the same scheduler.

This adds a dedicated scheduler to the `JobsLogService` to avoid any
interference.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)