### PR TITLE
Cleanup static table definitions to be more concise and typesafe.

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/StaticTableReferenceResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/StaticTableReferenceResolver.java
@@ -58,7 +58,6 @@ public class StaticTableReferenceResolver<R> implements ReferenceResolver<Nestab
         return getImplementationByRootTraversal(factories, columnIdent);
     }
 
-
     private static <R> NestableCollectExpression<R, ?> getImplementationByRootTraversal(
         Map<ColumnIdent, ? extends RowCollectExpressionFactory<R>> innerFactories,
         ColumnIdent columnIdent) {

--- a/sql/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
@@ -21,14 +21,14 @@
 
 package io.crate.metadata.information;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.types.DataTypes;
+
+import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
 
@@ -37,51 +37,24 @@ public class InformationReferentialConstraintsTableInfo extends InformationTable
     public static final String NAME = "referential_constraints";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
-    public static class Columns {
-        static final ColumnIdent CONSTRAINT_CATALOG = new ColumnIdent("constraint_catalog");
-        static final ColumnIdent CONSTRAINT_SCHEMA = new ColumnIdent("constraint_schema");
-        static final ColumnIdent CONSTRAINT_NAME = new ColumnIdent("constraint_name");
-        static final ColumnIdent UNIQUE_CONSTRAINT_CATALOG = new ColumnIdent("unique_constraint_catalog");
-        static final ColumnIdent UNIQUE_CONSTRAINT_SCHEMA = new ColumnIdent("unique_constraint_schema");
-        static final ColumnIdent UNIQUE_CONSTRAINT_NAME = new ColumnIdent("unique_constraint_name");
-        static final ColumnIdent MATCH_OPTION = new ColumnIdent("match_option");
-        static final ColumnIdent UPDATE_RULE = new ColumnIdent("update_rule");
-        static final ColumnIdent DELETE_RULE = new ColumnIdent("delete_rule");
+    private static ColumnRegistrar<Void> columnRegistrar() {
+        return new ColumnRegistrar<Void>(IDENT, RowGranularity.DOC)
+            .register("constraint_catalog", DataTypes.STRING, () -> constant(null))
+            .register("constraint_schema", DataTypes.STRING, () -> constant(null))
+            .register("constraint_name", DataTypes.STRING, () -> constant(null))
+            .register("unique_constraint_catalog", DataTypes.STRING, () -> constant(null))
+            .register("unique_constraint_schema", DataTypes.STRING, () -> constant(null))
+            .register("unique_constraint_name", DataTypes.STRING, () -> constant(null))
+            .register("match_option", DataTypes.STRING, () -> constant(null))
+            .register("update_rule", DataTypes.STRING, () -> constant(null))
+            .register("delete_rule", DataTypes.STRING, () -> constant(null));
     }
 
-    private static ColumnRegistrar columnRegistrar() {
-        return new ColumnRegistrar(IDENT, RowGranularity.DOC)
-            .register(Columns.CONSTRAINT_CATALOG, DataTypes.STRING)
-            .register(Columns.CONSTRAINT_SCHEMA, DataTypes.STRING)
-            .register(Columns.CONSTRAINT_NAME, DataTypes.STRING)
-            .register(Columns.UNIQUE_CONSTRAINT_CATALOG, DataTypes.STRING)
-            .register(Columns.UNIQUE_CONSTRAINT_SCHEMA, DataTypes.STRING)
-            .register(Columns.UNIQUE_CONSTRAINT_NAME, DataTypes.STRING)
-            .register(Columns.MATCH_OPTION, DataTypes.STRING)
-            .register(Columns.UPDATE_RULE, DataTypes.STRING)
-            .register(Columns.DELETE_RULE, DataTypes.STRING);
-
-    }
-
-    public static ImmutableMap<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
-            .put(Columns.CONSTRAINT_CATALOG, () -> constant(null))
-            .put(Columns.CONSTRAINT_SCHEMA, () -> constant(null))
-            .put(Columns.CONSTRAINT_NAME, () -> constant(null))
-            .put(Columns.UNIQUE_CONSTRAINT_CATALOG, () -> constant(null))
-            .put(Columns.UNIQUE_CONSTRAINT_SCHEMA, () -> constant(null))
-            .put(Columns.UNIQUE_CONSTRAINT_NAME, () -> constant(null))
-            .put(Columns.MATCH_OPTION, () -> constant(null))
-            .put(Columns.UPDATE_RULE, () -> constant(null))
-            .put(Columns.DELETE_RULE, () -> constant(null))
-            .build();
+    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return columnRegistrar().expressions();
     }
 
     InformationReferentialConstraintsTableInfo() {
-        super(
-            IDENT,
-            columnRegistrar(),
-            ImmutableList.of(Columns.CONSTRAINT_CATALOG, Columns.CONSTRAINT_SCHEMA, Columns.CONSTRAINT_NAME)
-        );
+        super(IDENT, columnRegistrar(), "constraint_catalog", "constraint_schema", "constraint_name");
     }
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationRoutinesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationRoutinesTableInfo.java
@@ -21,8 +21,6 @@
 
 package io.crate.metadata.information;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
@@ -30,64 +28,33 @@ import io.crate.metadata.RoutineInfo;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.types.DataTypes;
 
 import java.util.Map;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.BOOLEAN;
 
 public class InformationRoutinesTableInfo extends InformationTableInfo {
 
     public static final String NAME = "routines";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
-    public static class Columns {
-        static final ColumnIdent SPECIFIC_NAME = new ColumnIdent("specific_name");
-        static final ColumnIdent ROUTINE_NAME = new ColumnIdent("routine_name");
-        static final ColumnIdent ROUTINE_TYPE = new ColumnIdent("routine_type");
-        static final ColumnIdent ROUTINE_SCHEMA = new ColumnIdent("routine_schema");
-        static final ColumnIdent ROUTINE_BODY = new ColumnIdent("routine_body");
-        static final ColumnIdent ROUTINE_DEFINITION = new ColumnIdent("routine_definition");
-        static final ColumnIdent DATA_TYPE = new ColumnIdent("data_type");
-        static final ColumnIdent IS_DETERMINISTIC = new ColumnIdent("is_deterministic");
+    private static ColumnRegistrar<RoutineInfo> columnRegistrar() {
+        return new ColumnRegistrar<RoutineInfo>(IDENT, RowGranularity.DOC)
+            .register("routine_name", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::name))
+            .register("routine_type", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::type))
+            .register("routine_schema", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::schema))
+            .register("specific_name", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::specificName))
+            .register("routine_body", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::body))
+            .register("routine_definition", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::definition))
+            .register("data_type", STRING, () -> NestableCollectExpression.forFunction(RoutineInfo::dataType))
+            .register("is_deterministic", BOOLEAN, () -> NestableCollectExpression.forFunction(RoutineInfo::isDeterministic));
     }
 
