### PR TITLE
Drop support for s3 repository client settings in crate.yml.

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -763,12 +763,6 @@ auth:
 # "file" urls must be prefixed with an entry configured in ``path.repo``
 #repositories.url.allowed_urls: ["http://example.org/root/*", "https://*.mydomain.com/*?*#*"]
 
-# If S3 buckets are used for snapshot repositories the following settings provide
-# default credentials to be used if no credentials are defined as parameters in the
-# SQL  ``CREATE REPOSITORY`` statement.
-#s3.client.default.access_key: Access_Key
-#s3.client.default.secret_key: Secret_Key
-
 ###################### POSTGRES WIRE PROTOCOL SUPPORT ########################
 
 # CrateDB supports the PostgreSQL wire protocol v3 and emulates a PostgreSQL

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -88,6 +88,10 @@ The following settings are removed:
 Breaking Changes
 ----------------
 
+- Removed the possibility of configuring the AWS S3 repository client via the
+  ``crate.yaml`` configuration file and command line arguments. Please, use
+  the :ref:`ref-create-repository` statement parameters for this purpose.
+
 - Removed :ref:`HDFS repository setting<ref-create-repository-types-hdfs>`:
   ``concurrent_streams`` as it is no longer supported.
 

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -1098,37 +1098,3 @@ Metadata Gateway
   because you only want the cluster state to be recovered once all nodes are
   started. However, the value must be bigger than the half of the expected
   number of nodes in the cluster.
-
-.. _s3-credentials:
-
-Credentials for S3 Repositories
-...............................
-
-CrateDB has built-in support for configuring
-:ref:`S3 buckets as repositories for snapshots
-<ref-create-repository-types-s3>`. If no credentials are provided as parameters
-to the SQL statement the following default credentials will be used:
-
-.. _s3-credentials-access-key:
-
-**s3.client.default.access_key**
-  | *Runtime:*  ``no``
-
-  The access key ID to identify the API calls.
-
-.. _s3-credentials-secret-key:
-
-**s3.client.default.secret_key**
-  | *Runtime:*  ``no``
-
-  The secret key to identify the API calls.
-
-
-.. TIP::
-
-   Configuring the settings above in the ``crate.yml`` file, is an easy way to
-   prevent credentials from being exposed.
-
-   If a repository is created with the credentials passed as parameters to the
-   SQL statement, then those credentials will be visible as plain text to
-   anyone querying the :ref:`sys.repositories table <sys-repositories>`.

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -30,7 +30,8 @@ Description
    If the repository configuration points to a location with existing
    snapshots, these are made available to the cluster.
 
-Repositories are declared using a ``repository_name`` and ``type``.
+Repositories are declared using a ``repository_name``, ``type`` and set of
+parameters.
 
 Further configuration parameters are given in the WITH Clause.
 
@@ -41,6 +42,14 @@ Further configuration parameters are given in the WITH Clause.
 
 :type:
   The type of the repository, see :ref:`ref-create-repository-types`.
+
+It is not possible to change parameters that were used to create a repository.
+Any changes to repository parameters that would prevent it from functioning
+would require removing the old and creating a new repository with the same
+type, name, and adjusted parameters. Please use the :ref:`ref-drop-repository`
+and :ref:`ref-create-repository` for this purpose. Note that the repository's
+snapshots won't be affected by this change and can be accessed via the new
+repository.
 
 Clauses
 =======
@@ -191,12 +200,30 @@ A repository that stores its snapshot on the Amazon S3 service.
 
 .. rubric:: Parameters
 
+**access_key**
+  | *Type:*    ``text``
+  | *Required:* ``true``
+
+  Access key used for authentication against AWS.
+
+**secret_key**
+  | *Type:*    ``text``
+  | *Required:* ``true``
+
+  Secret key used for authentication against AWS.
+
 **bucket**
   | *Type:*    ``text``
 
   Name of the S3 bucket used for storing snapshots. If the bucket
   does not yet exist, a new bucket will be created on S3 (assuming the
   required permissions are set).
