### PR TITLE
Introduce Setting.Property.Masked for masking sensitive information

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -90,6 +90,7 @@ import org.elasticsearch.transport.TransportSettings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -97,14 +98,24 @@ import java.util.function.Predicate;
  * Encapsulates all valid cluster level settings.
  */
 public final class ClusterSettings extends AbstractScopedSettings {
+
+    private final List<Setting<?>> maskedSettings;
+
     public ClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {
-        this(nodeSettings, settingsSet, Collections.emptySet());
+        this(nodeSettings, List.of(), settingsSet, Collections.emptySet());
     }
 
-    public ClusterSettings(
-            final Settings nodeSettings, final Set<Setting<?>> settingsSet, final Set<SettingUpgrader<?>> settingUpgraders) {
+    public ClusterSettings(final Settings nodeSettings,
+                           final List<Setting<?>> maskedSettings,
+                           final Set<Setting<?>> settingsSet,
+                           final Set<SettingUpgrader<?>> settingUpgraders) {
         super(nodeSettings, settingsSet, settingUpgraders, Property.NodeScope);
+        this.maskedSettings = maskedSettings;
         addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
+    }
+
+    public List<Setting<?>> maskedSettings() {
+        return maskedSettings;
     }
 
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -134,7 +135,12 @@ public class Setting<T> implements ToXContentObject {
         /**
          * Indicates an index-level setting that is privately managed. Such a setting can not even be set on index creation.
          */
-        PrivateIndex
+        PrivateIndex,
+
+        /**
+         * Indicates a setting that contains sensitive information. Such a setting will be masked when shown to the users.
+         */
+        Masked
     }
 
     private final Key key;
@@ -335,6 +341,10 @@ public class Setting<T> implements ToXContentObject {
      */
     public boolean isDeprecated() {
         return properties.contains(Property.Deprecated);
+    }
+
+    public final boolean isMasked() {
+        return properties.contains(Property.Masked);
     }
 
     /**

--- a/es/es-server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -873,6 +873,7 @@ public class ScopedSettingsTests extends ESTestCase {
         final AbstractScopedSettings service =
                 new ClusterSettings(
                         Settings.EMPTY,
+                        List.of(),
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
                         Collections.singleton(new SettingUpgrader<String>() {
 
@@ -915,6 +916,7 @@ public class ScopedSettingsTests extends ESTestCase {
         final AbstractScopedSettings service =
                 new ClusterSettings(
                         Settings.EMPTY,
+                        List.of(),
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
                         Collections.singleton(new SettingUpgrader<String>() {
 
@@ -947,6 +949,7 @@ public class ScopedSettingsTests extends ESTestCase {
         final AbstractScopedSettings service =
                 new ClusterSettings(
                         Settings.EMPTY,
+                        List.of(),
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
                         Collections.singleton(new SettingUpgrader<String>() {
 
@@ -1001,6 +1004,7 @@ public class ScopedSettingsTests extends ESTestCase {
         final AbstractScopedSettings service =
                 new ClusterSettings(
                         Settings.EMPTY,
+                        List.of(),
                         new HashSet<>(Arrays.asList(oldSetting, newSetting)),
                         Collections.singleton(new SettingUpgrader<List<String>>() {
 

--- a/es/es-server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -614,5 +615,25 @@ public class SettingsTests extends ESTestCase {
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
                                                     () -> Settings.builder().copy("not_there", settings));
         assertEquals("source key not found in the source settings", iae.getMessage());
+    }
+
+    @Test
+    public void testGetAsStructuredMapNoSettingToMask() {
+        Settings settings = Settings.builder()
+            .put("masked", "masked_value")
+            .build();
+
+        Map<String, Object> map = settings.getAsStructuredMap(Set.of());
+        assertThat(map, hasEntry("masked", "masked_value"));
+    }
+
+    @Test
+    public void testGetAsStructuredMapMaskingValues() {
+        Settings settings = Settings.builder()
+            .put("masked", "masked_value")
+            .build();
+
+        Map<String, Object> map = settings.getAsStructuredMap(Set.of("masked"));
+        assertThat(map, hasEntry("masked", Settings.MASKED_VALUE));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Same as #8714 which was closed as it was based on a brach that got merged

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)