-    private static ColumnRegistrar columnRegistrar() {
-        return new ColumnRegistrar(IDENT, RowGranularity.DOC)
-            .register(Columns.ROUTINE_NAME, DataTypes.STRING)
-            .register(Columns.ROUTINE_TYPE, DataTypes.STRING)
-            .register(Columns.ROUTINE_SCHEMA, DataTypes.STRING)
-            .register(Columns.SPECIFIC_NAME, DataTypes.STRING)
-            .register(Columns.ROUTINE_BODY, DataTypes.STRING)
-            .register(Columns.ROUTINE_DEFINITION, DataTypes.STRING)
-            .register(Columns.DATA_TYPE, DataTypes.STRING)
-            .register(Columns.IS_DETERMINISTIC, DataTypes.BOOLEAN);
-    }
-
-    public static Map<ColumnIdent, RowCollectExpressionFactory<RoutineInfo>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<RoutineInfo>>builder()
-            .put(InformationRoutinesTableInfo.Columns.ROUTINE_NAME,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::name))
-            .put(InformationRoutinesTableInfo.Columns.ROUTINE_TYPE,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::type))
-            .put(InformationRoutinesTableInfo.Columns.ROUTINE_SCHEMA,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::schema))
-            .put(InformationRoutinesTableInfo.Columns.SPECIFIC_NAME,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::specificName))
-            .put(InformationRoutinesTableInfo.Columns.ROUTINE_BODY,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::body))
-            .put(InformationRoutinesTableInfo.Columns.ROUTINE_DEFINITION,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::definition))
-            .put(InformationRoutinesTableInfo.Columns.DATA_TYPE,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::dataType))
-            .put(InformationRoutinesTableInfo.Columns.IS_DETERMINISTIC,
-                () -> NestableCollectExpression.forFunction(RoutineInfo::isDeterministic))
-            .build();
+    static Map<ColumnIdent, RowCollectExpressionFactory<RoutineInfo>> expressions() {
+        return columnRegistrar().expressions();
     }
 
     InformationRoutinesTableInfo() {
-        super(
-            IDENT,
-            columnRegistrar(),
-            ImmutableList.of()
-        );
+        super(IDENT, columnRegistrar());
     }
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
@@ -21,16 +21,15 @@
 
 package io.crate.metadata.information;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.SchemaInfo;
-import io.crate.types.DataTypes;
+
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.STRING;
 
 import java.util.Map;
 
