### PR TITLE
Remove deprecation warning when using s3 cred in `create repo` statement.

### DIFF
--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -163,7 +163,7 @@ public final class S3ClientSettings {
         return Map.of(DEFAULT, getClientSettings(settings));
     }
 
-    static boolean checkDeprecatedCredentials(Settings repositorySettings) {
+    static boolean checkRepositoryCredentials(Settings repositorySettings) {
         if (S3Repository.ACCESS_KEY_SETTING.exists(repositorySettings)) {
             if (S3Repository.SECRET_KEY_SETTING.exists(repositorySettings) == false) {
                 throw new IllegalArgumentException("Repository setting [" + S3Repository.ACCESS_KEY_SETTING.getKey()
@@ -178,8 +178,8 @@ public final class S3ClientSettings {
     }
 
     // backcompat for reading keys out of repository settings (clusterState)
-    static BasicAWSCredentials loadDeprecatedCredentials(Settings repositorySettings) {
-        assert checkDeprecatedCredentials(repositorySettings);
+    static BasicAWSCredentials loadRepositoryCredentials(Settings repositorySettings) {
+        assert checkRepositoryCredentials(repositorySettings);
         try (SecureString key = S3Repository.ACCESS_KEY_SETTING.get(repositorySettings);
                 SecureString secret = S3Repository.SECRET_KEY_SETTING.get(repositorySettings)) {
             return new BasicAWSCredentials(key.toString(), secret.toString());

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -216,18 +216,16 @@ public class S3Repository extends BlobStoreRepository {
 
         this.clientName = CLIENT_NAME.get(metadata.settings());
 
-        if (CLIENT_NAME.exists(metadata.settings()) && S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
+        if (CLIENT_NAME.exists(metadata.settings()) && S3ClientSettings.checkRepositoryCredentials(metadata.settings())) {
             LOGGER.warn(
                     "ignoring use of named client [{}] for repository [{}] as insecure credentials were specified",
                     clientName,
                     metadata.name());
         }
 
-        if (S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
+        if (S3ClientSettings.checkRepositoryCredentials(metadata.settings())) {
             // provided repository settings
-            DEPRECATION_LOGGER.deprecated("Using s3 access/secret key from repository settings. Instead "
-                    + "store these in named clients and the CrateDB keystore for secure settings.");
-            final BasicAWSCredentials insecureCredentials = S3ClientSettings.loadDeprecatedCredentials(metadata.settings());
+            final BasicAWSCredentials insecureCredentials = S3ClientSettings.loadRepositoryCredentials(metadata.settings());
             final S3ClientSettings s3ClientSettings = S3ClientSettings.getClientSettings(metadata, insecureCredentials);
             this.reference = new AmazonS3Reference(service.buildClient(s3ClientSettings));
         } else {
@@ -247,7 +245,7 @@ public class S3Repository extends BlobStoreRepository {
     @Override
     protected S3BlobStore createBlobStore() {
         if (reference != null) {
-            assert S3ClientSettings.checkDeprecatedCredentials(metadata.settings()) : metadata.name();
+            assert S3ClientSettings.checkRepositoryCredentials(metadata.settings()) : metadata.name();
             return new S3BlobStore(service, clientName, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass) {
                 @Override
                 public AmazonS3Reference clientReference() {
@@ -288,7 +286,7 @@ public class S3Repository extends BlobStoreRepository {
     @Override
     protected void doClose() {
         if (reference != null) {
-            assert S3ClientSettings.checkDeprecatedCredentials(metadata.settings()) : metadata.name();
+            assert S3ClientSettings.checkRepositoryCredentials(metadata.settings()) : metadata.name();
             reference.decRef();
         }
         super.doClose();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
