### PR TITLE
Changes titles in CrateDB reference to sentence-style capitalization

### DIFF
--- a/blackbox/docs/README.rst
+++ b/blackbox/docs/README.rst
@@ -2,7 +2,7 @@
 Documentation README
 ====================
 
-Top-Level Structure
+Top-level structure
 ===================
 
 The documentation is structured as follows:
@@ -41,7 +41,7 @@ The documentation is structured as follows:
 |                        | changes.                                           |
 +------------------------+----------------------------------------------------+
 
-How to Document a Feature
+How to document a feature
 =========================
 
 A single feature may have three types of documentation:

--- a/blackbox/docs/admin/auth/hba.rst
+++ b/blackbox/docs/admin/auth/hba.rst
@@ -41,7 +41,7 @@ See: :ref:`applying-cluster-settings`.
 .. contents::
    :local:
 
-Authentication Against CrateDB
+Authentication against CrateDB
 ==============================
 
 Client access and authentication is configured via the
@@ -156,7 +156,7 @@ superuser) can authenticate to CrateDB from any IP address using the
 
    For general help managing users, see :ref:`administration_user_management`.
 
-Authenticating as a Superuser
+Authenticating as a superuser
 =============================
 
 When CrateDB is started, the cluster contains one predefined superuser. This

--- a/blackbox/docs/admin/auth/methods.rst
+++ b/blackbox/docs/admin/auth/methods.rst
@@ -18,7 +18,7 @@ There are multiple ways to authenticate against CrateDB.
 
 .. _auth_trust:
 
-Trust Method
+Trust method
 ============
 
 When the ``trust`` authentication method is used, the server just takes the
@@ -26,13 +26,13 @@ username provided by the client as is without further validation. This is
 useful for any setup where access is controlled by other means, like network
 restrictions as implemented by :ref:`admin_hba`.
 
-Trust Authentication Over Postgres Protocol
+Trust authentication over Postgres Protocol
 -------------------------------------------
 
 The Postgres Protocol requires a user for every connection which is sent by all
 client implementations.
 
-Trust Authentication Over HTTP
+Trust authentication over HTTP
 ------------------------------
 
 The HTTP implementation extracts the username from the
@@ -70,7 +70,7 @@ setting like this:
 
 .. _auth_password:
 
-Password Authentication Method
+Password authentication method
 ==============================
 
 When the ``password`` authentication method is used, the client has to provide
@@ -97,7 +97,7 @@ PBKDF2_ key derivation function and the `SHA-512 hash algorithm`_.
 
 .. _auth_cert:
 
-Client Certificate Authentication Method
+Client certificate authentication method
 ========================================
 
 When the ``cert`` authentication method is used, the client has to connect to

--- a/blackbox/docs/admin/discovery.rst
+++ b/blackbox/docs/admin/discovery.rst
@@ -106,7 +106,7 @@ You can download the libraries using a simple ``build.gradle`` file:
 Running ``gradle azureLibs`` will fetch the required jars and put them into the
 ``libs/`` folder from where you can copy them into the plugin folder.
 
-Basic Configuration
+Basic configuration
 -------------------
 
 To enable Azure discovery simply change the ``discovery.seed_providers``

--- a/blackbox/docs/admin/monitoring.rst
+++ b/blackbox/docs/admin/monitoring.rst
@@ -18,7 +18,7 @@ The JMX monitoring feature exposes query metrics via the `JMX`_ API.
 Setup
 =====
 
-Enable Collecting Stats
+Enable collecting stats
 -----------------------
 
 .. highlight:: psql

--- a/blackbox/docs/admin/optimization.rst
+++ b/blackbox/docs/admin/optimization.rst
@@ -39,7 +39,7 @@ data, etc. See :ref:`sql_ref_optimize` for detailed description of parameters.
 
     System tables cannot be optimized.
 
-Multiple Table Optimization
+Multiple table optimization
 ===========================
 
 .. Hidden: CREATE TABLE::
@@ -74,7 +74,7 @@ completed.
    tables/partitions are optimized and an error is returned. The error returns
    only the first non-existent table/partition.
 
-Partition Optimization
+Partition optimization
 ======================
 
 Additionally it is possible to define a specific ``PARTITION`` of a partitioned
@@ -102,7 +102,7 @@ reasons.
 
 .. _optimize_segments_upgrade:
 
-Segments Upgrade
+Segments upgrade
 ================
 
 In case that some or all of the segments of a table or a table partition are

--- a/blackbox/docs/admin/privileges.rst
+++ b/blackbox/docs/admin/privileges.rst
@@ -49,7 +49,7 @@ have to other users as well.
 
 .. _privilege_types:
 
-Privilege Types
+Privilege types
 ===============
 
 ``DQL``
@@ -104,7 +104,7 @@ granting this on a schema or table level will have no effect.
 
 .. _hierarchical_privileges_inheritance:
 
-Hierarchical Inheritance of Privileges
+Hierarchical inheritance of privileges
 ======================================
 .. hide:
 
@@ -336,7 +336,7 @@ like this::
     has no effect. The effect of the ``REVOKE`` statement will be reflected
     in the row count.
 
-List Privileges
+List privileges
 ===============
 
 CrateDB exposes privileges ``sys.privileges`` system table.

--- a/blackbox/docs/admin/snapshots.rst
+++ b/blackbox/docs/admin/snapshots.rst
@@ -21,7 +21,7 @@ tables in a CrateDB cluster at the time the *Snapshot* was created. A
 
    You cannot snapshot BLOB tables.
 
-Creating a Repository
+Creating a repository
 .....................
 
 Repositories are used to store, manage and restore snapshots.
@@ -54,7 +54,7 @@ Creating a repository with the same name will result in an error::
 
 .. _plugins: https://github.com/crate/crate/blob/master/devs/docs/plugins.rst
 
-Creating a Snapshot
+Creating a snapshot
 ...................
 
 Snapshots are created inside a repository and can contain any number of tables.
@@ -196,7 +196,7 @@ restore.
 Cleanup
 -------
 
-Dropping Snapshots
+Dropping snapshots
 ..................
 
 Dropping a snapshot deletes all files inside the repository that are only
@@ -207,7 +207,7 @@ few files (e.g. for intermediate snapshots). Snapshots are dropped using the
     cr> DROP SNAPSHOT where_my_snapshots_go.snapshot3;
     DROP OK, 1 row affected (... sec)
 
-Dropping Repositories
+Dropping repositories
 .....................
 
 .. Hidden: create repository
@@ -238,7 +238,7 @@ in the cluster state, so it's not accessible any more.
 
 .. _snapshot-restore_hfs-requirements:
 
-Requirements for Using HDFS Repositories
+Requirements for using HDFS repositories
 ----------------------------------------
 
 CrateDB supports repositories of type
@@ -305,7 +305,7 @@ ignored::
 .. _Hadoop: https://hadoop.apache.org/
 .. _Hadoop (YARN): https://hadoop.apache.org/docs/r2.8.0/hadoop-yarn/hadoop-yarn-site/YARN.html
 
-Working with a Secured HA HDFS
+Working with a secured HA HDFS
 ..............................
 
 For users with Kerberos-secured HA NameNode configurations, configuring the plugin

--- a/blackbox/docs/admin/ssl.rst
+++ b/blackbox/docs/admin/ssl.rst
@@ -27,7 +27,7 @@ usage, please consult the :ref:`admin_hba`.
 .. contents::
    :local:
 
-SSL/TLS Configuration
+SSL/TLS configuration
 =====================
 
 To enable SSL a ``keystore`` and a few configuration changes are necessary.
@@ -47,8 +47,8 @@ the following steps:
 
 .. _ssl_configure_keystore:
 
-Configure the KeyStore
-----------------------
+Configuring the Keystore
+------------------------
 
 SSL/TLS needs a keystore. The keystore holds the node certificate(s) which
 should be signed by a certificate authority (CA). A third-party CA or your
@@ -81,7 +81,7 @@ Also, define the password needed to decrypt the keystore by using the
 ``ssl.keystore_password`` setting.
 
 Use ``ssl.keystore_key_password`` setting to define the key password used when
-creating the keystore.
+creating the Keystore.
 
 For a full list of the settings needed to configure SSL/TLS, refer to
 :ref:`SSL configuration reference <ssl_config>`.
@@ -89,8 +89,8 @@ For a full list of the settings needed to configure SSL/TLS, refer to
 
 .. _ssl_configure_truststore:
 
-Configure a Separate Truststore
--------------------------------
+Configuring a separate Truststore
+---------------------------------
 
 Trusted CA certificates can be stored in a node's keystore or a separate
 truststore can be used to store them.
@@ -111,10 +111,10 @@ Also define the password needed to decrypt the keystore by using the
 For a full list of the settings needed to configure SSL/TLS, refer to
 :ref:`SSL configuration reference <ssl_config>`.
 
-Connecting to a CrateDB Node Using HTTPS
+Connecting to a CrateDB node using HTTPS
 ----------------------------------------
 
-Connect to a CrateDB Node Using the Admin UI
+Connect to a CrateDB node using the Admin UI
 ............................................
 
 Crate's HTTP endpoint remains unchanged. When you have turned on secure
@@ -122,7 +122,7 @@ communication, it will use HTTPS instead of plain HTTP. Simply point your
 browser to the same URL you used before but changing the protocol to https:
 
 For example, ``http://localhost:4200`` becomes ``https://localhost:4200``.
-If you have not configured the CrateDB node's Keystore with a signed
+If you have not configured the CrateDB node's keystore with a signed
 certificate from a Certificate Authority (CA), then you will get something
 like the following: ``NET::ERR_CERT_AUTHORITY_INVALID``. You either need to
 get your certificate signed from one of the CAs included in your browser or
@@ -130,7 +130,7 @@ import your owned certificates into the browser. A third option is storing
 an exception for the CrateDB node certification in your browser after
 verifying that this is indeed a certificate you trust.
 
-Connect to a CrateDB Node Using Crash
+Connect to a CrateDB node using Crash
 .....................................
 
 You can connect to a CrateDB node using a secure communication::
@@ -140,7 +140,7 @@ You can connect to a CrateDB node using a secure communication::
 To validate the provided certificates, please see the options
 ``--verify-ssl`` and ``--key-file``.
 
-Connect to a CrateDB Node Using REST
+Connect to a CrateDB node using REST
 ....................................
 
 Issue your REST requests to the node using the ``https://`` protocol. You
@@ -148,10 +148,10 @@ may have to configure your client to validate the received certificate
 accordingly.
 
 
-Connecting to a CrateDB Node Using PostgreSQL Wire Protocol With SSL/TLS
-------------------------------------------------------------------------
+Connecting to a CrateDB node using the PostgreSQL wire protocol with SSL/TLS
+----------------------------------------------------------------------------
 
-Connect to a CrateDB Node Using JDBC
+Connect to a CrateDB node using JDBC
 ....................................
 
 JDBC needs to validate the CrateDB node's identity by checking that the node