+
+**base_path**
+  | *Type:*    ``text``
+  | *Default:* ``root directory``
+
+  Specifies the path within bucket to repository data.
 
 **endpoint**
   | *Type:*    ``text``
@@ -211,37 +238,6 @@ A repository that stores its snapshot on the Amazon S3 service.
   | *Default:* ``https``
 
   Protocol to be used.
-
-**base_path**
-  | *Type:*    ``text``
-
-  Path within the bucket to the repository.
-
-**access_key**
-  | *Type:*    ``text``
-  | *Default:* Value defined through :ref:`s3.client.default.access_key
-        <s3-credentials-access-key>` setting.
-
-  Access key used for authentication against AWS.
-
-  .. WARNING::
-
-     If the secret key is set explicitly (not via :ref:`configuration setting
-     <s3-credentials-access-key>`) it will be visible in plain text when
-     querying the ``sys.repositories`` table.
-
-**secret_key**
-  | *Type:*    ``text``
-  | *Default:* Value defined through :ref:`s3.client.default.secret_key
-     <s3-credentials-secret-key>` setting.
-
-  Secret key used for authentication against AWS.
-
-  .. WARNING::
-
-     If the secret key is set explicitly (not via :ref:`configuration setting
-     <s3-credentials-secret-key>`) it will be visible in plain text when
-     querying the ``sys.repositories`` table.
 
 **chunk_size**
   | *Type:*    ``bigint`` or ``text``
@@ -322,10 +318,9 @@ A repository type that stores its snapshots on the Azure Storage service.
 
 **base_path**
   | *Type:* ``text``
-  | *Default:* `` ``
+  | *Default:* ``root directory``
 
