### PR TITLE
Support caching of GenericFunctionQuery

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -224,6 +224,11 @@ Deprecations
 Changes
 =======
 
+- Predicates like ``abs(x) = 1`` which require a scalar function evaluation and
+  cannot operate on table indices directly are now candidates for the query
+  cache. This can result in order of magnitude performance increases on
+  subsequent queries.
+
 - Mask sensitive user account information in
   :ref:`sys.repositories <sys-repositories>` for repository types:
   ``azure``, ``s3``.

--- a/sql/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/sql/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -26,6 +26,9 @@ import io.crate.data.Input;
 import io.crate.expression.InputCondition;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.RefVisitor;
+import io.crate.expression.symbol.SymbolVisitors;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -40,6 +43,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 
@@ -83,7 +87,12 @@ class GenericFunctionQuery extends Query {
         return new Weight(this) {
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                return false;
+                if (SymbolVisitors.any(s -> s instanceof Function && !((Function) s).info().isDeterministic(), function)) {
+                    return false;
+                }
+                var fields = new ArrayList<String>();
+                RefVisitor.visitRefs(function, ref -> fields.add(ref.column().fqn()));
+                return DocValues.isCacheable(ctx, fields.toArray(new String[0]));
             }
 
             @Override

--- a/sql/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
+++ b/sql/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.QueryTester;
+import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+
+public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_generic_function_query_cannot_be_cached_with_un_deterministic_functions_present() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table t (x int)"
+        );
+        builder.indexValues("x", 1, 2, 3);
+        try (QueryTester tester = builder.build()) {
+            var query = tester.toQuery("x = random()");
+            var searcher = tester.searcher();
+            var weight = query.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+            assertThat(weight.isCacheable(searcher.getTopReaderContext().leaves().get(0)), is(false));
+        }
+    }
+
+    @Test
+    public void test_generic_function_query_can_be_cached_if_deterministic() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table t (x int)"
+        );
+        builder.indexValues("x", 1, 2, 3);
+        try (QueryTester tester = builder.build()) {
+            var query = tester.toQuery("abs(x) = 1");
+            var searcher = tester.searcher();
+            var weight = query.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+            assertThat(weight.isCacheable(searcher.getTopReaderContext().leaves().get(0)), is(true));
+            assertThat(tester.runQuery("x", "abs(x) = 1"), contains(1));
+        }
+    }
+}


### PR DESCRIPTION
```
Q: SELECT * FROM uservisits WHERE abs("adRevenue") > 10 LIMIT 5
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       39.124 ±    3.422 |     36.328 |     37.668 |     39.896 |     58.311 |
|   V2    |        3.166 ±    7.071 |      1.696 |      2.034 |      2.221 |     64.310 |
mean:   - 170.06%
median: - 179.51%
```

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)