### PR TITLE
Improve error message if a column is used as arg to table function

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -637,12 +637,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             functions,
             statementContext.transactionContext(),
             statementContext.convertParamFunction(),
-            new FieldProvider() {
-                @Override
-                public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
-                    throw new UnsupportedOperationException("Can only resolve literals");
-                }
-            },
+            FieldProvider.UNSUPPORTED,
             null
         );
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`FieldProvider.UNSUPPORTED` has a better default error message.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)