@@ -176,7 +176,7 @@ connection.
 
 For further information, visit `jdbc ssl documentation`_.
 
-Connect to a CrateDB Node Using ``psql``
+Connect to a CrateDB node using ``psql``
 ........................................
 
 By default, ``psql`` attempts to use ssl if available on the node. For further
@@ -187,20 +187,20 @@ information including the different SSL modes please visit the
 .. _psql documentation: https://www.postgresql.org/docs/current/static/app-psql.html
 
 
-Setting up a Keystore/Truststore With a Certificate Chain
+Setting up a Keystore/Truststore with a certificate chain
 =========================================================
 
-In case you need to setup a Keystore or a Trustore, here are the commands
+In case you need to setup a Kestore or a Trustore, here are the commands
 to get you started. All the commands use a validity of 36500 days
 (about 100 years). You might want to use less.
 
 
 .. _ssl_generate_keystore:
 
-Generate Keystore With a Private Key
+Generate Keystore with a private key
 ------------------------------------
 
-The first step is to create a keystore with a private key using the RSA
+The first step is to create a Kestore with a private key using the RSA
 algorithm. The "first and last name" is the common name (CN) which should
 overlap with the URL the service it is used with.
 
@@ -232,7 +232,7 @@ Output::
     Re-enter new password:
 
 
-Generate a Certificate Signing Request
+Generate a certificate signing request
 --------------------------------------
 
 To establish trust for this key, we need to sign it. This is done by generating
@@ -254,7 +254,7 @@ Output::
     Enter key password for <server>
 
 
-Optional: Use a Self-Signed Certificate to Act as a Certificate Authority (CA)
+Optional: Use a self-signed certificate to act as a Certificate Authority (CA)
 ------------------------------------------------------------------------------
 
 .. NOTE::
@@ -264,7 +264,7 @@ Optional: Use a Self-Signed Certificate to Act as a Certificate Authority (CA)
    certificate from one of the CAs bundled with Java.
 
 
-Generate a Self-Signed Certificate
+Generate a self-signed certificate
 ..................................
 
 If you don't get your certificate signed from one of the official CAs,
@@ -310,7 +310,7 @@ Output::
     Email Address []:info@crate.io
 
 
-Generate a Signed Cert
+Generate a signed cert
 ......................
 
 In order that the server can prove itself to have a valid and trusted domain it
@@ -342,10 +342,10 @@ Output::
 
 .. _subjectAltName: http://wiki.cacert.org/FAQ/subjectAltName
 
-Import the CA Certificate Into the Keystore
+Import the CA certificate into the Keystore
 ...........................................
 
-The CA needs to be imported to the Keystore for the certificate chain to be
+The CA needs to be imported to the Kestore for the certificate chain to be
 available when we import our signed certificate.
 
 Command::
@@ -396,7 +396,7 @@ Output::
     Certificate was added to keystore
 
 
-Import CA Into Truststore
+Import CA into Truststore
 .........................
 
 If we are using our own CA, we should also import the certificate to the
@@ -452,11 +452,11 @@ Output::
     Certificate was added to keystore
 
 
-Import the Signed Certificate
+Import the signed certificate
 -----------------------------
 
 Now we have a signed certificate, signed by either from a official CA
-or from our own CA. Let's import it to the keystore.
+or from our own CA. Let's import it to the Kestore.
 
 Command::
 
@@ -472,5 +472,5 @@ Output::
 Configuring CrateDB
 -------------------
 
-Finally, you want to supply the keystore/truststore configuration in the
+Finally, you want to supply the Keystore/Truststore configuration in the
 CrateDB config, see :ref:`ssl_config`.

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -56,7 +56,7 @@ The result has at most 1 row::
 
 .. _sys-cluster-license:
 
-Cluster License
+Cluster license
 ---------------
 
 The ``sys.cluster.license`` expression returns information about the currently
@@ -83,7 +83,7 @@ registered license.
 
 .. _sys-cluster-settings:
 
-Cluster Settings
+Cluster settings
 ----------------
 
 The ``sys.cluster.settings`` expression returns information about the currently
@@ -545,7 +545,7 @@ calculate the time difference between 2 probes.
 
 .. _os_cgroup_limitations:
 
-Cgroup Limitations
+Cgroup limitations
 ..................
 
 .. NOTE::
@@ -555,7 +555,7 @@ Cgroup Limitations
 
 .. _os_uptime_limitations:
 
-Uptime Limitations
+Uptime limitations
 ..................
 
 .. NOTE::
@@ -745,7 +745,7 @@ probes.
 
 .. _sys-node-checks:
 
-Node Checks
+Node checks
 ===========
 
 The table ``sys.node_checks`` exposes a list of internal node checks and
@@ -796,7 +796,7 @@ Example query::
 
 .. _sys-node-checks-ack:
 
-Acknowledge Failed Checks
+Acknowledge failed checks
 -------------------------
 
 It is possible to acknowledge every check by updating the ``acknowledged``
@@ -822,10 +822,10 @@ flag::
    Updates on this column are transient, so changed values are lost after the
    affected node is restarted.
 
-Description of Checked Node Settings
+Description of checked node settings
 ------------------------------------
 
-Recovery Expected Nodes
+Recovery expected nodes
 .......................
 
 The check for the :ref:`gateway.expected_nodes <gateway.expected_nodes>`
@@ -833,7 +833,7 @@ setting checks that the number of nodes that should be waited for the immediate
 cluster state recovery, must be equal to the maximum number of data and master
 nodes in the cluster.
 
-Recovery After Nodes
+Recovery after nodes
 ....................
 
 The check for the :ref:`gateway.recover_after_nodes
@@ -848,7 +848,7 @@ nodes and equal/less than number of nodes in the cluster.
 where ``R`` is the number of recovery nodes, ``E`` is the number of expected
 nodes.
 
-Recovery After Time
+Recovery after time
 ...................
 
 If :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` is set,
@@ -858,7 +858,7 @@ have any effect.
 
 .. _node_checks_watermark_high:
 
-Routing Allocation Disk Watermark High
+Routing allocation disk watermark high
 ......................................
 
 The check for the :ref:`cluster.routing.allocation.disk.watermark.high
@@ -870,7 +870,7 @@ or more verification fails the check is marked as not passed.
 
 .. _node_checks_watermark_low:
 
-Routing Allocation Disk Watermark Low
+Routing allocation disk watermark low
 .....................................
 
 The check for the :ref:`cluster.routing.allocation.disk.watermark.low
@@ -881,7 +881,7 @@ for configured CrateDB data paths. The check is not passed if the verification
 for one or more disk fails.
 
 
-JVM Version
+JVM version
 ...........
 
 
@@ -900,7 +900,7 @@ Shards
 The table ``sys.shards`` contains real-time statistics for all shards of all
 (non-system) tables.
 
-Table Schema
+Table schema
 ------------
 
 +------------------------------------+----------------------------------------------------+-------------+
@@ -1068,7 +1068,7 @@ For example, you can query shards like this::
 
 .. _jobs_operations_logs:
 
-Jobs, Operations, and Logs
+Jobs, operations, and logs
 ==========================
 
 To let you inspect the activities currently taking place in a cluster, CrateDB
@@ -1119,7 +1119,7 @@ Jobs
 The ``sys.jobs`` table is a constantly updated view of all jobs that are
 currently being executed in the cluster.
 
-Table Schema
+Table schema
 ............
 
 +------------------+--------------------------------------------------+------------------------------+
@@ -1170,7 +1170,7 @@ that tries to query a non-existent table) will not show up as jobs.
 
 .. _sys-jobs-metrics:
 
-Jobs Metrics
+Jobs metrics
 ------------
 
 The ``sys.jobs_metrics`` table provides an overview of the query latency in the
@@ -1187,7 +1187,7 @@ statements.
   longer than that are capped to 10 minutes.
 
 
-``sys.jobs_metrics`` Table Schema
+``sys.jobs_metrics`` Table schema
 .................................
 
 +------------------------------+----------------------------------------------------+----------------------+
@@ -1270,7 +1270,7 @@ An operation is a node-specific sub-component of a job (for when a job involves
 multi-node processing). Jobs that do not require multi-node processing will not
 produce any operations.
 
-Table Schema
+Table schema
 ............
 
 +------------------+---------------------------------------------------+------------------------------+
@@ -1310,7 +1310,7 @@ Logs
 The :ref:`sys.jobs <sys-jobs>` and :ref:`sys.operations <sys-operations>` tables
 have corresponding log tables: ``sys.jobs_log`` and ``sys.operations_log``.
 
-``sys.jobs_log`` Table Schema
+``sys.jobs_log`` Table schema
 .............................
 
 +------------------------------+---------------------------------------+------------------------------+
@@ -1357,7 +1357,7 @@ have corresponding log tables: ``sys.jobs_log`` and ``sys.operations_log``.
    The ``sys.jobs_log`` table is subject to :ref:`jobs_table_permissions`.
 
 
-``sys.operations_log`` Table Schema
+``sys.operations_log`` Table schema
 ...................................
 
 +----------------+--------------------------------------------------+------------------------------+
@@ -1408,7 +1408,7 @@ See :ref:`conf_collecting_stats` for information on how to configure logs.
 
 .. _sys-checks:
 
-Cluster Checks
+Cluster checks
 ==============
 
 The table ``sys.checks`` exposes a list of internal cluster checks and results
@@ -1457,14 +1457,14 @@ severity level:
 Current Checks
 --------------
 
-Number of Partitions
+Number of partitions
 ....................
 
 This check warns if any :ref:`partitioned table <partitioned_tables>` has more
 than 1000 partitions to detect the usage of a high cardinality field for
 partitioning.
 
-Tables Need to Be Upgraded
+Tables need to be upgraded
 ..........................
 
 .. WARNING::
@@ -1575,7 +1575,7 @@ Example of getting a `cluster health` (`health` of all tables):
 
 .. _sys-health-def:
 
-Health Definition
+Health definition
 -----------------
 
 +------------+---------------------------------------------------+
@@ -1834,7 +1834,7 @@ node.
 
 .. _shard_table_permissions:
 
-Shard Table Permissions
+Shard table permissions
 =======================
 
 Accessing tables that return shards (``sys.shards``, ``sys.allocations``) is
@@ -1858,7 +1858,7 @@ but no privilege at all on ``doc.locations``, when ``john`` issues a
 
 .. _jobs_table_permissions:
 
-Sys Jobs Tables Permissions
+Sys jobs tables permissions
 ===========================
 
 Accessing :ref:`sys.jobs <sys-jobs>` and :ref:`sys.jobs_log <sys-logs>` tables
@@ -1870,13 +1870,13 @@ A user that doesn't have superuser privileges is allowed to retrieve only
 their own job logs entries, while a user with superuser privileges has access
 to all.
 
-Before Upgrading
+Before upgrading
 ================
 
 In certain cases, for compatibility with future versions of CrateDB,
 you need to perform some actions before upgrading to a new CrateDB version.
 
