### PR TITLE
Remove LGTM requirement for mergify merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,8 +10,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - status-success=ci/jenkins/pr_tests
       - status-success=crate.crate
-      - 'status-success=LGTM analysis: Java'
-      - 'status-success=LGTM analysis: Python'
     name: default
   - name: Delete branch after merge
     actions:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Due to the switch to the checks API on LGTM the `No code changes
detected` state is no longer detected by mergify as succeeding, which
would block it from merging.

- LGTM doesn't report alert introductions as error, the only scenario
where it fails is if it fails to build.

- It sometimes takes a long time (longer than Azure pipelines)

We should still get the analysis results and can look at it
occasionally.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)