@@ -39,26 +38,16 @@ public class InformationSchemataTableInfo extends InformationTableInfo {
     public static final String NAME = "schemata";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
-    public static class Columns {
-        static final ColumnIdent SCHEMA_NAME = new ColumnIdent("schema_name");
+    private static ColumnRegistrar<SchemaInfo> columnRegistrar() {
+        return new ColumnRegistrar<SchemaInfo>(IDENT, RowGranularity.DOC)
+            .register("schema_name", STRING, () -> forFunction(SchemaInfo::name));
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<SchemaInfo>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<SchemaInfo>>builder()
-            .put(Columns.SCHEMA_NAME,
-                () -> NestableCollectExpression.forFunction(SchemaInfo::name)).build();
-    }
-
-    private static ColumnRegistrar columnRegistrar() {
-        return new ColumnRegistrar(IDENT, RowGranularity.DOC)
-            .register(Columns.SCHEMA_NAME, DataTypes.STRING);
+    static Map<ColumnIdent, RowCollectExpressionFactory<SchemaInfo>> expressions() {
+        return columnRegistrar().expressions();
     }
 
     InformationSchemataTableInfo() {
-        super(
-            IDENT,
-            columnRegistrar(),
-            ImmutableList.of(Columns.SCHEMA_NAME)
-        );
+        super(IDENT, columnRegistrar(), "schema_name");
     }
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
@@ -42,6 +42,12 @@ public class InformationTableInfo extends StaticTableInfo {
         super(ident, columnRegistrar, primaryKey);
     }
 
+    InformationTableInfo(RelationName ident,
+                         ColumnRegistrar columnRegistrar,
+                         String... primaryKey) {
+        super(ident, columnRegistrar, primaryKey);
+    }
+
     @Override
     public RowGranularity rowGranularity() {
         return RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
@@ -22,10 +22,8 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
@@ -34,43 +32,34 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterState;
 
 import java.util.Collections;
 import java.util.Map;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+
 
 public class PgAttrDefTable extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attrdef");
 
-    static class Columns {
-        static final ColumnIdent OID = new ColumnIdent("oid");
-        static final ColumnIdent ADRELID = new ColumnIdent("adrelid");
-        static final ColumnIdent ADNUM = new ColumnIdent("adnum");
-        static final ColumnIdent ADBIN = new ColumnIdent("adbin");
-        static final ColumnIdent ADSRC = new ColumnIdent("adsrc");
+    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return columnRegistrar().expressions();
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
-            .put(Columns.OID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ADRELID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ADNUM, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ADBIN, () -> NestableCollectExpression.constant(null))
-            .put(Columns.ADSRC, () -> NestableCollectExpression.constant(null))
-            .build();
-
+    private static ColumnRegistrar<Void> columnRegistrar() {
+        return new ColumnRegistrar<Void>(IDENT, RowGranularity.DOC)
+            .register("oid", INTEGER, () -> constant(0))
+            .register("adrelid", INTEGER, () -> constant(0))
+            .register("adnum", INTEGER, () -> constant(0))
+            .register("adbin", STRING, () -> constant(null))
+            .register("adsrc", STRING, () -> constant(null));
     }
 
     PgAttrDefTable() {
-        super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register(Columns.OID.name(), DataTypes.INTEGER)
-                .register(Columns.ADRELID.name(), DataTypes.INTEGER)
-                .register(Columns.ADNUM.name(), DataTypes.INTEGER)
-                .register(Columns.ADBIN.name(), DataTypes.STRING)
-                .register(Columns.ADSRC.name(), DataTypes.STRING),
-            Collections.emptyList());
+        super(IDENT, columnRegistrar(), Collections.emptyList());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -22,10 +22,8 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.reference.information.ColumnContext;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
@@ -37,98 +35,58 @@ import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
 
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.metadata.pgcatalog.OidHash.relationOid;
 import static io.crate.types.DataTypes.isCollectionType;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 
 public class PgAttributeTable extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attribute");
 
-    static class Columns {
-        static final ColumnIdent ATTRELID = new ColumnIdent("attrelid");
-        static final ColumnIdent ATTNAME = new ColumnIdent("attname");
-        static final ColumnIdent ATTTYPID = new ColumnIdent("atttypid");
-        static final ColumnIdent ATTSTATTARGET = new ColumnIdent("attstattarget");
-        static final ColumnIdent ATTLEN = new ColumnIdent("attlen");
-        static final ColumnIdent ATTNUM = new ColumnIdent("attnum");
-        static final ColumnIdent ATTNDIMS = new ColumnIdent("attndims");
-        static final ColumnIdent ATTCACHEOFF = new ColumnIdent("attcacheoff");
-        static final ColumnIdent ATTTYPMOD = new ColumnIdent("atttypmod");
-        static final ColumnIdent ATTBYVAL = new ColumnIdent("attbyval");
-        static final ColumnIdent ATTSTORAGE = new ColumnIdent("attstorage");
-        static final ColumnIdent ATTALIGN = new ColumnIdent("attalign");
-        static final ColumnIdent ATTNOTNULL = new ColumnIdent("attnotnull");
-        static final ColumnIdent ATTHASDEF = new ColumnIdent("atthasdef");
-        static final ColumnIdent ATTIDENTITY = new ColumnIdent("attidentity");
-        static final ColumnIdent ATTISDROPPED = new ColumnIdent("attisdropped");
-        static final ColumnIdent ATTISLOCAL = new ColumnIdent("attislocal");
-        static final ColumnIdent ATTINHCOUNT = new ColumnIdent("attinhcount");
-        static final ColumnIdent ATTCOLLATION = new ColumnIdent("attcollation");
-        static final ColumnIdent ATTACL = new ColumnIdent("attacl");
-        static final ColumnIdent ATTOPTIONS = new ColumnIdent("attoptions");
-        static final ColumnIdent ATTFDWOPTIONS = new ColumnIdent("attfdwoptions");
+    static Map<ColumnIdent, RowCollectExpressionFactory<ColumnContext>> expressions() {
+        return columnRegistrar().expressions();
     }
 
-
-    public static Map<ColumnIdent, RowCollectExpressionFactory<ColumnContext>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ColumnContext>>builder()
-            .put(Columns.ATTRELID, () -> NestableCollectExpression.forFunction(c -> relationOid(c.tableInfo)))
-            .put(Columns.ATTNAME, () -> NestableCollectExpression.forFunction(c -> c.info.column().fqn()))
-            .put(Columns.ATTTYPID, () -> NestableCollectExpression.forFunction(c -> PGTypes.get(c.info.valueType()).oid()))
-            .put(Columns.ATTSTATTARGET, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ATTLEN, () -> NestableCollectExpression.forFunction(c -> PGTypes.get(c.info.valueType()).typeLen()))
-            .put(Columns.ATTNUM, () -> NestableCollectExpression.forFunction(c -> c.ordinal))
-            .put(Columns.ATTNDIMS, () -> NestableCollectExpression.forFunction(c -> isCollectionType(c.info.valueType()) ? 1 : 0))
-            .put(Columns.ATTCACHEOFF, () -> NestableCollectExpression.constant(-1))
-            .put(Columns.ATTTYPMOD, () -> NestableCollectExpression.constant(-1))
-            .put(Columns.ATTBYVAL, () -> NestableCollectExpression.constant(false))
-            .put(Columns.ATTSTORAGE, () -> NestableCollectExpression.constant(null))
-            .put(Columns.ATTALIGN, () -> NestableCollectExpression.constant(null))
-            .put(Columns.ATTNOTNULL, () -> NestableCollectExpression.forFunction(c -> !c.info.isNullable()))
-            .put(Columns.ATTHASDEF, () -> NestableCollectExpression.constant(false)) // don't support default values
-            .put(Columns.ATTIDENTITY, () -> NestableCollectExpression.constant(""))
-            .put(Columns.ATTISDROPPED, () -> NestableCollectExpression.constant(false)) // don't support dropping columns
-            .put(Columns.ATTISLOCAL, () -> NestableCollectExpression.constant(true))
-            .put(Columns.ATTINHCOUNT, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ATTCOLLATION, () -> NestableCollectExpression.constant(0))
-            .put(Columns.ATTACL, () -> NestableCollectExpression.constant(null))
-            .put(Columns.ATTOPTIONS, () -> NestableCollectExpression.constant(null))
-            .put(Columns.ATTFDWOPTIONS, () -> NestableCollectExpression.constant(null))
-            .build();
+    @SuppressWarnings({"unchecked"})
+    private static ColumnRegistrar<ColumnContext> columnRegistrar() {
+        return new ColumnRegistrar<ColumnContext>(IDENT, RowGranularity.DOC)
+            .register("attrelid", INTEGER, () -> forFunction(c -> relationOid(c.tableInfo)))
+            .register("attname", STRING, () -> forFunction(c -> c.info.column().fqn()))
+            .register("atttypid", INTEGER, () -> forFunction(c -> PGTypes.get(c.info.valueType()).oid()))
+            .register("attstattarget", INTEGER, () -> constant(0))
+            .register("attlen", SHORT, () -> forFunction(c -> PGTypes.get(c.info.valueType()).typeLen()))
+            .register("attnum", INTEGER, () -> forFunction(c -> c.ordinal))
+            .register("attndims", INTEGER, () -> forFunction(c -> isCollectionType(c.info.valueType()) ? 1 : 0))
+            .register("attcacheoff", INTEGER, () -> constant(-1))
+            .register("atttypmod", INTEGER, () -> constant(-1))
+            .register("attbyval", BOOLEAN, () -> constant(false))
+            .register("attstorage", STRING, () -> constant(null))
+            .register("attalign", STRING, () -> constant(null))
+            .register("attnotnull", BOOLEAN, () -> forFunction(c -> !c.info.isNullable()))
+            .register("atthasdef", BOOLEAN, () -> constant(false)) // don't support default values
+            .register("attidentity", STRING, () -> constant(""))
+            .register("attisdropped", BOOLEAN, () -> constant(false)) // don't support dropping columns
+            .register("attislocal", BOOLEAN, () -> constant(true))
+            .register("attinhcount", INTEGER, () -> constant(0))
+            .register("attcollation", INTEGER, () -> constant(0))
+            .register("attacl", new ArrayType(ObjectType.untyped()),() -> constant(null))
+            .register("attoptions", STRING_ARRAY, () -> constant(null))
+            .register("attfdwoptions", STRING_ARRAY, () -> constant(null));
     }
 
     PgAttributeTable() {
-        super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register(Columns.ATTRELID.name(), DataTypes.INTEGER)
-                .register(Columns.ATTNAME.name(), DataTypes.STRING)
-                .register(Columns.ATTTYPID.name(), DataTypes.INTEGER)
-                .register(Columns.ATTSTATTARGET.name(), DataTypes.INTEGER)
-                .register(Columns.ATTLEN.name(), DataTypes.SHORT)
-                .register(Columns.ATTNUM.name(), DataTypes.INTEGER)
-                .register(Columns.ATTNDIMS.name(), DataTypes.INTEGER)
-                .register(Columns.ATTCACHEOFF.name(), DataTypes.INTEGER)
-                .register(Columns.ATTTYPMOD.name(), DataTypes.INTEGER)
-                .register(Columns.ATTBYVAL.name(), DataTypes.BOOLEAN)
-                .register(Columns.ATTSTORAGE.name(), DataTypes.STRING)
-                .register(Columns.ATTALIGN.name(), DataTypes.STRING)
-                .register(Columns.ATTNOTNULL.name(), DataTypes.BOOLEAN)
-                .register(Columns.ATTHASDEF.name(), DataTypes.BOOLEAN)
-                .register(Columns.ATTIDENTITY.name(), DataTypes.STRING)
-                .register(Columns.ATTISDROPPED.name(), DataTypes.BOOLEAN)
-                .register(Columns.ATTISLOCAL.name(), DataTypes.BOOLEAN)
-                .register(Columns.ATTINHCOUNT.name(), DataTypes.INTEGER)
-                .register(Columns.ATTCOLLATION.name(), DataTypes.INTEGER)
-                .register(Columns.ATTACL.name(), new ArrayType(ObjectType.untyped()))
-                .register(Columns.ATTOPTIONS.name(), DataTypes.STRING_ARRAY)
-                .register(Columns.ATTFDWOPTIONS.name(), DataTypes.STRING_ARRAY),
-            Collections.emptyList());
+        super(IDENT, columnRegistrar());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -22,10 +22,8 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
@@ -36,138 +34,74 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
 
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.FLOAT;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 
 public class PgClassTable extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_class");
-
-    static class Columns {
-        static final ColumnIdent OID = new ColumnIdent("oid");
-        static final ColumnIdent RELNAME = new ColumnIdent("relname");
-        static final ColumnIdent RELNAMESPACE = new ColumnIdent("relnamespace");
-        static final ColumnIdent RELTYPE = new ColumnIdent("reltype");
-        static final ColumnIdent RELOFTYPE = new ColumnIdent("reloftype");
-        static final ColumnIdent RELOWNER = new ColumnIdent("relowner");
-        static final ColumnIdent RELAM = new ColumnIdent("relam");
-        static final ColumnIdent RELFILENODE = new ColumnIdent("relfilenode");
-        static final ColumnIdent RELTABLESPACE = new ColumnIdent("reltablespace");
-        static final ColumnIdent RELPAGES = new ColumnIdent("relpages");
-        static final ColumnIdent RELTUPLES = new ColumnIdent("reltuples");
-        static final ColumnIdent RELALLVISIBLE = new ColumnIdent("relallvisible");
-        static final ColumnIdent RELTOASTRELID = new ColumnIdent("reltoastrelid");
-        static final ColumnIdent RELHASINDEX = new ColumnIdent("relhasindex");
-        static final ColumnIdent RELISSHARED = new ColumnIdent("relisshared");
-        static final ColumnIdent RELPERSISTENCE = new ColumnIdent("relpersistence");
-        static final ColumnIdent RELKIND = new ColumnIdent("relkind");
-        static final ColumnIdent RELNATTS = new ColumnIdent("relnatts");
-        static final ColumnIdent RELCHECKS = new ColumnIdent("relchecks");
-        static final ColumnIdent RELHASOIDS = new ColumnIdent("relhasoids");
-        static final ColumnIdent RELHASPKEY = new ColumnIdent("relhaspkey");
-        static final ColumnIdent RELHASRULES = new ColumnIdent("relhasrules");
-        static final ColumnIdent RELHASTRIGGERS = new ColumnIdent("relhastriggers");
-        static final ColumnIdent RELHASSUBCLASS = new ColumnIdent("relhassubclass");
-        static final ColumnIdent RELROWSECURITY = new ColumnIdent("relrowsecurity");
-        static final ColumnIdent RELFORCEROWSECURITY = new ColumnIdent("relforcerowsecurity");
-        static final ColumnIdent RELISPOPULATED = new ColumnIdent("relispopulated");
-        static final ColumnIdent RELREPLIDENT = new ColumnIdent("relreplident");
-        static final ColumnIdent RELISPARTITION = new ColumnIdent("relispartition");
-        static final ColumnIdent RELFROZENXID = new ColumnIdent("relfrozenxid");
-        static final ColumnIdent RELMINMXID = new ColumnIdent("relminmxid");
-        static final ColumnIdent RELACL = new ColumnIdent("relacl");
-        static final ColumnIdent RELOPTIONS = new ColumnIdent("reloptions");
-        static final ColumnIdent RELPARTBOUND = new ColumnIdent("relpartbound");
-    }
-
     private static final String KIND_TABLE = "r";
     private static final String KIND_VIEW = "v";
 
     private static final String PERSISTENCE_PERMANENT = "p";
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<RelationInfo>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<RelationInfo>>builder()
-            .put(Columns.OID, () -> NestableCollectExpression.forFunction(OidHash::relationOid))
-            .put(Columns.RELNAME, () -> NestableCollectExpression.forFunction(r -> r.ident().name()))
-            .put(Columns.RELNAMESPACE, () -> NestableCollectExpression.forFunction(r -> schemaOid(r.ident().schema())))
-            .put(Columns.RELTYPE, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELOFTYPE, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELOWNER, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELAM, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELFILENODE, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELTABLESPACE, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELPAGES, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELTUPLES, () -> NestableCollectExpression.constant(0.0f))
-            .put(Columns.RELALLVISIBLE, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELTOASTRELID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELHASINDEX, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELISSHARED, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELPERSISTENCE, () -> NestableCollectExpression.constant(PERSISTENCE_PERMANENT))
-            .put(Columns.RELKIND, () -> NestableCollectExpression.forFunction(
-                r -> r.relationType() == RelationType.VIEW ? KIND_VIEW : KIND_TABLE))
-            .put(Columns.RELNATTS, () -> NestableCollectExpression.forFunction(r -> (short) r.columns().size()))
-            .put(Columns.RELCHECKS, () -> NestableCollectExpression.constant((short) 0))
-            .put(Columns.RELHASOIDS, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELHASPKEY, () -> NestableCollectExpression.forFunction(r -> r.primaryKey().size() > 0))
-            .put(Columns.RELHASRULES, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELHASTRIGGERS, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELHASSUBCLASS, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELROWSECURITY, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELFORCEROWSECURITY, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELISPOPULATED, () -> NestableCollectExpression.constant(true))
-            .put(Columns.RELREPLIDENT, () -> NestableCollectExpression.constant("p"))
-            .put(Columns.RELISPARTITION, () -> NestableCollectExpression.constant(false))
-            .put(Columns.RELFROZENXID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELMINMXID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.RELACL, () -> NestableCollectExpression.constant(null))
-            .put(Columns.RELOPTIONS, () -> NestableCollectExpression.constant(null))
-            .put(Columns.RELPARTBOUND, () -> NestableCollectExpression.constant(null))
-            .build();
+    static Map<ColumnIdent, RowCollectExpressionFactory<RelationInfo>> expressions() {
+        return columnRegistrar().expressions();
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private static ColumnRegistrar<RelationInfo> columnRegistrar() {
+        return new ColumnRegistrar<RelationInfo>(IDENT, RowGranularity.DOC)
+            .register("oid", INTEGER, () -> forFunction(OidHash::relationOid))
+            .register("relname", STRING, () -> forFunction(r -> r.ident().name()))
+            .register("relnamespace", INTEGER,() -> forFunction(r -> schemaOid(r.ident().schema())))
+            .register("reltype", INTEGER, () -> constant(0))
+            .register("reloftype", INTEGER, () -> constant(0))
+            .register("relowner", INTEGER, () -> constant(0))
+            .register("relam", INTEGER, () -> constant(0))
+            .register("relfilenode", INTEGER, () -> constant(0))
+            .register("reltablespace", INTEGER, () -> constant(0))
+            .register("relpages", INTEGER, () -> constant(0))
+            .register("reltuples", FLOAT, () -> constant(0.0f))
+            .register("relallvisible", INTEGER, () -> constant(0))
+            .register("reltoastrelid", INTEGER, () -> constant(0))
+            .register("relhasindex", BOOLEAN, () -> constant(false))
+            .register("relisshared", BOOLEAN, () -> constant(false))
+            .register("relpersistence", STRING, () -> constant(PERSISTENCE_PERMANENT))
+            .register("relkind", STRING, () -> forFunction(r -> r.relationType() == RelationType.VIEW ? KIND_VIEW : KIND_TABLE))
+            .register("relnatts", SHORT, () -> forFunction(r -> (short) r.columns().size()))
+            .register("relchecks", SHORT, () -> constant((short) 0))
+            .register("relhasoids", BOOLEAN, () -> constant(false))
+            .register("relhaspkey", BOOLEAN, () -> forFunction(r -> r.primaryKey().size() > 0))
+            .register("relhasrules", BOOLEAN, () -> constant(false))
+            .register("relhastriggers", BOOLEAN, () -> constant(false))
+            .register("relhassubclass", BOOLEAN, () -> constant(false))
+            .register("relrowsecurity", BOOLEAN, () -> constant(false))
+            .register("relforcerowsecurity", BOOLEAN, () -> constant(false))
+            .register("relispopulated", BOOLEAN, () -> constant(true))
+            .register("relreplident", STRING, () -> constant("p"))
+            .register("relispartition", BOOLEAN, () -> constant(false))
+            .register("relfrozenxid", INTEGER,() -> constant(0))
+            .register("relminmxid", INTEGER, () -> constant(0))
+            .register("relacl", new ArrayType(ObjectType.untyped()), () -> constant(null))
+            .register("reloptions", STRING_ARRAY, () -> constant(null))
+            .register("relpartbound", ObjectType.untyped(), () -> constant(null));
     }
 
     PgClassTable() {
-        super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register(Columns.OID.name(), DataTypes.INTEGER)
-                .register(Columns.RELNAME.name(), DataTypes.STRING)
-                .register(Columns.RELNAMESPACE.name(), DataTypes.INTEGER)
-                .register(Columns.RELTYPE.name(), DataTypes.INTEGER)
-                .register(Columns.RELOFTYPE.name(), DataTypes.INTEGER)
-                .register(Columns.RELOWNER.name(), DataTypes.INTEGER)
-                .register(Columns.RELAM.name(), DataTypes.INTEGER)
-                .register(Columns.RELFILENODE.name(), DataTypes.INTEGER)
-                .register(Columns.RELTABLESPACE.name(), DataTypes.INTEGER)
-                .register(Columns.RELPAGES.name(), DataTypes.INTEGER)
-                .register(Columns.RELTUPLES.name(), DataTypes.FLOAT)
-                .register(Columns.RELALLVISIBLE.name(), DataTypes.INTEGER)
-                .register(Columns.RELTOASTRELID.name(), DataTypes.INTEGER)
-                .register(Columns.RELHASINDEX.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELISSHARED.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELPERSISTENCE.name(), DataTypes.STRING)
-                .register(Columns.RELKIND.name(), DataTypes.STRING)
-                .register(Columns.RELNATTS.name(), DataTypes.SHORT)
-                .register(Columns.RELCHECKS.name(), DataTypes.SHORT)
-                .register(Columns.RELHASOIDS.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELHASPKEY.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELHASRULES.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELHASTRIGGERS.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELHASSUBCLASS.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELROWSECURITY.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELFORCEROWSECURITY.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELISPOPULATED.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELREPLIDENT.name(), DataTypes.STRING)
-                .register(Columns.RELISPARTITION.name(), DataTypes.BOOLEAN)
-                .register(Columns.RELFROZENXID.name(), DataTypes.INTEGER)
-                .register(Columns.RELMINMXID.name(), DataTypes.INTEGER)
-                .register(Columns.RELACL.name(), new ArrayType(ObjectType.untyped()))
-                .register(Columns.RELOPTIONS.name(), DataTypes.STRING_ARRAY)
-                .register(Columns.RELPARTBOUND.name(), ObjectType.untyped()),
-            Collections.emptyList());
+        super(IDENT, columnRegistrar());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
@@ -22,7 +22,6 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.Constants;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
@@ -34,84 +33,51 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 
 public class PgDatabaseTable extends StaticTableInfo {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_database");
 
-    static class Columns {
-        static final ColumnIdent OID = new ColumnIdent("oid");
-        static final ColumnIdent DATNAME = new ColumnIdent("datname");
-        static final ColumnIdent DATDBA = new ColumnIdent("datdba");
-        static final ColumnIdent ENCODING = new ColumnIdent("encoding");
-        static final ColumnIdent DATCOLLATE = new ColumnIdent("datcollate");
-        static final ColumnIdent DATCTYPE = new ColumnIdent("datctype");
-        static final ColumnIdent DATISTEMPLATE = new ColumnIdent("datistemplate");
-        static final ColumnIdent DATALLOWCONN = new ColumnIdent("datallowconn");
-        static final ColumnIdent DATCONNLIMIT = new ColumnIdent("datconnlimit");
-        static final ColumnIdent DATLASTSYSOID = new ColumnIdent("datlastsysoid");
-        static final ColumnIdent DATFROZENXID = new ColumnIdent("datfrozenxid");
-        static final ColumnIdent DATMINMXID = new ColumnIdent("datminmxid");
-        static final ColumnIdent DATTABLESPACE = new ColumnIdent("dattablespace");
-        static final ColumnIdent DATACL = new ColumnIdent("datacl");
+    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return columnRegistrar().expressions();
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
-            .put(Columns.OID, () -> constant(0))
-            .put(Columns.DATNAME, () -> constant(Constants.DB_NAME))
-
-            // Owner of the DB - our users don't have OIDs
-            .put(Columns.DATDBA, () -> constant(1))
-
-            // pg_encoding_to_char(6) -> UTF8
-            .put(Columns.ENCODING, () -> constant(6))
-            .put(Columns.DATCOLLATE, () -> constant("en_US.UTF-8"))
-            .put(Columns.DATCTYPE, () -> constant("en_US.UTF-8"))
-            .put(Columns.DATISTEMPLATE, () -> constant(false))
-            .put(Columns.DATALLOWCONN, () -> constant(true))
-            .put(Columns.DATCONNLIMIT, () -> constant(-1)) // no limit
-
+    @SuppressWarnings({"unchecked"})
+    private static ColumnRegistrar<Void> columnRegistrar() {
+        return new ColumnRegistrar<Void>(NAME, RowGranularity.DOC)
+            .register("oid", INTEGER, () -> constant(0))
+            .register("datname", STRING, () -> constant(Constants.DB_NAME))
+            .register("datdba", INTEGER, () -> constant(1))
+            .register("encoding", INTEGER, () -> constant(6))
+            .register("datcollate", STRING, () -> constant("en_US.UTF-8"))
+            .register("datctype", STRING, () -> constant("en_US.UTF-8"))
+            .register("datistemplate", BOOLEAN,() -> constant(false))
+            .register("datallowconn", BOOLEAN, () -> constant(true))
+            .register("datconnlimit", INTEGER,() -> constant(-1)) // no limit
             // We don't have any good values for these
-            .put(Columns.DATLASTSYSOID, () -> constant(null))
-            .put(Columns.DATFROZENXID, () -> constant(null))
-            .put(Columns.DATMINMXID, () -> constant(null))
-            .put(Columns.DATTABLESPACE, () -> constant(null))
-            .put(Columns.DATACL, () -> constant(null))
-            .build();
+            .register("datlastsysoid", INTEGER, () -> constant(null))
+            .register("datfrozenxid", INTEGER, () -> constant(null))
+            .register("datminmxid", INTEGER, () -> constant(null))
+            .register("dattablespace", INTEGER, () -> constant(null))
+            .register("datacl", STRING_ARRAY, () -> constant(null));
     }
-
 
     public PgDatabaseTable() {
-        super(NAME, new ColumnRegistrar(NAME, RowGranularity.DOC)
-            .register(Columns.OID, DataTypes.INTEGER)
-            .register(Columns.DATNAME, DataTypes.STRING)
-            .register(Columns.DATDBA, DataTypes.INTEGER)
-            .register(Columns.ENCODING, DataTypes.INTEGER)
-            .register(Columns.DATCOLLATE, DataTypes.STRING)
-            .register(Columns.DATCTYPE, DataTypes.STRING)
-            .register(Columns.DATISTEMPLATE, DataTypes.BOOLEAN)
-            .register(Columns.DATALLOWCONN, DataTypes.BOOLEAN)
-            .register(Columns.DATCONNLIMIT, DataTypes.INTEGER)
-            .register(Columns.DATLASTSYSOID, DataTypes.INTEGER)
-            .register(Columns.DATFROZENXID, DataTypes.INTEGER)
-            .register(Columns.DATMINMXID, DataTypes.INTEGER)
-            .register(Columns.DATTABLESPACE, DataTypes.INTEGER)
-            .register(Columns.DATACL, new ArrayType(DataTypes.STRING)),
-            Collections.emptyList()
-        );
+        super(NAME, columnRegistrar());
     }
 
     @Override
-    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause, RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
+    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause,
+                              RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
         return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
@@ -22,7 +22,6 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.ColumnIdent;
@@ -36,7 +35,6 @@ import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
@@ -45,34 +43,25 @@ public final class PgDescriptionTable extends StaticTableInfo {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_description");
 
-    static class Columns {
-        private static final ColumnIdent OBJOID = new ColumnIdent("objoid");
-        private static final ColumnIdent CLASSOID = new ColumnIdent("classoid");
-        private static final ColumnIdent OBJSUBID = new ColumnIdent("objsubid");
-        private static final ColumnIdent DESCRIPTION = new ColumnIdent("description");
-    }
-
     PgDescriptionTable() {
-        super(NAME, new ColumnRegistrar(NAME, RowGranularity.DOC)
-            .register(Columns.OBJOID, DataTypes.INTEGER)
-            .register(Columns.CLASSOID, DataTypes.INTEGER)
-            .register(Columns.OBJSUBID, DataTypes.INTEGER)
-            .register(Columns.DESCRIPTION, DataTypes.STRING),
-            Collections.emptyList()
-        );
+        super(NAME, columnRegistrar());
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
-            .put(Columns.OBJOID, () -> constant(null))
-            .put(Columns.CLASSOID, () -> constant(null))
-            .put(Columns.OBJSUBID, () -> constant(null))
-            .put(Columns.DESCRIPTION, () -> constant(null))
-            .build();
+    private static ColumnRegistrar<Void> columnRegistrar() {
+        return new ColumnRegistrar<Void>(NAME, RowGranularity.DOC)
+            .register("objoid", DataTypes.INTEGER, () -> constant(null))
+            .register("classoid", DataTypes.INTEGER, () -> constant(null))
+            .register("objsubid", DataTypes.INTEGER, () -> constant(null))
+            .register("description", DataTypes.STRING , () -> constant(null));
+    }
+
+    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return columnRegistrar().expressions();
     }
 
     @Override
-    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause, RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
+    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause,
+                              RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
         return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -22,10 +22,8 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
@@ -34,85 +32,52 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
+
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.SHORT_ARRAY;
+import static io.crate.types.DataTypes.INTEGER_ARRAY;
 
 public class PgIndexTable extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_index");
 
-    static class Columns {
-        static final ColumnIdent INDRELID = new ColumnIdent("indrelid");
-        static final ColumnIdent INDEXRELID = new ColumnIdent("indexrelid");
-        static final ColumnIdent INDNATTS = new ColumnIdent("indnatts");
-        static final ColumnIdent INDISUNIQUE = new ColumnIdent("indisunique");
-        static final ColumnIdent INDISPRIMARY = new ColumnIdent("indisprimary");
-        static final ColumnIdent INDISEXCLUSION = new ColumnIdent("indisexclusion");
-        static final ColumnIdent INDIMMEDIATE = new ColumnIdent("indimmediate");
-        static final ColumnIdent INDISCLUSTERED = new ColumnIdent("indisclustered");
-        static final ColumnIdent INDISVALID = new ColumnIdent("indisvalid");
-        static final ColumnIdent INDCHECKXMIN = new ColumnIdent("indcheckxmin");
-        static final ColumnIdent INDISREADY = new ColumnIdent("indisready");
-        static final ColumnIdent INDISLIVE = new ColumnIdent("indislive");
-        static final ColumnIdent INDISREPLIDENT = new ColumnIdent("indisreplident");
-        static final ColumnIdent INDKEY = new ColumnIdent("indkey");
-        static final ColumnIdent INDCOLLATION = new ColumnIdent("indcollation");
-        static final ColumnIdent INDCLASS = new ColumnIdent("indclass");
-        static final ColumnIdent INDOPTION = new ColumnIdent("indoption");
-        static final ColumnIdent INDEXPRS = new ColumnIdent("indexprs");
-        static final ColumnIdent INDPRED = new ColumnIdent("indpred");
+    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
+        return columnRegistrar().expressions();
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
-            .put(Columns.INDRELID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.INDEXRELID, () -> NestableCollectExpression.constant(0))
-            .put(Columns.INDNATTS, () -> NestableCollectExpression.constant((short) 0))
-            .put(Columns.INDISUNIQUE, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDISPRIMARY, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDISEXCLUSION, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDIMMEDIATE, () -> NestableCollectExpression.constant(true))
-            .put(Columns.INDISCLUSTERED, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDISVALID, () -> NestableCollectExpression.constant(true))
-            .put(Columns.INDCHECKXMIN, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDISREADY, () -> NestableCollectExpression.constant(true))
-            .put(Columns.INDISLIVE, () -> NestableCollectExpression.constant(true))
-            .put(Columns.INDISREPLIDENT, () -> NestableCollectExpression.constant(false))
-            .put(Columns.INDKEY, () -> NestableCollectExpression.constant((short) 0))
-            .put(Columns.INDCOLLATION, () -> NestableCollectExpression.constant(null))
-            .put(Columns.INDCLASS, () -> NestableCollectExpression.constant(null))
-            .put(Columns.INDOPTION, () -> NestableCollectExpression.constant(null))
-            .put(Columns.INDEXPRS, () -> NestableCollectExpression.constant(null))
-            .put(Columns.INDPRED, () -> NestableCollectExpression.constant(null))
-            .build();
+    @SuppressWarnings({"unchecked"})
+    private static ColumnRegistrar<Void> columnRegistrar() {
+        return new ColumnRegistrar<Void>(IDENT, RowGranularity.DOC)
+            .register("indrelid", INTEGER, () -> constant(0))
+            .register("indexrelid", INTEGER, () -> constant(0))
+            .register("indnatts", SHORT, () -> constant((short) 0))
+            .register("indisunique", BOOLEAN, () -> constant(false))
+            .register("indisprimary", BOOLEAN, () -> constant(false))
+            .register("indisexclusion", BOOLEAN, () -> constant(false))
+            .register("indimmediate", BOOLEAN, () -> constant(true))
+            .register("indisclustered", BOOLEAN, () -> constant(false))
+            .register("indisvalid", BOOLEAN, () -> constant(true))
+            .register("indcheckxmin", BOOLEAN, () -> constant(false))
+            .register("indisready", BOOLEAN, () -> constant(true))
+            .register("indislive", BOOLEAN, () -> constant(true))
+            .register("indisreplident", BOOLEAN, () -> constant(false))
+            .register("indkey", SHORT_ARRAY, () -> constant((short) 0))
+            .register("indcollation", INTEGER_ARRAY, () -> constant(null))
+            .register("indclass", INTEGER_ARRAY, () -> constant(null))
+            .register("indoption", SHORT_ARRAY, () -> constant(null))
+            .register("indexprs", ObjectType.untyped(), () -> constant(null))
+            .register("indpred", ObjectType.untyped(), () -> constant(null));
     }
 
     PgIndexTable() {
-        super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register(Columns.INDRELID.name(), DataTypes.INTEGER)
-                .register(Columns.INDEXRELID.name(), DataTypes.INTEGER)
-                .register(Columns.INDNATTS.name(), DataTypes.SHORT)
-                .register(Columns.INDISUNIQUE.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISPRIMARY.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISEXCLUSION.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDIMMEDIATE.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISCLUSTERED.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISVALID.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDCHECKXMIN.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISREADY.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISLIVE.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDISREPLIDENT.name(), DataTypes.BOOLEAN)
-                .register(Columns.INDKEY.name(), DataTypes.SHORT_ARRAY)
-                .register(Columns.INDCOLLATION.name(), DataTypes.INTEGER_ARRAY)
-                .register(Columns.INDCLASS.name(), DataTypes.INTEGER_ARRAY)
-                .register(Columns.INDOPTION.name(), DataTypes.SHORT_ARRAY)
-                .register(Columns.INDEXPRS.name(), ObjectType.untyped())
-                .register(Columns.INDPRED.name(), ObjectType.untyped()),
-            Collections.emptyList());
+        super(IDENT, columnRegistrar());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
@@ -24,7 +24,6 @@ package io.crate.metadata.pgcatalog;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
@@ -34,88 +33,50 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.settings.session.NamedSessionSetting;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static java.util.Map.entry;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.BOOLEAN;
 
 
 public class PgSettingsTable extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_settings");
 
-    static class Columns {
-        static final ColumnIdent NAME = new ColumnIdent("name");
-        static final ColumnIdent SETTING = new ColumnIdent("setting");
-        static final ColumnIdent UNIT = new ColumnIdent("unit");
-        static final ColumnIdent CATEGORY = new ColumnIdent("category");
-        static final ColumnIdent SHORT_DESC = new ColumnIdent("short_desc");
-        static final ColumnIdent EXTRA_DESC = new ColumnIdent("extra_desc");
-        static final ColumnIdent CONTEXT = new ColumnIdent("context");
-        static final ColumnIdent VARTYPE = new ColumnIdent("vartype");
-        static final ColumnIdent SOURCE = new ColumnIdent("source");
-        static final ColumnIdent ENUMVALS = new ColumnIdent("enumvals");
-        static final ColumnIdent MIN_VAL = new ColumnIdent("min_val");
-        static final ColumnIdent MAX_VAL = new ColumnIdent("max_val");
-        static final ColumnIdent BOOT_VAL = new ColumnIdent("boot_val");
-        static final ColumnIdent RESET_VAL = new ColumnIdent("reset_val");
-        static final ColumnIdent SOURCEFILE = new ColumnIdent("sourcefile");
-        static final ColumnIdent SOURCELINE = new ColumnIdent("sourceline");
-        static final ColumnIdent PENDING_RESTART = new ColumnIdent("pending_restart");
+    @SuppressWarnings({"unchecked"})
+    private static ColumnRegistrar<NamedSessionSetting> columnRegistrar() {
+        return new ColumnRegistrar<NamedSessionSetting>(IDENT, RowGranularity.DOC)
+            .register("name", STRING, () -> forFunction(NamedSessionSetting::name))
+            .register("setting", STRING, () -> forFunction(NamedSessionSetting::value))
+            .register("unit", STRING, () -> constant(null))
+            .register("category", STRING, () -> constant(null))
+            .register("short_desc", STRING, () -> forFunction(NamedSessionSetting::description))
+            .register("extra_desc", STRING, () -> constant(null))
+            .register("context", STRING, () -> constant(null))
+            .register("vartype", STRING, () -> forFunction(NamedSessionSetting::type))
+            .register("source", STRING, () -> constant(null))
+            .register("enumvals", STRING_ARRAY, () -> constant(null))
+            .register("min_val", STRING, () -> constant(null))
+            .register("max_val", STRING, () -> constant(null))
+            .register("boot_val", STRING, () -> forFunction(NamedSessionSetting::defaultValue))
+            .register("reset_val", STRING, () -> forFunction(NamedSessionSetting::defaultValue))
+            .register("sourcefile", STRING, () -> constant(null))
+            .register("sourceline", INTEGER, () -> constant(null))
+            .register("pending_restart", BOOLEAN, () -> constant(null));
     }
 
     PgSettingsTable() {
-        super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register(Columns.NAME.name(), DataTypes.STRING)
-                .register(Columns.SETTING.name(), DataTypes.STRING)
-                .register(Columns.UNIT.name(), DataTypes.STRING)
-                .register(Columns.CATEGORY.name(), DataTypes.STRING)
-                .register(Columns.SHORT_DESC.name(), DataTypes.STRING)
-                .register(Columns.EXTRA_DESC.name(), DataTypes.STRING)
-                .register(Columns.CONTEXT.name(), DataTypes.STRING)
-                .register(Columns.VARTYPE.name(), DataTypes.STRING)
-                .register(Columns.SOURCE.name(), DataTypes.STRING)
-                .register(Columns.ENUMVALS.name(), DataTypes.STRING_ARRAY)
-                .register(Columns.MIN_VAL.name(), DataTypes.STRING)
-                .register(Columns.MAX_VAL.name(), DataTypes.STRING)
-                .register(Columns.BOOT_VAL.name(), DataTypes.STRING)
-                .register(Columns.RESET_VAL.name(), DataTypes.STRING)
-                .register(Columns.SOURCEFILE.name(), DataTypes.STRING)
-                .register(Columns.SOURCELINE.name(), DataTypes.INTEGER)
-                .register(Columns.PENDING_RESTART.name(), DataTypes.BOOLEAN),
-            Collections.emptyList());
+        super(IDENT, columnRegistrar());
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<NamedSessionSetting>> expressions() {
-        return Map.ofEntries(
-            entry(Columns.NAME,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::name)),
-            entry(Columns.SETTING,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::value)),
-            entry(Columns.UNIT, () -> constant(null)),
-            entry(Columns.CATEGORY, () -> constant(null)),
-            entry(Columns.SHORT_DESC,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::description)),
-            entry(Columns.EXTRA_DESC, () -> constant(null)),
-            entry(Columns.CONTEXT, () -> constant(null)),
-            entry(Columns.VARTYPE,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::type)),
-            entry(Columns.ENUMVALS, () -> constant(null)),
-            entry(Columns.SOURCE, () -> constant(null)),
-            entry(Columns.MIN_VAL, () -> constant(null)),
-            entry(Columns.MAX_VAL, () -> constant(null)),
-            entry(Columns.BOOT_VAL,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::defaultValue)),
-            entry(Columns.RESET_VAL,
-                () -> NestableCollectExpression.forFunction(NamedSessionSetting::defaultValue)),
-            entry(Columns.SOURCEFILE, () -> constant(null)),
-            entry(Columns.SOURCELINE, () -> constant(null)),
-            entry(Columns.PENDING_RESTART, () -> constant(null))
-        );
+    static Map<ColumnIdent, RowCollectExpressionFactory<NamedSessionSetting>> expressions() {
+        return columnRegistrar().expressions();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -87,7 +87,7 @@ public class SysAllocationsTableInfo extends StaticTableInfo {
             .put(Columns.EXPLANATION,
                 () -> NestableCollectExpression.forFunction(SysAllocation::explanation))
             .put(Columns.DECISIONS,
-                () -> new SysAllocationDecisionsExpression<Map<String, Object>>() {
+                () -> new SysAllocationDecisionsExpression<>() {
 
                     @Override
                     protected Map<String, Object> valueForItem(SysAllocation.SysAllocationNodeDecision input) {

--- a/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
@@ -68,7 +68,6 @@ public class SysRepositoriesTableInfo extends StaticTableInfo {
             .build();
     }
 
-
     SysRepositoriesTableInfo() {
         super(IDENT, new ColumnRegistrar(IDENT, GRANULARITY)
             .register(Columns.NAME, DataTypes.STRING)

--- a/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
@@ -22,11 +22,8 @@
 
 package io.crate.metadata.sys;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
-import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
@@ -36,64 +33,39 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.execution.engine.collect.files.SummitsContext;
-import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterState;
 
-import java.util.List;
 import java.util.Map;
+
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.GEO_POINT;
 
 public class SysSummitsTableInfo extends StaticTableInfo {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "summits");
-    private static final List<ColumnIdent> PRIMARY_KEYS = ImmutableList.of(Columns.MOUNTAIN);
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;
 
-    public static class Columns {
-        static final ColumnIdent MOUNTAIN = new ColumnIdent("mountain");
-        static final ColumnIdent HEIGHT = new ColumnIdent("height");
-        static final ColumnIdent PROMINENCE = new ColumnIdent("prominence");
-        static final ColumnIdent COORDINATES = new ColumnIdent("coordinates");
-        static final ColumnIdent RANGE = new ColumnIdent("range");
-        static final ColumnIdent CLASSIFICATION = new ColumnIdent("classification");
-        static final ColumnIdent REGION = new ColumnIdent("region");
-        static final ColumnIdent COUNTRY = new ColumnIdent("country");
-        static final ColumnIdent FIRST_ASCENT = new ColumnIdent("first_ascent");
-    }
-
     public static Map<ColumnIdent, RowCollectExpressionFactory<SummitsContext>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<SummitsContext>>builder()
-            .put(SysSummitsTableInfo.Columns.MOUNTAIN,
-                () -> NestableCollectExpression.forFunction(SummitsContext::mountain))
-            .put(SysSummitsTableInfo.Columns.HEIGHT,
-                () -> NestableCollectExpression.forFunction(SummitsContext::height))
-            .put(SysSummitsTableInfo.Columns.PROMINENCE,
-                () -> NestableCollectExpression.forFunction(SummitsContext::prominence))
-            .put(SysSummitsTableInfo.Columns.COORDINATES,
-                () -> NestableCollectExpression.forFunction(SummitsContext::coordinates))
-            .put(SysSummitsTableInfo.Columns.RANGE,
-                () -> NestableCollectExpression.forFunction(SummitsContext::range))
-            .put(SysSummitsTableInfo.Columns.CLASSIFICATION,
-                () -> NestableCollectExpression.forFunction(SummitsContext::classification))
-            .put(SysSummitsTableInfo.Columns.REGION,
-                () -> NestableCollectExpression.forFunction(SummitsContext::region))
-            .put(SysSummitsTableInfo.Columns.COUNTRY,
-                () -> NestableCollectExpression.forFunction(SummitsContext::country))
-            .put(SysSummitsTableInfo.Columns.FIRST_ASCENT,
-                () -> NestableCollectExpression.forFunction(SummitsContext::firstAscent))
-            .build();
+        return columnRegistrar().expressions();
     }
 
     public SysSummitsTableInfo() {
-        super(IDENT, new ColumnRegistrar(IDENT, GRANULARITY)
-            .register(Columns.MOUNTAIN, DataTypes.STRING)
-            .register(Columns.HEIGHT, DataTypes.INTEGER)
-            .register(Columns.PROMINENCE, DataTypes.INTEGER)
-            .register(Columns.COORDINATES, DataTypes.GEO_POINT)
-            .register(Columns.RANGE, DataTypes.STRING)
-            .register(Columns.CLASSIFICATION, DataTypes.STRING)
-            .register(Columns.REGION, DataTypes.STRING)
-            .register(Columns.COUNTRY, DataTypes.STRING)
-            .register(Columns.FIRST_ASCENT, DataTypes.INTEGER), PRIMARY_KEYS);
+        super(IDENT, columnRegistrar(), "mountain");
+    }
+
+    private static ColumnRegistrar<SummitsContext> columnRegistrar() {
+        return new ColumnRegistrar<SummitsContext>(IDENT, GRANULARITY)
+            .register("mountain", STRING, () -> forFunction(SummitsContext::mountain))
+            .register("height", INTEGER, () -> forFunction(SummitsContext::height))
+            .register("prominence", INTEGER, () -> forFunction(SummitsContext::prominence))
+            .register("coordinates", GEO_POINT, () -> forFunction(SummitsContext::coordinates))
+            .register("range", STRING, () -> forFunction(SummitsContext::range))
+            .register("classification", STRING, () -> forFunction(SummitsContext::classification))
+            .register("region", STRING, () -> forFunction(SummitsContext::region))
+            .register("country", STRING, () -> forFunction(SummitsContext::country))
+            .register("first_ascent", INTEGER, () -> forFunction(SummitsContext::firstAscent));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -98,7 +98,7 @@ public class SysTableDefinitions {
             (user, allocation) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, allocation.fqn()),
             SysAllocationsTableInfo.expressions()
         ));
-
+    
         SummitsIterable summits = new SummitsIterable();
         tableDefinitions.put(SysSummitsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(summits),

--- a/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
@@ -27,12 +27,14 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import static io.crate.common.collections.Lists2.map;
 
 public abstract class StaticTableInfo implements TableInfo {
 
@@ -57,6 +59,10 @@ public abstract class StaticTableInfo implements TableInfo {
 
     public StaticTableInfo(RelationName ident, ColumnRegistrar columnRegistrar, List<ColumnIdent> primaryKey) {
         this(ident, columnRegistrar.infos(), columnRegistrar.columns(), primaryKey);
+    }
+
+    public StaticTableInfo(RelationName ident, ColumnRegistrar columnRegistrar, String... primaryKey) {
+        this(ident, columnRegistrar.infos(), columnRegistrar.columns(), map(Arrays.asList(primaryKey), ColumnIdent::new));
     }
 
     @Nullable

--- a/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -49,7 +49,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-
 public class NodeStatsTest extends SQLTransportIntegrationTest {
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