-Tables Need to Be Recreated
+Tables need to be recreated
 ---------------------------
 
 The following should be performed if there are tables

--- a/blackbox/docs/admin/udc.rst
+++ b/blackbox/docs/admin/udc.rst
@@ -25,7 +25,7 @@ identifiable information.
 .. contents::
    :local:
 
-Technical Information
+Technical information
 =====================
 
 To gather good statistics about CrateDB usage, UDC collects this information:
@@ -45,7 +45,7 @@ CrateDB Version   The CrateDB version.
 Java Version      The Java version CrateDB is currently running with.
 Hardware Address  MAC address to uniquely identify instances behind
                   firewalls.
-Processor count   Number of available CPUs as reported by 
+Processor count   Number of available CPUs as reported by
                   ``Runtime.availableProcessors``
 Enterprise        Identifies whether the Enterprise Edition is used.
 License           License information of the CrateDB Enterprise Edition.
@@ -57,7 +57,7 @@ UDC, and secondly, we want to keep pings from automatic tests to a minimum. By
 default, UDC is sending pings every 24 hours. The ping to the UDC servers is
 done with a HTTP GET.
 
-Admin UI Tracking
+Admin UI tracking
 =================
 
 Since Admin UI v0.16.0 we are tracking the user ID along with the cluster ID to
@@ -71,7 +71,7 @@ configuration file or adding a system property setting. Refer to
 :ref:`conf_usage_data_collector` to see how these settings can be accessed and
 how they are configured.
 
-How to Disable UDC
+How to disable UDC
 ==================
 
 Below are two ways you can disable UDC. However we hope you support us offering
@@ -85,14 +85,14 @@ CrateDB.
 
 .. highlight:: yaml
 
-By Configuration
+By configuration
 ----------------
 
 Just add following to your ``crate.yml`` configuration file::
 
     udc.enabled:  false
 
-By System Property
+By system property
 ------------------
 
 If you do not want to make any change to the jars or to the configuration,

--- a/blackbox/docs/admin/user-management.rst
+++ b/blackbox/docs/admin/user-management.rst
@@ -126,7 +126,7 @@ statement returns an error::
 
     It is not possible to drop the built-in superuser ``crate``.
 
-List Users
+List users
 ==========
 
 CrateDB exposes database users via the read-only ``sys.users`` system table.

--- a/blackbox/docs/appendices/compatibility.rst
+++ b/blackbox/docs/appendices/compatibility.rst
@@ -13,10 +13,10 @@ is worth being aware of some unique characteristics in CrateDB's SQL dialect.
 .. contents::
    :local:
 
-Implementation Notes
+Implementation notes
 ====================
 
-Data Types
+Data types
 ----------
 
 CrateDB supports a set of primitive data types: integer, long, short, double,
@@ -47,20 +47,20 @@ The following table defines how data types of standard SQL map to CrateDB
 | double precision                  | double                 |
 +-----------------------------------+------------------------+
 
-Create Table
+Create table
 ------------
 
 :ref:`ref-create-table` supports additional storage and table parameters for
 sharding, replication and routing of the data, and does not support
 inheritance.
 
-Alter Table
+Alter table
 -----------
 
 ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported (see
 :ref:`ref-alter-table`).
 
-System Information Tables
+System information tables
 -------------------------
 
 The read-only :ref:`system-information` and :ref:`information_schema` tables
@@ -68,7 +68,7 @@ have a slightly different schema than specified in standard SQL. They provide
 schema information and can be queried to get real-time statistical data about
 the cluster, its nodes, and their shards.
 
-BLOB Support
+BLOB support
 ------------
 
 Standard SQL defines a binary string type, called ``BLOB`` or ``BINARY LARGE
@@ -88,7 +88,7 @@ the record is modified. This version number can be used to implement patterns
 like :ref:`sql_occ`, which can be used to solve many of the use cases that
 would otherwise require traditional transactions.
 
-Unsupported Features and Functions
+Unsupported features and functions
 ==================================
 
 These **features** of standard SQL are not supported:

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -3,7 +3,7 @@
 .. _conf-cluster-settings:
 
 =====================
-Cluster Wide Settings
+Cluster-Wide Settings
 =====================
 
 All current applied cluster settings can be read by querying the
@@ -18,7 +18,7 @@ cluster settings can be :ref:`changed at runtime
 
 .. _applying-cluster-settings:
 
-Non-Runtime Cluster Wide Settings
+Non-runtime cluster-wide settings
 ---------------------------------
 
 Cluster wide settings which cannot be changed at runtime need to be specified
@@ -32,7 +32,7 @@ in the configuration of each node in the cluster.
 
 .. _conf_collecting_stats:
 
-Collecting Stats
+Collecting stats
 ----------------
 
 .. _stats.enabled:
@@ -180,7 +180,7 @@ Collecting Stats
 
 .. _conf_usage_data_collector:
 
-Usage Data Collector
+Usage data collector
 --------------------
 
 The settings of the Usage Data Collector are read-only and cannot be set during
@@ -231,7 +231,7 @@ about its usage.
 
 .. _conf_graceful_stop:
 
-Graceful Stop
+Graceful stop
 -------------
 
 By default, when the CrateDB process stops it simply shuts down, possibly
@@ -288,7 +288,7 @@ nodes of the cluster:
 
 .. _conf_bulk_operations:
 
-Bulk Operations
+Bulk operations
 ---------------
 
 SQL DML Statements involving a huge amount of rows like :ref:`copy_from`,
@@ -358,8 +358,8 @@ new master node is elected.
 
 .. _conf_host_discovery:
 
-Unicast Host Discovery
-.......................
+Unicast host discovery
+......................
 
 As described above, CrateDB has built-in support for statically specifying a
 list of addresses that will act as the seed nodes in the discovery process
@@ -541,7 +541,7 @@ To enable Azure discovery set the ``discovery.seed_providers`` setting to
 
 .. _conf_routing:
 
-Routing Allocation
+Routing allocation
 ------------------
 
 .. _cluster.routing.allocation.enable:
@@ -667,7 +667,7 @@ across generic attributes associated with nodes.
   shards will be allocated (with no replicas). Only when we start more shards
   with ``node.attr.zone`` set to ``zone2`` the replicas will be allocated.
 
-Balanced Shards
+Balanced shards
 ...............
 
 All these values are relative to one another. The first three are used to
@@ -706,7 +706,7 @@ to forced awareness or allocation filtering.
   negative float). Increasing this value will cause the cluster to be less
   aggressive about optimising the shard balance.
 
-Cluster-Wide Allocation Filtering
+Cluster-wide allocation filtering
 .................................
 
 Allow to control the allocation of all shards based on include/exclude filters.
@@ -739,7 +739,7 @@ specific IP addresses or custom attributes.
   to allocate a shard on it. This is in contrast to include which will include
   a node if ANY rule matches.
 
-Disk-based Shard Allocation
+Disk-based shard allocation
 ...........................
 
 .. _cluster.routing.allocation.disk.threshold_enabled:
@@ -865,7 +865,7 @@ Recovery
   fail. Defaults to :ref:`internal_action_long_timeout
   <indices.recovery.internal_action_long_timeout>`.
 
-Query Circuit Breaker
+Query circuit breaker
 ---------------------
 
 The Query circuit breaker will keep track of the used memory during the
@@ -889,7 +889,7 @@ keeps working.
   A constant that all data estimations are multiplied with to determine a final
   estimation.
 
-Field Data Circuit Breaker
+Field data circuit breaker
 --------------------------
 
 The field data circuit breaker allows estimation of needed heap memory required
@@ -909,7 +909,7 @@ is raised.
   A constant that all field data estimations are multiplied with to determine a
   final estimation.
 
-Request Circuit Breaker
+Request circuit breaker
 -----------------------
 
 The request circuit breaker allows an estimation of required heap memory per
@@ -929,7 +929,7 @@ exception is raised.
   A constant that all request estimations are multiplied with to determine a
   final estimation.
 
-Accounting Circuit Breaker
+Accounting circuit breaker
 --------------------------
 
 Tracks things that are held in memory independent of queries. For example the
@@ -951,7 +951,7 @@ memory used by Lucene for segments.
 
 .. _stats.breaker.log:
 
-Stats Circuit Breakers
+Stats circuit breakers
 ----------------------
 
 Settings that control the behaviour of the stats circuit breaker. There are two
@@ -985,7 +985,7 @@ each of them, the breaker limit can be set.
   error message and clears the :ref:`sys.operations_log <sys-logs>` table
   completely.
 
-Total Circuit Breaker
+Total circuit breaker
 ---------------------
 
 **indices.breaker.total.limit**
@@ -999,7 +999,7 @@ Total Circuit Breaker
   queries might still get aborted if several circuit breakers together would
   hit the memory limit configured in ``indices.breaker.total.limit``.
 
-Thread Pools
+Thread pools
 ------------
 
 Every node holds several thread pools to improve how threads are managed within
@@ -1056,7 +1056,7 @@ Metadata
 
 .. _metadata_gateway:
 
-Metadata Gateway
+Metadata gateway
 ................
 
   The gateway persists cluster meta data on disk every time the meta data

--- a/blackbox/docs/config/environment.rst
+++ b/blackbox/docs/config/environment.rst
@@ -32,7 +32,7 @@ application and the JVM itself, which runs CrateDB.
 
 .. _conf-env-app:
 
-Application Variables
+Application variables
 =====================
 
 .. _conf-env-crate-home:
@@ -52,7 +52,7 @@ Application Variables
 
 .. _conf-env-java:
 
-JVM Variables
+JVM variables
 =============
 
 .. _conf-env-java-general:
@@ -118,7 +118,7 @@ General
 
       Make sure there is enough disk space available for heap dumps.
 
-Garbage Collection
+Garbage collection
 ------------------
 
 Collector

--- a/blackbox/docs/config/index.rst
+++ b/blackbox/docs/config/index.rst
@@ -11,7 +11,8 @@ CrateDB can be configured via configuration files. These files are located in
 the ``config`` directory inside the :ref:`CRATE_HOME <conf-env-crate-home>`
 directory.
 
-The configuration directory can changed via the ``path.conf`` setting, like so:
+The configuration directory can changed via the ``path.conf`` setting, like
+so:
 
 .. code-block:: sh
 

--- a/blackbox/docs/config/logging.rst
+++ b/blackbox/docs/config/logging.rst
@@ -22,7 +22,7 @@ differently and is configured differently.
 
 .. _conf-logging-app:
 
-Application Logging
+Application logging
 ===================
 
 .. _conf-logging-log4j:
@@ -34,7 +34,7 @@ CrateDB uses `Log4j`_.
 
 .. _conf-logging-log4j-file:
 
-Configuration File
+Configuration file
 ..................
 
 You can configure Log4j with the ``log4j2.properties`` file in the CrateDB
@@ -70,7 +70,7 @@ You get the point.
 
 .. _conf-logging-log4j-loggers:
 
-Log Levels
+Log levels
 ..........
 
 Possible log levels are the same as for Log4j_, in order of increasing
@@ -92,7 +92,7 @@ Log levels must be provided as string literals in the ``SET`` statement.
 
 .. _conf-logging-log4j-run-time:
 
-Run-Time Configuration
+Run-time configuration
 ......................
 
 It's possible to set the log level of loggers at runtime using :ref:`SET
