### PR TITLE
Release resources correctly in SslReqHandlerTest.

### DIFF
--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -93,7 +93,7 @@ public class CrateHttpsTransportTest extends CrateUnitTest {
                 pipelineRegistry,
                 mock(NodeClient.class));
 
-        Channel channel = new EmbeddedChannel();
+        EmbeddedChannel channel = new EmbeddedChannel();
         try {
             transport.start();
 
@@ -107,6 +107,7 @@ public class CrateHttpsTransportTest extends CrateUnitTest {
         } finally {
             transport.stop();
             transport.close();
+            channel.releaseInbound();
             channel.close().awaitUninterruptibly();
         }
     }

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
@@ -44,6 +44,7 @@ public class SslReqHandlerTest extends CrateUnitTest {
     @After
     public void dispose() {
         if (channel != null) {
+            channel.releaseInbound();
             channel.close().awaitUninterruptibly();
             channel = null;
         }
@@ -67,6 +68,7 @@ public class SslReqHandlerTest extends CrateUnitTest {
         ByteBuf responseBuffer = channel.readOutbound();
         byte response = responseBuffer.readByte();
         assertEquals(response, 'S');
+        responseBuffer.release();
 
         // ...and continue encrypted (ssl handler)
         assertThat(channel.pipeline().first(), instanceOf(SslHandler.class));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes the Netty's ByteBuf leak test checks.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
