### PR TITLE
Drop azure repository credentials from crate.yaml and support them as `create repo` statement params.

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -769,19 +769,6 @@ auth:
 #s3.client.default.access_key: Access_Key
 #s3.client.default.secret_key: Secret_Key
 
-# If Azure Storage is used for snapshot repositories the following settings
-# must be provided:
-#azure.client.account: azure_account_name
-#azure.client.key: azure_account_key
-#
-# Additional Azure Storage client settings:
-#azure.client.max_retries: 3
-#azure.client.endpoint_suffix: core.windows.net
-#azure.client.timeout: 30s
-#azure.client.proxy.host: proxy.host
-#azure.client.proxy.port: 8888
-#azure.client.proxy.type: http
-
 ###################### POSTGRES WIRE PROTOCOL SUPPORT ########################
 
 # CrateDB supports the PostgreSQL wire protocol v3 and emulates a PostgreSQL

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -322,8 +322,10 @@ A repository type that stores its snapshots on the Azure Storage service.
 
 **base_path**
   | *Type:* ``text``
+  | *Default:* `` ``
 
-  The path within the Azure Storage container to repository data.
+  The path within the Azure Storage container to repository data. Defaults to
+  root if not set.
 
 **chunk_size**
   | *Type:*    ``bigint`` or ``text``
@@ -356,11 +358,8 @@ A repository type that stores its snapshots on the Azure Storage service.
   The location mode for storing data on the Azure Storage.
   Note that if you set it to ``secondary_only``, it will force readonly to true.
 
-Azure Client Settings
-.....................
-
-All the setting values are specified via ``azure.client.`` in the crate.yaml
-configuration file.
+Client Specific Settings
+........................
 
 **account**
   | *Type:*    ``text``
@@ -392,19 +391,19 @@ configuration file.
   The initial backoff period. Time to wait before retrying after a first
   timeout or failure.
 
-**proxy.type**
+**proxy_type**
   | *Type:*    ``text``
   | *Values:* ``http``, ``socks``, or ``direct``
   | *Default:* ``direct``
 
   The type of the proxy to connect to the Azure Storage account through.
 
-**proxy.host**
+**proxy_host**
   | *Type:* ``text``
 
   The host name of a proxy to connect to the Azure Storage account through.
 
