### PR TITLE
Fix cast corner case in analyzed column definition.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -378,6 +378,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused an error when trying to create a table with
+  a column definition that contains a predefined array data type and generated
+  expression. For instance, a statement like
+  ``CREATE TABLE foo (col ARRAY(TEXT) AS ['bar'])`` would fail.
+
 - Fixed a bug that led to failures of group by a single text column queries
   on columns with the cardinality ration lower than ``0.5``.
 

--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 
 public class ArrayType extends CollectionType {
 
+    public static final String NAME = "array";
     public static final int ID = 100;
 
     public ArrayType(DataType<?> innerType) {
@@ -48,7 +49,7 @@ public class ArrayType extends CollectionType {
 
     @Override
     public String getCollectionName() {
-        return "array";
+        return NAME;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -160,6 +160,10 @@ public class AnalyzedColumnDefinition {
         this.collectionType = type;
     }
 
+    String collectionType() {
+        return collectionType;
+    }
+
     boolean isIndexColumn() {
         return isIndex;
     }

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -156,7 +156,7 @@ public class TableElementsAnalyzer {
                     if (parentRef != null) {
                         parent.position = parentRef.column().isTopLevel() ? parentRef.position() : null;
                         if (parentRef.valueType().equals(new ArrayType(ObjectType.untyped()))) {
-                            parent.collectionType("array");
+                            parent.collectionType(ArrayType.NAME);
                         } else {
                             parent.objectType(parentRef.columnPolicy());
                         }
@@ -218,7 +218,7 @@ public class TableElementsAnalyzer {
                 throw new UnsupportedOperationException("the SET dataType is currently not supported");
             }
 
-            context.analyzedColumnDefinition.collectionType("array");
+            context.analyzedColumnDefinition.collectionType(ArrayType.NAME);
 
             if (node.innerType().type() != ColumnType.Type.PRIMITIVE &&
                 node.innerType().type() != ColumnType.Type.OBJECT) {

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -938,6 +938,16 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         assertThat(tsMapping.get("type"), is("date"));
     }
 
+    @Test
+    public void testCreateTableWithColumnOfArrayTypeAndGeneratedExpression() {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table foo (arr array(integer) as ([1.0, 2.0]))");
+
+        assertThat(
+            mapToSortedString(analysis.mappingProperties()),
+            is("arr={inner={position=1, type=integer}, type=array}"));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testCreateTableGeneratedColumnWithCast() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It was not possible to create a cast expression for analysed column
definition and generated expression in cases where a column definition
has a predefined data type of the array type and generated expression.
The reason was the negligence of the column definition’s array collection
type when checking whether generated expression type is convertible to
the predefined type.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