@@ -127,20 +127,20 @@ overrides the start-up configuration defined in each respective
 
 .. _conf-logging-jvm:
 
-JVM Logging
+JVM logging
 ===========
 
 CrateDB exposes some native JVM logging functionality.
 
 .. _conf-logging-gc:
 
-Garbage Collection
+Garbage collection
 ------------------
 
 CrateDB logs JVM garbage collection times using the built-in garbage
 collection logging of the JVM.
 
-Environment Variables
+Environment variables
 .....................
 
 The following :ref:`environment variables <config>` can be used to configure

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -39,7 +39,7 @@ Basics
   Defines how many nodes are allowed to be started on the same machine using
   the same configured data path defined via `path.data`_.
 
-Node Types
+Node types
 ==========
 
 CrateDB supports different kinds of nodes.
@@ -248,15 +248,15 @@ Paths
   See also :ref:`location <ref-create-repository-types-fs-location>` setting of
   repository type ``fs``.
 
-Plugins
-=======
+Plug-ins
+========
 
 **plugin.mandatory**
   | *Runtime:* ``no``
 
-  A list of plugins that are required for a node to startup.
+  A list of plug-ins that are required for a node to startup.
 
-  If any plugin listed here is missing, the CrateDB node will fail to start.
+  If any plug-in listed here is missing, the CrateDB node will fail to start.
 
 CPU
 ===
@@ -285,7 +285,7 @@ Memory
   system call on startup to ensure that the memory pages of the CrateDB process
   are locked into RAM.
 
-Garbage Collection
+Garbage collection
 ==================
 
 CrateDB logs if JVM garbage collection on different memory pools takes too
@@ -342,7 +342,7 @@ Authentication
 
 .. _host_based_auth:
 
-Trust Authentication
+Trust authentication
 --------------------
 
 **auth.trust.http_default_user**
@@ -353,7 +353,7 @@ Trust Authentication
   to CrateDB via HTTP protocol and they do not specify a user via the
   ``Authorization`` request header.
 
-Host Based Authentication
+Host-based authentication
 -------------------------
 
 Authentication settings (``auth.host_based.*``) are node settings, which means
@@ -367,7 +367,7 @@ nodes may have different authentication settings.
   Setting to enable or disable Host Based Authentication (HBA). It is disabled
   by default.
 
-HBA Entries
+HBA entries
 ...........
 
 The ``auth.host_based.config.`` setting is a group setting that can have zero,
@@ -456,7 +456,7 @@ The meaning of the fields of the are as follows:
 
 .. _ssl_config:
 
-Secured Communications (SSL/TLS)
+Secured communications (SSL/TLS)
 ================================
 
 Secured communications via SSL allows you to encrypt traffic between CrateDB
@@ -514,7 +514,7 @@ Layer Security (TLS).
   The password used to decrypt the truststore file defined with
   ``ssl.truststore_filepath``.
 
-Cross-Origin Resource Sharing (CORS)
+Cross-origin resource sharing (CORS)
 ====================================
 
 Many browsers support the `same-origin policy`_ which requires web applications
@@ -637,7 +637,7 @@ Queries
 
 .. _conf-node-lang-js:
 
-Javascript Language
+Javascript language
 ===================
 
 **lang.js.enabled**
@@ -653,7 +653,7 @@ Javascript Language
 
 .. _conf-node-attributes:
 
-Custom Attributes
+Custom attributes
 =================
 
 The ``node.attr`` namespace is a bag of custom attributes.
@@ -666,4 +666,3 @@ Custom attributes are not validated by CrateDB, unlike core node attributes.
 
 Custom attributes can, however, be :ref:`used to control shard allocation
 <conf-routing-allocation-awareness>`.
-

--- a/blackbox/docs/config/session.rst
+++ b/blackbox/docs/config/session.rst
@@ -32,7 +32,7 @@ Besides using ``SHOW``, it is also possible to use the :ref:`current_setting
 <scalar_current_setting>` scalar function.
 
 
-Supported Session Settings
+Supported session settings
 ==========================
 
 .. _conf-session-search-path:

--- a/blackbox/docs/editions.rst
+++ b/blackbox/docs/editions.rst
@@ -33,7 +33,7 @@ CrateDB
 
 .. _enterprise-features:
 
-Enterprise Features
+Enterprise features
 -------------------
 
 - :ref:`administration_user_management`: manage multiple database users
@@ -55,7 +55,7 @@ Enterprise Features
 
 .. _node-limitations:
 
-Node Limitation
+Node limitation
 ---------------
 
 To make full use of CrateDB, you must `acquire an Enterprise License`_. Unless and

--- a/blackbox/docs/general/blobs.rst
+++ b/blackbox/docs/general/blobs.rst
@@ -14,7 +14,7 @@ regular data.
 .. contents::
    :local:
 
-Creating a Table for Blobs
+Creating a table for blobs
 ==========================
 
 Before adding blobs a ``blob table`` must be created. Blob tables can be
@@ -27,7 +27,7 @@ Lets use the CrateDB shell crash to issue the SQL statement::
 Now CrateDB is configured to allow blobs to be management under the
 ``/_blobs/myblobs`` endpoint.
 
-Custom Location for Storing Blob Data
+Custom location for storing blob data
 =====================================
 
 It is possible to define a custom directory path for storing blob data which
@@ -44,7 +44,7 @@ Blob data will be stored under this path with the following layout::
 
   /<blobs.path>/nodes/<NODE_NO>/indices/<INDEX_UUID>/<SHARD_ID>/blobs
 
-Global by Config
+Global by config
 ----------------
 
 Just uncomment or add following entry at the CrateDB config in order to define a
@@ -54,7 +54,7 @@ custom path globally for all blob tables::
 
 Also see :ref:`config`.
 
-Per Blob Table Setting
+Per blob table setting
 ----------------------
 
 It is also possible to define a custom blob data path per table instead of
@@ -98,7 +98,7 @@ To list all blobs inside a blob table a ``SELECT`` statement can be used::
     HTTP/1.1 204 No Content
 
 
-Altering a Blob Table
+Altering a blob table
 =====================
 
 The number of replicas a blob table has can be changed using the ``ALTER BLOB
@@ -107,7 +107,7 @@ TABLE`` clause::
     sh$ crash -c "alter blob table myblobs set (number_of_replicas=0)"
     ALTER OK, 1 row affected (... sec)
 
-Deleting a Blob Table
+Deleting a blob table
 =====================
 
 Blob tables can be deleted similar to normal tables::
@@ -121,7 +121,7 @@ Blob tables can be deleted similar to normal tables::
     CREATE OK, 1 row affected (... sec)
 
 
-Using Blob Tables
+Using blob tables
 =================
 
 The usage of Blob Tables is only supported using the HTTP/HTTPS protocol. This
@@ -155,8 +155,8 @@ If a blob already exists with the given hash a 409 Conflict is returned::
     HTTP/1.1 409 Conflict
     content-length: 0
 
-Download
---------
+Downloading
+-----------
 
 To download a blob simply use a GET request::
 
@@ -184,8 +184,8 @@ used::
     The cache headers for blobs are static and basically allows clients to
     cache the response forever since the blob is immutable.
 
-Delete
-------
+Deleting
+--------
 
 To delete a blob simply use a DELETE request::
 

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -12,7 +12,7 @@ Scalar functions return a single value.
 .. contents::
    :local:
 
-String Functions
+String functions
 ================
 
 ``concat('first_arg', second_arg, [ parameter , ... ])``
@@ -356,7 +356,7 @@ The quoted string can be used as an identifier in an SQL statement.
    +----------------------------+
    SELECT 1 row in set (... sec)
 
-Date and Time Functions
+Date and time functions
 =======================
 
 .. _scalar-date-trunc:
@@ -668,7 +668,7 @@ The ``timezone`` will be ``UTC`` if not provided::
     +------------------+
     SELECT 1 row in set (... sec)
 
-Geo Functions
+Geo functions
 =============
 
 .. _scalar_distance:
@@ -836,7 +836,7 @@ Example::
 
 .. _mathematical_functions:
 
-Mathematical Functions
+Mathematical functions
 ======================
 
 All mathematical functions can be used within ``WHERE`` and ``ORDER BY``
@@ -1136,7 +1136,7 @@ See below for an example::
 
 .. _scalar-regexp:
 
-Regular Expression Functions
+Regular expression functions
 ============================
 
 The regular expression functions in CrateDB use `Java Regular Expressions`_.
@@ -1345,7 +1345,7 @@ Examples
     +---------------------+--------------+
     SELECT 5 rows in set (... sec)
 
-Array Functions
+Array functions
 ===============
 
 ``array_cat(first_array, second_array)``
@@ -1646,7 +1646,7 @@ If the ``null_string`` argument is omitted or NULL, none of the substrings of
 the input will be replaced by NULL.
 
 
-Conditional Functions and Expressions
+Conditional functions and expressions
 =====================================
 
 ``CASE WHEN ... THEN ... END``
@@ -1856,7 +1856,7 @@ Returns: same type as arguments
     +-----------------------------+
     SELECT 1 row in set (... sec)
 
-System Information Functions
+System information functions
 ============================
 
 .. _scalar_current_schema:
@@ -2126,7 +2126,7 @@ Example::
     +---------------------------+
     SELECT 1 row in set (... sec)
 
-Special Functions
+Special functions
 =================
 
 .. _ignore3vl:

--- a/blackbox/docs/general/ddl/alter-table.rst
+++ b/blackbox/docs/general/ddl/alter-table.rst
@@ -19,7 +19,7 @@ Altering Tables
     cr> CREATE TABLE my_table (id BIGINT);
     CREATE OK, 1 row affected (... sec)
 
-Updating Parameters
+Updating parameters
 ===================
 
 The parameters of a table can be modified using the ``ALTER TABLE`` clause::
@@ -34,7 +34,7 @@ In order to set a parameter to its default value use ``reset``::
 
 .. _alter_change_number_of_shard:
 
-Changing the Number of Shards
+Changing the number of shards
 -----------------------------
 
 Changing the number of shards in general works in the following steps.
@@ -54,8 +54,8 @@ Changing the number of shards in general works in the following steps.
 To change the number of primary shards of a table, it is necessary to first
 satisfy certain conditions.
 
-Decrease the Number of Shards
-.............................
+Decreasing the number of shards
+...............................
 
 To decrease the number of shards, it is necessary to ensure the following
 two conditions:
@@ -86,7 +86,7 @@ It is necessary to use a factor of the current number of primary shards as
 the target number of shards. For example, a table with 8 shards can be shrunk
 into 4, 2 or 1 primary shards.
 
