### PR TITLE
Move forWireTransmission exception handling out of Session

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -302,7 +302,7 @@ public class Session implements AutoCloseable {
             }
         } catch (Throwable t) {
             jobsLogs.logPreExecutionFailure(UUID.randomUUID(), portal.getLastQuery(), SQLExceptions.messageOf(t), sessionContext.user());
-            throw SQLExceptions.forWireTransmission(accessControl, t);
+            throw t;
         }
     }
 
@@ -343,12 +343,8 @@ public class Session implements AutoCloseable {
                 if (preparedStmt.isRelationInitialized()) {
                     analyzedStatement = preparedStmt.analyzedStatement();
                 } else {
-                    try {
-                        analyzedStatement = analyzer.unboundAnalyze(statement, sessionContext, preparedStmt.paramTypes());
-                        preparedStmt.analyzedStatement(analyzedStatement);
-                    } catch (Throwable t) {
-                        throw SQLExceptions.forWireTransmission(accessControl, t);
-                    }
+                    analyzedStatement = analyzer.unboundAnalyze(statement, sessionContext, preparedStmt.paramTypes());
+                    preparedStmt.analyzedStatement(analyzedStatement);
                 }
                 if (analyzedStatement == null) {
                     // statement without result set -> return null for NoData msg

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -292,6 +292,9 @@ class PostgresWireProtocol {
                 dispatchState(buffer, channel);
             } catch (Throwable t) {
                 ignoreTillSync = true;
+                if (session != null) {
+                    t = SQLExceptions.forWireTransmission(getAccessControl.apply(session.sessionContext()), t);
+                }
                 try {
                     Messages.sendErrorResponse(channel, t);
                 } catch (Throwable ti) {

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -608,7 +608,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
             conn.setAutoCommit(true);
             PreparedStatement stmt = conn.prepareStatement("create table test(a integer)");
             expectedException.expect(PSQLException.class);
-            expectedException.expectMessage("ERROR: Only read operations are allowed on this node");
+            expectedException.expectMessage("Only read operations are allowed on this node");
             stmt.executeQuery();
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This makes the error handling in Session consistent. We've had 2 places
in the Session where an exception was wrapped with `forWireTransmission`
and a lot more where it wasn't. This removes the 2 places and instead
adds the handling to the `PostgresWireProtocol`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)