### PR TITLE
Use GroupBySingleNumberCollector also for timestamp types

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollector.java
@@ -142,41 +142,40 @@ public final class GroupBySingleNumberCollector implements Collector<Row, GroupB
          * The Ram accounting for new elements takes place in batches when the map is about
          * to grow by doubling its size. See #addWithAccounting()
          */
-
-        final Map statesByKey;
-        long entryOverhead;
         switch (valueType.id()) {
             case ByteType.ID:
-                entryOverhead = 6L;
-                ramAccounting.addBytes(4 * entryOverhead);
-                statesByKey = new ByteObjectHashMap<Object[]>();
-                break;
+                return () -> {
+                    long entryOverhead = 6L;
+                    ramAccounting.addBytes(4 * entryOverhead);
+                    return new Groups((Map) new ByteObjectHashMap<Object[]>(), entryOverhead);
+                };
 
             case ShortType.ID:
-                entryOverhead = 6L;
-                ramAccounting.addBytes(4 * entryOverhead);
-                statesByKey = new ShortObjectHashMap<Object[]>();
-                break;
+                return () -> {
+                    long entryOverhead = 6L;
+                    ramAccounting.addBytes(4 * entryOverhead);
+                    return new Groups((Map) new ShortObjectHashMap<Object[]>(), entryOverhead);
+                };
 
             case IntegerType.ID:
-                entryOverhead = 8L;
-                ramAccounting.addBytes(4 * entryOverhead);
-                statesByKey = new IntObjectHashMap<Object[]>();
-                break;
+                return () -> {
+                    long entryOverhead = 8L;
+                    ramAccounting.addBytes(4 * entryOverhead);
+                    return new Groups((Map) new IntObjectHashMap<Object[]>(), entryOverhead);
+                };
 
             case LongType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
-                entryOverhead = 12L;
-                ramAccounting.addBytes(4 * entryOverhead);
-                statesByKey = new LongObjectHashMap<Object[]>();
-                break;
+                return () -> {
+                    long entryOverhead = 12L;
+                    ramAccounting.addBytes(4 * entryOverhead);
+                    return new Groups((Map) new LongObjectHashMap<Object[]>(), entryOverhead);
+                };
 
             default:
                 throw new IllegalArgumentException("Unsupported input type " + valueType.getName());
         }
-        //noinspection unchecked
-        return () -> new Groups(statesByKey, entryOverhead);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -67,9 +67,7 @@ public class GroupingProjector implements Projector {
         }
         if (keys.size() == 1) {
             Symbol key = keys.get(0);
-            if (DataTypes.NUMERIC_PRIMITIVE_TYPES.contains(key.valueType()) &&
-                !key.valueType().equals(DataTypes.FLOAT) &&
-                !key.valueType().equals(DataTypes.DOUBLE)) {
+            if (GroupBySingleNumberCollector.SUPPORTED_TYPES.contains(key.valueType())) {
                 collector = new GroupBySingleNumberCollector(
                     key.valueType(),
                     collectExpressions,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

```
Q: select date_trunc('day', "visitDate"), count(*) from uservisits group by 1 order by 2 desc limit 30
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1592.896 ±  554.824 |    387.680 |   1391.589 |   1573.717 |   2981.713 |
|   V2    |     1466.598 ±  578.396 |    379.720 |   1336.275 |   1693.382 |   2828.032 |
mean:   -   8.26%
median: -   4.06%
```


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)