-Increase the Number of Shards
+Increase the number of shards
 .............................
 
 Increasing the number of shards is limited to tables which have been created
@@ -115,7 +115,7 @@ for instance::
 Read :ref:`Alter Partitioned Tables <partitioned_tables_alter>` to see how to
 alter parameters of partitioned tables.
 
-Adding Columns
+Adding columns
 ==============
 
 In order to add a column to an existing table use ``ALTER TABLE`` with the
@@ -150,7 +150,7 @@ And now a nested column named ``name`` is added to the ``obj_column``::
     +--------------------+-----------+
     SELECT 3 rows in set (... sec)
 
-Closing and Opening Tables
+Closing and opening tables
 ==========================
 
 A table can be closed by using ``ALTER TABLE`` with the ``CLOSE`` clause::
@@ -173,7 +173,7 @@ clause::
     Closing and opening a table will preserve these settings if they are
     already set.
 
-Renaming Tables
+Renaming tables
 ===============
 
 A table can be renamed by using ``ALTER TABLE`` with the ``RENAME TO`` clause::
@@ -185,7 +185,7 @@ During the rename operation the shards of the table become temporarily unavailab
 
 .. _ddl_reroute_shards:
 
-Reroute Shards
+Reroute shards
 ==============
 
 With the ``REROUTE`` command it is possible to control the allocations of

--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -51,7 +51,7 @@ listed. They can be used as is or can be extended.
 
 .. _builtin-analyzer:
 
-Built-in Analyzers
+Built-in analyzers
 ==================
 
 .. _standard-analyzer:
@@ -126,7 +126,7 @@ Uses a :ref:`whitespace-tokenizer` tokenizer
 
 ``type='stop'``
 
-Uses a :ref:`lowercase-tokenizer` Tokenizer, with :ref:`stop-tokenfilter` Token
+Uses a :ref:`lowercase-tokenizer` tokenizer, with :ref:`stop-tokenfilter` Token
 Filter.
 
 .. rubric:: Parameters
@@ -221,7 +221,7 @@ stem_exclusion
 
 ``type='snowball'``
 
-Uses the :ref:`standard-tokenizer` Tokenizer, with :ref:`standard-tokenfilter`
+Uses the :ref:`standard-tokenizer` tokenizer, with :ref:`standard-tokenfilter`
 filter, :ref:`lowercase-tokenfilter` filter, :ref:`stop-tokenfilter` filter,
 and :ref:`snowball-tokenfilter` filter.
 
@@ -245,7 +245,7 @@ The fingerprint analyzer implements a fingerprinting algorithm which is used by
 the OpenRefine project to assist in clustering. Input text is lowercased,
 normalized to remove extended characters, sorted, deduplicated and concatenated
 into a single token. If a stopword list is configured, stop words will also be
-removed. It uses the :ref:`standard-tokenizer` Tokenizer and the following
+removed. It uses the :ref:`standard-tokenizer` tokenizer and the following
 filters: :ref:`lowercase-tokenfilter`, :ref:`asciifolding-tokenfilter`,
 :ref:`fingerprint-tokenfilter` and ref:`stop-tokenfilter`.
 
@@ -267,12 +267,12 @@ stopwords_path
 
 .. _builtin-tokenizer:
 
-Built-in Tokenizers
+Built-in tokenizers
 ===================
 
 .. _standard-tokenizer:
 
-Standard Tokenizer
+Standard tokenizer
 ------------------
 
 ``type='standard'``
@@ -290,7 +290,7 @@ max_token_length
 
 .. _classic-tokenizer:
 
-Classic Tokenizer
+Classic tokenizer
 -----------------
 
 ``type='classic'``
@@ -309,7 +309,7 @@ max_token_length
 
 .. _thai-tokenizer:
 
-Thai Tokenizer
+Thai tokenizer
 --------------
 
 ``type='thai'``
@@ -319,7 +319,7 @@ like the `standard-tokenizer`_ does.
 
 .. _letter-tokenizer:
 
-Letter Tokenizer
+Letter tokenizer
 ----------------
 
 ``type='letter'``
@@ -328,7 +328,7 @@ The ``letter`` tokenzier splits text at non-letters.
 
 .. _lowercase-tokenizer:
 
-Lowercase Tokenizer
+Lowercase tokenizer
 -------------------
 
 ``type='lowercase'``
@@ -339,8 +339,8 @@ converts them to lower case.
 
 .. _whitespace-tokenizer:
 
-Witespace Tokenizer
--------------------
+Whitespace tokenizer
+--------------------
 
 ``type='whitespace'``
 
@@ -354,7 +354,7 @@ max_token_length
 
 .. _uaxemailurl-tokenizer:
 
-UAX URL Email Tokenizer
+UAX URL email tokenizer
 -----------------------
 
 ``type='uax_url_email'``
@@ -370,7 +370,7 @@ max_token_length
 
 .. _ngram-tokenizer:
 
-N-Gram Tokenizer
+N-gram tokenizer
 ----------------
 
 ``type='ngram'``
@@ -391,7 +391,7 @@ token_chars
 
 .. _edgengram-tokenizer:
 
-Edge N-Gram Tokenizer
+Edge n-gram tokenizer
 ---------------------
 
 ``type='edge_ngram'``
@@ -415,7 +415,7 @@ token_chars
 
 .. _keyword-tokenizer:
 
-Keywork Tokenizer
+Keyword tokenizer
 -----------------
 
 ``type='keyword'``
@@ -429,7 +429,7 @@ buffer_size
 
 .. _pattern-tokenizer:
 
-Pattern Tokenizer
+Pattern tokenizer
 -----------------
 
 ``type='pattern'``
