### PR TITLE
Make "Cannot resolve field references" error msg more user friendly

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -28,31 +28,19 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
-import io.crate.sql.tree.QualifiedName;
-import org.elasticsearch.common.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class AlterUserAnalyzer {
     private final Functions functions;
 
-    private static final FieldProvider FIELD_PROVIDER = new FieldProvider() {
-        @Override
-        public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
-            throw new UnsupportedOperationException("Cannot resolve field references");
-        }
-    };
-
     public AlterUserAnalyzer(Functions functions) {
         this.functions = functions;
     }
-
 
     public AlterUserAnalyzedStatement analyze(AlterUser node, ParamTypeHints typeHints, CoordinatorTxnCtx txnContext) {
         ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext();
@@ -60,7 +48,7 @@ public class AlterUserAnalyzer {
             functions,
             txnContext,
             typeHints,
-            FIELD_PROVIDER,
+            FieldProvider.UNSUPPORTED,
             null
         );
 

--- a/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
@@ -28,27 +28,16 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
-import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.Expression;
-import io.crate.sql.tree.QualifiedName;
-import org.elasticsearch.common.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class CreateUserAnalyzer {
 
     private final Functions functions;
-
-    private static final FieldProvider FIELD_PROVIDER = new FieldProvider() {
-        @Override
-        public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
-            throw new UnsupportedOperationException("Cannot resolve field references");
-        }
-    };
 
     CreateUserAnalyzer(Functions functions) {
         this.functions = functions;
@@ -60,7 +49,7 @@ public class CreateUserAnalyzer {
                 functions,
                 txnContext,
                 typeHints,
-                FIELD_PROVIDER,
+                FieldProvider.UNSUPPORTED,
                 null
             );
             Map<String, Symbol> rows = new HashMap<>();

--- a/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -32,8 +32,9 @@ public interface FieldProvider<T extends Symbol> {
 
     T resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation);
 
-
     FieldProvider UNSUPPORTED = (qualifiedName, path, operation) -> {
-        throw new UnsupportedOperationException("Cannot resolve field references");
+        throw new UnsupportedOperationException(
+            "Columns cannot be used in this context. " +
+            "Maybe you wanted to use a string literal which requires single quotes: '" + qualifiedName + "'");
     };
 }

--- a/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
@@ -73,8 +73,10 @@ public class UserDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCreateUserWithPasswordIsStringLiteral() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot resolve field references");
-        CreateUserAnalyzedStatement analysis = e.analyze("CREATE USER ROO WITH (PASSWORD = NO_STRING)");
+        expectedException.expectMessage(
+            "Columns cannot be used in this context. " +
+            "Maybe you wanted to use a string literal which requires single quotes: 'no_string'");
+        e.analyze("CREATE USER ROO WITH (PASSWORD = NO_STRING)");
     }
 
     @Test


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)