### PR TITLE
Add support for default expressions - `Create Table` part

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -25,7 +25,6 @@ package io.crate.execution.engine.collect.collectors;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.breaker.RowAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
@@ -107,6 +106,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName),
             RowGranularity.DOC,
             DataTypes.INTEGER,
+            null,
             null
         );
         orderBy = new OrderBy(

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -73,6 +74,7 @@ public class BinaryFieldMapper extends FieldMapper {
             return new BinaryFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 context.indexSettings(),
@@ -150,12 +152,13 @@ public class BinaryFieldMapper extends FieldMapper {
 
     protected BinaryFieldMapper(String simpleName,
                                 Integer position,
+                                @Nullable String defaultExpression,
                                 MappedFieldType fieldType,
                                 MappedFieldType defaultFieldType,
                                 Settings indexSettings,
                                 MultiFields multiFields,
                                 CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -84,6 +85,7 @@ public class BooleanFieldMapper extends FieldMapper {
             return new BooleanFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 context.indexSettings(),
@@ -203,12 +205,13 @@ public class BooleanFieldMapper extends FieldMapper {
 
     protected BooleanFieldMapper(String simpleName,
                                  Integer position,
+                                 @Nullable String defaultExpression,
                                  MappedFieldType fieldType,
                                  MappedFieldType defaultFieldType,
                                  Settings indexSettings,
                                  MultiFields multiFields,
                                  CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -138,6 +138,7 @@ public class DateFieldMapper extends FieldMapper {
             return new DateFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 ignoreMalformed(context),
@@ -350,6 +351,7 @@ public class DateFieldMapper extends FieldMapper {
     private DateFieldMapper(
             String simpleName,
             Integer position,
+            @Nullable String defaultExpression,
             MappedFieldType fieldType,
             MappedFieldType defaultFieldType,
             Explicit<Boolean> ignoreMalformed,
@@ -357,7 +359,7 @@ public class DateFieldMapper extends FieldMapper {
             Settings indexSettings,
             MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
         this.ignoreTimezone = ignoreTimezone;
     }

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -63,6 +63,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         protected final MultiFields.Builder multiFieldsBuilder;
         protected CopyTo copyTo = CopyTo.empty();
         protected Integer position;
+        @Nullable
+        protected String defaultExpression;
 
         protected Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType) {
             super(name);
@@ -100,6 +102,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return builder;
         }
 
+        @Nullable
         protected IndexOptions getDefaultIndexOption() {
             return defaultOptions;
         }
@@ -225,6 +228,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         public void position(int position) {
             this.position = position;
         }
+
+        public void defaultExpression(String defaultExpression) {
+            this.defaultExpression = defaultExpression;
+        }
     }
 
     protected final Version indexCreatedVersion;
@@ -241,8 +248,14 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     @Nullable
     protected Integer position;
 
+    /**
+     * Expression that is used as the default value for a field
+     */
+    @Nullable String defaultExpression;
+
     protected FieldMapper(String simpleName,
                           @Nullable Integer position,
+                          @Nullable String defaultExpression,
                           MappedFieldType fieldType,
                           MappedFieldType defaultFieldType,
                           Settings indexSettings,
@@ -251,6 +264,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         super(simpleName);
         assert indexSettings != null;
         this.position = position;
+        this.defaultExpression = defaultExpression;
         this.indexCreatedVersion = Version.indexCreated(indexSettings);
         if (simpleName.isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty string");
@@ -405,6 +419,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
         if (position != null) {
             builder.field("position", position);
+        }
+        if (defaultExpression != null) {
+            builder.field("default_expr", defaultExpression);
         }
         if (includeDefaults || fieldType().stored() != defaultFieldType.stored()) {
             builder.field("store", fieldType().stored());

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -120,6 +121,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             return new GeoPointFieldMapper(
                 simpleName,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 indexSettings,
@@ -189,6 +191,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
 
     public GeoPointFieldMapper(String simpleName,
                                Integer position,
+                               @Nullable String defaultExpression,
                                MappedFieldType fieldType,
                                MappedFieldType defaultFieldType,
                                Settings indexSettings,
@@ -196,7 +199,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
                                Explicit<Boolean> ignoreMalformed,
                                Explicit<Boolean> ignoreZValue,
                                CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
         this.ignoreZValue = ignoreZValue;
     }

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -32,6 +32,7 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.XShapeCollection;
@@ -193,6 +194,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
             return new GeoShapeFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 ignoreMalformed(context),
                 coerce(context),
@@ -494,6 +496,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
 
     public GeoShapeFieldMapper(String simpleName,
                                Integer position,
+                               @Nullable String defaultExpression,
                                MappedFieldType fieldType,
                                Explicit<Boolean> ignoreMalformed,
                                Explicit<Boolean> coerce,
@@ -501,7 +504,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
                                Settings indexSettings,
                                MultiFields multiFields,
                                CopyTo copyTo) {
-        super(simpleName, position, fieldType, Defaults.FIELD_TYPE, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, Defaults.FIELD_TYPE, indexSettings, multiFields, copyTo);
         this.coerce = coerce;
         this.ignoreMalformed = ignoreMalformed;
         this.ignoreZValue = ignoreZValue;

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -88,6 +88,7 @@ public class IpFieldMapper extends FieldMapper {
             return new IpFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 ignoreMalformed(context),
@@ -264,13 +265,14 @@ public class IpFieldMapper extends FieldMapper {
     private IpFieldMapper(
             String simpleName,
             Integer position,
+            String defaultExpression,
             MappedFieldType fieldType,
             MappedFieldType defaultFieldType,
             Explicit<Boolean> ignoreMalformed,
             Settings indexSettings,
             MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
     }
 

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -32,6 +32,7 @@ import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -145,6 +146,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             return new KeywordFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 ignoreAbove,
@@ -326,13 +328,14 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     protected KeywordFieldMapper(String simpleName,
                                  Integer position,
+                                 @Nullable String defaultExpression,
                                  MappedFieldType fieldType,
                                  MappedFieldType defaultFieldType,
                                  int ignoreAbove,
                                  Settings indexSettings,
                                  MultiFields multiFields,
                                  CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.ignoreAbove = ignoreAbove;
     }

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -53,7 +53,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     }
 
     protected MetadataFieldMapper(String simpleName, Integer position, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
+        super(simpleName, position, null, fieldType, defaultFieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
@@ -132,6 +133,7 @@ public class NumberFieldMapper extends FieldMapper {
             return new NumberFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 ignoreMalformed(context),
@@ -950,6 +952,7 @@ public class NumberFieldMapper extends FieldMapper {
     private NumberFieldMapper(
             String simpleName,
             Integer position,
+            @Nullable String defaultExpression,
             MappedFieldType fieldType,
             MappedFieldType defaultFieldType,
             Explicit<Boolean> ignoreMalformed,
@@ -957,7 +960,7 @@ public class NumberFieldMapper extends FieldMapper {
             Settings indexSettings,
             MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
         this.coerce = coerce;
     }

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -198,6 +198,7 @@ public class TextFieldMapper extends FieldMapper {
             return new TextFieldMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType(),
                 defaultFieldType,
                 positionIncrementGap,
@@ -413,7 +414,7 @@ public class TextFieldMapper extends FieldMapper {
     private static final class PhraseFieldMapper extends FieldMapper {
 
         PhraseFieldMapper(PhraseFieldType fieldType, Settings indexSettings) {
-            super(fieldType.name(), null, fieldType, fieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
+            super(fieldType.name(), null, null, fieldType, fieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
         }
 
         @Override
@@ -430,7 +431,7 @@ public class TextFieldMapper extends FieldMapper {
     private static final class PrefixFieldMapper extends FieldMapper {
 
         protected PrefixFieldMapper(PrefixFieldType fieldType, Settings indexSettings) {
-            super(fieldType.name(), null, fieldType, fieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
+            super(fieldType.name(), null, null, fieldType, fieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
         }
 
         void addField(String value, List<IndexableField> fields) {
@@ -682,6 +683,7 @@ public class TextFieldMapper extends FieldMapper {
 
     protected TextFieldMapper(String simpleName,
                               Integer position,
+                              String defaultExpression,
                               TextFieldType fieldType,
                               MappedFieldType defaultFieldType,
                               int positionIncrementGap,
@@ -689,7 +691,7 @@ public class TextFieldMapper extends FieldMapper {
                               Settings indexSettings,
                               MultiFields multiFields,
                               CopyTo copyTo) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         assert fieldType.tokenized();
         assert fieldType.hasDocValues() == false;
         if (fieldType().indexOptions() == IndexOptions.NONE && fieldType().fielddata()) {

--- a/es/es-server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -192,7 +192,10 @@ public class TypeParsers {
                 iterator.remove();
             } else if (propName.equals("position")) {
                 builder.position(nodeIntegerValue(propNode));
-                iterator.remove();;
+                iterator.remove();
+            } else if (propName.equals("default_expr")) {
+                builder.defaultExpression(nodeStringValue(propNode, null));
+                iterator.remove();
             }
         }
     }

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -494,13 +494,13 @@ blobClusteredInto
     ;
 
 tableElement
-    : columnDefinition                                                               #columndDefinitionDefault
+    : columnDefinition                                                               #columnDefinitionDefault
     | PRIMARY_KEY columns                                                            #primaryKeyConstraint
     | INDEX name=ident USING method=ident columns withProperties?                    #indexDefinition
     ;
 
 columnDefinition
-    : ident dataType? ((GENERATED ALWAYS)? AS expr)? columnConstraint*
+    : ident dataType? (DEFAULT defaultExpr=expr)? ((GENERATED ALWAYS)? AS generatedExpr=expr)? columnConstraint*
     ;
 
 addColumnDefinition

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -528,9 +528,13 @@ public final class SqlFormatter {
             if (type != null) {
                 type.accept(this, indent);
             }
-            if (node.expression() != null) {
+            if (node.defaultExpression() != null) {
+                builder.append(" DEFAULT ")
+                    .append(formatStandaloneExpression(node.defaultExpression(), parameters));
+            }
+            if (node.generatedExpression() != null) {
                 builder.append(" GENERATED ALWAYS AS ")
-                    .append(formatStandaloneExpression(node.expression(), parameters));
+                    .append(formatStandaloneExpression(node.generatedExpression(), parameters));
             }
 
             if (!node.constraints().isEmpty()) {

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -700,7 +700,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitColumnDefinition(SqlBaseParser.ColumnDefinitionContext context) {
         return new ColumnDefinition(
             getIdentText(context.ident()),
-            visitOptionalContext(context.expr(), Expression.class),
+            visitOptionalContext(context.defaultExpr, Expression.class),
+            visitOptionalContext(context.generatedExpr, Expression.class),
             visitOptionalContext(context.dataType(), ColumnType.class),
             visitCollection(context.columnConstraint(), ColumnConstraint.class));
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
@@ -30,14 +30,25 @@ import java.util.List;
 public class ColumnDefinition extends TableElement {
 
     private final String ident;
+
+    @Nullable
+    private final Expression defaultExpression;
+
     @Nullable
     private final Expression generatedExpression;
+
     @Nullable
     private final ColumnType type;
+
     private final List<ColumnConstraint> constraints;
 
-    public ColumnDefinition(String ident, @Nullable Expression generatedExpression, @Nullable ColumnType type, List<ColumnConstraint> constraints) {
+    public ColumnDefinition(String ident,
+                            @Nullable Expression defaultExpression,
+                            @Nullable Expression generatedExpression,
+                            @Nullable ColumnType type,
+                            List<ColumnConstraint> constraints) {
         this.ident = ident;
+        this.defaultExpression = defaultExpression;
         this.generatedExpression = generatedExpression;
         this.type = type;
         this.constraints = constraints;
@@ -49,14 +60,25 @@ public class ColumnDefinition extends TableElement {
             throw new IllegalArgumentException("Column [" + ident + "]: data type needs to be provided " +
                                                "or column should be defined as a generated expression");
         }
+
+        if (defaultExpression != null && generatedExpression != null) {
+            throw new IllegalArgumentException("Column [" + ident + "]: the default and generated expressions " +
+                                               "are mutually exclusive");
+        }
     }
 
     public String ident() {
         return ident;
     }
 
-    public Expression expression() {
+    @Nullable
+    public Expression generatedExpression() {
         return generatedExpression;
+    }
+
+    @Nullable
+    public Expression defaultExpression() {
+        return defaultExpression;
     }
 
     @Nullable
@@ -70,7 +92,7 @@ public class ColumnDefinition extends TableElement {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(ident, generatedExpression, type, constraints);
+        return Objects.hashCode(ident, defaultExpression, generatedExpression, type, constraints);
     }
 
     @Override
@@ -81,6 +103,8 @@ public class ColumnDefinition extends TableElement {
         ColumnDefinition that = (ColumnDefinition) o;
 
         if (!ident.equals(that.ident)) return false;
+        if (defaultExpression != null ? !defaultExpression.equals(that.defaultExpression) :
+            that.defaultExpression != null) return false;
         if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
             that.generatedExpression != null) return false;
         if (type != null ? !type.equals(that.type) : that.type != null) return false;
@@ -93,6 +117,7 @@ public class ColumnDefinition extends TableElement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("ident", ident)
+            .add("defaultExpression", defaultExpression)
             .add("generatedExpression", generatedExpression)
             .add("type", type)
             .add("constraints", constraints)

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -522,6 +522,19 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testCreateTableDefaultExpression() {
+        printStatement("create table test (col1 int default 1)");
+        printStatement("create table test (col1 int default random())");
+    }
+
+    @Test
+    public void testCreateTableBothDefaultAndGeneratedExpressionsNotAllowed() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Column [col1]: the default and generated expressions are mutually exclusive");
+        printStatement("create table test (col1 int default random() as 1+1)");
+    }
+
+    @Test
     public void testCreateTableOptionsMultipleTimesNotAllowed() {
         expectedException.expect(ParsingException.class);
         expectedException.expectMessage("line 1:83: mismatched input 'partitioned' expecting {<EOF>, ';'}");
@@ -1353,6 +1366,14 @@ public class TestStatementBuilder {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Column [\"col2\"]: data type needs to be provided or column should be defined as a generated expression");
         printStatement("alter table t add column col2");
+    }
+
+
+    @Test
+    public void testAddColumnWithDefaultExpressionIsNotSupported() {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage("mismatched input 'default'");
+        printStatement("alter table t add col1 text default 'foo'");
     }
 
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -98,6 +98,12 @@ public class AnalyzedColumnDefinition {
     @Nullable
     private Expression generatedExpression;
 
+    @Nullable
+    private String formattedDefaultExpression;
+
+    @Nullable
+    private Expression defaultExpression;
+
     AnalyzedColumnDefinition(Integer position, @Nullable AnalyzedColumnDefinition parent) {
         this.position = position;
         this.parent = parent;
@@ -257,6 +263,14 @@ public class AnalyzedColumnDefinition {
         if (columnStore == false) {
             mapping.put(DOC_VALUES, "false");
         }
+
+        assert ((formattedDefaultExpression != null && defaultExpression != null) ||
+               (formattedDefaultExpression == null && defaultExpression == null))
+            : "Default Expression is not properly initialized";
+        if (formattedDefaultExpression != null) {
+            mapping.put("default_expr", formattedDefaultExpression);
+        }
+
         return mapping;
     }
 
@@ -393,6 +407,19 @@ public class AnalyzedColumnDefinition {
     @Nullable
     public Expression generatedExpression() {
         return generatedExpression;
+    }
+
+    public void formattedDefaultExpression(String formattedDefaultExpression) {
+        this.formattedDefaultExpression = formattedDefaultExpression;
+    }
+
+    @Nullable
+    public Expression defaultExpression() {
+        return defaultExpression;
+    }
+
+    public void defaultExpression(Expression defaultExpression) {
+        this.defaultExpression = defaultExpression;
     }
 
     void setColumnStore(boolean columnStore) {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
+import io.crate.analyze.relations.FieldProvider;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.symbol.Symbol;
@@ -246,7 +247,7 @@ public class AnalyzedTableElements {
                              ParameterContext parameterContext,
                              CoordinatorTxnCtx coordinatorTxnCtx) {
         expandColumnIdents();
-        validateGeneratedColumns(relationName, existingColumns, functions, parameterContext, coordinatorTxnCtx);
+        validateExpressions(relationName, existingColumns, functions, parameterContext, coordinatorTxnCtx);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -256,11 +257,11 @@ public class AnalyzedTableElements {
         validateColumnStorageDefinitions();
     }
 
-    private void validateGeneratedColumns(RelationName relationName,
-                                          Collection<? extends Reference> existingColumns,
-                                          Functions functions,
-                                          ParameterContext parameterContext,
-                                          CoordinatorTxnCtx coordinatorTxnCtx) {
+    private void validateExpressions(RelationName relationName,
+                                     Collection<? extends Reference> existingColumns,
+                                     Functions functions,
+                                     ParameterContext parameterContext,
+                                     CoordinatorTxnCtx coordinatorTxnCtx) {
         List<Reference> tableReferences = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReference(relationName, columnDefinition, tableReferences);
@@ -268,44 +269,59 @@ public class AnalyzedTableElements {
         tableReferences.addAll(existingColumns);
 
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(tableReferences, relationName);
-        ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
+        ExpressionAnalyzer generatedExpressionAnalyzer = new ExpressionAnalyzer(
             functions, coordinatorTxnCtx, parameterContext, tableReferenceResolver, null);
+        ExpressionAnalysisContext generatedExpressionAnalysisContext = new ExpressionAnalysisContext();
+
+        // Default expressions must not contain column references,
+        // so a separate instance with FieldProvider.UNSUPPORTED is used.
+        ExpressionAnalyzer defaultExpressionAnalyzer = new ExpressionAnalyzer(
+            functions, coordinatorTxnCtx, parameterContext, FieldProvider.UNSUPPORTED, null);
+        ExpressionAnalysisContext defaultExpressionAnalysisContext = new ExpressionAnalysisContext();
+
         SymbolPrinter printer = new SymbolPrinter(functions);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+
         for (AnalyzedColumnDefinition columnDefinition : columns) {
-            processGeneratedExpressions(
-                columnDefinition,
-                expressionAnalyzer,
-                printer,
-                expressionAnalysisContext
-            );
+            processExpressions(columnDefinition,
+                               generatedExpressionAnalyzer,
+                               generatedExpressionAnalysisContext,
+                               defaultExpressionAnalyzer,
+                               defaultExpressionAnalysisContext,
+                               printer);
         }
     }
 
-    private static void processGeneratedExpressions(AnalyzedColumnDefinition columnDefinition,
-                                                    ExpressionAnalyzer expressionAnalyzer,
-                                                    SymbolPrinter printer,
-                                                    ExpressionAnalysisContext expressionAnalysisContext) {
+    private static void processExpressions(AnalyzedColumnDefinition columnDefinition,
+                                           ExpressionAnalyzer generatedExpressionAnalyzer,
+                                           ExpressionAnalysisContext generatedExpressionAnalysisContext,
+                                           ExpressionAnalyzer defaultExpressionAnalyzer,
+                                           ExpressionAnalysisContext defaultExpressionAnalysisContext,
+                                           SymbolPrinter printer) {
         if (columnDefinition.generatedExpression() != null) {
-            processGeneratedExpression(expressionAnalyzer, printer, columnDefinition, expressionAnalysisContext);
+            Symbol function = generatedExpressionAnalyzer.convert(columnDefinition.generatedExpression(), generatedExpressionAnalysisContext);
+            final String formattedExpression = validateAndFormatExpression(function, columnDefinition, printer);
+            columnDefinition.formattedGeneratedExpression(formattedExpression);
+        }
+        if (columnDefinition.defaultExpression() != null) {
+            Symbol function = defaultExpressionAnalyzer.convert(columnDefinition.defaultExpression(), defaultExpressionAnalysisContext);
+            final String formattedExpression = validateAndFormatExpression(function, columnDefinition, printer);
+            columnDefinition.formattedDefaultExpression(formattedExpression);
         }
         for (AnalyzedColumnDefinition child : columnDefinition.children()) {
-            processGeneratedExpressions(
+            processExpressions(
                 child,
-                expressionAnalyzer,
-                printer,
-                expressionAnalysisContext
+                generatedExpressionAnalyzer,
+                generatedExpressionAnalysisContext,
+                defaultExpressionAnalyzer,
+                defaultExpressionAnalysisContext,
+                printer
             );
         }
     }
 
-    private static void processGeneratedExpression(ExpressionAnalyzer expressionAnalyzer,
-                                                   SymbolPrinter symbolPrinter,
-                                                   AnalyzedColumnDefinition columnDefinition,
-                                                   ExpressionAnalysisContext expressionAnalysisContext) {
-        // validate expression
-        Symbol function = expressionAnalyzer.convert(columnDefinition.generatedExpression(), expressionAnalysisContext);
-
+    private static String validateAndFormatExpression(Symbol function,
+                                                      AnalyzedColumnDefinition columnDefinition,
+                                                      SymbolPrinter symbolPrinter) {
         String formattedExpression;
         DataType valueType = function.valueType();
         DataType definedType = columnDefinition.dataType();
@@ -313,7 +329,7 @@ public class AnalyzedTableElements {
         // check for optional defined type and add `cast` to expression if possible
         if (definedType != null && !definedType.equals(valueType)) {
             Preconditions.checkArgument(valueType.isConvertableTo(definedType),
-                "generated expression value type '%s' not supported for conversion to '%s'", valueType, definedType.getName());
+                                        "expression value type '%s' not supported for conversion to '%s'", valueType, definedType.getName());
 
             Symbol castFunction = CastFunctionResolver.generateCastFunction(function, definedType, false);
             formattedExpression = symbolPrinter.printUnqualified(castFunction);
@@ -328,9 +344,9 @@ public class AnalyzedTableElements {
             }
             formattedExpression = symbolPrinter.printUnqualified(function);
         }
-
-        columnDefinition.formattedGeneratedExpression(formattedExpression);
+        return formattedExpression;
     }
+
 
     private void buildReference(RelationName relationName, AnalyzedColumnDefinition columnDefinition, List<Reference> references) {
         Reference reference;
@@ -339,7 +355,8 @@ public class AnalyzedTableElements {
                 new ReferenceIdent(relationName, columnDefinition.ident()),
                 RowGranularity.DOC,
                 columnDefinition.dataType(),
-                columnDefinition.position
+                columnDefinition.position,
+                null // not required in this context
             );
         } else {
             reference = new GeneratedReference(

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -177,7 +177,7 @@ public class MetaDataToASTNodeResolver {
                 }
 
                 String columnName = ident.isTopLevel() ? ident.name() : ident.path().get(ident.path().size() - 1);
-                ColumnDefinition column = new ColumnDefinition(columnName, expression, columnType, constraints);
+                ColumnDefinition column = new ColumnDefinition(columnName, null, expression, columnType, constraints);
                 elements.add(column);
             }
             return elements;

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -127,8 +127,8 @@ public class TableElementsAnalyzer {
             if (node.type() != null) {
                 process(node.type(), context);
             }
-            if (node.expression() != null) {
-                context.analyzedColumnDefinition.generatedExpression(node.expression());
+            if (node.generatedExpression() != null) {
+                context.analyzedColumnDefinition.generatedExpression(node.generatedExpression());
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -127,6 +127,9 @@ public class TableElementsAnalyzer {
             if (node.type() != null) {
                 process(node.type(), context);
             }
+            if (node.defaultExpression() != null) {
+                context.analyzedColumnDefinition.defaultExpression(node.defaultExpression());
+            }
             if (node.generatedExpression() != null) {
                 context.analyzedColumnDefinition.generatedExpression(node.generatedExpression());
             }

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -156,7 +156,8 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
                 reference.indexType(),
                 reference.isNullable(),
                 reference.isColumnStoreDisabled(),
-                reference.position()
+                reference.position(),
+                reference.defaultExpression()
             );
     }
 

--- a/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -62,18 +62,21 @@ public class WriterProjection extends Projection {
         new ReferenceIdent(SysShardsTableInfo.IDENT, SysShardsTableInfo.Columns.ID),
         RowGranularity.SHARD,
         IntegerType.INSTANCE,
+        null,
         null
     );
     private static final Reference TABLE_NAME_REF = new Reference(
         new ReferenceIdent(SysShardsTableInfo.IDENT, SysShardsTableInfo.Columns.TABLE_NAME),
         RowGranularity.SHARD,
         StringType.INSTANCE,
+        null,
         null
     );
     private static final Reference PARTITION_IDENT_REF = new Reference(
         new ReferenceIdent(SysShardsTableInfo.IDENT, SysShardsTableInfo.Columns.PARTITION_IDENT),
         RowGranularity.SHARD,
         StringType.INSTANCE,
+        null,
         null
     );
 

--- a/sql/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
@@ -37,7 +37,7 @@ public class SourceLineNumberExpression extends LineCollectorExpression<Long> {
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new Reference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.LONG, null
+            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.LONG, null, null
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
@@ -49,7 +49,7 @@ public class SourceUriExpression extends LineCollectorExpression<String> {
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new Reference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, 0
+            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, 0, null
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
@@ -52,7 +52,7 @@ public class SourceUriFailureExpression extends LineCollectorExpression<String> 
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new Reference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, null
+            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, null, null
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/DynamicReference.java
+++ b/sql/src/main/java/io/crate/expression/symbol/DynamicReference.java
@@ -38,11 +38,11 @@ public class DynamicReference extends Reference {
     }
 
     public DynamicReference(ReferenceIdent ident, RowGranularity granularity) {
-        super(ident, granularity, DataTypes.UNDEFINED, null);
+        super(ident, granularity, DataTypes.UNDEFINED, null, null);
     }
 
     public DynamicReference(ReferenceIdent ident, RowGranularity granularity, ColumnPolicy columnPolicy) {
-        super(ident, granularity, DataTypes.UNDEFINED, columnPolicy, IndexType.NOT_ANALYZED, true, null);
+        super(ident, granularity, DataTypes.UNDEFINED, columnPolicy, IndexType.NOT_ANALYZED, true, null, null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -123,7 +123,8 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         Reference reference = new Reference(new ReferenceIdent(RELATION_NAME, col1),
                                             RowGranularity.DOC,
                                             info.returnType(),
-                                            1);
+                                            1,
+                                            null);
         Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col1, reference);
         return new StaticTableInfo(RELATION_NAME, referenceByColumn, Collections.singletonList(reference), Collections.emptyList()) {
             @Override

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -107,7 +107,8 @@ public class TableFunctionFactory {
             Reference reference = new Reference(new ReferenceIdent(TABLE_IDENT, col),
                                                 RowGranularity.DOC,
                                                 info().returnType(),
-                                                1);
+                                                1,
+                                                null);
             Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col, reference);
             return new StaticTableInfo(TABLE_IDENT, referenceByColumn, List.of(reference), List.of()) {
                 @Override

--- a/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -162,7 +162,7 @@ public class UnnestFunction {
                 ColumnIdent columnIdent = new ColumnIdent("col" + (i + 1));
                 DataType dataType = ((CollectionType) info.ident().argumentTypes().get(i)).innerType();
                 Reference reference = new Reference(
-                    new ReferenceIdent(TABLE_IDENT, columnIdent), RowGranularity.DOC, dataType, i
+                    new ReferenceIdent(TABLE_IDENT, columnIdent), RowGranularity.DOC, dataType, i, null
                 );
 
                 columns.add(reference);

--- a/sql/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/sql/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -61,7 +61,7 @@ public class GeneratedReference extends Reference {
                               IndexType indexType,
                               String formattedGeneratedExpression,
                               boolean nullable) {
-        super(ident, granularity, type, columnPolicy, indexType, nullable, position);
+        super(ident, granularity, type, columnPolicy, indexType, nullable, position, null);
         this.formattedGeneratedExpression = formattedGeneratedExpression;
     }
 
@@ -70,7 +70,7 @@ public class GeneratedReference extends Reference {
                               RowGranularity granularity,
                               DataType type,
                               String formattedGeneratedExpression) {
-        super(ident, granularity, type, position);
+        super(ident, granularity, type, position, null);
         this.formattedGeneratedExpression = formattedGeneratedExpression;
     }
 

--- a/sql/src/main/java/io/crate/metadata/GeoReference.java
+++ b/sql/src/main/java/io/crate/metadata/GeoReference.java
@@ -52,7 +52,7 @@ public class GeoReference extends Reference {
                         @Nullable String precision,
                         @Nullable Integer treeLevels,
                         @Nullable Double distanceErrorPct) {
-        super(ident, RowGranularity.DOC, DataTypes.GEO_SHAPE, position);
+        super(ident, RowGranularity.DOC, DataTypes.GEO_SHAPE, position, null);
         this.geoTree = MoreObjects.firstNonNull(tree, DEFAULT_TREE);
         this.precision = precision;
         this.treeLevels = treeLevels;

--- a/sql/src/main/java/io/crate/metadata/IndexReference.java
+++ b/sql/src/main/java/io/crate/metadata/IndexReference.java
@@ -95,7 +95,7 @@ public class IndexReference extends Reference {
                           IndexType indexType,
                           List<Reference> columns,
                           @Nullable String analyzer) {
-        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, false, true, position);
+        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, false, true, position, null);
         this.columns = MoreObjects.firstNonNull(columns, Collections.<Reference>emptyList());
         this.analyzer = analyzer;
     }

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -158,7 +158,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         int pos = 0;
         for (Tuple<String, DataType> column : STATIC_COLUMNS) {
             Reference ref = new Reference(
-                new ReferenceIdent(ident(), column.v1(), null), RowGranularity.DOC, column.v2(), pos
+                new ReferenceIdent(ident(), column.v1(), null), RowGranularity.DOC, column.v2(), pos, null
             );
             assert ref.column().isTopLevel() : "only top-level columns should be added to columns list";
             pos++;

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -34,8 +34,10 @@ import io.crate.analyze.TableParameterInfo;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
+import io.crate.analyze.relations.FieldProvider;
 import io.crate.collections.Lists2;
 import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
@@ -120,6 +122,11 @@ public class DocIndexMetaData {
     @Nullable
     private final Version versionUpgraded;
 
+    /**
+     * Analyzer used for Column Default expressions
+     */
+    private final ExpressionAnalyzer expressionAnalyzer;
+
     DocIndexMetaData(Functions functions, IndexMetaData metaData, RelationName ident) throws IOException {
         this.functions = functions;
         this.ident = ident;
@@ -140,6 +147,13 @@ public class DocIndexMetaData {
         versionCreated = IndexMetaData.SETTING_INDEX_VERSION_CREATED.get(settings);
         versionUpgraded = settings.getAsVersion(IndexMetaData.SETTING_VERSION_UPGRADED, null);
         closed = state == IndexMetaData.State.CLOSE;
+
+        this.expressionAnalyzer = new ExpressionAnalyzer(
+            functions,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            ParamTypeHints.EMPTY,
+            FieldProvider.UNSUPPORTED,
+            null);
     }
 
     private static Map<String, Object> getMappingMap(IndexMetaData metaData) {
@@ -165,6 +179,7 @@ public class DocIndexMetaData {
     private void add(Integer position,
                      ColumnIdent column,
                      DataType type,
+                     @Nullable String defaultExpression,
                      ColumnPolicy columnPolicy,
                      Reference.IndexType indexType,
                      boolean isNotNull,
@@ -176,7 +191,7 @@ public class DocIndexMetaData {
             indexType = Reference.IndexType.NOT_ANALYZED;
         }
         if (generatedExpression == null) {
-            ref = newInfo(position, column, type, columnPolicy, indexType, isNotNull, columnStoreEnabled);
+            ref = newInfo(position, column, type, defaultExpression, columnPolicy, indexType, isNotNull, columnStoreEnabled);
         } else {
             ref = newGeneratedColumnInfo(position, column, type, columnPolicy, indexType, generatedExpression, isNotNull);
         }
@@ -237,12 +252,26 @@ public class DocIndexMetaData {
     private Reference newInfo(Integer position,
                               ColumnIdent column,
                               DataType type,
+                              @Nullable String formattedDefaultExpression,
                               ColumnPolicy columnPolicy,
                               Reference.IndexType indexType,
                               boolean nullable,
                               boolean columnStoreEnabled) {
+        Symbol defaultExpression = null;
+        if (formattedDefaultExpression != null) {
+            Expression expression = SqlParser.createExpression(formattedDefaultExpression);
+            defaultExpression = expressionAnalyzer.convert(expression, new ExpressionAnalysisContext());
+        }
         return new Reference(
-            refIdent(column), granularity(column), type, columnPolicy, indexType, nullable, columnStoreEnabled, position
+            refIdent(column),
+            granularity(column),
+            type,
+            columnPolicy,
+            indexType,
+            nullable,
+            columnStoreEnabled,
+            position,
+            defaultExpression
         );
     }
 
@@ -367,6 +396,7 @@ public class DocIndexMetaData {
             boolean nullable = !notNullColumns.contains(newIdent);
             columnProperties = furtherColumnProperties(columnProperties);
             Integer position = (Integer) columnProperties.getOrDefault("position", null);
+            String defaultExpression = (String) columnProperties.getOrDefault("default_expr", null);
             Reference.IndexType columnIndexType = getColumnIndexType(columnProperties);
             boolean columnsStoreDisabled = !Booleans.parseBoolean(
                 columnProperties.getOrDefault(DOC_VALUES, true).toString());
@@ -380,7 +410,7 @@ public class DocIndexMetaData {
                        || (columnDataType.id() == ArrayType.ID
                            && ((ArrayType) columnDataType).innerType().id() == ObjectType.ID)) {
                 ColumnPolicy columnPolicy = ColumnPolicies.decodeMappingValue(columnProperties.get("dynamic"));
-                add(position, newIdent, columnDataType, columnPolicy, Reference.IndexType.NO, nullable, false);
+                add(position, newIdent, columnDataType, defaultExpression, columnPolicy, Reference.IndexType.NO, nullable, false);
 
                 if (columnProperties.get("properties") != null) {
                     // walk nested
@@ -394,7 +424,7 @@ public class DocIndexMetaData {
                     for (String copyToColumn : copyToColumns) {
                         ColumnIdent targetIdent = ColumnIdent.fromPath(copyToColumn);
                         IndexReference.Builder builder = getOrCreateIndexBuilder(targetIdent);
-                        builder.addColumn(newInfo(position, newIdent, columnDataType, ColumnPolicy.DYNAMIC, columnIndexType, false, columnsStoreDisabled));
+                        builder.addColumn(newInfo(position, newIdent, columnDataType, defaultExpression, ColumnPolicy.DYNAMIC, columnIndexType, false, columnsStoreDisabled));
                     }
                 }
                 // is it an index?
@@ -403,7 +433,7 @@ public class DocIndexMetaData {
                     builder.indexType(columnIndexType)
                         .analyzer((String) columnProperties.get("analyzer"));
                 } else {
-                    add(position, newIdent, columnDataType, ColumnPolicy.DYNAMIC, columnIndexType, nullable, columnsStoreDisabled);
+                    add(position, newIdent, columnDataType, defaultExpression, ColumnPolicy.DYNAMIC, columnIndexType, nullable, columnsStoreDisabled);
                 }
             }
         }
@@ -523,15 +553,15 @@ public class DocIndexMetaData {
         return DocSysColumns.ID;
     }
 
-    private void initializeGeneratedExpressions() {
+    private void initializeReferenceExpressions() {
         if (generatedColumnReferences.isEmpty()) {
             return;
         }
         Collection<Reference> references = this.references.values();
+        ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions, CoordinatorTxnCtx.systemTransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
-        ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;
             Expression expression = SqlParser.createExpression(generatedReference.formattedGeneratedExpression());
@@ -564,7 +594,7 @@ public class DocIndexMetaData {
         primaryKey = getPrimaryKey();
         routingCol = getRoutingCol();
 
-        initializeGeneratedExpressions();
+        initializeReferenceExpressions();
         return this;
     }
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -98,6 +98,7 @@ public class DocSysColumns {
                              ColumnPolicy.STRICT,
                              Reference.IndexType.NOT_ANALYZED,
                              false,
+                             null,
                              null
         );
     }

--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -72,7 +72,8 @@ public class ColumnRegistrar {
             ColumnPolicy.STRICT,
             Reference.IndexType.NOT_ANALYZED,
             nullable,
-            position
+            position,
+            null
         );
         position++;
         if (ref.column().isTopLevel()) {
@@ -104,7 +105,8 @@ public class ColumnRegistrar {
                 ColumnPolicy.STRICT,
                 Reference.IndexType.NOT_ANALYZED,
                 true,
-                pos
+                pos,
+                null
             );
             pos++;
             infosBuilder.put(ref.column(), ref);

--- a/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
@@ -71,6 +71,7 @@ public class InternalViewInfoFactory implements ViewInfoFactory {
                     new Reference(new ReferenceIdent(ident, field.path().sqlFqn()),
                                   RowGranularity.DOC,
                                   field.valueType(),
+                                  null,
                                   null)));
             columns = collectedColumns;
         } catch (ResourceUnknownException e) {

--- a/sql/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/sql/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -23,6 +23,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -77,12 +78,13 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
 
     ArrayMapper(String simpleName,
                 Integer position,
+                @Nullable String defaultExpression,
                 MappedFieldType fieldType,
                 MappedFieldType defaultFieldType,
                 Settings indexSettings,
                 MultiFields multiFields,
                 Mapper innerMapper) {
-        super(simpleName, position, fieldType, defaultFieldType, indexSettings, multiFields, CopyTo.empty());
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, CopyTo.empty());
         this.innerMapper = innerMapper;
     }
 
@@ -108,6 +110,7 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
             return new ArrayMapper(
                 name,
                 position,
+                defaultExpression,
                 fieldType,
                 defaultFieldType,
                 context.indexSettings(),

--- a/sql/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/sql/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -54,6 +54,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
             return new ArrayMapper(
                 name,
                 fieldMapper.position(),
+                null,
                 mappedFieldType,
                 mappedFieldType.clone(),
                 context.indexSettings().getSettings(),

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -993,7 +993,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void testCreateTableGeneratedColumnWithInvalidType() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("generated expression value type" +
+        expectedException.expectMessage("expression value type" +
             " 'timestamp with time zone' not supported for conversion to 'ip'");
         e.analyze(
             "create table foo (" +
@@ -1028,6 +1028,60 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "   ts timestamp with time zone," +
             "   day as date_trunc('day', ts)," +
             "   date_string as cast(unknown_col as string))");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateTableWithDefaultExpressionLiteral() {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table foo (name text default 'bar')");
+
+        Map<String, Object> mappingProperties = analysis.mappingProperties();
+        assertThat(mapToSortedString(mappingProperties),
+                   is("name={default_expr='bar', position=1, type=keyword}"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateTableWithDefaultExpressionFunction() {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table foo (name text default upper('bar'))");
+
+        Map<String, Object> mappingProperties = analysis.mappingProperties();
+        assertThat(mapToSortedString(mappingProperties),
+                   is("name={default_expr='BAR', position=1, type=keyword}"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateTableWithDefaultExpressionWithCast() {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table foo (id int default 3.5)");
+
+        Map<String, Object> mappingProperties = analysis.mappingProperties();
+        assertThat(mapToSortedString(mappingProperties),
+                   is("id={default_expr=cast(3.5 AS integer), position=1, type=integer}"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateTableWithDefaultExpressionIsNotNormalized() {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table foo (ts timestamp with time zone default current_timestamp(3))");
+
+        Map<String, Object> mappingProperties = analysis.mappingProperties();
+        assertThat(mapToSortedString(mappingProperties),
+                   is("ts={default_expr=current_timestamp(3), " +
+                      "format=epoch_millis||strict_date_optional_time, " +
+                      "position=1, type=date}"));
+    }
+
+    @Test
+    public void testCreateTableWithDefaultExpressionRefToColumnsNotAllowed() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Columns cannot be used in this context. " +
+                                        "Maybe you wanted to use a string literal which requires single quotes: 'name'");
+        e.analyze("create table foo (name text, name_def text default upper(name))");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -50,7 +50,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         Map<ColumnIdent, NestableInput> referenceImplementationMap = new HashMap<>(1, 1);
 
         ReferenceIdent dummyLoadIdent = new ReferenceIdent(new RelationName("test", "dummy"), "load");
-        dummyLoadInfo = new Reference(dummyLoadIdent, RowGranularity.NODE, DataTypes.DOUBLE, null);
+        dummyLoadInfo = new Reference(dummyLoadIdent, RowGranularity.NODE, DataTypes.DOUBLE, null, null);
 
         referenceImplementationMap.put(dummyLoadIdent.columnIdent(), constant(0.08d));
         functions = getFunctions();
@@ -76,6 +76,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "foo"), "name"),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
         Symbol x_literal = Literal.of("x");

--- a/sql/src/test/java/io/crate/analyze/OrderByTest.java
+++ b/sql/src/test/java/io/crate/analyze/OrderByTest.java
@@ -40,7 +40,7 @@ public class OrderByTest extends CrateUnitTest {
     private static final RelationName TI = new RelationName("doc", "people");
 
     private Reference ref(String name) {
-        return new Reference(new ReferenceIdent(TI, name), RowGranularity.DOC, DataTypes.STRING, null);
+        return new Reference(new ReferenceIdent(TI, name), RowGranularity.DOC, DataTypes.STRING, null, null);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -85,7 +85,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNormalizePrimitiveLiteral() throws Exception {
         Reference ref = new Reference(
-            new ReferenceIdent(TEST_TABLE_IDENT, new ColumnIdent("bool")), RowGranularity.DOC, DataTypes.BOOLEAN, null
+            new ReferenceIdent(TEST_TABLE_IDENT, new ColumnIdent("bool")), RowGranularity.DOC, DataTypes.BOOLEAN, null, null
         );
         Literal<Boolean> trueLiteral = Literal.of(true);
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -207,6 +207,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new Reference(new ReferenceIdent(new RelationName("doc", "t"), "id"),
                           RowGranularity.DOC,
                           DataTypes.INTEGER,
+                          null,
                           null));
         when(tableInfo.ident()).thenReturn(new RelationName("doc", "t"));
         TableRelation tr1 = new TableRelation(tableInfo);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -50,9 +50,17 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
     private static final RelationName CHARACTERS_IDENTS = new RelationName(Schemas.DOC_SCHEMA_NAME, "characters");
 
     private static final Reference ID_REF = new Reference(
-        new ReferenceIdent(CHARACTERS_IDENTS, "id"), RowGranularity.DOC, DataTypes.INTEGER, null);
+        new ReferenceIdent(CHARACTERS_IDENTS, "id"),
+        RowGranularity.DOC,
+        DataTypes.INTEGER,
+        null,
+        null);
     private static final Reference NAME_REF = new Reference(
-        new ReferenceIdent(CHARACTERS_IDENTS, "name"), RowGranularity.DOC, DataTypes.STRING, null);
+        new ReferenceIdent(CHARACTERS_IDENTS, "name"),
+        RowGranularity.DOC,
+        DataTypes.STRING,
+        null,
+        null);
 
     @Test
     public void testStreaming() throws Exception {

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -90,7 +90,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     private final static RelationName TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "characters");
     private final static String PARTITION_INDEX = new PartitionName(TABLE_IDENT, Arrays.asList("1395874800000")).asIndexName();
     private final static Reference ID_REF = new Reference(
-        new ReferenceIdent(TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.SHORT, null);
+        new ReferenceIdent(TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.SHORT, null, null);
 
     private final static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
         "dummyUser",

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -101,10 +101,10 @@ public class ColumnIndexWriterProjectionTest {
     }
 
     private Reference ref(ColumnIdent column, DataType type) {
-        return new Reference(new ReferenceIdent(relationName, column), RowGranularity.DOC, type, null);
+        return new Reference(new ReferenceIdent(relationName, column), RowGranularity.DOC, type, null, null);
     }
 
     private Reference partitionRef(ColumnIdent column, DataType type) {
-        return new Reference(new ReferenceIdent(relationName, column), RowGranularity.PARTITION, type, null);
+        return new Reference(new ReferenceIdent(relationName, column), RowGranularity.PARTITION, type, null, null);
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -87,12 +87,14 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, TEST_TABLE_NAME), "doc"),
         RowGranularity.DOC,
         DataTypes.INTEGER,
+        null,
         null
     );
     private static final Reference underscoreIdReference = new Reference(
         new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, TEST_TABLE_NAME), "_id"),
         RowGranularity.DOC,
         DataTypes.STRING,
+        null,
         null
     );
 
@@ -214,10 +216,10 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         RoutedCollectPhase collectNode = getCollectNode(
             Arrays.asList(
                 new Reference(
-                    new ReferenceIdent(relationName, "id"), RowGranularity.DOC, DataTypes.INTEGER, null
+                    new ReferenceIdent(relationName, "id"), RowGranularity.DOC, DataTypes.INTEGER, null, null
                 ),
                 new Reference(
-                    new ReferenceIdent(relationName, "date"), RowGranularity.SHARD, DataTypes.TIMESTAMPZ, null
+                    new ReferenceIdent(relationName, "date"), RowGranularity.SHARD, DataTypes.TIMESTAMPZ, null, null
                 )),
             routing,
             WhereClause.MATCH_ALL

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -120,6 +120,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
             new ReferenceIdent(SysClusterTableInfo.IDENT, new ColumnIdent(ClusterNameExpression.NAME)),
             RowGranularity.CLUSTER,
             DataTypes.STRING,
+            null,
             null
         );
         RoutedCollectPhase collectNode = collectNode(routing, Arrays.<Symbol>asList(clusterNameRef), RowGranularity.CLUSTER);

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -89,6 +89,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "table"), "value"),
         RowGranularity.DOC,
         DataTypes.LONG,
+        null,
         null
     );
     private final NumberFieldMapper.NumberType fieldType = NumberFieldMapper.NumberType.LONG;
@@ -258,7 +259,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
             new Reference(
                 new ReferenceIdent(
                     new RelationName(Schemas.DOC_SCHEMA_NAME, "table"),
-                    DocSysColumns.SCORE), RowGranularity.DOC, DataTypes.FLOAT, null
+                    DocSysColumns.SCORE), RowGranularity.DOC, DataTypes.FLOAT, null, null
             );
 
         OrderBy orderBy = new OrderBy(ImmutableList.of(sysColReference, REFERENCE),

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -80,18 +80,21 @@ public class NodeStatsTest extends CrateUnitTest {
             new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.ID),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
         nameRef = new Reference(
             new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.ID),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
         hostnameRef = new Reference(
             new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.HOSTNAME),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
         collectPhase = mock(RoutedCollectPhase.class);

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
@@ -72,12 +72,14 @@ public class NodeStatsCollectSourceTest extends CrateUnitTest {
             new Reference(new ReferenceIdent(new RelationName("sys", "nodes"), "id"),
                           RowGranularity.DOC,
                           DataTypes.STRING,
+                          null,
                           null));
         when(tableInfo.getReference(SysNodesTableInfo.Columns.NAME)).thenReturn(
             new Reference(
                 new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.NAME),
                 RowGranularity.DOC,
                 DataTypes.STRING,
+                null,
                 null
             )
         );
@@ -86,6 +88,7 @@ public class NodeStatsCollectSourceTest extends CrateUnitTest {
                 new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.HOSTNAME),
                 RowGranularity.DOC,
                 DataTypes.STRING,
+                null,
                 null
             )
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -62,7 +62,11 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
         SystemCollectSource systemCollectSource = internalCluster().getDataNodeInstance(SystemCollectSource.class);
 
         Reference shardId = new Reference(
-            new ReferenceIdent(new RelationName("sys", "shards"), "id"), RowGranularity.SHARD, DataTypes.INTEGER, null
+            new ReferenceIdent(new RelationName("sys", "shards"), "id"),
+            RowGranularity.SHARD,
+            DataTypes.INTEGER,
+            null,
+            null
         );
 
         RoutedCollectPhase collectPhase = new RoutedCollectPhase(

--- a/sql/src/test/java/io/crate/execution/engine/fetch/FetchBatchAccumulatorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/fetch/FetchBatchAccumulatorTest.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertThat;
 public class FetchBatchAccumulatorTest {
 
     private static final Reference ID = new Reference(
-        new ReferenceIdent(USER_TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.LONG, null
+        new ReferenceIdent(USER_TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.LONG, null, null
     );
     private DummyFetchOperation fetchOperation = new DummyFetchOperation();
 

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -97,6 +97,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             new Reference(new ReferenceIdent(bulkImportIdent, DocSysColumns.RAW),
                           RowGranularity.DOC,
                           DataTypes.STRING,
+                          null,
                           null),
             Collections.singletonList(ID_IDENT),
             Collections.<Symbol>singletonList(new InputColumn(0)),

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -66,7 +66,11 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
     private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
     private static final RelationName BULK_IMPORT_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "bulk_import");
     private static final Reference RAW_SOURCE_REFERENCE = new Reference(
-        new ReferenceIdent(BULK_IMPORT_IDENT, "_raw"), RowGranularity.DOC, DataTypes.STRING, null);
+        new ReferenceIdent(BULK_IMPORT_IDENT, "_raw"),
+        RowGranularity.DOC,
+        DataTypes.STRING,
+        null,
+        null);
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduler;

--- a/sql/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -44,14 +44,14 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     public void testGetImplementationWithColumnsOfTypeCollection() {
         Reference arrayRef = new Reference(
             new ReferenceIdent(
-            new RelationName("s", "t"), "a"), RowGranularity.DOC, DataTypes.DOUBLE_ARRAY, null
+            new RelationName("s", "t"), "a"), RowGranularity.DOC, DataTypes.DOUBLE_ARRAY, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(arrayRef),
             instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
 
         Reference setRef = new Reference(
             new ReferenceIdent(
-            new RelationName("s", "t"), "a"), RowGranularity.DOC, new SetType(DataTypes.DOUBLE), null
+            new RelationName("s", "t"), "a"), RowGranularity.DOC, new SetType(DataTypes.DOUBLE), null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(setRef),
             instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
@@ -61,7 +61,7 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     public void testGetImplementationForSequenceNumber() {
         Reference seqNumberRef = new Reference(
             new ReferenceIdent(
-                new RelationName("s", "t"), "_seq_no"), RowGranularity.DOC, DataTypes.LONG, null
+                new RelationName("s", "t"), "_seq_no"), RowGranularity.DOC, DataTypes.LONG, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(seqNumberRef), instanceOf(SeqNoCollectorExpression.class));
     }
@@ -70,7 +70,7 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     public void testGetImplementationForPrimaryTerm() {
         Reference primaryTerm = new Reference(
             new ReferenceIdent(
-                new RelationName("s", "t"), "_primary_term"), RowGranularity.DOC, DataTypes.LONG, null
+                new RelationName("s", "t"), "_primary_term"), RowGranularity.DOC, DataTypes.LONG, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(primaryTerm),
                    instanceOf(PrimaryTermCollectorExpression.class));

--- a/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -158,7 +158,8 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
             ColumnPolicy.STRICT,
             Reference.IndexType.NOT_ANALYZED,
             true,
-            3
+            3,
+            null
         );
         assertEquals(info, schemas.getTableInfo(SysShardsTableInfo.IDENT).getReference(SysShardsTableInfo.Columns.ID));
     }

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -158,7 +158,11 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         Reference r = new Reference(
             new ReferenceIdent(
             new RelationName("sys", "table"),
-            new ColumnIdent("column", Arrays.asList("path", "nested"))), RowGranularity.DOC, DataTypes.STRING, null
+            new ColumnIdent("column", Arrays.asList("path", "nested"))),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            null,
+            null
         );
         assertPrint(r, "sys.\"table\".\"column\"['path']['nested']");
     }
@@ -168,7 +172,11 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         Reference r = new Reference(
             new ReferenceIdent(
             new RelationName("doc", "table"),
-            new ColumnIdent("column", Arrays.asList("path", "nested"))), RowGranularity.DOC, DataTypes.STRING, null
+            new ColumnIdent("column", Arrays.asList("path", "nested"))),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            null,
+            null
         );
         assertPrint(r, "doc.\"table\".\"column\"['path']['nested']");
     }
@@ -184,9 +192,12 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testReferenceEscaped() throws Exception {
         Reference r = new Reference(
-            new ReferenceIdent(
-            new RelationName("doc", "table"),
-            new ColumnIdent("colum\"n")), RowGranularity.DOC, DataTypes.STRING, null
+            new ReferenceIdent(new RelationName("doc", "table"),
+            new ColumnIdent("colum\"n")),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            null,
+            null
         );
         assertPrint(r, "doc.\"table\".\"colum\"\"n\"");
     }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -192,6 +192,17 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testCreateColumnWithDefaultExpression() throws Exception {
+        execute("create table test (col1 text default 'foo')");
+        String expectedMapping = "{\"default\":{" +
+                                 "\"dynamic\":\"strict\",\"_meta\":{}," +
+                                 "\"dynamic_templates\":[{\"strings\":{\"match_mapping_type\":\"string\",\"mapping\":{\"doc_values\":true,\"store\":false,\"type\":\"keyword\"}}}]," +
+                                 "\"properties\":{\"col1\":{\"type\":\"keyword\",\"position\":1,\"default_expr\":\"'foo'\"}}}}";
+        assertEquals(expectedMapping, getIndexMapping("test"));
+
+    }
+
+    @Test
     public void testCreateGeoShape() throws Exception {
         execute("create table test (col1 geo_shape)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/metadata/DocReferencesTest.java
+++ b/sql/src/test/java/io/crate/metadata/DocReferencesTest.java
@@ -33,7 +33,7 @@ public class DocReferencesTest {
 
     private static Reference stringRef(String path) {
         ColumnIdent columnIdent = ColumnIdent.fromPath(path);
-        return new Reference(new ReferenceIdent(RELATION_ID, columnIdent), RowGranularity.DOC, DataTypes.STRING, null);
+        return new Reference(new ReferenceIdent(RELATION_ID, columnIdent), RowGranularity.DOC, DataTypes.STRING, null, null);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/sql/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -37,7 +37,7 @@ public class IndexReferenceTest extends CrateUnitTest {
     public void testStreaming() throws Exception {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "string_col");
-        Reference reference = new Reference(referenceIdent, RowGranularity.DOC, StringType.INSTANCE, null);
+        Reference reference = new Reference(referenceIdent, RowGranularity.DOC, StringType.INSTANCE, null, null);
 
         ReferenceIdent indexReferenceIdent = new ReferenceIdent(relationName, "index_column");
         IndexReference indexReferenceInfo = new IndexReference(

--- a/sql/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
+++ b/sql/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
@@ -47,6 +47,7 @@ public class MapBackedRefResolverTest {
                 new ReferenceIdent(USERS_TI, new ColumnIdent("obj", Arrays.asList("x", "z"))),
                 RowGranularity.DOC,
                 DataTypes.STRING,
+                null,
                 null
             ));
 

--- a/sql/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -21,34 +21,59 @@
 
 package io.crate.metadata;
 
+import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.relations.FieldProvider;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.table.TableInfo;
+import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.ColumnPolicy;
-import io.crate.test.integration.CrateUnitTest;
+import io.crate.sql.tree.Expression;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.IntegerType;
 import io.crate.types.ObjectType;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-public class ReferenceTest extends CrateUnitTest {
+public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor executor;
+    private TableInfo tableInfo;
+
+    @Before
+    public void prepare() throws Exception {
+        executor = SQLExecutor.builder(clusterService)
+            .addTable(
+                "create table doc.test (" +
+                "  int_column integer" +
+                ")"
+            )
+            .build();
+        tableInfo = executor.schemas().getTableInfo(new RelationName("doc", "test"));
+
+    }
 
     @Test
-    public void testEquals() throws Exception {
-        RelationName relationName = new RelationName("doc", "test");
-        ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
+    public void testEquals()  {
+        ReferenceIdent referenceIdent = new ReferenceIdent(tableInfo.ident(), "object_column");
         DataType dataType1 = new ArrayType(ObjectType.untyped());
         DataType dataType2 = new ArrayType(ObjectType.untyped());
-        Reference reference1 = new Reference(referenceIdent, RowGranularity.DOC, dataType1, null);
-        Reference reference2 = new Reference(referenceIdent, RowGranularity.DOC, dataType2, null);
-        assertTrue(reference1.equals(reference2));
+        Reference reference1 = new Reference(referenceIdent, RowGranularity.DOC, dataType1, null, null);
+        Reference reference2 = new Reference(referenceIdent, RowGranularity.DOC, dataType2, null, null);
+        assertThat(reference1, is(reference2));
     }
 
     @Test
     public void testStreaming() throws Exception {
-        RelationName relationName = new RelationName("doc", "test");
-        ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
+        ReferenceIdent referenceIdent = new ReferenceIdent(tableInfo.ident(), "object_column");
         Reference reference = new Reference(
             referenceIdent,
             RowGranularity.DOC,
@@ -56,7 +81,40 @@ public class ReferenceTest extends CrateUnitTest {
             ColumnPolicy.STRICT,
             Reference.IndexType.ANALYZED,
             false,
+            null,
             null
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Reference.toStream(reference, out);
+
+        StreamInput in = out.bytes().streamInput();
+        Reference reference2 = Reference.fromStream(in);
+
+        assertThat(reference2, is(reference));
+    }
+
+    @Test
+    public void testStreamingWithDefaultExpression() throws Exception {
+        ReferenceIdent referenceIdent = new ReferenceIdent(tableInfo.ident(), "int_column");
+        ExpressionAnalyzer analyzer
+            = new ExpressionAnalyzer(executor.functions(),
+                                     CoordinatorTxnCtx.systemTransactionContext(),
+                                     ParamTypeHints.EMPTY,
+                                     FieldProvider.UNSUPPORTED,
+                                     null);
+        Expression expression = SqlParser.createExpression("1+1");
+        Symbol defaultExpression = analyzer.convert(expression, new ExpressionAnalysisContext());
+
+        Reference reference = new Reference(
+            referenceIdent,
+            RowGranularity.DOC,
+            IntegerType.INSTANCE,
+            ColumnPolicy.STRICT,
+            Reference.IndexType.ANALYZED,
+            false,
+            null,
+            defaultExpression
         );
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/sql/src/test/java/io/crate/metadata/ReferenceToLiteralConverterTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceToLiteralConverterTest.java
@@ -41,7 +41,11 @@ public class ReferenceToLiteralConverterTest extends CrateUnitTest {
     public void testReplaceSimpleReference() throws Exception {
         Object[] inputValues = new Object[]{1};
         Reference idRef = new Reference(
-            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("id")), RowGranularity.DOC, DataTypes.INTEGER, null
+            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("id")),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            null,
+            null
         );
 
         ReferenceToLiteralConverter convertFunction = new ReferenceToLiteralConverter(
@@ -58,12 +62,17 @@ public class ReferenceToLiteralConverterTest extends CrateUnitTest {
             MapBuilder.newMapBuilder().put("name", "Ford").map()};
 
         Reference userRef = new Reference(
-            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user")), RowGranularity.DOC, ObjectType.untyped(), null
+            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user")),
+            RowGranularity.DOC,
+            ObjectType.untyped(),
+            null,
+            null
         );
         Reference nameRef = new Reference(
             new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user", ImmutableList.of("name"))),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
 
@@ -83,12 +92,17 @@ public class ReferenceToLiteralConverterTest extends CrateUnitTest {
             ).map()};
 
         Reference userRef = new Reference(
-            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user")), RowGranularity.DOC, ObjectType.untyped(), null
+            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user")),
+            RowGranularity.DOC,
+            ObjectType.untyped(),
+            null,
+            null
         );
         Reference nameRef = new Reference(
             new ReferenceIdent(TABLE_IDENT, new ColumnIdent("user", ImmutableList.of("profile", "name"))),
             RowGranularity.DOC,
             DataTypes.STRING,
+            null,
             null
         );
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 // @formatter:off
@@ -255,36 +256,47 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         Reference birthday = md.references().get(new ColumnIdent("person", "birthday"));
         assertThat(birthday.valueType(), is(DataTypes.TIMESTAMPZ));
         assertThat(birthday.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(birthday.defaultExpression(), is(nullValue()) );
 
         Reference integerIndexed = md.references().get(new ColumnIdent("integerIndexed"));
         assertThat(integerIndexed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(integerIndexed.defaultExpression(), is(nullValue()) );
 
         Reference integerIndexedBWC = md.references().get(new ColumnIdent("integerIndexedBWC"));
         assertThat(integerIndexedBWC.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(integerIndexedBWC.defaultExpression(), is(nullValue()) );
 
         Reference integerNotIndexed = md.references().get(new ColumnIdent("integerNotIndexed"));
         assertThat(integerNotIndexed.indexType(), is(Reference.IndexType.NO));
+        assertThat(integerNotIndexed.defaultExpression(), is(nullValue()) );
 
         Reference integerNotIndexedBWC = md.references().get(new ColumnIdent("integerNotIndexedBWC"));
         assertThat(integerNotIndexedBWC.indexType(), is(Reference.IndexType.NO));
+        assertThat(integerNotIndexedBWC.defaultExpression(), is(nullValue()) );
 
         Reference stringNotIndexed = md.references().get(new ColumnIdent("stringNotIndexed"));
         assertThat(stringNotIndexed.indexType(), is(Reference.IndexType.NO));
+        assertThat(stringNotIndexed.defaultExpression(), is(nullValue()) );
 
         Reference stringNotIndexedBWC = md.references().get(new ColumnIdent("stringNotIndexedBWC"));
         assertThat(stringNotIndexedBWC.indexType(), is(Reference.IndexType.NO));
+        assertThat(stringNotIndexedBWC.defaultExpression(), is(nullValue()) );
 
         Reference stringNotAnalyzed = md.references().get(new ColumnIdent("stringNotAnalyzed"));
         assertThat(stringNotAnalyzed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(stringNotAnalyzed.defaultExpression(), is(nullValue()) );
 
         Reference stringNotAnalyzedBWC = md.references().get(new ColumnIdent("stringNotAnalyzedBWC"));
         assertThat(stringNotAnalyzedBWC.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(stringNotAnalyzedBWC.defaultExpression(), is(nullValue()) );
 
         Reference stringAnalyzed = md.references().get(new ColumnIdent("stringAnalyzed"));
         assertThat(stringAnalyzed.indexType(), is(Reference.IndexType.ANALYZED));
+        assertThat(stringAnalyzed.defaultExpression(), is(nullValue()) );
 
         Reference stringAnalyzedBWC = md.references().get(new ColumnIdent("stringAnalyzedBWC"));
         assertThat(stringAnalyzedBWC.indexType(), is(Reference.IndexType.ANALYZED));
+        assertThat(stringAnalyzedBWC.defaultExpression(), is(nullValue()) );
 
         ImmutableList<Reference> references = ImmutableList.copyOf(md.references().values());
         List<String> fqns = Lists.transform(references, r -> r.column().fqn());
@@ -294,6 +306,86 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
                 "person", "person.birthday", "person.first_name",
                 "stringAnalyzed", "stringAnalyzedBWC", "stringNotAnalyzed", "stringNotAnalyzedBWC",
                 "stringNotIndexed", "stringNotIndexedBWC")));
+    }
+
+    @Test
+    public void testExtractColumnDefinitionsWithDefaultExpression() throws Exception {
+        // @formatter:off
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+                .startObject("_meta")
+                    .field("primary_keys", "integerIndexed")
+                .endObject()
+                .startObject("properties")
+                    .startObject("integerIndexed")
+                        .field("type", "integer")
+                        .field("default_expr", "1")
+                    .endObject()
+                    .startObject("integerNotIndexed")
+                        .field("type", "integer")
+                        .field("index", "false")
+                        .field("default_expr", "1")
+                    .endObject()
+                    .startObject("stringNotIndexed")
+                        .field("type", "string")
+                        .field("index", "false")
+                        .field("default_expr", "'default'")
+                    .endObject()
+                    .startObject("stringNotAnalyzed")
+                        .field("type", "keyword")
+                        .field("default_expr", "'default'")
+                    .endObject()
+                    .startObject("stringAnalyzed")
+                        .field("type", "text")
+                        .field("analyzer", "standard")
+                        .field("default_expr", "'default'")
+                    .endObject()
+
+                    .startObject("birthday")
+                        .field("type", "date")
+                        .field("default_expr", "current_timestamp(3)")
+                    .endObject()
+                .endObject()
+            .endObject();
+        // @formatter:on
+
+        IndexMetaData metaData = getIndexMetaData("test1", builder);
+        DocIndexMetaData md = newMeta(metaData, "test1");
+
+        assertThat(md.columns().size(), is(6));
+        assertThat(md.references().size(), is(16));
+
+        Reference birthday = md.references().get(new ColumnIdent("birthday"));
+        assertThat(birthday.valueType(), is(DataTypes.TIMESTAMPZ));
+        assertThat(birthday.defaultExpression(), isFunction("current_timestamp", List.of(DataTypes.INTEGER)));
+
+        Reference integerIndexed = md.references().get(new ColumnIdent("integerIndexed"));
+        assertThat(integerIndexed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(integerIndexed.defaultExpression(), isLiteral(1L));
+
+
+        Reference integerNotIndexed = md.references().get(new ColumnIdent("integerNotIndexed"));
+        assertThat(integerNotIndexed.indexType(), is(Reference.IndexType.NO));
+        assertThat(integerNotIndexed.defaultExpression(), isLiteral(1L));
+
+        Reference stringNotIndexed = md.references().get(new ColumnIdent("stringNotIndexed"));
+        assertThat(stringNotIndexed.indexType(), is(Reference.IndexType.NO));
+        assertThat(stringNotIndexed.defaultExpression(), isLiteral("default"));
+
+        Reference stringNotAnalyzed = md.references().get(new ColumnIdent("stringNotAnalyzed"));
+        assertThat(stringNotAnalyzed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
+        assertThat(stringNotAnalyzed.defaultExpression(), isLiteral("default"));
+
+        Reference stringAnalyzed = md.references().get(new ColumnIdent("stringAnalyzed"));
+        assertThat(stringAnalyzed.indexType(), is(Reference.IndexType.ANALYZED));
+        assertThat(stringAnalyzed.defaultExpression(), isLiteral("default"));
+
+        ImmutableList<Reference> references = ImmutableList.copyOf(md.references().values());
+        List<String> fqns = Lists.transform(references, r -> r.column().fqn());
+        assertThat(fqns, Matchers.is(
+            ImmutableList.of("_doc", "_fetchid", "_id", "_raw", "_score", "_uid", "_version", "_docid", "_seq_no",
+                "_primary_term", "birthday", "integerIndexed", "integerNotIndexed",
+                "stringAnalyzed", "stringNotAnalyzed", "stringNotIndexed")));
     }
 
     @Test
@@ -1319,6 +1411,15 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         DocIndexMetaData md = getDocIndexMetaDataFromStatement("create table t1 (x as ([10, 20]))");
         GeneratedReference generatedReference = md.generatedColumnReferences().get(0);
         assertThat(generatedReference.valueType(), is(new ArrayType(DataTypes.LONG)));
+    }
+
+    @Test
+    public void testColumnWithDefaultExpression() throws Exception {
+        DocIndexMetaData md = getDocIndexMetaDataFromStatement("create table t1 (" +
+                                                               " ts timestamp with time zone default current_timestamp)");
+        Reference reference = md.references().get(new ColumnIdent("ts"));
+        assertThat(reference.valueType(), is(DataTypes.TIMESTAMPZ));
+        assertThat(reference.defaultExpression(), isFunction("current_timestamp", List.of(DataTypes.INTEGER)));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -35,6 +35,7 @@ public class DocTableInfoTest extends CrateUnitTest {
                     new ReferenceIdent(relationName, new ColumnIdent("o", ImmutableList.of())),
                     RowGranularity.DOC,
                     ObjectType.untyped(),
+                    null,
                     null
                 )
             ),
@@ -82,6 +83,7 @@ public class DocTableInfoTest extends CrateUnitTest {
             ColumnPolicy.STRICT,
             Reference.IndexType.NOT_ANALYZED,
             true,
+            null,
             null
         );
 

--- a/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -451,7 +451,8 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "parted_pks"), "date"),
             RowGranularity.PARTITION,
             DataTypes.TIMESTAMPZ,
-            3)));
+            3,
+            null)));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
@@ -60,7 +60,7 @@ public class FetchPhaseTest {
         tableIndices.put(new RelationName(Schemas.DOC_SCHEMA_NAME, "i2"), "i2_s2");
 
         ReferenceIdent nameIdent = new ReferenceIdent(t1, "name");
-        Reference name = new Reference(nameIdent, RowGranularity.DOC, DataTypes.STRING, null);
+        Reference name = new Reference(nameIdent, RowGranularity.DOC, DataTypes.STRING, null, null);
 
         FetchPhase orig = new FetchPhase(
             1,

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -188,6 +188,7 @@ public class TestingHelpers {
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, tableName), columnIdent),
             RowGranularity.DOC,
             dataType,
+            null,
             null
         );
     }
@@ -290,7 +291,7 @@ public class TestingHelpers {
             default:
                 throw new IllegalArgumentException("fqColumnName must contain <table>.<column> or <schema>.<table>.<column>");
         }
-        return new Reference(refIdent, rowGranularity, dataType, null);
+        return new Reference(refIdent, rowGranularity, dataType, null, null);
     }
 
     public static <T> Matcher<T> isSQL(final String stmt) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Default expression for each field is stored in the cluster state index metadata mapping.
Introduced a new field for that: `default_expr`.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