-  The path within the Azure Storage container to repository data. Defaults to
-  root if not set.
+  The path within the Azure Storage container to repository data.
 
 **chunk_size**
   | *Type:*    ``bigint`` or ``text``

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -50,9 +50,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.repositories.s3.S3Repository.MAX_FILE_SIZE;
-import static org.elasticsearch.repositories.s3.S3Repository.MAX_FILE_SIZE_USING_MULTIPART;
-import static org.elasticsearch.repositories.s3.S3Repository.MIN_PART_SIZE_USING_MULTIPART;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.MAX_FILE_SIZE;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.MAX_FILE_SIZE_USING_MULTIPART;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.MIN_PART_SIZE_USING_MULTIPART;
 
 class S3BlobContainer extends AbstractBlobContainer {
 

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -21,28 +21,23 @@ package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.util.json.Jackson;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
 
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * A plugin to add a repository type that writes to and from the AWS S3.
  */
-public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, ReloadablePlugin {
+public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -61,15 +56,8 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
 
     protected final S3Service service;
 
-    public S3RepositoryPlugin(final Settings settings) {
-        this(settings, new S3Service());
-    }
-
-    S3RepositoryPlugin(final Settings settings, final S3Service service) {
-        this.service = Objects.requireNonNull(service, "S3 service must not be null");
-        // eagerly load client settings so that secure settings are read
-        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings);
-        this.service.refreshAndClearCache(clientsSettings);
+    public S3RepositoryPlugin() {
+        this.service = new S3Service();
     }
 
     // proxy method for testing
@@ -82,33 +70,6 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
     @Override
     public Map<String, Repository.Factory> getRepositories(final Environment env, final NamedXContentRegistry registry) {
         return Collections.singletonMap(S3Repository.TYPE, (metadata) -> createRepository(metadata, env.settings(), registry));
-    }
-
-    @Override
-    public List<Setting<?>> getSettings() {
-        return Arrays.asList(
-            // named s3 client configuration settings
-            S3ClientSettings.ACCESS_KEY_SETTING,
-            S3ClientSettings.SECRET_KEY_SETTING,
-            S3ClientSettings.SESSION_TOKEN_SETTING,
-            S3ClientSettings.ENDPOINT_SETTING,
-            S3ClientSettings.PROTOCOL_SETTING,
-            S3ClientSettings.PROXY_HOST_SETTING,
-            S3ClientSettings.PROXY_PORT_SETTING,
-            S3ClientSettings.PROXY_USERNAME_SETTING,
-            S3ClientSettings.PROXY_PASSWORD_SETTING,
-            S3ClientSettings.READ_TIMEOUT_SETTING,
-            S3ClientSettings.MAX_RETRIES_SETTING,
-            S3ClientSettings.USE_THROTTLE_RETRIES_SETTING,
-            S3Repository.ACCESS_KEY_SETTING,
-            S3Repository.SECRET_KEY_SETTING);
-    }
-
-    @Override
-    public void reload(Settings settings) {
-        // secure settings should be readable
-        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings);
-        service.refreshAndClearCache(clientsSettings);
     }
 
     @Override

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import java.util.Locale;
+
+class S3RepositorySettings {
+
+    /**
+     * The access key to authenticate with s3.
+     * This setting is insecure because cluster settings are stored in cluster state
+     */
+    static final Setting<SecureString> ACCESS_KEY_SETTING = SecureSetting.insecureString("access_key");
+
+    /**
+     * The secret key to authenticate with s3.
+     * This setting is insecure because cluster settings are stored in cluster state
+     */
+    static final Setting<SecureString> SECRET_KEY_SETTING = SecureSetting.insecureString("secret_key");
+
+    /**
+     * Default is to use 100MB (S3 defaults) for heaps above 2GB and 5% of
+     * the available memory for smaller heaps.
+     */
+    private static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(
+        Math.max(
+            ByteSizeUnit.MB.toBytes(5), // minimum value
+            Math.min(
+                ByteSizeUnit.MB.toBytes(100),
+                JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 20)),
+        ByteSizeUnit.BYTES);
+
+
+    static final Setting<String> BUCKET_SETTING = Setting.simpleString("bucket");
+
+    /**
+     * When set to true files are encrypted on server side using AES256 algorithm.
+     * Defaults to false.
+     */
+    static final Setting<Boolean> SERVER_SIDE_ENCRYPTION_SETTING =
+        Setting.boolSetting("server_side_encryption", false);
+
+    /**
+     * Maximum size of files that can be uploaded using a single upload request.
+     */
+    static final ByteSizeValue MAX_FILE_SIZE = new ByteSizeValue(5, ByteSizeUnit.GB);
+
+    /**
+     * Minimum size of parts that can be uploaded using the Multipart Upload API.
+     * (see http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html)
+     */
+    static final ByteSizeValue MIN_PART_SIZE_USING_MULTIPART = new ByteSizeValue(5, ByteSizeUnit.MB);
+
+    /**
+     * Maximum size of parts that can be uploaded using the Multipart Upload API.
+     * (see http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html)
+     */
+    private static final ByteSizeValue MAX_PART_SIZE_USING_MULTIPART = MAX_FILE_SIZE;
+
+    /**
+     * Maximum size of files that can be uploaded using the Multipart Upload API.
+     */
+    static final ByteSizeValue MAX_FILE_SIZE_USING_MULTIPART = new ByteSizeValue(5, ByteSizeUnit.TB);
+
+    /**
+     * Minimum threshold below which the chunk is uploaded using a single request. Beyond this threshold,
+     * the S3 repository will use the AWS Multipart Upload API to split the chunk into several parts,
+     * each of buffer_size length, and to upload each part in its own request. Note that setting a
+     * buffer size lower than 5mb is not allowed since it will prevents the use of the Multipart API
+     * and may result in upload errors. Defaults to the minimum between 100MB and 5% of the heap size.
+     */
+    static final Setting<ByteSizeValue> BUFFER_SIZE_SETTING = Setting.byteSizeSetting(
+        "buffer_size",
+        DEFAULT_BUFFER_SIZE,
+        MIN_PART_SIZE_USING_MULTIPART,
+        MAX_PART_SIZE_USING_MULTIPART);
+
+    /**
+     * Big files can be broken down into chunks during snapshotting if needed. Defaults to 1g.
+     */
+    static final Setting<ByteSizeValue> CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
+        "chunk_size",
+        new ByteSizeValue(1, ByteSizeUnit.GB),
+        new ByteSizeValue(5, ByteSizeUnit.MB),
+        new ByteSizeValue(5, ByteSizeUnit.TB));
+
+    /**
+     * Sets the S3 storage class type for the backup files. Values may be standard, reduced_redundancy,
+     * standard_ia. Defaults to standard.
+     */
+    static final Setting<String> STORAGE_CLASS_SETTING = Setting.simpleString("storage_class");
+
+    /**
+     * The S3 repository supports all S3 canned ACLs : private, public-read, public-read-write,
+     * authenticated-read, log-delivery-write, bucket-owner-read, bucket-owner-full-control.
+     * Defaults to private.
+     */
+    static final Setting<String> CANNED_ACL_SETTING = Setting.simpleString("canned_acl");
+
+    /**
+     * Specifies the path within bucket to repository data. Defaults to root directory.
+     */
+    static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path");
+
+    /**
+     * The secret key (ie password) for connecting to s3.
+     */
+    static final Setting<SecureString> SESSION_TOKEN_SETTING = SecureSetting.insecureString("session_token");
+
+    /**
+     * An override for the s3 endpoint to connect to.
+     */
+    static final Setting<String> ENDPOINT_SETTING = Setting.simpleString(
+        "endpoint",
+        s -> s.toLowerCase(Locale.ROOT),
+        Setting.Property.NodeScope);
+
+    /**
+     * The protocol to use to connect to s3.
+     */
+    static final Setting<Protocol> PROTOCOL_SETTING = new Setting<>(
+        "protocol",
+        "https",
+        s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
+        Setting.Property.NodeScope);
+
+    /**
+     * The host name of a proxy to connect to s3 through.
+     */
+    static final Setting<String> PROXY_HOST_SETTING =
+        Setting.simpleString("proxy_host", Setting.Property.NodeScope);
+
+    /**
+     * The port of a proxy to connect to s3 through.
+     */
+    static final Setting<Integer> PROXY_PORT_SETTING =
+        Setting.intSetting("proxy_port", 80, 0, 1 << 16, Setting.Property.NodeScope);
+
+    /**
+     * The username of a proxy to connect to s3 through.
+     */
+    static final Setting<SecureString> PROXY_USERNAME_SETTING = SecureSetting.insecureString("proxy_username");
+
+    /**
+     * The password of a proxy to connect to s3 through.
+     */
+    static final Setting<SecureString> PROXY_PASSWORD_SETTING = SecureSetting.insecureString("proxy_password");
+
+    /**
+     * The socket timeout for connecting to s3.
+     */
+    static final Setting<TimeValue> READ_TIMEOUT_SETTING = Setting.timeSetting(
+        "read_timeout",
+        TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT),
+        Setting.Property.NodeScope);
+
+    /**
+     * The number of retries to use when an s3 request fails.
+     */
+    static final Setting<Integer> MAX_RETRIES_SETTING = Setting.intSetting(
+        "max_retries",
+        ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry(),
+        0,
+        Setting.Property.NodeScope);
+
+    /**
+     * Whether retries should be throttled (ie use backoff).
+     */
+    static final Setting<Boolean> USE_THROTTLE_RETRIES_SETTING = Setting.boolSetting(
+        "use_throttle_retries",
+        ClientConfiguration.DEFAULT_THROTTLE_RETRIES,
+        Setting.Property.NodeScope);
+}

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -32,12 +32,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Map;
-
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.text.IsEmptyString.emptyString;
 
 public class S3ClientSettingsTests extends ESTestCase {
 
@@ -46,84 +43,80 @@ public class S3ClientSettingsTests extends ESTestCase {
 
     @Test
     public void testThereIsADefaultClientByDefault() {
-        final Map<String, S3ClientSettings> settings = S3ClientSettings.load(Settings.EMPTY);
-        assertThat(settings.keySet(), contains("default"));
+        final S3ClientSettings settings = S3ClientSettings.getClientSettings(Settings.EMPTY);
 
-        final S3ClientSettings defaultSettings = settings.get("default");
-        assertThat(defaultSettings.credentials, nullValue());
-        assertThat(defaultSettings.endpoint, isEmptyString());
-        assertThat(defaultSettings.protocol, is(Protocol.HTTPS));
-        assertThat(defaultSettings.proxyHost, isEmptyString());
-        assertThat(defaultSettings.proxyPort, is(80));
-        assertThat(defaultSettings.proxyUsername, isEmptyString());
-        assertThat(defaultSettings.proxyPassword, isEmptyString());
-        assertThat(defaultSettings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));
-        assertThat(defaultSettings.maxRetries, is(ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry()));
-        assertThat(defaultSettings.throttleRetries, is(ClientConfiguration.DEFAULT_THROTTLE_RETRIES));
+        assertThat(settings.credentials, nullValue());
+        assertThat(settings.endpoint, is(emptyString()));
+        assertThat(settings.protocol, is(Protocol.HTTPS));
+        assertThat(settings.proxyHost, is(emptyString()));
+        assertThat(settings.proxyPort, is(80));
+        assertThat(settings.proxyUsername, is(emptyString()));
+        assertThat(settings.proxyPassword, is(emptyString()));
+        assertThat(settings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));
+        assertThat(settings.maxRetries, is(ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry()));
+        assertThat(settings.throttleRetries, is(ClientConfiguration.DEFAULT_THROTTLE_RETRIES));
     }
 
     @Test
     public void testDefaultClientSettingsCanBeSet() {
-        final Map<String, S3ClientSettings> settings = S3ClientSettings.load(
+        final S3ClientSettings settings = S3ClientSettings.getClientSettings(
             Settings.builder()
-                .put("s3.client.default.max_retries", 10)
+                .put("max_retries", 10)
                 .build());
-        assertThat(settings.keySet(), contains("default"));
-
-        final S3ClientSettings defaultSettings = settings.get("default");
-        assertThat(defaultSettings.maxRetries, is(10));
+        assertThat(settings.maxRetries, is(10));
     }
 
     @Test
     public void testRejectionOfLoneAccessKey() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Missing secret key for s3 client [default]");
-        S3ClientSettings.load(Settings.builder()
-                                  .put("s3.client.default.access_key", "aws_key")
-                                  .build());
+        expectedException.expectMessage("Missing secret key for s3 client");
+        S3ClientSettings.getClientSettings(
+            Settings.builder()
+                .put("access_key", "aws_key")
+                .build());
     }
 
     @Test
     public void testRejectionOfLoneSecretKey() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Missing access key for s3 client [default]");
