### PR TITLE
Avoid duplicate ReferenceCounted release

### DIFF
--- a/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -121,7 +121,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
                         LOGGER.error("Error sending response", ex);
                         throw ex;
                     } finally {
-                        content.release();
                         request.release();
                     }
                 });


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`request.release()` releases the content as well. This generated an
exception which was swallowed.

Spotted the exception generation in profiling traces.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)