### PR TITLE
 Evaluate is null predicates against UNDEFINED data types

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -378,6 +378,9 @@ Changes
 Fixes
 =====
 
+- Fixed a bug that led to ``is null`` predicates against ``ignored`` objects
+  fields to always evaluate to true.
+
 - Fixed ``collect_set`` to return an ``array`` type in order to be able to
   return the results over ``JDBC``. ``collection_count`` and ``collection_avg``
   are also changed to receive ``arrays`` as arguments, instead of ``sets``.

--- a/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -32,8 +32,8 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionResolver;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.DataType;
@@ -72,7 +72,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
         assert symbol.arguments().size() == 1 : "function's number of arguments must be 1";
 
         Symbol arg = symbol.arguments().get(0);
-        if (arg.equals(Literal.NULL) || arg.valueType().equals(DataTypes.UNDEFINED)) {
+        if (arg.equals(Literal.NULL)) {
             return Literal.of(true);
         } else if (arg.symbolType().isValueSymbol()) {
             return Literal.of(((Input) arg).value() == null);

--- a/sql/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/sql/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.expression.predicate;
 
-import io.crate.expression.symbol.Literal;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -44,6 +44,11 @@ public class IsNullPredicateTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeReference() throws Exception {
         assertNormalize("name is null", isFunction(IsNullPredicate.NAME));
+    }
+
+    @Test
+    public void testNormalizeUndefinedType() {
+        assertNormalize("obj_ignored['column'] is null", isFunction(IsNullPredicate.NAME));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -103,7 +103,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             "  double_val double precision," +
             "  float_val real," +
             "  short_val smallint," +
-            "  obj object" +
+            "  obj object," +
+            "  obj_ignored object(ignored)" +
             ")";
 
         DocTableInfo tableInfo = SQLExecutor.tableInfo(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
