### PR TITLE
Allow using SET GLOBAL as user with AL privileges

### DIFF
--- a/blackbox/docs/admin/privileges.rst
+++ b/blackbox/docs/admin/privileges.rst
@@ -60,10 +60,6 @@ user is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH`` and ``COPY TO``
 statements, as well as using the available user defined functions, on the
 object for which the privilege applies.
 
-.. NOTE::
-
-   :ref:`SET GLOBAL <ref-set-desc>` privileges cannot be granted because ``SET
-   GLOBAL`` statements can only be issued by the superuser.
 
 ``DML``
 .......
@@ -100,6 +96,7 @@ to execute the following statements:
 
 - ``CREATE USER``
 - ``DROP USER``
+- ``SET GLOBAL``
 
 All statements enabled via the ``AL`` privilege operate on a cluster level. So
 granting this on a schema or table level will have no effect.

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -207,7 +207,8 @@ Changes
 =======
 
 - Added a new ``Administration Language (AL)`` privilege type which allows
-  users to manage other users. See :ref:`administration-privileges`.
+  users to manage other users and use ``SET GLOBAL``. See
+  :ref:`administration-privileges`.
 
 - Changed the circuit breaker logic to measure the real heap usage instead of
   the memory reserved by child circuit breakers. This should reduce the chance

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -462,8 +462,13 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         public Void visitSetStatement(SetAnalyzedStatement analysis, User user) {
             if (analysis.scope().equals(SetStatement.Scope.GLOBAL)) {
-                throwRequiresSuperUserPermission(user.name());
-                return null;
+                Privileges.ensureUserHasPrivilege(
+                    Privilege.Type.AL,
+                    Privilege.Clazz.CLUSTER,
+                    null,
+                    user,
+                    defaultSchema
+                );
             }
             return null;
         }

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -183,11 +183,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testSetGlobalNotAllowedAsNormalUser() throws Exception {
-        expectedException.expect(UnauthorizedException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement. " +
-                                        "Superuser permissions are required");
+    public void test_set_global_statements_can_be_executed_with_al_cluster_privileges() throws Exception {
         analyze("set global stats.enabled = true");
+        assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)