### PR TITLE
Fetch sys.jobs and sys.jobs_log rows that belong to current user.

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1164,6 +1164,10 @@ Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request
 that tries to query a non-existent table) will not show up as jobs.
 
+.. NOTE::
+
+   The ``sys.jobs`` table is subject to :ref:`jobs_table_permissions`.
+
 .. _sys-jobs-metrics:
 
 Jobs Metrics
@@ -1347,6 +1351,10 @@ have corresponding log tables: ``sys.jobs_log`` and ``sys.operations_log``.
 
   You can control which jobs are recorded using the :ref:`stats.jobs_log_filter
   <stats.jobs_log_filter>`
+
+.. NOTE::
+
+   The ``sys.jobs_log`` table is subject to :ref:`jobs_table_permissions`.
 
 
 ``sys.operations_log`` Table Schema
@@ -1847,6 +1855,20 @@ For example, if the user ``john`` has any privilege on the ``doc.books`` table
 but no privilege at all on ``doc.locations``, when ``john`` issues a
 ``SELECT * FROM sys.shards`` statement, the shards information related to the
 ``doc.locations`` table will not be returned.
+
+.. _jobs_table_permissions:
+
+Sys Jobs Tables Permissions
+===========================
+
+Accessing :ref:`sys.jobs <sys-jobs>` and :ref:`sys.jobs_log <sys-logs>` tables
+is subjected to the same privileges constraints as other tables. To query
+them, the current user needs to have the ``DQL`` privilege on that particular
+table, either directly or inherited from the ``SCHEMA`` or ``CLUSTER``.
+
+A user that doesn't have superuser privileges is allowed to retrieve only
+their own job logs entries, while a user with superuser privileges has access
+to all.
 
 Before Upgrading
 ================

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -206,6 +206,10 @@ Deprecations
 Changes
 =======
 
+- Restrict access to log entries in :ref:`sys.jobs <sys-jobs>` and
+  :ref:`sys.jobs_log <sys-logs>` to the current user.
+  This doesn't apply to superusers.
+
 - Added a new ``Administration Language (AL)`` privilege type which allows
   users to manage other users. See :ref:`administration-privileges`.
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -57,11 +57,13 @@ public class SysTableDefinitions {
                                TableHealthService tableHealthService) {
         tableDefinitions.put(SysJobsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.activeJobs()),
-            SysJobsTableInfo.expressions(clusterService::localNode)
+            SysJobsTableInfo.expressions(clusterService::localNode),
+            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username())
         ));
         tableDefinitions.put(SysJobsLogTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.jobsLog()),
-            SysJobsLogTableInfo.expressions()
+            SysJobsLogTableInfo.expressions(),
+            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username())
         ));
         tableDefinitions.put(SysOperationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.activeOperations()),

--- a/sql/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference;
+
+import com.google.common.collect.Iterables;
+import io.crate.auth.user.User;
+import io.crate.expression.reference.sys.job.JobContext;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.settings.SessionSettings;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static io.crate.auth.user.User.CRATE_USER;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class StaticTableDefinitionTest {
+
+    private final TransactionContext dummyTxnCtx = TransactionContext.of(
+        new SessionSettings("", SearchPath.createSearchPathFrom("")));
+
+    private final User dummyUser = User.of("dummy");
+
+    @Test
+    public void testTableDefinitionWithPredicate() throws ExecutionException, InterruptedException {
+        List<JobContext> actual = List.of(
+            new JobContext(UUID.randomUUID(), "select 1", 1L, CRATE_USER, null),
+            new JobContext(UUID.randomUUID(), "select 2", 1L, CRATE_USER, null),
+            new JobContext(UUID.randomUUID(), "select 3", 1L, dummyUser, null));
+
+        StaticTableDefinition<JobContext> tableDef = new StaticTableDefinition<>(
+            () -> completedFuture(actual),
+            Map.of(),
+            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()));
+
+        Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
+        assertThat(Iterables.size(expected), is(3));
+
+        expected = tableDef.retrieveRecords(dummyTxnCtx, dummyUser).get();
+        assertThat(Iterables.size(expected), is(1));
+    }
+
+    @Test
+    public void testTableDefinitionWithPredicateOnEmptyRecords()
+        throws ExecutionException, InterruptedException {
+        StaticTableDefinition<JobContext> tableDef = new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            Map.of(),
+            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()));
+
+        Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
+        assertThat(Iterables.size(expected), is(0));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
