### PR TITLE
Use the ServiceLoader approach to integrate SslContext.

### DIFF
--- a/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslContextProviderImpl.java
+++ b/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslContextProviderImpl.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.protocols.ssl;
+
+import io.netty.handler.ssl.SslContext;
+import org.elasticsearch.common.settings.Settings;
+
+public class SslContextProviderImpl implements SslContextProvider {
+
+    private volatile SslContext sslContext;
+
+    // required by service provider
+    public SslContextProviderImpl() {
+    }
+
+    @Override
+    public SslContext getSslContext(Settings settings) {
+        if (sslContext == null) {
+            synchronized (this) {
+                if (sslContext == null) {
+                    sslContext = SslConfiguration.buildSslContext(settings);
+                }
+            }
+        }
+        return sslContext;
+    }
+}

--- a/enterprise/ssl-impl/src/main/resources/META-INF/services/io.crate.protocols.ssl.SslContextProvider
+++ b/enterprise/ssl-impl/src/main/resources/META-INF/services/io.crate.protocols.ssl.SslContextProvider
@@ -1,0 +1,1 @@
+io.crate.protocols.ssl.SslContextProviderImpl

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -20,7 +20,6 @@ package io.crate.protocols.http;
 
 import io.crate.plugin.PipelineRegistry;
 import io.crate.protocols.ssl.SslConfigSettings;
-import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -80,8 +79,7 @@ public class CrateHttpsTransportTest extends CrateUnitTest {
             }
         }));
 
-        PipelineRegistry pipelineRegistry = new PipelineRegistry();
-        new SslContextProvider(settings, pipelineRegistry);
+        PipelineRegistry pipelineRegistry = new PipelineRegistry(settings);
 
         CrateNettyHttpServerTransport transport =
             new CrateNettyHttpServerTransport(

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
@@ -18,20 +18,20 @@
 
 package io.crate.protocols.ssl;
 
-import io.crate.plugin.PipelineRegistry;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.handler.ssl.SslContext;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 
 import static io.crate.protocols.ssl.SslConfigurationTest.getAbsoluteFilePathFromClassPath;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.Matchers.is;
 
 public class SslContextProviderTest extends CrateUnitTest {
 
@@ -51,10 +51,10 @@ public class SslContextProviderTest extends CrateUnitTest {
             .put(SslConfigSettings.SSL_HTTP_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_PSQL_ENABLED.getKey(), true)
             .build();
-        PipelineRegistry pipelineRegistry = new PipelineRegistry();
         expectedException.expect(SslConfigurationException.class);
         expectedException.expectMessage("Failed to build SSL configuration");
-        new SslContextProvider(settings, pipelineRegistry).get();
+        var sslContextProvider = new SslContextProviderImpl();
+        sslContextProvider.getSslContext(settings);
     }
 
     @Test
@@ -68,9 +68,10 @@ public class SslContextProviderTest extends CrateUnitTest {
             .put(SslConfigSettings.SSL_KEYSTORE_PASSWORD.getKey(), "keystorePassword")
             .put(SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.getKey(), "serverKeyPassword")
             .build();
-        PipelineRegistry pipelineRegistry = Mockito.mock(PipelineRegistry.class);
-        SslContext sslContext = new SslContextProvider(settings, pipelineRegistry).get();
+        var sslContextProvider = new SslContextProviderImpl();
+        SslContext sslContext = sslContextProvider.getSslContext(settings);
         assertThat(sslContext, instanceOf(SslContext.class));
-        Mockito.verify(pipelineRegistry).registerSslContextProvider(any());
+        assertThat(sslContext.isServer(), is(true));
+        assertThat(sslContext.cipherSuites(), not(empty()));
     }
 }

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':es:es-server')
     implementation project(':es:es-transport')
     implementation project(':common')
+    implementation project(':ssl')
     implementation "io.netty:netty-buffer:${versions.netty4}"
     implementation "io.netty:netty-codec-http:${versions.netty4}"
     implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"

--- a/http/src/main/java/io/crate/plugin/HttpTransportPlugin.java
+++ b/http/src/main/java/io/crate/plugin/HttpTransportPlugin.java
@@ -56,8 +56,8 @@ public class HttpTransportPlugin extends Plugin implements NetworkPlugin, Action
 
     private final PipelineRegistry pipelineRegistry;
 
