### PR TITLE
default clause: sql reference doc and information_schema.columns  

### DIFF
--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -371,7 +371,7 @@ infinite recursion of your mind, beware!)::
 |                               |                                               |               |
 |                               | For further information see :ref:`data-types` |               |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``column_default``            | Not implemented (always returns ``NULL``)     | ``TEXT``      |
+| ``column_default``            | The default expression of the column          | ``TEXT``      |
 +-------------------------------+-----------------------------------------------+---------------+
 | ``character_maximum_length``  | Not implemented (always returns ``NULL``)     | ``INTEGER``   |
 |                               |                                               |               |

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -31,7 +31,9 @@ Synopsis
 
 where ``base_column_definition``::
 
-    column_name data_type [ column_constraint [ ... ] ]  [ storage_options ]
+    column_name data_type
+    [ DEFAULT default_expr ]
+    [ column_constraint [ ... ] ]  [ storage_options ]
 
 where ``generated_column_definition`` is::
 
@@ -63,7 +65,7 @@ Description
 
 CREATE TABLE will create a new, initially empty table.
 
-If the table_ident does not contain a schema, the table is created in the
+If the ``table_ident`` does not contain a schema, the table is created in the
 ``doc`` schema. Otherwise it is created in the given schema, which is
 implicitly created, if it didn't exist yet.
 
@@ -88,20 +90,30 @@ Table elements
 .. _ref-base-columns:
 
 Base Columns
-............
+~~~~~~~~~~~~
 
 A base column is a persistent column in the table metadata. In relational terms
-it is an attribute of the tuple of the table-relation. It has a name, a type
-and optional constraints.
+it is an attribute of the tuple of the table-relation. It has a name, type
+optional default clause and constraints.
 
 Base columns are readable and writable (if the table itself is writable).
 Values for base columns are given in DML statements explicitly or omitted, in
 which case their value is null.
 
+Default clause
+^^^^^^^^^^^^^^
+
+The optional default clause defines the default value of the column. The value
+is inserted when the column is a target of a ``INSERT`` statement that doesn't
+contain an explicit value for it.
+
+The default clause expression is variable-free, it means that subqueries and
+cross-references to other columns are not allowed.
+
 .. _ref-generated-columns:
 
 Generated columns
-.................
+~~~~~~~~~~~~~~~~~
 
 A generated column is a persistent column that is computed as needed from the
 ``generation_expression`` for every ``INSERT`` and ``UPDATE`` operation.
@@ -119,7 +131,7 @@ The ``GENERATED ALWAYS`` part of the syntax is optional.
    For more information, see :ref:`sql-ddl-generated-columns`.
 
 Table constraints
-.................
+~~~~~~~~~~~~~~~~~
 
 Table constraints are constraints that are applied to more than one column or
 to the table as a whole.
@@ -127,7 +139,7 @@ to the table as a whole.
 For further details see :ref:`table_constraints`.
 
 Column constraints
-..................
+~~~~~~~~~~~~~~~~~~
 
 Column constraints are constraints that are applied on each column of the table
 separately.
@@ -135,7 +147,7 @@ separately.
 For further details see :ref:`column_constraints`.
 
 Storage options
-...............
+~~~~~~~~~~~~~~~
 
 Storage options can be applied on each column of the table separately.
 

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.reference.information.ColumnContext;
+import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.RelationName;
@@ -135,8 +136,14 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
                 () -> NestableCollectExpression.forFunction(ColumnContext::getOrdinal))
             .put(Columns.DATA_TYPE,
                 () -> NestableCollectExpression.forFunction(r -> r.info.valueType().getName()))
-            .put(Columns.COLUMN_DEFAULT,
-                () -> NestableCollectExpression.constant(null))
+            .put(Columns.COLUMN_DEFAULT, () -> NestableCollectExpression.forFunction(
+                r -> {
+                    if (r.info.defaultExpression() != null) {
+                        return SymbolPrinter.INSTANCE.printUnqualified(r.info.defaultExpression());
+                    } else {
+                        return null;
+                    }
+                }))
             .put(Columns.CHARACTER_MAXIMUM_LENGTH,
                 () -> NestableCollectExpression.constant(null))
             .put(Columns.CHARACTER_OCTET_LENGTH,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
