### PR TITLE
Circuit-break based on real memory usage

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -206,6 +206,10 @@ Deprecations
 Changes
 =======
 
+- Changed the circuit breaker logic to measure the real heap usage instead of
+  the memory reserved by child circuit breakers. This should reduce the chance
+  of nodes running into an out of memory error.
+
 - Added support for the
   :ref:`Azure Storage repositories <ref-create-repository-types-azure>`.
 

--- a/es/es-server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -129,7 +129,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
 
         // Additionally, we need to check that we haven't exceeded the parent's limit
         try {
-            parent.checkParentLimit(label);
+            parent.checkParentLimit((long) (bytes * overheadConstant), label);
         } catch (CircuitBreakingException e) {
             // If the parent breaker is tripped, this breaker has to be
             // adjusted back down because the allocation is "blocked" but the

--- a/es/es-server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
@@ -52,7 +52,7 @@ public abstract class CircuitBreakerService extends AbstractLifecycleComponent {
      */
     public abstract CircuitBreakerStats stats(String name);
 
-    public abstract void checkParentLimit(String label) throws CircuitBreakingException;
+    public abstract void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException;
 
     @Override
     protected void doStart() {

--- a/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -236,7 +236,16 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
 
     //package private to allow overriding it in tests
     long currentMemoryUsage() {
-        return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
+        try {
+            return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
+        } catch (IllegalArgumentException ex) {
+            // This exception can happen (rarely) due to a race condition in the JVM when determining usage of memory pools. We do not want
+            // to fail requests because of this and thus return zero memory usage in this case. While we could also return the most
+            // recently determined memory usage, we would overestimate memory usage immediately after a garbage collection event.
+            assert ex.getMessage().matches("committed = \\d+ should be < max = \\d+");
+            logger.info("Cannot determine current memory usage due to JDK-8207200.", ex);
+            return 0;
+        }
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -31,6 +31,8 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,10 +50,12 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
 
     private static final String CHILD_LOGGER_PREFIX = "org.elasticsearch.indices.breaker.";
 
+    private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
+
     private final ConcurrentMap<String, CircuitBreaker> breakers = new ConcurrentHashMap<>();
 
     public static final Setting<ByteSizeValue> TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING =
-        Setting.memorySizeSetting("indices.breaker.total.limit", "70%", Property.Dynamic, Property.NodeScope);
+        Setting.memorySizeSetting("indices.breaker.total.limit", "95%", Property.Dynamic, Property.NodeScope);
 
     public static final Setting<ByteSizeValue> FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING =
         Setting.memorySizeSetting("indices.breaker.fielddata.limit", "60%", Property.Dynamic, Property.NodeScope);
@@ -203,17 +207,20 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
 
     @Override
     public AllCircuitBreakerStats stats() {
-        long parentEstimated = 0;
         List<CircuitBreakerStats> allStats = new ArrayList<>(this.breakers.size());
         // Gather the "estimated" count for the parent breaker by adding the
         // estimations for each individual breaker
         for (CircuitBreaker breaker : this.breakers.values()) {
             allStats.add(stats(breaker.getName()));
-            parentEstimated += breaker.getUsed();
         }
         // Manually add the parent breaker settings since they aren't part of the breaker map
-        allStats.add(new CircuitBreakerStats(CircuitBreaker.PARENT, parentSettings.getLimit(),
-            parentEstimated, 1.0, parentTripCount.get()));
+        allStats.add(new CircuitBreakerStats(
+            CircuitBreaker.PARENT,
+            parentSettings.getLimit(),
+            parentUsed(0L),
+            1.0,
+            parentTripCount.get()
+        ));
         return new AllCircuitBreakerStats(allStats.toArray(new CircuitBreakerStats[allStats.size()]));
     }
 
@@ -223,15 +230,20 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         return new CircuitBreakerStats(breaker.getName(), breaker.getLimit(), breaker.getUsed(), breaker.getOverhead(), breaker.getTrippedCount());
     }
 
+    private long parentUsed(long newBytesReserved) {
+        return currentMemoryUsage() + newBytesReserved;
+    }
+
+    //package private to allow overriding it in tests
+    long currentMemoryUsage() {
+        return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
+    }
+
     /**
      * Checks whether the parent breaker has been tripped
      */
-    public void checkParentLimit(String label) throws CircuitBreakingException {
-        long totalUsed = 0;
-        for (CircuitBreaker breaker : this.breakers.values()) {
-            totalUsed += (breaker.getUsed() * breaker.getOverhead());
-        }
-
+    public void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException {
+        long totalUsed = parentUsed(newBytesReserved);
         long parentLimit = this.parentSettings.getLimit();
         if (totalUsed > parentLimit) {
             this.parentTripCount.incrementAndGet();
@@ -240,13 +252,11 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                     ", which is larger than the limit of [" +
                     parentLimit + "/" + new ByteSizeValue(parentLimit) + "]");
                 message.append(", usages [");
-                message.append(String.join(", ",
-                    this.breakers.entrySet().stream().map(e -> {
-                        final CircuitBreaker breaker = e.getValue();
-                        final long breakerUsed = (long)(breaker.getUsed() * breaker.getOverhead());
-                        return e.getKey() + "=" + breakerUsed + "/" + new ByteSizeValue(breakerUsed);
-                    })
-                        .collect(Collectors.toList())));
+                message.append(this.breakers.entrySet().stream().map(e -> {
+                    final CircuitBreaker breaker = e.getValue();
+                    final long breakerUsed = (long)(breaker.getUsed() * breaker.getOverhead());
+                    return e.getKey() + "=" + breakerUsed + "/" + new ByteSizeValue(breakerUsed);
+                }).collect(Collectors.joining(", ")));
                 message.append("]");
             throw new CircuitBreakingException(message.toString(), totalUsed, parentLimit);
         }

--- a/es/es-server/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
@@ -54,7 +54,7 @@ public class NoneCircuitBreakerService extends CircuitBreakerService {
     }
 
     @Override
-    public void checkParentLimit(String label) throws CircuitBreakingException {
+    public void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException {
         // ignore
     }
 }

--- a/es/es-testing/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -137,6 +137,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
 import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOSTS_FILE;
+import static org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING;
 import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.awaitBusy;
@@ -363,6 +364,9 @@ public final class InternalTestCluster extends TestCluster {
         if (Strings.hasLength(System.getProperty("es.logger.prefix"))) {
             builder.put("logger.prefix", System.getProperty("es.logger.prefix"));
         }
+
+        builder.put(TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "100%");
+
         // Default the watermarks to absurdly low to prevent the tests
         // from failing on nodes without enough disk space
         builder.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b");

--- a/sql/src/main/java/io/crate/breaker/CrateCircuitBreakerService.java
+++ b/sql/src/main/java/io/crate/breaker/CrateCircuitBreakerService.java
@@ -131,8 +131,8 @@ public class CrateCircuitBreakerService extends CircuitBreakerService {
     }
 
     @Override
-    public void checkParentLimit(String label) throws CircuitBreakingException {
-        esCircuitBreakerService.checkParentLimit(label);
+    public void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException {
+        esCircuitBreakerService.checkParentLimit(newBytesReserved, label);
     }
 
     public static String breakingExceptionMessage(String label, long limit) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)