-    public HttpTransportPlugin() {
-        this.pipelineRegistry = new PipelineRegistry();
+    public HttpTransportPlugin(Settings settings) {
+        this.pipelineRegistry = new PipelineRegistry(settings);
     }
 
     public String name() {

--- a/http/src/main/java/io/crate/plugin/PipelineRegistry.java
+++ b/http/src/main/java/io/crate/plugin/PipelineRegistry.java
@@ -22,12 +22,17 @@
 
 package io.crate.plugin;
 
+import io.crate.protocols.ssl.SslConfigSettings;
+import io.crate.protocols.ssl.SslContextProvider;
+import io.crate.protocols.ssl.SslContextProviderFactory;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import org.elasticsearch.common.inject.Provider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
 
 import java.util.ArrayList;
@@ -44,11 +49,23 @@ import java.util.function.Function;
 @Singleton
 public class PipelineRegistry {
 
-    private final List<ChannelPipelineItem> addBeforeList;
-    private Provider<SslContext> sslContextProvider;
+    private static final Logger LOGGER = LogManager.getLogger(PipelineRegistry.class);
 
-    public PipelineRegistry() {
+    private final List<ChannelPipelineItem> addBeforeList;
+    private final SslContextProvider sslContextProvider;
+    private final Settings settings;
+
+    public PipelineRegistry(Settings settings) {
         this.addBeforeList = new ArrayList<>();
+        this.settings = settings;
+
+        if (SslConfigSettings.isHttpsEnabled(settings)) {
+            LOGGER.info("HTTP SSL support is enabled.");
+            this.sslContextProvider = SslContextProviderFactory.getInstance();
+        } else {
+            LOGGER.info("HTTP SSL support is disabled.");
+            this.sslContextProvider = null;
+        }
     }
 
     /**
@@ -86,17 +103,13 @@ public class PipelineRegistry {
         }
     }
 
-    public void registerSslContextProvider(Provider<SslContext> sslContextProvider) {
-        this.sslContextProvider = sslContextProvider;
-    }
-
     public void registerItems(ChannelPipeline pipeline, Netty4CorsConfig corsConfig) {
         for (PipelineRegistry.ChannelPipelineItem item : addBeforeList) {
             pipeline.addBefore(item.base, item.name, item.handlerFactory.apply(corsConfig));
         }
 
         if (sslContextProvider != null) {
-            SslContext sslContext = sslContextProvider.get();
+            SslContext sslContext = sslContextProvider.getSslContext(settings);
             if (sslContext != null) {
                 SslHandler sslHandler = sslContext.newHandler(pipeline.channel().alloc());
                 pipeline.addFirst(sslHandler);

--- a/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
+++ b/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
@@ -24,6 +24,7 @@ package io.crate.plugin;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -34,15 +35,15 @@ public class PipelineRegistryTest {
     private static PipelineRegistry.ChannelPipelineItem channelPipelineItem(String base, String name) {
         return new PipelineRegistry.ChannelPipelineItem(base, name, (f) -> new SimpleChannelInboundHandler() {
             @Override
-            protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
 
             }
         });
     }
 
     @Test
-    public void testAddSortedToPipline() throws Exception {
-        PipelineRegistry pipelineRegistry = new PipelineRegistry();
+    public void testAddSortedToPipeline() throws Exception {
+        PipelineRegistry pipelineRegistry = new PipelineRegistry(Settings.EMPTY);
 
         pipelineRegistry.addBefore(channelPipelineItem("c", "d"));
         pipelineRegistry.addBefore(channelPipelineItem("a", "b"));

--- a/sql/src/main/java/io/crate/plugin/SQLModule.java
+++ b/sql/src/main/java/io/crate/plugin/SQLModule.java
@@ -30,7 +30,6 @@ import io.crate.planner.Planner;
 import io.crate.planner.TableStats;
 import io.crate.planner.TableStatsService;
 import io.crate.protocols.postgres.PostgresNetty;
-import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.rest.action.RestSQLAction;
 import org.elasticsearch.common.inject.AbstractModule;
 
@@ -47,7 +46,6 @@ public class SQLModule extends AbstractModule {
         bind(TableStats.class).asEagerSingleton();
         bind(TableStatsService.class).asEagerSingleton();
         bind(UserDefinedFunctionService.class).asEagerSingleton();
-        bind(SslContextProvider.class).asEagerSingleton();
         bind(RestSQLAction.class).asEagerSingleton();
         bind(DanglingArtifactsService.class).asEagerSingleton();
     }

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
@@ -24,7 +24,6 @@ package io.crate.protocols.postgres;
 
 import io.crate.action.sql.SQLOperations;
 import io.crate.auth.AlwaysOKNullAuthentication;
-import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.user.StubUserManager;
 import org.elasticsearch.common.network.NetworkService;
@@ -82,9 +81,7 @@ public class PostgresNettyPublishPortTest extends CrateUnitTest {
             Mockito.mock(SQLOperations.class),
             new StubUserManager(),
             networkService,
-            new AlwaysOKNullAuthentication(),
-            Mockito.mock(SslContextProvider.class)
-        );
+            new AlwaysOKNullAuthentication());
         try {
             psql.doStart();
         } finally {
@@ -102,9 +99,7 @@ public class PostgresNettyPublishPortTest extends CrateUnitTest {
             Mockito.mock(SQLOperations.class),
             new StubUserManager(),
             networkService,
-            new AlwaysOKNullAuthentication(),
-            Mockito.mock(SslContextProvider.class)
-        );
+            new AlwaysOKNullAuthentication());
         try {
             psql.doStart();
             fail("Should have failed due to custom hostname");
@@ -126,9 +121,7 @@ public class PostgresNettyPublishPortTest extends CrateUnitTest {
             Mockito.mock(SQLOperations.class),
             new StubUserManager(),
             networkService,
-            new AlwaysOKNullAuthentication(),
-            Mockito.mock(SslContextProvider.class)
-        );
+            new AlwaysOKNullAuthentication());
         try {
             psql.doStart();
             fail("Should have failed due to custom hostname");
@@ -150,9 +143,7 @@ public class PostgresNettyPublishPortTest extends CrateUnitTest {
             Mockito.mock(SQLOperations.class),
             new StubUserManager(),
             networkService,
-            new AlwaysOKNullAuthentication(),
-            Mockito.mock(SslContextProvider.class)
-        );
+            new AlwaysOKNullAuthentication());
         try {
             psql.doStart();
             fail("Should have failed due to custom hostname");

--- a/ssl/build.gradle
+++ b/ssl/build.gradle
@@ -8,5 +8,4 @@ dependencies {
     implementation project(':common')
     implementation project(':es:es-server')
     implementation "io.netty:netty-handler:${versions.netty4}"
-    implementation project(':http')
 }

--- a/ssl/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
+++ b/ssl/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
@@ -70,7 +70,7 @@ public final class SslConfigSettings {
         Setting.simpleString(SSL_KEYSTORE_KEY_PASSWORD_SETTING_NAME, Setting.Property.NodeScope),
         DataTypes.STRING);
 
-    static boolean isHttpsEnabled(Settings settings) {
+    public static boolean isHttpsEnabled(Settings settings) {
         return SSL_HTTP_ENABLED.setting().get(settings);
     }
 

--- a/ssl/src/main/java/io/crate/protocols/ssl/SslContextProviderFactory.java
+++ b/ssl/src/main/java/io/crate/protocols/ssl/SslContextProviderFactory.java
@@ -22,13 +22,29 @@
 
 package io.crate.protocols.ssl;
 
-import io.netty.handler.ssl.SslContext;
-import org.elasticsearch.common.settings.Settings;
+import io.crate.plugin.EnterpriseLoader;
+import org.elasticsearch.common.Nullable;
 
 /**
- * Provides Netty's SslContext.
+ * Creates an instance of {@link SslContextProvider}. The factory is used in
+ * bundle with a service provider mechanism. See {@link io.crate.plugin.EnterpriseLoader}.
+ *
+ * @see PostgresWireProtocol
+ * @see PipelineRegistry
  */
-public interface SslContextProvider {
+public class SslContextProviderFactory {
 
-    SslContext getSslContext(Settings settings);
+    private static SslContextProvider sslContextProvider;
+
+    @Nullable
+    public static SslContextProvider getInstance() {
+        if (sslContextProvider == null) {
+            synchronized (SslContextProviderFactory.class) {
+                if (sslContextProvider == null) {
+                    sslContextProvider = EnterpriseLoader.loadSingle(SslContextProvider.class);
+                }
+            }
+        }
+        return sslContextProvider;
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The SslContext is loaded to HTTP and PostgreSQL protocols related
modules via SslContextProvider using the ServiceLoader pattern.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