@@ -457,7 +457,7 @@ Pattern API`_ for more details about flags options.
 
 .. _simple_pattern-tokenizer:
 
-Simple Pattern Tokenizer
+Simple pattern tokenizer
 ------------------------
 
 ``type='simple_pattern'``
@@ -474,7 +474,7 @@ pattern
 
 .. _simple_pattern_split-tokenizer:
 
-Simple Pattern Split Tokenizer
+Simple pattern split tokenizer
 ------------------------------
 
 ``type='simple_patten_split'``
@@ -490,7 +490,7 @@ pattern
 
 .. _pathhierarchy-tokenizer:
 
-Path Hierarchy Tokenizer
+Path hierarchy tokenizer
 ------------------------
 
 ``type='path_hierarchy'``
@@ -524,7 +524,7 @@ skip
 
 .. _analyzers_char_group:
 
-Char Group Tokenizer
+Char group tokenizer
 --------------------
 
 ``type=char_group``
@@ -540,7 +540,7 @@ tokenize_on_chars
 
 .. _builtin-token-filter:
 
-Built-in Token Filters
+Built-in token filters
 ======================
 
 .. _standard-tokenfilter:
@@ -550,7 +550,7 @@ Built-in Token Filters
 
 ``type='standard'``
 
-Normalizes tokens extracted with the :ref:`standard-tokenizer` Tokenizer.
+Normalizes tokens extracted with the :ref:`standard-tokenizer` tokenizer.
 
 .. _classic-tokenfilter:
 
@@ -659,8 +659,8 @@ Transforms the token stream as per the Porter stemming algorithm.
 .. NOTE::
 
     The input to the stemming filter must already be in lower case, so you will
-    need to use Lower Case Token Filter or Lower Case Tokenizer farther down
-    the Tokenizer chain in order for this to work properly! For example, when
+    need to use Lower Case Token Filter or Lower Case tokenizer farther down
+    the tokenizer chain in order for this to work properly! For example, when
     using custom analyzer, make sure the lowercase filter comes before the
     porterStem filter in the list of filters.
 
@@ -1249,8 +1249,8 @@ A token filter that drops identical tokens at the same position.
 
 .. _builtin-char-filter:
 
-Builtin Char Filter
-===================
+Built-in char filter
+====================
 
 .. _mapping-charfilter:
 

--- a/blackbox/docs/general/ddl/constraints.rst
+++ b/blackbox/docs/general/ddl/constraints.rst
@@ -9,7 +9,7 @@ Columns can be constrained in two ways:
 
 The values of a constrained column must comply with the constraint.
 
-Primary Key
+Primary key
 ===========
 
 The primary key constraint combines a unique constraint and a not-null
@@ -51,7 +51,7 @@ Or using a alternate syntax::
 
    See :ref:`primary_key_constraint`.
 
-Not Null
+Not null
 ========
 
 The not null constraint can be used on any table column and it prevents null

--- a/blackbox/docs/general/ddl/create-table.rst
+++ b/blackbox/docs/general/ddl/create-table.rst
@@ -119,7 +119,7 @@ the ``doc`` schema::
 
 .. _sql_ddl_naming_restrictions:
 
-Naming Restrictions
+Naming restrictions
 ===================
 
 Table, schema and column identifiers cannot have the same names as reserved key

--- a/blackbox/docs/general/ddl/data-types.rst
+++ b/blackbox/docs/general/ddl/data-types.rst
@@ -25,7 +25,7 @@ Classification
 
 .. _sql_ddl_datatypes_primitives:
 
-Primitive Types
+Primitive types
 ---------------
 
 Primitive types represent primitive values.
@@ -47,7 +47,7 @@ or collections.
 
 .. _sql_ddl_datatypes_geographic:
 
-Geographic Types
+Geographic types
 ----------------
 
 Geographic types represent points or shapes in a 2d world:
@@ -57,7 +57,7 @@ Geographic types represent points or shapes in a 2d world:
 
 .. _sql_ddl_datatypes_compound:
 
-Compound Types
+Compound types
 --------------
 
 Compound types represent values that are composed out of distinct parts like
@@ -102,7 +102,7 @@ Columns of type string can also be analyzed. See :ref:`sql_ddl_index_fulltext`.
    with UTF-8 unless the string is analyzed using full text or indexing and
    the usage of the :ref:`ddl-storage-columnstore` is disabled.
 
-Numeric Types
+Numeric types
 =============
 
 CrateDB supports a set of the following numeric data types:
@@ -130,7 +130,7 @@ For instance, the result of applying ``sum`` or ``avg`` aggregate functions may
 slightly vary between query executions or comparing floating-point values for
 equality might not always be correct.
 
-Special Floating Point Values
+Special floating point values
 -----------------------------
 
 CrateDB conforms to the `IEEE 754`_ standard concerning special values for
@@ -200,7 +200,7 @@ Example::
 
 .. _date-time-types:
 
-Date/Time Types
+Date/Time types
 ===============
 
 +---------------------------------+---------+-------------------------+--------------------+
@@ -427,7 +427,7 @@ Both of these index types accept the following parameters:
 
 .. _geo_shape_data_type_index:
 
-Geo Shape Index Structure
+Geo shape index structure
 -------------------------
 
 Computations on very complex polygons and geometry collections are exact but
@@ -642,7 +642,7 @@ inserted into it, but otherwise ignore them.
 
 .. _data-type-object-literals:
 
-Object Literals
+Object literals
 ---------------
 
 To insert values into object columns one can use object literals or parameters.
@@ -738,7 +738,7 @@ Array types are defined as follows::
 
 .. _data-type-array-literals:
 
-Array Constructor
+Array constructor
 -----------------
 
 Arrays can be written using the array constructor ``ARRAY[]`` or short ``[]``.
@@ -767,7 +767,7 @@ Some valid arrays are::
     ARRAY[column_a, column_b]
     ARRAY[ARRAY[1, 2, 1 + 2], ARRAY[3, 4, 3 + 4]]
 
-Array Representation
+Array representation
 ....................
 
 Arrays are always represented as zero or more literal elements inside square
@@ -776,7 +776,7 @@ brackets (``[]``), for example::
     [1, 2, 3]
     ['Zaphod', 'Ford', 'Arthur']
 
-Special Character Types
+Special character types
 =======================
 
 +----------+--------+------------------+
@@ -787,7 +787,7 @@ Special Character Types
 
 .. _type_conversion:
 
-Type Conversion
+Type conversion
 ===============
 
 .. _type_cast:

--- a/blackbox/docs/general/ddl/fulltext-indices.rst
+++ b/blackbox/docs/general/ddl/fulltext-indices.rst
@@ -19,7 +19,7 @@ be defined for the related columns.
 
 .. _sql_ddl_index_definition:
 
-Index Definition
+Index definition
 ================
 
 In CrateDB, every column's data is indexed using the ``plain`` index method by
@@ -71,7 +71,7 @@ When a not indexed column is queried the query will return an error.
 
 .. _sql_ddl_index_plain:
 
-Plain index (Default)
+Plain index (default)
 =====================
 
 An index of type ``plain`` is indexing the input data as-is without analyzing.
@@ -92,7 +92,7 @@ This results in the same behaviour than without any index declaration::
 
 .. _sql_ddl_index_fulltext:
 
-Fulltext Index With Analyzer
+Fulltext index with analyzer
 ----------------------------
 
 By defining an index on a column, it's analyzed data is indexed instead of the
@@ -116,7 +116,7 @@ analyzer as a parameter using the ``WITH`` statement::
     ... );
     CREATE OK, 1 row affected (... sec)
 
-Defining a Named Index Column Definition
+Defining a named index column definition
 ----------------------------------------
 
 It's also possible to define an index column which treat the data of a given
@@ -140,7 +140,7 @@ Of course defining a custom analyzer is possible here too::
 
 .. _sql-ddl-composite-index:
 
-Defining a Composite Index
+Defining a composite index
 --------------------------
 
 Defining a composite (or combined) index is done using the same syntax as above
@@ -170,8 +170,8 @@ Composite indices can include nested columns within object columns as well::
 
 .. _create_custom_analyzer:
 
-Create a Custom Analyzer
-========================
+Creating a custom analyzer
+==========================
 
 An analyzer consists of one tokenizer, zero or more token-filters, and zero or
 more char-filters.
@@ -267,8 +267,8 @@ Tokenizer and token-filters can be customized in the same way.
 
   :ref:`builtin-char-filter` for a list of built-in char-filter.
 
-Extending a Bultin Analyzer
-===========================
+Extending a built-in analyzer
+=============================
 
 Existing Analyzers can be used to create custom Analyzers by means of extending
 them.

--- a/blackbox/docs/general/ddl/partitioned-tables.rst
+++ b/blackbox/docs/general/ddl/partitioned-tables.rst
@@ -86,7 +86,7 @@ suitable partition value from the given values on database-side::
     ... ) PARTITIONED BY (month);
     CREATE OK, 1 row affected (... sec)
 
-Information Schema
+Information schema
 ==================
 
 This table shows up in the ``information_schema.tables`` table, recognizable as
@@ -315,7 +315,7 @@ list of partitions that need to be accessed.
     cr> DELETE FROM parted_table;
     DELETE OK, -1 rows affected (... sec)
 
-Generated Columns in ``PARTITIONED BY``
+Generated columns in ``PARTITIONED BY``
 ---------------------------------------
 
 Querying on tables partitioned by generated columns is also optimized to infer
@@ -373,7 +373,7 @@ both existing and new partitions of the table.
     ALTER OK, -1 rows affected (... sec)
 
 
-Changing the Number of Shards
+Changing the number of shards
 -----------------------------
 
 It is possible at any time to change the number of shards of a partitioned
@@ -426,7 +426,7 @@ table.
     +--------------------------+------------------------+------------------+
     SELECT 1 row in set (... sec)
 
-Altering a Single Partition
+Altering a single partition
 ...........................
 
 We also provide the option to change the number of shards that are already
@@ -461,7 +461,7 @@ thus a specific partition needs to be specified
    The same prerequisites and restrictions as with normal
    tables apply. See :ref:`alter_change_number_of_shard`.
 
-Alter Partitions
+Alter partitions
 ----------------
 
 It is also possible to alter parameters of single partitions of a partitioned
@@ -478,7 +478,7 @@ settings use the :ref:`ref-alter-table-partition-clause`.
 
 .. _partitioned_tables_alter_table_only:
 
-Alter Table ``ONLY``
+Alter table ``ONLY``
 --------------------
 
 Sometimes one wants to alter a partitioned table, but the changes should only
@@ -490,7 +490,7 @@ affect new partitions and not existing ones. This can be done by using the
     cr> ALTER TABLE ONLY parted_table SET (number_of_replicas = 1);
     ALTER OK, -1 rows affected (... sec)
 
-Closing and Opening a Partition
+Closing and opening a partition
 -------------------------------
 
 A single partition within a partitioned table can be opened and closed in the
@@ -512,7 +512,7 @@ Limitations
 * ``WHERE`` clauses cannot contain queries like ``partitioned_by_column='x' OR
   normal_column=x``
 
-Consistency Notes Related to Concurrent DML Statement
+Consistency notes related to concurrent DML statement
 =====================================================
 
 If a partition is deleted during an active insert or update bulk operation this

--- a/blackbox/docs/general/ddl/shard-allocation.rst
+++ b/blackbox/docs/general/ddl/shard-allocation.rst
@@ -1,7 +1,7 @@
 .. _ddl_shard_allocation:
 
 ============================
- Shard Allocation Filtering
+ Shard allocation filtering
 ============================
 
 Shard allocation filters allows to configure shard and replicas allocation per
@@ -37,7 +37,7 @@ set of nodes to another:
    Assign the table to a node whose *{attribute}* has **none** of the
    comma-separated values.
 
-Special Attributes
+Special attributes
 ==================
 
 Following special attributes are supported:

--- a/blackbox/docs/general/ddl/sharding.rst
+++ b/blackbox/docs/general/ddl/sharding.rst
@@ -28,7 +28,7 @@ think about shards when querying a table.
 Read requests are broken down and executed in parallel across multiple shards
 on multiple nodes, massively improving read performance.
 
-Number of Shards
+Number of shards
 ================
 
 The number of shards can be defined by using the ``CLUSTERED INTO <number>

--- a/blackbox/docs/general/ddl/storage.rst
+++ b/blackbox/docs/general/ddl/storage.rst
@@ -8,7 +8,7 @@ Data storage options can be tuned for each column similar to how indexing is def
 
 .. _ddl-storage-columnstore:
 
-Column Store
+Column store
 ============
 
 Beside of storing the row data as-is (and indexing each value by default), each

--- a/blackbox/docs/general/ddl/views.rst
+++ b/blackbox/docs/general/ddl/views.rst
@@ -9,7 +9,7 @@ Views
 .. contents::
     :local:
 
-Introduction: Creating Views
+Introduction: Creating views
 ============================
 
 Views are stored named queries which can be used in place of table names.
@@ -25,7 +25,7 @@ pre-defined filter::
     CREATE OK, 1 row affected (... sec)
 
 
-Querying Views
+Querying views
 ==============
 
 Once created, views can be used instead of a table in a statement::
@@ -62,7 +62,7 @@ be able to query it.
 
 See also :ref:`administration-privileges`.
 
-Dropping Views
+Dropping views
 ==============
 
 Views can be dropped using the :ref:`DROP VIEW statement <ref-drop-view>`::

--- a/blackbox/docs/general/dml.rst
+++ b/blackbox/docs/general/dml.rst
@@ -13,7 +13,7 @@ Data Manipulation
 
 .. _inserting_data:
 
-Inserting Data
+Inserting data
 ==============
 
 Inserting data to CrateDB is done by using the SQL ``INSERT`` statement.
@@ -92,7 +92,7 @@ column and the currently inserted row::
     ... ('Arthur Dent', 9876, 5432, 642935);
     SQLActionException[SQLParseException: Given value 642935 for generated column does not match defined generated expression value 642936]
 
-Inserting Data By Query
+Inserting data by query
 -----------------------
 
 .. Hidden: refresh locations
@@ -346,7 +346,7 @@ This can also be done when using a query instead of values::
 
 .. _dml_updating_data:
 
-Updating Data
+Updating data
 =============
 
 In order to update documents in CrateDB the SQL ``UPDATE`` statement can be
@@ -375,7 +375,7 @@ increment a number like this::
 
 .. _dml_deleting_data:
 
-Deleting Data
+Deleting data
 =============
 
 Deleting rows in CrateDB is done using the SQL ``DELETE`` statement::
@@ -385,10 +385,10 @@ Deleting rows in CrateDB is done using the SQL ``DELETE`` statement::
 
 .. _importing_data:
 
-Import and Export
+Import and export
 =================
 
-Importing Data
+Importing data
 --------------
 
 Using the ``COPY FROM`` statement, CrateDB nodes can import data from local
@@ -493,7 +493,7 @@ This wildcard can also be used to only match certain files in a directory::
     cr> refresh table quotes;
     REFRESH OK, 1 row affected (... sec)
 
-Detailed Error Reporting
+Detailed error reporting
 ........................
 
 If the ``RETURN_SUMMARY`` clause is specified, a result set containing information
@@ -545,7 +545,7 @@ See :ref:`copy_from` for more information.
 
 .. _exporting_data:
 
-Exporting Data
+Exporting data
 --------------
 
 Data can be exported using the ``COPY TO`` statement. Data is exported in a

--- a/blackbox/docs/general/dql/joins.rst
+++ b/blackbox/docs/general/dql/joins.rst
@@ -11,7 +11,7 @@ Joins
 
 .. _cross-joins:
 
-Cross Joins
+Cross joins
 -----------
 
 Referencing two tables results in a ``CROSS JOIN``.
@@ -61,7 +61,7 @@ the ``FROM`` list::
     +------------------------------+---------------+----------+
     SELECT 8 rows in set (... sec)
 
-Inner Joins
+Inner joins
 -----------
 
 Inner Joins require each record of one table to have matching records on the
@@ -82,7 +82,7 @@ other table::
     +----+------------+------------------+
     SELECT 4 rows in set (... sec)
 
-Left Outer Joins
+Left outer joins
 ----------------
 
 **Left** outer join returns tuples for all matching records of the *left* and
@@ -118,7 +118,7 @@ null values for the columns of the *right* relation::
     +--------------------+-----------------------+
     SELECT 18 rows in set (... sec)
 
-Right Outer Joins
+Right outer joins
 -----------------
 
 **Right** outer join returns tuples for all matching records of the *right* and
@@ -142,7 +142,7 @@ null values for the columns of the *left* relation::
     +-------------+-----------------------+
     SELECT 6 rows in set (... sec)
 
-Full Outer Joins
+Full outer joins
 ----------------
 
 **Full** outer join returns tuples for all matching records of the *left* and
@@ -181,7 +181,7 @@ tuples for all other records from *right* that don't match any record on the
     +--------------------+-----------------------+
     SELECT 19 rows in set (... sec)
 
-Join Conditions
+Join conditions
 ---------------
 
 CrateDB supports all operators and scalar functions as join conditions in the
@@ -203,10 +203,10 @@ Example with ``within`` scalar function::
 
 .. _available-join-algo:
 
-Available Join Algorithms
+Available join algorithms
 -------------------------
 
-Nested Loop Join Algorithm
+Nested loop join algorithm
 ..........................
 
 The nested loop algorithm evaluates the join conditions on every record of the
@@ -216,7 +216,7 @@ in the left table.
 
 This is the default algorithm used for all types of joins.
 
-Block Hash Join Algorithm
+Block hash join algorithm
 .........................
 
 The performance of `Equi-Joins`_  is substantially improved by using the
@@ -247,8 +247,8 @@ session setting :ref:`enable_hashjoin <conf-session-enable-hashjoin>`::
 Limitations
 -----------
 
- - Joining more than 2 tables can result in execution plans which perform
-   poorly as there is no query optimizer in place yet.
+Joining more than 2 tables can result in execution plans which
+perform poorly as there is no query optimizer in place yet.
 
 
 .. _`nightly builds`: https://cdn.crate.io/downloads/releases/nightly/

--- a/blackbox/docs/general/dql/selects.rst
+++ b/blackbox/docs/general/dql/selects.rst
@@ -54,7 +54,7 @@ Aliases can be used to change the output name of the columns::
 
 .. _sql_dql_from_clause:
 
-``FROM`` Clause
+``FROM`` clause
 ===============
 
 The ``FROM`` clause is used to reference the relation this select query is
@@ -115,7 +115,7 @@ Joins
 
 .. _sql_dql_distinct_clause:
 
-``DISTINCT`` Clause
+``DISTINCT`` clause
 ===================
 
 If DISTINCT is specified, one unique row is kept. All other duplicate rows are
@@ -137,7 +137,7 @@ removed from the result set::
 
 .. _sql_dql_where_clause:
 
-``WHERE`` Clause
+``WHERE`` clause
 ================
 
 A simple where clause example using an equality operator::
@@ -150,7 +150,7 @@ A simple where clause example using an equality operator::
     +---------------------------------------...--------------------------------------+
     SELECT 1 row in set (... sec)
 
-Comparison Operators
+Comparison operators
 --------------------
 
 These :ref:`sql_operators` are supported and can be used for all simple data
@@ -200,7 +200,7 @@ may fail.
 
 .. _sql_ddl_regexp:
 
-Regular Expressions
+Regular expressions
 ===================
 
 Operators for matching using regular expressions.
@@ -624,7 +624,7 @@ for operators
 
 .. _sql_dql_objects:
 
-Inner Objects and Nested Objects
+Inner objects and nested objects
 ================================
 
 CrateDB supports an ``object`` data type, used for simple storing a whole
@@ -663,11 +663,11 @@ Inserting objects::
 
 .. _sql_dql_object_arrays:
 
-Object Arrays
+Object arrays
 =============
 
 Arrays in CrateDB can be queried for containment using the
-:ref:`sql_dql_any_array` operator. 
+:ref:`sql_dql_any_array` operator.
 
 It is possible to access fields of :ref:`sql_dql_objects` using subscript
 expressions. If the parent is an object array, you'll get an array of the
@@ -736,7 +736,7 @@ Examples::
 
 .. _sql_dql_object_arrays_select:
 
-Selecting Array Elements
+Selecting array elements
 ------------------------
 
 Array elements can be selected directly using a integer value greater than or
@@ -766,7 +766,7 @@ index greater than the actual array size results in a NULL value.
 
 .. _sql_dql_aggregation:
 
-Data Aggregation
+Data aggregation
 ================
 
 CrateDB supports :ref:`aggregation` via the following aggregation functions.
@@ -956,7 +956,7 @@ Some Examples::
     +---------------+-------------+
     SELECT 4 rows in set (... sec)
 
-Window Functions
+Window functions
 ================
 
 CrateDB supports the :ref:`OVER <over>` clause to enable the execution of

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -31,7 +31,7 @@ but no privilege at all on ``doc.locations``, when ``john`` issues a ``SELECT *
 FROM information_schema.tables`` statement, the tables information related to
 the ``doc.locations`` table will not be returned.
 
-Virtual Tables
+Virtual tables
 ==============
 
 .. _information_schema_tables:

--- a/blackbox/docs/general/occ.rst
+++ b/blackbox/docs/general/occ.rst
@@ -61,7 +61,7 @@ and deletes.
     checking for the exact ``_seq_no`` and ``_primary_term`` your update/delete
     is based on.
 
-Optimistic Update
+Optimistic update
 =================
 
 Querying for the correct ``_seq_no`` and ``_primary_term`` ensures that no
@@ -78,16 +78,16 @@ not execute the update and results in 0 affected rows::
     ... where id=5 and "_seq_no" = 222 and "_primary_term" = 1;
     UPDATE OK, 0 rows affected (... sec)
 
-Optimistic Delete
+Optimistic delete
 =================
 
 The same can be done when deleting a row::
 
-    cr> delete from locations where id = '6' and "_seq_no" = 13 
+    cr> delete from locations where id = '6' and "_seq_no" = 13
     ... and "_primary_term" = 1;
     DELETE OK, 1 row affected (... sec)
 
-Known Limitations
+Known limitations
 =================
 
  - The ``_seq_no`` and ``_primary_term`` columns can only be used when

--- a/blackbox/docs/general/user-defined-functions.rst
+++ b/blackbox/docs/general/user-defined-functions.rst
@@ -102,7 +102,7 @@ You can explicitly assign a schema like this::
    :ref:`snapshot-restore` can't be used to backup functions, because snapshots
    contain table data only.
 
-Supported Types
+Supported types
 ===============
 
 The argument types, and the return type of the function can be any of the
@@ -194,7 +194,7 @@ Optionally, you can provide a schema::
      cr> DROP FUNCTION my_schema.log10(bigint);
      DROP OK, 1 row affected  (... sec)
 
-Supported Languages
+Supported languages
 ===================
 
 CrateDB currently only supports the UDF language ``javascript``.
@@ -373,7 +373,7 @@ is returned::
     cr> DROP FUNCTION utc(bigint, bigint, bigint);
     DROP OK, 1 row affected  (... sec)
 
-Working With ``Array`` Methods
+Working with ``Array`` methods
 ------------------------------
 
 The JavaScript ``Array`` object has a number of prototype methods you can

--- a/blackbox/docs/interfaces/http.rst
+++ b/blackbox/docs/interfaces/http.rst
@@ -57,7 +57,7 @@ A simple ``SELECT`` statement can be submitted like this::
 
 .. _parameter_substitution:
 
-Parameter Substitution
+Parameter substitution
 ======================
 
 In addition to the ``stmt`` key the request body may also contain an ``args``
@@ -144,7 +144,7 @@ The same query using question marks as placeholders looks like this::
     With some queries the row count is not ascertainable. In this cases
     rowcount is ``-1``.
 
-Default Schema
+Default schema
 ==============
 
 It is possible to set a default schema while querying the CrateDB cluster via
@@ -180,7 +180,7 @@ It is possible to set a default schema while querying the CrateDB cluster via
 If the schema name is not specified in the header, the default ``doc`` schema
 will be used instead.
 
-Column Types
+Column types
 ============
 
 CrateDB can respond a list ``col_types`` with the data type ID of every
@@ -272,7 +272,7 @@ ID    Data Type
 
 .. _bulk_operations:
 
-Bulk Operations
+Bulk operations
 ===============
 
 The REST endpoint allows to issue bulk operations which are executed as single
@@ -326,7 +326,7 @@ insert three records at once::
       ]
     }
 
-Error Handling
+Error handling
 ==============
 
 Queries that are invalid or cannot be satisfied will result in an error
@@ -456,7 +456,7 @@ Code   Error
 5030   The query was killed by a ``kill`` statement
 ====== =====================================================================
 
-Bulk Errors
+Bulk errors
 -----------
 
 If a bulk operation fails, the resulting rowcount will be ``-2`` and the

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -38,7 +38,7 @@ which is why clients should generally enable ``autocommit``.
     Write operations will still behave as if autocommit was enabled and commit
     or rollback calls are ignored.
 
-Server Compatibility and Implementation Status
+Server compatibility and implementation status
 ==============================================
 
 CrateDB emulates PostgreSQL server version ``10.5``.
@@ -91,12 +91,12 @@ is ``UTF8``.
 Query Modes
 -----------
 
-Simple Query
+Simple query
 ............
 
 The `Simple Query`_ protocol mode is fully implemented.
 
-Extended Query
+Extended query
 ..............
 
 The `Extended Query`_ protocol mode is implemented with the following limitations:
@@ -107,17 +107,17 @@ The `Extended Query`_ protocol mode is implemented with the following limitation
 - To optimize the execution of bulk operations the execution of statements is
   delayed until the ``Sync`` message is received
 
-Copy Operations
+Copy operations
 ---------------
 
 CrateDB does not support the ``COPY`` sub-protocol.
 
-Function Call
+Function call
 -------------
 
 The function call sub-protocol is not supported since it's a legacy feature.
 
-Canceling Requests
+Canceling requests
 ------------------
 
 Operations can be cancelled using the ``KILL`` statement, hence the
@@ -191,7 +191,7 @@ CrateDB::
    Check table :ref:`information_schema.columns <information_schema_columns>`
    to get information for all supported columns.
 
-Show Transaction Isolation
+Show transaction isolation
 --------------------------
 
 For compatibility with JDBC the ``SHOW TRANSACTION ISOLATION LEVEL`` statement
@@ -205,7 +205,7 @@ is implemented::
     +-----------------------+
     SHOW 1 row in set (... sec)
 
-BEGIN/COMMIT Statements
+BEGIN/COMMIT statements
 -----------------------
 
 For compatibility with clients that use the Postgres wire protocol, such as the
@@ -224,7 +224,7 @@ implemented, for example::
 Since CrateDB does not support transactions, both the ``COMMIT`` and ``BEGIN``
 statement and any of its parameters are ignored.
 
-Client Compatibility
+Client compatibility
 ====================
 
 JDBC
@@ -263,7 +263,7 @@ Limitations
   `Extended Query`_ API from working due to a `bug
   <https://github.com/pgjdbc/pgjdbc/issues/653>`_ at `pgjdbc`_.
 