-**proxy.port**
+**proxy_port**
   | *Type:* ``integer``
   | *Default:* ``0``
 

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -41,13 +41,14 @@ public class AzureBlobStore implements BlobStore {
     private final LocationMode locationMode;
 
     public AzureBlobStore(RepositoryMetaData metadata, AzureStorageService service) {
-        this.container = Repository.CONTAINER_SETTING.get(metadata.settings());
         this.service = service;
-        // locationMode is set per repository, not per client
+        this.container = Repository.CONTAINER_SETTING.get(metadata.settings());
         this.locationMode = Repository.LOCATION_MODE_SETTING.get(metadata.settings());
-        final AzureStorageSettings prevSettings = this.service.refreshAndClearCache(null);
-        final AzureStorageSettings newSettings = AzureStorageSettings.overrideLocationMode(prevSettings, this.locationMode);
-        this.service.refreshAndClearCache(newSettings);
+
+        AzureStorageSettings repositorySettings = AzureStorageSettings
+            .getClientSettings(metadata.settings());
+
+        this.service.refreshSettings(repositorySettings);
     }
 
     @Override

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -21,6 +21,7 @@ package org.elasticsearch.repositories.azure;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.azure.storage.LocationMode;
+import com.microsoft.azure.storage.RetryPolicy;
 import com.microsoft.azure.storage.StorageException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,9 +31,12 @@ import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.IndexId;
@@ -40,6 +44,7 @@ import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotCreationException;
 import org.elasticsearch.snapshots.SnapshotId;
 
+import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
@@ -65,23 +70,93 @@ public class AzureRepository extends BlobStoreRepository {
     public static final String TYPE = "azure";
 
     public static final class Repository {
-        static final Setting<String> CONTAINER_SETTING =
-            new Setting<>("container", "crate-snapshots", Function.identity(), Property.NodeScope);
-        static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path", Property.NodeScope);
-        static final Setting<LocationMode> LOCATION_MODE_SETTING = new Setting<>("location_mode",
-            s -> LocationMode.PRIMARY_ONLY.toString(), s -> LocationMode.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope);
-        static final Setting<ByteSizeValue> CHUNK_SIZE_SETTING =
-            Setting.byteSizeSetting("chunk_size", MAX_CHUNK_SIZE, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE, Property.NodeScope);
-        static final Setting<Boolean> READONLY_SETTING = Setting.boolSetting("readonly", false, Property.NodeScope);
+        static final Setting<SecureString> ACCOUNT_SETTING = SecureSetting.insecureString("account");
+
+        static final Setting<SecureString> KEY_SETTING = SecureSetting.insecureString("key");
+
+        static final Setting<String> CONTAINER_SETTING = new Setting<>(
+                "container",
+                "crate-snapshots",
+                Function.identity(),
+                Property.NodeScope);
+
+        static final Setting<String> BASE_PATH_SETTING =
+            Setting.simpleString("base_path", Property.NodeScope);
+
+        static final Setting<LocationMode> LOCATION_MODE_SETTING = new Setting<>(
+            "location_mode",
+            s -> LocationMode.PRIMARY_ONLY.toString(),
+            s -> LocationMode.valueOf(s.toUpperCase(Locale.ROOT)),
+            Property.NodeScope);
+
+        static final Setting<ByteSizeValue> CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
+            "chunk_size",
+            MAX_CHUNK_SIZE,
+            MIN_CHUNK_SIZE,
+            MAX_CHUNK_SIZE,
+            Property.NodeScope);
+
+        static final Setting<Boolean> READONLY_SETTING =
+            Setting.boolSetting("readonly", false, Property.NodeScope);
+
+        /**
+         * max_retries: Number of retries in case of Azure errors.
+         * Defaults to 3 (RetryPolicy.DEFAULT_CLIENT_RETRY_COUNT).
+         */
+        static final Setting<Integer> MAX_RETRIES_SETTING = Setting.intSetting(
+            "max_retries",
+            RetryPolicy.DEFAULT_CLIENT_RETRY_COUNT,
+            Setting.Property.NodeScope);
+
+        /**
+         * Azure endpoint suffix. Default to core.windows.net (CloudStorageAccount.DEFAULT_DNS).
+         */
+        static final Setting<String> ENDPOINT_SUFFIX_SETTING = Setting
+            .simpleString("endpoint_suffix", Property.NodeScope);
+
+        static final Setting<TimeValue> TIMEOUT_SETTING =
+            Setting.timeSetting("timeout", TimeValue.timeValueMinutes(-1), Property.NodeScope);
+
+        /**
+         * The type of the proxy to connect to azure through. Can be direct (no proxy, default), http or socks
+         */
+        static final Setting<Proxy.Type> PROXY_TYPE_SETTING = new Setting<>(
+            "proxy_type",
+            "direct",
+            s -> Proxy.Type.valueOf(s.toUpperCase(Locale.ROOT)),
+            Property.NodeScope);
+
+        /**
+         * The host name of a proxy to connect to azure through.
+         */
+        static final Setting<String> PROXY_HOST_SETTING =
+            Setting.simpleString("proxy_host", Property.NodeScope);
+
+        /**
+         * The port of a proxy to connect to azure through.
+         */
+        static final Setting<Integer> PROXY_PORT_SETTING =
+            Setting.intSetting("proxy_port", 0, 0, 65535, Setting.Property.NodeScope);
     }
 
     public static List<Setting<?>> optionalSettings() {
         return List.of(Repository.CONTAINER_SETTING,
                        Repository.BASE_PATH_SETTING,
                        Repository.CHUNK_SIZE_SETTING,
-                       COMPRESS_SETTING,
                        Repository.READONLY_SETTING,
-                       Repository.LOCATION_MODE_SETTING);
+                       Repository.LOCATION_MODE_SETTING,
+                       COMPRESS_SETTING,
+                       // client specific repository settings
+                       Repository.MAX_RETRIES_SETTING,
+                       Repository.ENDPOINT_SUFFIX_SETTING,
+                       Repository.TIMEOUT_SETTING,
+                       Repository.PROXY_TYPE_SETTING,
+                       Repository.PROXY_HOST_SETTING,
+                       Repository.PROXY_PORT_SETTING);
+    }
+
+    public static List<Setting<?>> mandatorySettings() {
+        return List.of(Repository.ACCOUNT_SETTING, Repository.KEY_SETTING);
     }
 
     private final BlobPath basePath;

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -19,32 +19,24 @@
 
 package org.elasticsearch.repositories.azure;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
  * A plugin to add a repository type that writes to and from the Azure cloud storage service.
  */
