### PR TITLE
Remove unsued code that supports multiple clients in Azure repo.

### DIFF
--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.repositories.azure;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.StorageException;
 import org.apache.logging.log4j.LogManager;
@@ -52,9 +53,9 @@ import static org.elasticsearch.repositories.azure.AzureStorageService.MIN_CHUNK
  * <p>
  * Azure file system repository supports the following settings:
  * <dl>
- * <dt>{@code container}</dt><dd>Azure container name. Defaults to elasticsearch-snapshots</dd>
+ * <dt>{@code container}</dt><dd>Azure container name. Defaults to crate-snapshots</dd>
  * <dt>{@code base_path}</dt><dd>Specifies the path within bucket to repository data. Defaults to root directory.</dd>
- * <dt>{@code chunk_size}</dt><dd>Large file can be divided into chunks. This parameter specifies the chunk size. Defaults to 64mb.</dd>
+ * <dt>{@code chunk_size}</dt><dd>Large file can be divided into chunks. This parameter specifies the chunk size. Defaults to 256mb.</dd>
  * <dt>{@code compress}</dt><dd>If set to true metadata files will be stored compressed. Defaults to false.</dd>
  * </dl>
  */
@@ -64,8 +65,6 @@ public class AzureRepository extends BlobStoreRepository {
     public static final String TYPE = "azure";
 
     public static final class Repository {
-        static final Setting<String> CLIENT_NAME =
-            new Setting<>("client", "default", Function.identity(), Property.NodeScope);
         static final Setting<String> CONTAINER_SETTING =
             new Setting<>("container", "crate-snapshots", Function.identity(), Property.NodeScope);
         static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path", Property.NodeScope);
@@ -119,7 +118,7 @@ public class AzureRepository extends BlobStoreRepository {
         }
     }
 
-    // only use for testing
+    @VisibleForTesting
     @Override
     protected BlobStore getBlobStore() {
         return super.getBlobStore();
@@ -129,7 +128,7 @@ public class AzureRepository extends BlobStoreRepository {
      * {@inheritDoc}
      */
     @Override
-    protected AzureBlobStore createBlobStore() throws URISyntaxException, StorageException {
+    protected AzureBlobStore createBlobStore() {
         final AzureBlobStore blobStore = new AzureBlobStore(metadata, storageService);
 
         LOGGER.debug((org.apache.logging.log4j.util.Supplier<?>) () -> new ParameterizedMessage(

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.repositories.azure;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
@@ -39,7 +39,7 @@ import java.util.Map;
  */
 public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, ReloadablePlugin {
 
-    // protected for testing
+    @VisibleForTesting
     final AzureStorageService azureStoreService;
 
     public AzureRepositoryPlugin(Settings settings) {
@@ -70,11 +70,7 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
 
     @Override
     public void reload(Settings settings) {
-        // secure settings should be readable
-        final Map<String, AzureStorageSettings> clientsSettings = AzureStorageSettings.load(settings);
-        if (clientsSettings.isEmpty()) {
-            throw new SettingsException("If you want to use an azure repository, you need to define a client configuration.");
-        }
+        final AzureStorageSettings clientsSettings = AzureStorageSettings.getClientSettings(settings);
         azureStoreService.refreshAndClearCache(clientsSettings);
     }
 }

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -34,23 +34,14 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.UnknownHostException;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 public final class AzureStorageSettings {
 
-    // prefix for azure client settings
     private static final String AZURE_CLIENT_PREFIX = "azure.client.";
 
-    /**
-     * Azure account name
-     */
     static final Setting<SecureString> ACCOUNT_SETTING = SecureSetting.insecureString(AZURE_CLIENT_PREFIX + "account");
 
-    /**
-     * Azure key
-     */
     static final Setting<SecureString> KEY_SETTING = SecureSetting.insecureString(AZURE_CLIENT_PREFIX + "key");
 
     /**
@@ -98,8 +89,12 @@ public final class AzureStorageSettings {
     private final Proxy proxy;
     private final LocationMode locationMode;
 
-    // copy-constructor
-    private AzureStorageSettings(String account, String key, String endpointSuffix, TimeValue timeout, int maxRetries, Proxy proxy,
+    private AzureStorageSettings(String account,
+                                 String key,
+                                 String endpointSuffix,
+                                 TimeValue timeout,
+                                 int maxRetries,
+                                 Proxy proxy,
                                  LocationMode locationMode) {
         this.account = account;
         this.key = key;
@@ -110,8 +105,14 @@ public final class AzureStorageSettings {
         this.locationMode = locationMode;
     }
 
-    private AzureStorageSettings(String account, String key, String endpointSuffix, TimeValue timeout, int maxRetries,
-                                 Proxy.Type proxyType, String proxyHost, Integer proxyPort) {
+    private AzureStorageSettings(String account,
+                                 String key,
+                                 String endpointSuffix,
+                                 TimeValue timeout,
+                                 int maxRetries,
+                                 Proxy.Type proxyType,
+                                 String proxyHost,
+                                 Integer proxyPort) {
         this.account = account;
         this.key = key;
         this.endpointSuffix = endpointSuffix;
@@ -162,6 +163,10 @@ public final class AzureStorageSettings {
         return proxy;
     }
 
+    public LocationMode getLocationMode() {
+        return locationMode;
+    }
+
     public String buildConnectionString() {
         final StringBuilder connectionStringBuilder = new StringBuilder();
         connectionStringBuilder.append("DefaultEndpointsProtocol=https")
@@ -175,37 +180,7 @@ public final class AzureStorageSettings {
         return connectionStringBuilder.toString();
     }
 
-    public LocationMode getLocationMode() {
-        return locationMode;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("AzureStorageSettings{");
-        sb.append("account='").append(account).append('\'');
-        sb.append(", key='").append(key).append('\'');
-        sb.append(", timeout=").append(timeout);
-        sb.append(", endpointSuffix='").append(endpointSuffix).append('\'');
-        sb.append(", maxRetries=").append(maxRetries);
-        sb.append(", proxy=").append(proxy);
-        sb.append(", locationMode='").append(locationMode).append('\'');
-        sb.append('}');
-        return sb.toString();
-    }
-
-    /**
-     * Parse and read all settings available under the azure.client
-     * @param settings settings to parse
-     * @return All the named configurations
-     */
-    public static Map<String, AzureStorageSettings> load(Settings settings) {
-        return Map.of("default", getClientSettings(settings));
-    }
-
-    /**
-     * Parse settings for a single client.
-     */
-    private static AzureStorageSettings getClientSettings(Settings settings) {
+    static AzureStorageSettings getClientSettings(Settings settings) {
         try (SecureString account = getConfigValue(settings, ACCOUNT_SETTING);
              SecureString key = getConfigValue(settings, KEY_SETTING)) {
             return new AzureStorageSettings(
@@ -224,15 +199,38 @@ public final class AzureStorageSettings {
         return clientSetting.get(settings);
     }
 
-    static Map<String, AzureStorageSettings> overrideLocationMode(Map<String, AzureStorageSettings> clientsSettings,
-                                                                  LocationMode locationMode) {
-        final var map = new HashMap<String, AzureStorageSettings>();
-        for (final Map.Entry<String, AzureStorageSettings> entry : clientsSettings.entrySet()) {
-            final AzureStorageSettings azureSettings = new AzureStorageSettings(entry.getValue().account, entry.getValue().key,
-                    entry.getValue().endpointSuffix, entry.getValue().timeout, entry.getValue().maxRetries, entry.getValue().proxy,
-                    locationMode);
-            map.put(entry.getKey(), azureSettings);
-        }
-        return Map.copyOf(map);
+    static AzureStorageSettings overrideLocationMode(AzureStorageSettings clientSettings,
+                                                     LocationMode locationMode) {
+        return new AzureStorageSettings(
+            clientSettings.account,
+            clientSettings.key,
+            clientSettings.endpointSuffix,
+            clientSettings.timeout,
+            clientSettings.maxRetries,
+            clientSettings.proxy,
+            locationMode);
+    }
+
+    static AzureStorageSettings copy(AzureStorageSettings settings) {
+        return new AzureStorageSettings(
+            settings.account,
+            settings.key,
+            settings.endpointSuffix,
+            settings.timeout,
+            settings.maxRetries,
+            settings.proxy,
+            settings.locationMode);
+    }
+
+    @Override
+    public String toString() {
+        return "AzureStorageSettings{" + "account='" + account + '\'' +
+               ", key='" + key + '\'' +
+               ", timeout=" + timeout +
+               ", endpointSuffix='" + endpointSuffix + '\'' +
+               ", maxRetries=" + maxRetries +
+               ", proxy=" + proxy +
+               ", locationMode='" + locationMode + '\'' +
+               '}';
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We do not use the logic that enables usage of multiple clients for azure repository, so it is ok to drop it. 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