-Connection Failover and Load Balancing
+Connection failover and load balancing
 ......................................
 
 Connection failover and load balancing is supported as described here:
@@ -274,7 +274,7 @@ Connection failover and load balancing is supported as described here:
    It is not recommended to use the **targetServerType** parameter since
    CrateDB has no concept of master-replica nodes.
 
-Implementation Differences
+Implementation differences
 ==========================
 
 The PostgreSQL Wire Protocol makes it easy to use many PostgreSQL compatible
@@ -310,7 +310,7 @@ or ``HSTORE`` are not supported. CrateDB alternatively allows the definition of
 nested documents (of type :ref:`object_data_type`) that store fieldscontaining
 any CrateDB supported data type, including nested object types.
 
-Type Casts
+Type casts
 ----------
 
 CrateDB accepts the :ref:`type_conversion` syntax for conversion of one data
@@ -319,7 +319,7 @@ type to another (see `Value Expressions`_).
 Arrays
 ------
 
-Declaration of Arrays
+Declaration of arrays
 .....................
 
 While multidimensional arrays in PostgreSQL must have matching extends for each
@@ -334,14 +334,14 @@ shows::
     +---------------------+
     SELECT 1 row in set (... sec)
 
-Accessing Arrays
+Accessing arrays
 ................
 
 Fetching arbitrary rectangular slices of an array using
 ``lower-bound:upper-bound`` expression (see `Arrays`_) in the array subscript
 is not supported.
 
