### PR TITLE
Reduce `prepareCreate` usages in tests

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -53,13 +53,8 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertWithColumnNames() throws Exception {
-        prepareCreate(getFqn("test"))
-            .addMapping("default",
-                "firstName", "type=keyword",
-                "lastName", "type=keyword")
-            .execute().actionGet();
-        ensureYellow();
-        execute("insert into test (\"firstName\", \"lastName\") values('Youri', 'Zoon')");
+        execute("create table test (\"firstName\" text, \"lastName\" text)");
+        execute("insert into test (\"firstName\", \"lastName\") values ('Youri', 'Zoon')");
         assertEquals(1, response.rowCount());
         refresh();
 
@@ -87,18 +82,16 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertAllCoreDatatypes() throws Exception {
-        prepareCreate(getFqn("test"))
-            .addMapping("default",
-                "boolean", "type=boolean",
-                "datetime", "type=date",
-                "double", "type=double",
-                "float", "type=float",
-                "integer", "type=integer",
-                "long", "type=long",
-                "short", "type=short",
-                "string", "type=keyword")
-            .execute().actionGet();
-        ensureYellow();
+        execute("create table test (" +
+                "   boolean boolean," +
+                "   datetime timestamptz," +
+                "   double double," +
+                "   float real," +
+                "   integer integer," +
+                "   long bigint," +
+                "   short smallint," +
+                "   string text" +
+                ")");
 
         execute("insert into test values(true, '2013-09-10T21:51:43', 1.79769313486231570e+308, 3.402, 2147483647, 9223372036854775807, 32767, 'Youri')");
         execute("insert into test values(?, ?, ?, ?, ?, ?, ?, ?)",
@@ -197,12 +190,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertMultipleRows() throws Exception {
-        prepareCreate(getFqn("test"))
-            .addMapping("default",
-                "age", "type=integer",
-                "name", "type=keyword")
-            .execute().actionGet();
-        ensureYellow();
+        execute("create table test (age integer, name text)");
 
         execute("insert into test values(32, 'Youri'), (42, 'Ruben')");
         assertEquals(2, response.rowCount());
@@ -217,12 +205,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertWithParams() throws Exception {
-        prepareCreate(getFqn("test"))
-            .addMapping("default",
-                "age", "type=integer",
-                "name", "type=keyword")
-            .execute().actionGet();
-        ensureYellow();
+        execute("create table test (age integer, name text)");
 
         Object[] args = new Object[]{32, "Youri"};
         execute("insert into test values(?, ?)", args);

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SQLActionException;
 import io.crate.exceptions.SQLExceptions;
@@ -47,7 +46,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -632,19 +630,16 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("insert into test (pk_col, message) values ('1', 'foo')");
         execute("insert into test (pk_col, message) values ('2', 'bar')");
         execute("insert into test (pk_col, message) values ('3', 'baz')");
-        refresh();
 
         execute("SELECT * FROM test WHERE pk_col='1' OR pk_col='2'");
-        assertEquals(2, response.rowCount());
+        assertThat(response.rowCount(), is(2L));
 
         execute("SELECT * FROM test WHERE pk_col=? OR pk_col=?", new Object[]{"1", "2"});
-        assertEquals(2, response.rowCount());
+        assertThat(response.rowCount(), is(2L));
 
-        awaitBusy(() -> {
-            execute("SELECT * FROM test WHERE (pk_col=? OR pk_col=?) OR pk_col=?", new Object[]{"1", "2", "3"});
-            return response.rowCount() == 3
-                   && Joiner.on(',').join(Arrays.asList(response.cols())).equals("message,pk_col");
-        }, 10, TimeUnit.SECONDS);
+        execute("SELECT * FROM test WHERE (pk_col=? OR pk_col=?) OR pk_col=?", new Object[]{"1", "2", "3"});
+        assertThat(response.rowCount(), is(3L));
+        assertThat(String.join(", ", List.of(response.cols())), is("pk_col, message"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)