### PR TITLE
Add a mapping timeout disruption test

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -66,6 +66,11 @@ public class ShardStats implements Streamable, Writeable {
         return this.commonStats;
     }
 
+    @Nullable
+    public SeqNoStats getSeqNoStats() {
+        return this.seqNoStats;
+    }
+
     public String getDataPath() {
         return dataPath;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