-Text Search Functions and Operators
+Text search functions and operators
 -----------------------------------
 
 The functions and operators provided by PostgreSQL for full-text search (see
@@ -353,7 +353,7 @@ If you are missing features, functions or dialect improvements and have a great
 use case for it, let us know on `Github`_. We're always improving and extending
 CrateDB, and we love to hear feedback.
 
-Expression Evaluation
+Expression evaluation
 ---------------------
 
 Unlike PostgreSQL, expressions are not evaluated if the query results in 0 rows

--- a/blackbox/docs/run.rst
+++ b/blackbox/docs/run.rst
@@ -48,7 +48,7 @@ To stop the process that is running in the background send the ``TERM`` or
 
 The ``crate`` executable supports the following command line options:
 
-Command Line Options
+Command-line options
 ====================
 
 +------------------+----------------------------------------------------------+
@@ -76,7 +76,7 @@ Example::
 
 .. _cli_signals:
 
-Signal Handling
+Signal handling
 ===============
 
 The CrateDB process can handle the following signals.

--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -19,14 +19,14 @@ character symbol.
 
 .. _string_literal:
 
-String Literal
+String literal
 ==============
 
 String literals are defined as an arbitrary sequence of characters that are
 delimited with single quotes ``'`` as defined in ANSI SQL, for example
 ``'This is a string'``.
 
-Escape Strings
+Escape strings
 --------------
 
 The escape character in CrateDB is the single-quote ``'``. A character gets
@@ -41,7 +41,7 @@ single quotes, e.g. ``'Jack''s car'``.
 
 .. _sql_escape_string_literals:
 
-String Literals with C-Style Escapes
+String literals with C-Style escapes
 ------------------------------------
 
 In addition to the escaped character ``'``, CrateDB supports C-Style escaped
@@ -102,7 +102,7 @@ single-quote described in :ref:`String Literals <string_literal>`.
 
 .. _sql_lexical_keywords_identifiers:
 
-Key Words and Identifiers
+Key words and identifiers
 =========================
 
 The table bellow lists all **reserved key words** in CrateDB. These need to be
@@ -185,7 +185,7 @@ double quotes (``"``). Quoted identifiers are never keywords, so you can use
 
 .. _sql_lexical_special_chars:
 
-Special Characters
+Special characters
 ==================
 
 Some non-alphanumeric characters do have a special meaning. For their usage

--- a/blackbox/docs/sql/general/value-expressions.rst
+++ b/blackbox/docs/sql/general/value-expressions.rst
@@ -32,7 +32,7 @@ Different types have different notations. The simplest forms are:
     - :ref:`sql_lexical`
     - :ref:`data-types`
 
-Column Reference
+Column reference
 ================
 
 A column reference is the name of a column. It's represented using an
@@ -52,7 +52,7 @@ multiple alias or table definitions::
 
     :ref:`sql_lexical`
 
-Parameter Reference
+Parameter reference
 ===================
 
 A parameter reference is a placeholder for a value.
@@ -65,7 +65,7 @@ Parameter references can either be unnumbered or numbered:
 
 - ``$n`` as numbered placeholder: ``select * from t where x = $1 or x = $2``
 
-Operator Invocation
+Operator invocation
 ===================
 
 There are two different types of operators in CrateDB:
@@ -81,13 +81,13 @@ There are two different types of operators in CrateDB:
 
 .. _sql_expressions_subscript:
 
-Subscript Expression
+Subscript expression
 ====================
 
 A subscript expression is an expression which contains a subscript operator
 (``[ ]``). It can be used to access a sub value of a composite type value.
 
-Array Subscript
+Array subscript
 ---------------
 
 The subscript operator can be used on array expressions to retrieve a single
@@ -102,7 +102,7 @@ the array which should be retrieved.
 
     :ref:`sql_dql_object_arrays_select`
 
-Object Subscript
+Object subscript
 ----------------
 
 On object expressions the subscript operator can be used to access an inner
@@ -117,7 +117,7 @@ should be retrieved.
 
     :ref:`sql_dql_objects`
 
-Function Call
+Function call
 =============
 
 A function is declared by its name followed by its arguments enclosed in
@@ -132,7 +132,7 @@ parentheses::
     - :ref:`aggregation`
     - :ref:`window-functions`
 
-Type Cast
+Type cast
 =========
 
 A type cast specifies the conversion from one type to another. The syntax is::
@@ -148,7 +148,7 @@ this returns ``null`` if a value cannot be converted to the given type::
 
     :ref:`data-types`
 
-Object Constructor
+Object constructor
 ==================
 
 A object constructor is an expression which builds an object using its
@@ -163,7 +163,7 @@ enclosed in curly brackets::
 
     :ref:`data-type-object-literals`
 
-Array Constructor
+Array constructor
 =================
 
 A array constructor is an expression which builds an array. It consists of one
@@ -198,7 +198,7 @@ Example::
 
     Array constructor only supports subqueries returning a single column.
 
-Scalar Subquery
+Scalar subquery
 ===============
 
 A scalar subquery is a regular SELECT statement in parentheses that returns

--- a/blackbox/docs/sql/statements/copy-from.rst
+++ b/blackbox/docs/sql/statements/copy-from.rst
@@ -44,7 +44,7 @@ Here's an example:
     cr> COPY quotes FROM 'file:///tmp/import_data/quotes.json';
     COPY OK, 3 rows affected (... sec)
 
-Supported Formats
+Supported formats
 -----------------
 
 CrateDB accepts both JSON and CSV inputs. The format is inferred from the file
@@ -73,7 +73,7 @@ Example CSV data::
 
 See also: :ref:`importing_data`.
 
-Type Casts and Constraints
+Type casts and constraints
 --------------------------
 
 CrateDB does not check if the column's data types match the types from the
@@ -112,7 +112,7 @@ Will be converted to:
 
     'file:///tmp%20folder/file.json'
 
-Supported Schemes
+Supported schemes
 -----------------
 
 ``file``

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -353,7 +353,7 @@ A repository type that stores its snapshots on the Azure Storage service.
   The location mode for storing data on the Azure Storage.
   Note that if you set it to ``secondary_only``, it will force readonly to true.
 
-Client Specific Settings
+Client specific settings
 ........................
 
 **account**

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -82,7 +82,7 @@ encompass more than one column. Every column constraint can also be written as
 a table constraint; a column constraint is only a notational convenience for
 use when the constraint only affects one column.
 
-Table Elements
+Table elements
 --------------
 
 .. _ref-base-columns:
@@ -100,7 +100,7 @@ which case their value is null.
 
 .. _ref-generated-columns:
 
-Generated Columns
+Generated columns
 .................
 
 A generated column is a persistent column that is computed as needed from the
@@ -118,7 +118,7 @@ The ``GENERATED ALWAYS`` part of the syntax is optional.
 
    For more information, see :ref:`sql-ddl-generated-columns`.
 
-Table Constraints
+Table constraints
 .................
 
 Table constraints are constraints that are applied to more than one column or
@@ -126,7 +126,7 @@ to the table as a whole.
 
 For further details see :ref:`table_constraints`.
 
-Column Constraints
+Column constraints
 ..................
 
 Column constraints are constraints that are applied on each column of the table

--- a/blackbox/docs/sql/statements/insert.rst
+++ b/blackbox/docs/sql/statements/insert.rst
@@ -47,7 +47,7 @@ type conversion will be attempted.
 -----------------------------
 
 This clause can be used to update a record if a conflicting record is
-encountered. 
+encountered.
 
 ::
 
@@ -86,7 +86,7 @@ In the above statement, if ``col1`` had a primary key constraint and the value
 ``1`` already existed for ``col1``, no insert would be performed. The conflict
 target after ``ON CONFLICT`` is optional.
 
-Insert From Dynamic Queries Constraints
+Insert from dynamic queries constraints
 ---------------------------------------
 
 In some cases ``SELECT`` statements produce invalid data. This opens a rare

--- a/blackbox/docs/sql/statements/select.rst
+++ b/blackbox/docs/sql/statements/select.rst
@@ -109,7 +109,7 @@ The FROM clause specifies the source relation for the SELECT::
 
 The relation can be any of the following relations.
 
-Relation Reference
+Relation reference
 ''''''''''''''''''
 
 A ``relation_reference`` is an ident which can either reference a table or a
@@ -138,7 +138,7 @@ view with an optional alias::
 
 .. _sql_reference_joined_tables:
 
-Joined Relation
+Joined relation
 '''''''''''''''
 
 A ``joined_relation`` is a relation which joins two relations together. See
@@ -156,7 +156,7 @@ A ``joined_relation`` is a relation which joins two relations together. See
   The join_condition is not applicable for joins of type CROSS and must
   have a returning value of type ``boolean``.
 
-Table Function
+Table function
 ''''''''''''''
 
 ``table_function`` is a function that produces a set of rows and has columns.
@@ -177,7 +177,7 @@ Available functions are documented in the :ref:`table functions
 
 .. _sql_reference_subselect:
 
-Sub Select
+Sub select
 ''''''''''
 
 A ``sub_select`` is another ``SELECT`` statement surrounded by parentheses with


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Changes the titles and headings in the CrateDB reference from title case to sentence-style case.

## Checklist

 - [ ] ~User relevant changes are recorded in ``CHANGES.txt``~
 - [ ] ~Touched code is covered by tests~
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes