### PR TITLE
Support the extract scalar on timestamp without time zone.

### DIFF
--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -444,7 +444,8 @@ Synopsis
   that should be extracted.
 
 :expression:
-  An expression that resolves to a timestamp or is castable to timestamp.
+  An expression that resolves to a timestamp data type with or without
+  timezone or is castable to timestamp data types.
 
 ::
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -76,7 +76,6 @@ import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.ExpressionFormatter;
 import io.crate.sql.parser.SqlParser;
@@ -535,11 +534,9 @@ public class ExpressionAnalyzer {
         @Override
         protected Symbol visitExtract(Extract node, ExpressionAnalysisContext context) {
             Symbol expression = process(node.getExpression(), context);
-            Scalar<Number, Long> scalar = ExtractFunctions.getScalar(node.getField());
-            FunctionInfo functionInfo = scalar.info();
             return allocateFunction(
-                functionInfo.ident().name(),
-                ImmutableList.of(expression),
+                ExtractFunctions.functionNameFrom(node.getField()),
+                List.of(expression),
                 context);
         }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -49,6 +49,14 @@ public class ExtractFunctionsTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void testExtractCenturyFromTimestampWithoutTimeZone() {
+        assertEvaluate(
+            "extract(day from timestamp)",
+            25,
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-03-25")));
+    }
+
+    @Test
     public void testExtractYear() throws Exception {
         assertEvaluate("extract(year from timestamp_tz)", 2014);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