-        S3ClientSettings.load(Settings.builder()
-                                  .put("s3.client.default.secret_key", "aws_key")
-                                  .build());
+        expectedException.expectMessage("Missing access key for s3 client");
+        S3ClientSettings.getClientSettings(
+            Settings.builder()
+                .put("secret_key", "aws_key")
+                .build());
     }
 
     @Test
     public void testRejectionOfLoneSessionToken() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Missing access key and secret key for s3 client [default]");
-        S3ClientSettings.load(Settings.builder()
-                                  .put("s3.client.default.session_token", "aws_key")
-                                  .build());
+        expectedException.expectMessage("Missing access key and secret key for s3 client");
+        S3ClientSettings.getClientSettings(
+            Settings.builder()
+                .put("session_token", "aws_key")
+                .build());
     }
 
     @Test
     public void testCredentialsTypeWithAccessKeyAndSecretKey() {
-        final Map<String, S3ClientSettings> settings = S3ClientSettings.load(
+        final S3ClientSettings settings = S3ClientSettings.getClientSettings(
             Settings.builder()
-                .put("s3.client.default.access_key", "access_key")
-                .put("s3.client.default.secret_key", "secret_key")
+                .put("access_key", "access_key")
+                .put("secret_key", "secret_key")
                 .build());
-        final S3ClientSettings defaultSettings = settings.get("default");
-        BasicAWSCredentials credentials = (BasicAWSCredentials) defaultSettings.credentials;
+        BasicAWSCredentials credentials = (BasicAWSCredentials) settings.credentials;
         assertThat(credentials.getAWSAccessKeyId(), is("access_key"));
         assertThat(credentials.getAWSSecretKey(), is("secret_key"));
     }
 
     @Test
     public void testCredentialsTypeWithAccessKeyAndSecretKeyAndSessionToken() {
-        final Map<String, S3ClientSettings> settings = S3ClientSettings.load(
+        final S3ClientSettings settings = S3ClientSettings.getClientSettings(
             Settings.builder()
-                .put("s3.client.default.access_key", "access_key")
-                .put("s3.client.default.secret_key", "secret_key")
-                .put("s3.client.default.session_token", "session_token")
+                .put("access_key", "access_key")
+                .put("secret_key", "secret_key")
+                .put("session_token", "session_token")
                 .build());
-        final S3ClientSettings defaultSettings = settings.get("default");
-        BasicSessionCredentials credentials = (BasicSessionCredentials) defaultSettings.credentials;
+        BasicSessionCredentials credentials = (BasicSessionCredentials) settings.credentials;
         assertThat(credentials.getAWSAccessKeyId(), is("access_key"));
         assertThat(credentials.getAWSSecretKey(), is("secret_key"));
         assertThat(credentials.getSessionToken(), is("session_token"));

--- a/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -90,25 +90,25 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
     public void testDropExistingRepo() {
         DropRepositoryAnalyzedStatement statement = e.analyze("DROP REPOSITORY my_repo");
         assertThat(statement.repositoryName(), is("my_repo"));
-
     }
 
     @Test
     public void testCreateS3RepositoryWithAllSettings() {
-        CreateRepositoryAnalyzedStatement analysis = e.analyze("CREATE REPOSITORY foo TYPE s3 WITH (" +
-                                                             "bucket='abc'," +
-                                                             "endpoint='www.example.com'," +
-                                                             "protocol='http'," +
-                                                             "base_path='/holz/'," +
-                                                             "access_key='0xAFFE'," +
-                                                             "secret_key='0xCAFEE'," +
-                                                             "chunk_size='12mb'," +
-                                                             "compress=true," +
-                                                             "server_side_encryption=false," +
-                                                             "buffer_size='5mb'," +
-                                                             "max_retries=2," +
-                                                             "use_throttle_retries=false," +
-                                                             "canned_acl=false)");
+        CreateRepositoryAnalyzedStatement analysis = e.analyze(
+            "CREATE REPOSITORY foo TYPE s3 WITH (" +
+            "   bucket='abc'," +
+            "   endpoint='www.example.com'," +
+            "   protocol='http'," +
+            "   base_path='/holz/'," +
+            "   access_key='0xAFFE'," +
+            "   secret_key='0xCAFEE'," +
+            "   chunk_size='12mb'," +
+            "   compress=true," +
+            "   server_side_encryption=false," +
+            "   buffer_size='5mb'," +
+            "   max_retries=2," +
+            "   use_throttle_retries=false," +
+            "   canned_acl=false)");
         assertThat(analysis.repositoryType(), is("s3"));
         assertThat(analysis.repositoryName(), is("foo"));
         assertThat(
@@ -126,9 +126,16 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
                 hasEntry("use_throttle_retries", "false"),
                 hasEntry("protocol", "http"),
                 hasEntry("secret_key", "0xCAFEE"),
-                hasEntry("server_side_encryption", "false")
-            )
+                hasEntry("server_side_encryption", "false"))
         );
+    }
+
+    @Test
+    public void testCreateS3RepoWithMissingMandatorySettings() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The following required parameters are missing to" +
+                                        " create a repository of type \"s3\": [secret_key]");
+        e.analyze("CREATE REPOSITORY foo TYPE s3 WITH (access_key='test')");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The client settings can be provided only as parameters
of the `CREATE REPOSITORY` statement. The reason for
this change is to prevent exposing client credentials in
plain text by setting access and secret key in ``crate.yml``.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
