### PR TITLE
Fix a bug in creating collector ctx for group by a single text column.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -378,6 +378,9 @@ Changes
 Fixes
 =====
 
+- Fixed a bug that led to failures of group by a single text column queries
+  on columns with the cardinality ration lower than ``0.5``.
+
 - Fixed ``NullPointerException`` that could occur when a column is defined as a
   :ref:`Base Column<ref-base-columns>` and the type is missing from the column definition.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -144,7 +144,7 @@ final class GroupByOptimizedIterator {
             collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
             InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
-            docCtx.add(collectPhase.toCollect().stream().filter(s -> !s.equals(keyRef))::iterator);
+            docCtx.add(collectPhase.toCollect().stream()::iterator);
             IndexOrdinalsFieldData keyIndexFieldData = queryShardContext.getForField(keyFieldType);
 
             InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations(collectTask.txnCtx());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
