### PR TITLE
Fix potential NullPointerException at 'create table' / 'alter table add column' statements

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -369,5 +369,8 @@ Changes
 Fixes
 =====
 
+- Fixed ``NullPointerException`` that could occur when a column is defined as a
+  :ref:`Base Column<ref-base-columns>` and the type is missing from the column definition.
+
 - Fixed function resolution for function :ref:`scalar_current_schema` when the schema prefix
   ``pg_catalog`` is included.

--- a/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
@@ -43,6 +43,14 @@ public class AddColumnDefinition extends TableElement {
         this.generatedExpression = generatedExpression;
         this.type = type;
         this.constraints = constraints;
+        validateColumnDefinition();
+    }
+
+    private void validateColumnDefinition() {
+        if (type == null && generatedExpression == null) {
+            throw new IllegalArgumentException("Column [" + name + "]: data type needs to be provided " +
+                                               "or column should be defined as a generated expression");
+        }
     }
 
     public Expression name() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
@@ -40,8 +40,15 @@ public class ColumnDefinition extends TableElement {
         this.ident = ident;
         this.generatedExpression = generatedExpression;
         this.type = type;
-        assert type != null || generatedExpression != null : "Either dataType or generatedExpression must be defined";
         this.constraints = constraints;
+        validateColumnDefinition();
+    }
+
+    private void validateColumnDefinition() {
+        if (type == null && generatedExpression == null) {
+            throw new IllegalArgumentException("Column [" + ident + "]: data type needs to be provided " +
+                                               "or column should be defined as a generated expression");
+        }
     }
 
     public String ident() {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -515,6 +515,13 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testCreateTableColumnTypeOrGeneratedExpressionAreDefined() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Column [col1]: data type needs to be provided or column should be defined as a generated expression");
+        printStatement("create table test (col1)");
+    }
+
+    @Test
     public void testCreateTableOptionsMultipleTimesNotAllowed() {
         expectedException.expect(ParsingException.class);
         expectedException.expectMessage("line 1:83: mismatched input 'partitioned' expecting {<EOF>, ';'}");

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1349,6 +1349,14 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testAlterTableAddColumnTypeOrGeneratedExpressionAreDefined() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Column [\"col2\"]: data type needs to be provided or column should be defined as a generated expression");
+        printStatement("alter table t add column col2");
+    }
+
+
+    @Test
     public void testAlterTableOpenClose() {
         printStatement("alter table t close");
         printStatement("alter table t open");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When neither the data type nor the generated expression is provided for a column, 
this resulted in NullPointerException in run time. 
I've turned the assertion into a validation.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)