### PR TITLE
default clause: release notes and doc edits

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -250,6 +250,8 @@ Deprecations
 Changes
 =======
 
+- Added support for column :ref:`ref-default-clause` for :ref:`ref-create-table`.
+
 - Added support for ``CURRENT ROW -> UNBOUNDED FOLLOWING`` window frame
   definitions in the context of `window functions <window-functions>`_.
 

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -93,12 +93,14 @@ Base Columns
 ~~~~~~~~~~~~
 
 A base column is a persistent column in the table metadata. In relational terms
-it is an attribute of the tuple of the table-relation. It has a name, type
+it is an attribute of the tuple of the table-relation. It has a name, type,
 optional default clause and constraints.
 
 Base columns are readable and writable (if the table itself is writable).
-Values for base columns are given in DML statements explicitly or omitted, in
+Values for base columns are given in DML statements explicitly or omitted in
 which case their value is null.
+
+.. _ref-default-clause:
 
 Default clause
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