-public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, ReloadablePlugin {
+public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin {
 
-    @VisibleForTesting
-    final AzureStorageService azureStoreService;
+    private final AzureStorageService azureStoreService;
 
-    public AzureRepositoryPlugin(Settings settings) {
-        // eagerly load client settings so that secure settings are read
-        this.azureStoreService = new AzureStorageService(settings);
+    public AzureRepositoryPlugin() {
+        this.azureStoreService = new AzureStorageService();
     }
 
     @Override
@@ -52,25 +44,5 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
                                                            NamedXContentRegistry namedXContentRegistry) {
         return Collections.singletonMap(AzureRepository.TYPE,
             (metadata) -> new AzureRepository(metadata, env, namedXContentRegistry, azureStoreService));
-    }
-
-    @Override
-    public List<Setting<?>> getSettings() {
-        return Arrays.asList(
-            AzureStorageSettings.ACCOUNT_SETTING,
-            AzureStorageSettings.KEY_SETTING,
-            AzureStorageSettings.ENDPOINT_SUFFIX_SETTING,
-            AzureStorageSettings.TIMEOUT_SETTING,
-            AzureStorageSettings.MAX_RETRIES_SETTING,
-            AzureStorageSettings.PROXY_TYPE_SETTING,
-            AzureStorageSettings.PROXY_HOST_SETTING,
-            AzureStorageSettings.PROXY_PORT_SETTING
-        );
-    }
-
-    @Override
-    public void reload(Settings settings) {
-        final AzureStorageSettings clientsSettings = AzureStorageSettings.getClientSettings(settings);
-        azureStoreService.refreshAndClearCache(clientsSettings);
     }
 }

--- a/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
+++ b/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
@@ -123,5 +123,4 @@ public class AzureRepositorySettingsTests extends ESTestCase {
             azureRepository(Settings.builder().put("chunk_size", "257mb").build()));
         assertEquals("failed to parse value [257mb] for setting [chunk_size], must be <= [256mb]", e.getMessage());
     }
-
 }

--- a/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -47,10 +47,6 @@ public class AzureStorageServiceMock extends AzureStorageService {
 
     protected final Map<String, ByteArrayOutputStream> blobs = new ConcurrentHashMap<>();
 
-    AzureStorageServiceMock() {
-        super(Settings.EMPTY);
-    }
-
     @Override
     public boolean doesContainerExist(String container) {
         return true;
@@ -148,7 +144,7 @@ public class AzureStorageServiceMock extends AzureStorageService {
     }
 
     @Override
-    public AzureStorageSettings refreshAndClearCache(AzureStorageSettings clientsSettings) {
-        return AzureStorageSettings.getClientSettings(Settings.EMPTY);
+    public void refreshSettings(AzureStorageSettings clientsSettings) {
+        AzureStorageSettings.getClientSettings(Settings.EMPTY);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -98,7 +98,7 @@ public class RepositorySettingsModule extends AbstractModule {
         ));
 
     private static final TypeSettings AZURE_SETTINGS = new TypeSettings(
-        Collections.emptyMap(),
+        groupSettingsByKey(AzureRepository.mandatorySettings()),
         groupSettingsByKey(AzureRepository.optionalSettings())
     );
 

--- a/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -140,7 +140,15 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
             "   chunk_size='12mb'," +
             "   compress=true," +
             "   readonly=true," +
-            "   location_mode='primary_only')");
+            "   location_mode='primary_only'," +
+            "   account='test_account'," +
+            "   key='test_key'," +
+            "   max_retries=3," +
+            "   endpoint_suffix='.com'," +
+            "   timeout='30s'," +
+            "   proxy_port=0," +
+            "   proxy_type='socks'," +
+            "   proxy_host='localhost')");
         assertThat(analysis.repositoryType(), is("azure"));
         assertThat(analysis.repositoryName(), is("foo"));
         assertThat(
@@ -150,9 +158,25 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
                 hasEntry("base_path", "test_path"),
                 hasEntry("chunk_size", "12mb"),
                 hasEntry("compress", "true"),
-                hasEntry("readonly", "true")
+                hasEntry("readonly", "true"),
+                hasEntry("account", "test_account"),
+                hasEntry("key", "test_key"),
+                hasEntry("max_retries", "3"),
+                hasEntry("endpoint_suffix", ".com"),
+                hasEntry("timeout", "30s"),
+                hasEntry("proxy_port", "0"),
+                hasEntry("proxy_type", "SOCKS"),
+                hasEntry("proxy_host", "localhost")
             )
         );
+    }
+
+    @Test
+    public void testCreateAzureRepoWithMissingMandatorySettings() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The following required parameters are missing to" +
+                                        " create a repository of type \"azure\": [key]");
+        e.analyze("CREATE REPOSITORY foo TYPE azure WITH (account='test')");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The PR allows using Azure Storage client credentials as parameters of the `CREATE REPOSITORY`
statment.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
