### PR TITLE
Remove SET SESSION mention from DQL privilege docs

### DIFF
--- a/blackbox/docs/admin/privileges.rst
+++ b/blackbox/docs/admin/privileges.rst
@@ -36,9 +36,9 @@ Privilege Types
 .......
 
 Granting ``Data Query Language (DQL)`` privilege to a user, indicates that this
-user is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH``, ``COPY TO``,
-and ``SET SESSION`` statements, as well as using the available user defined
-functions, on the object for which the privilege applies.
+user is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH`` and ``COPY TO``
+statements, as well as using the available user defined functions, on the
+object for which the privilege applies.
 
 .. NOTE::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Using SET SESSION doesn't require any privileges at all.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)