### PR TITLE
Support date_trunc on timestamp without time zone

### DIFF
--- a/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -61,9 +61,9 @@ public class DateTruncFunction extends Scalar<Long, Object> {
         .immutableMap();
 
     public static void register(ScalarFunctionModule module) {
-        List<DataType> supportedTimestampTypes = ImmutableList.of(
-            DataTypes.TIMESTAMPZ, DataTypes.LONG, DataTypes.STRING);
-        for (DataType dataType : supportedTimestampTypes) {
+        List<DataType<?>> supportedTimestampTypes = ImmutableList.of(
+            DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ, DataTypes.LONG, DataTypes.STRING);
+        for (DataType<?> dataType : supportedTimestampTypes) {
             module.register(new DateTruncFunction(info(DataTypes.STRING, dataType)));
             // time zone aware variant
             module.register(new DateTruncFunction(info(DataTypes.STRING, DataTypes.STRING, dataType)));
@@ -104,13 +104,13 @@ public class DateTruncFunction extends Scalar<Long, Object> {
         }
 
         // all validation is already done by {@link #normalizeSymbol()}
-        String interval = (String) ((Input) arguments.get(0)).value();
+        String interval = (String) ((Input<?>) arguments.get(0)).value();
         if (interval == null) {
             return this;
         }
         String timeZone = TimeZoneParser.DEFAULT_TZ_LITERAL.value();
         if (arguments.size() == 3) {
-            timeZone = (String) ((Input) arguments.get(1)).value();
+            timeZone = (String) ((Input<?>) arguments.get(1)).value();
         }
 
         return new DateTruncFunction(this.info, rounding(interval, timeZone));
@@ -197,6 +197,4 @@ public class DateTruncFunction extends Scalar<Long, Object> {
         }
         return intervalAsUnit;
     }
-
-
 }

--- a/sql/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
@@ -39,9 +39,16 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testDateTruncWithStringLiteral() {
         assertNormalize("date_trunc('day', '2014-06-03')", isLiteral(1401753600000L));
+    }
+
+    @Test
+    public void test_date_trunc_works_with_timestamp_without_timezone() {
+        assertNormalize(
+            "date_trunc('day', cast('2014-06-03' as timestamp without time zone))",
+            isLiteral(1401753600000L)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)