### PR TITLE
Allow 'pg_catalog.current_schema()' function resolution

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -338,4 +338,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed function resolution for function :ref:`scalar_current_schema` when the schema prefix
+  ``pg_catalog`` is included.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -219,6 +219,7 @@ valueExpression
 
 primaryExpression
     : parameterOrLiteral                                                             #defaultParamOrLiteral
+    | explicitFunction                                                               #explicitFunctionDefault
     | qname '(' ASTERISK ')' over?                                                   #functionCall
     | ident                                                                          #columnReference
     | qname '(' (setQuant? expr (',' expr)*)? ')' over?                              #functionCall
@@ -229,17 +230,20 @@ primaryExpression
     | EXISTS '(' query ')'                                                           #exists
     | value=primaryExpression '[' index=valueExpression ']'                          #subscript
     | ident ('.' ident)*                                                             #dereference
-    | name=CURRENT_DATE                                                              #specialDateTimeFunction
+    | primaryExpression CAST_OPERATOR dataType                                       #doubleColonCast
+    ;
+
+explicitFunction
+    : name=CURRENT_DATE                                                              #specialDateTimeFunction
     | name=CURRENT_TIME ('(' precision=integerLiteral')')?                           #specialDateTimeFunction
     | name=CURRENT_TIMESTAMP ('(' precision=integerLiteral')')?                      #specialDateTimeFunction
-    | CURRENT_SCHEMA ('(' ')')?                                                      #currentSchema
+    | CURRENT_SCHEMA                                                                 #currentSchema
     | (CURRENT_USER | USER)                                                          #currentUser
     | SESSION_USER                                                                   #sessionUser
     | SUBSTRING '(' expr FROM expr (FOR expr)? ')'                                   #substring
     | TRIM '(' ((trimMode=(LEADING | TRAILING | BOTH))?
                 (charsToTrim=expr)? FROM)? target=expr ')'                           #trim
     | EXTRACT '(' stringLiteralOrIdentifier FROM expr ')'                            #extract
-    | primaryExpression CAST_OPERATOR dataType                                       #doubleColonCast
     | CAST '(' expr AS dataType ')'                                                  #cast
     | TRY_CAST '(' expr AS dataType ')'                                              #cast
     | CASE operand=expr whenClause+ (ELSE elseExpr=expr)? END                        #simpleCase
@@ -643,7 +647,7 @@ nonReserved
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN | PRECISION
-    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM
+    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM | CURRENT_SCHEMA
     ;
 
 SELECT: 'SELECT';

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -812,8 +812,10 @@ public class TestStatementBuilder {
     public void testSystemInformationFunctionsStmtBuilder() {
         printStatement("select current_schema");
         printStatement("select current_schema()");
+        printStatement("select pg_catalog.current_schema()");
         printStatement("select * from information_schema.tables where table_schema = current_schema");
         printStatement("select * from information_schema.tables where table_schema = current_schema()");
+        printStatement("select * from information_schema.tables where table_schema = pg_catalog.current_schema()");
 
         printStatement("select current_user");
         printStatement("select user");

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -31,8 +31,10 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -43,8 +45,10 @@ public class CurrentSchemaFunction extends Scalar<String, Object> implements Fun
 
     public static final String NAME = "current_schema";
 
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, ImmutableList.of()),
+        new FunctionIdent(FQN, ImmutableList.of()),
         DataTypes.STRING,
         FunctionInfo.Type.SCALAR,
         Collections.emptySet());

--- a/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -23,13 +23,8 @@
 package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import io.crate.expression.symbol.Function;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
-import io.crate.metadata.Scalar;
-import io.crate.metadata.TransactionContext;
 import io.crate.testing.SqlExpressions;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -54,11 +49,11 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateCurrentSchema() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("current_schema()");
-        FunctionIdent ident = function.info().ident();
-        Scalar impl = (Scalar) functions.getQualified(ident);
-        assertThat(
-            impl.evaluate(TransactionContext.of(DUMMY_SESSION_INFO)),
-            Matchers.is("dummySchema"));
+        assertEvaluate("current_schema()", "doc");
+    }
+
+    @Test
+    public void testEvaluateCurrentSchemaWithFQNFunctionName() throws Exception {
+        assertEvaluate("pg_catalog.current_schema()", "doc");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Schema prefix was not supported for this function.  
`current_schema()` is now handled as a general function 
while specialized support is used only for the non-parenthesized version: `current_schema`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)