### PR TITLE
Allow UNBOUNDED PRECEDING - UNBOUNDED FOLLOWING frames.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -251,7 +251,7 @@ Changes
 =======
 
 - Added support for ``CURRENT ROW -> UNBOUNDED FOLLOWING`` window frame
-  definitions in the context of `window functions <window-functions>`_.
+  definitions in the context of :ref:`window-functions`.
 
 - Added the :ref:`pg_get_userbyid` scalar function to enhance PostgreSQL
   compatibility.

--- a/sql/src/main/java/io/crate/analyze/WindowDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowDefinition.java
@@ -59,6 +59,12 @@ public class WindowDefinition implements Writeable {
         new FrameBoundDefinition(UNBOUNDED_FOLLOWING)
     );
 
+    public static final WindowFrameDefinition UNBOUNDED_PRECEDING_UNBOUNDED_FOLLOWING = new WindowFrameDefinition(
+        RANGE,
+        new FrameBoundDefinition(UNBOUNDED_PRECEDING),
+        new FrameBoundDefinition(UNBOUNDED_FOLLOWING)
+    );
+
     private final List<Symbol> partitions;
     @Nullable
     private final OrderBy orderBy;

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -70,9 +70,11 @@ public class WindowAgg extends ForwardingLogicalPlan {
         for (WindowFunction windowFunction : windowFunctions) {
             WindowDefinition windowDefinition = windowFunction.windowDefinition();
             if (!windowDefinition.windowFrameDefinition().equals(WindowDefinition.UNBOUNDED_PRECEDING_CURRENT_ROW) &&
-                !windowDefinition.windowFrameDefinition().equals(WindowDefinition.CURRENT_ROW_UNBOUNDED_FOLLOWING)) {
-                throw new UnsupportedFeatureException("Only unbounded preceding -> current row and current row -> " +
-                                                      "unbounded following frame definitions are supported");
+                !windowDefinition.windowFrameDefinition().equals(WindowDefinition.CURRENT_ROW_UNBOUNDED_FOLLOWING) &&
+                !windowDefinition.windowFrameDefinition().equals(WindowDefinition.UNBOUNDED_PRECEDING_UNBOUNDED_FOLLOWING)) {
+                throw new UnsupportedFeatureException(
+                    "The only supported frame definitions are unbounded preceding -> current row, " +
+                    "current row -> unbounded following and unbounded preceding -> unbounded following");
             }
         }
 

--- a/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import static io.crate.analyze.WindowDefinition.CURRENT_ROW_UNBOUNDED_FOLLOWING;
+import static io.crate.analyze.WindowDefinition.UNBOUNDED_PRECEDING_UNBOUNDED_FOLLOWING;
 import static org.hamcrest.Matchers.contains;
 
 public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
@@ -42,6 +43,18 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
         new Object[]{5, 5},
         new Object[]{null, null}
     };
+
+    @Test
+    public void testSumOverUnboundedPrecedingToUnboundedFollowingFrames() throws Exception {
+        Object[] expected = new Object[]{5L, 5L, 5L, 12L, 12L, 12L, null};
+        assertEvaluate("sum(x) OVER(" +
+                       "PARTITION BY x>2 ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING" +
+                       ")",
+                       contains(expected),
+                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       UNBOUNDED_PRECEDING_UNBOUNDED_FOLLOWING,
+                       INPUT_ROWS);
+    }
 
     @Test
     public void testCountOverUnboundedFollowingFrames() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
