### PR TITLE
Backport some of s3 repository tests.

### DIFF
--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class AwsS3ServiceImplTests extends ESTestCase {
+
+    @Test
+    public void testSetDefaultCredential() {
+        final String awsAccessKey = randomAlphaOfLength(8);
+        final String awsSecretKey = randomAlphaOfLength(8);
+        final Settings settings = Settings.builder()
+            .put("access_key", awsAccessKey)
+            .put("secret_key", awsSecretKey).build();
+        final S3ClientSettings clientSettings = S3ClientSettings.getClientSettings(settings);
+        // test default exists and is an Instance provider
+        final AWSCredentialsProvider defaultCredentialsProvider = S3Service.buildCredentials(logger, clientSettings);
+        assertThat(defaultCredentialsProvider, instanceOf(StaticCredentialsProvider.class));
+        assertThat(defaultCredentialsProvider.getCredentials().getAWSAccessKeyId(), is(awsAccessKey));
+        assertThat(defaultCredentialsProvider.getCredentials().getAWSSecretKey(), is(awsSecretKey));
+    }
+
+    @Test
+    public void testAWSDefaultConfiguration() {
+        launchAWSConfigurationTest(Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, 3,
+                                   ClientConfiguration.DEFAULT_THROTTLE_RETRIES, ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
+    }
+
+    @Test
+    public void testAWSConfigurationWithAwsSettings() {
+        final Settings settings = Settings.builder()
+            .put("proxy_username", "aws_proxy_username")
+            .put("proxy_password", "aws_proxy_password")
+            .put("protocol", "http")
+            .put("proxy_host", "aws_proxy_host")
+            .put("proxy_port", 8080)
+            .put("read_timeout", "10s")
+            .build();
+        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
+            "aws_proxy_password", 3, ClientConfiguration.DEFAULT_THROTTLE_RETRIES, 10000);
+    }
+
+    @Test
+    public void testRepositoryMaxRetries() {
+        final Settings settings = Settings.builder()
+            .put("max_retries", 5)
+            .build();
+        launchAWSConfigurationTest(
+            settings, Protocol.HTTPS, null, -1, null,
+            null, 5, ClientConfiguration.DEFAULT_THROTTLE_RETRIES, 50000);
+    }
+
+    @Test
+    public void testRepositoryThrottleRetries() {
+        final boolean throttling = randomBoolean();
+
+        final Settings settings = Settings.builder().put("use_throttle_retries", throttling).build();
+        launchAWSConfigurationTest(settings, Protocol.HTTPS, null, -1, null, null, 3, throttling, 50000);
+    }
+
+    private void launchAWSConfigurationTest(Settings settings,
+                                            Protocol expectedProtocol,
+                                            String expectedProxyHost,
+                                            int expectedProxyPort,
+                                            String expectedProxyUsername,
+                                            String expectedProxyPassword,
+                                            Integer expectedMaxRetries,
+                                            boolean expectedUseThrottleRetries,
+                                            int expectedReadTimeout) {
+
+        final S3ClientSettings clientSettings = S3ClientSettings.getClientSettings(settings);
+        final ClientConfiguration configuration = S3Service.buildConfiguration(clientSettings);
+
+        assertThat(configuration.getResponseMetadataCacheSize(), is(0));
+        assertThat(configuration.getProtocol(), is(expectedProtocol));
+        assertThat(configuration.getProxyHost(), is(expectedProxyHost));
+        assertThat(configuration.getProxyPort(), is(expectedProxyPort));
+        assertThat(configuration.getProxyUsername(), is(expectedProxyUsername));
+        assertThat(configuration.getProxyPassword(), is(expectedProxyPassword));
+        assertThat(configuration.getMaxErrorRetry(), is(expectedMaxRetries));
+        assertThat(configuration.useThrottledRetries(), is(expectedUseThrottleRetries));
+        assertThat(configuration.getSocketTimeout(), is(expectedReadTimeout));
+    }
+}

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AbstractAmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
+import com.amazonaws.services.s3.model.HeadBucketResult;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.Streams;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class MockAmazonS3 extends AbstractAmazonS3 {
+
+    private final ConcurrentMap<String, byte[]> blobs;
+    private final String bucket;
+    private final boolean serverSideEncryption;
+    private final String cannedACL;
+    private final String storageClass;
+
+    MockAmazonS3(final ConcurrentMap<String, byte[]> blobs,
+                 final String bucket,
+                 final boolean serverSideEncryption,
+                 final String cannedACL,
+                 final String storageClass) {
+        this.blobs = Objects.requireNonNull(blobs);
+        this.bucket = Objects.requireNonNull(bucket);
+        this.serverSideEncryption = serverSideEncryption;
+        this.cannedACL = cannedACL;
+        this.storageClass = storageClass;
+    }
+
+    @Override
+    public boolean doesObjectExist(final String bucketName, final String objectName) throws SdkClientException {
+        assertThat(bucketName, equalTo(bucket));
+        return blobs.containsKey(objectName);
+    }
+
+    @Override
+    public PutObjectResult putObject(final PutObjectRequest request) throws AmazonClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+        assertThat(request.getMetadata().getSSEAlgorithm(), serverSideEncryption ? equalTo("AES256") : nullValue());
+        assertThat(request.getCannedAcl(), notNullValue());
+        assertThat(request.getCannedAcl().toString(), cannedACL != null ? equalTo(cannedACL) : equalTo("private"));
+        assertThat(request.getStorageClass(), storageClass != null ? equalTo(storageClass) : equalTo("STANDARD"));
+
+
+        final String blobName = request.getKey();
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            Streams.copy(request.getInputStream(), out);
+            blobs.put(blobName, out.toByteArray());
+        } catch (IOException e) {
+            throw new AmazonClientException(e);
+        }
+        return new PutObjectResult();
+    }
+
+    @Override
+    public S3Object getObject(final GetObjectRequest request) throws AmazonClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+
+        final String blobName = request.getKey();
+        final byte[] content = blobs.get(blobName);
+        if (content == null) {
+            AmazonS3Exception exception = new AmazonS3Exception("[" + blobName + "] does not exist.");
+            exception.setStatusCode(404);
+            throw exception;
+        }
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(content.length);
+
+        S3Object s3Object = new S3Object();
+        s3Object.setObjectContent(new S3ObjectInputStream(new ByteArrayInputStream(content), null, false));
+        s3Object.setKey(blobName);
+        s3Object.setObjectMetadata(metadata);
+
+        return s3Object;
+    }
+
+    @Override
+    public ObjectListing listObjects(final ListObjectsRequest request) throws AmazonClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+
+        final ObjectListing listing = new ObjectListing();
+        listing.setBucketName(request.getBucketName());
+        listing.setPrefix(request.getPrefix());
+
+        for (Map.Entry<String, byte[]> blob : blobs.entrySet()) {
+            if (Strings.isEmpty(request.getPrefix()) || blob.getKey().startsWith(request.getPrefix())) {
+                S3ObjectSummary summary = new S3ObjectSummary();
+                summary.setBucketName(request.getBucketName());
+                summary.setKey(blob.getKey());
+                summary.setSize(blob.getValue().length);
+                listing.getObjectSummaries().add(summary);
+            }
+        }
+        return listing;
+    }
+
+    @Override
+    public HeadBucketResult headBucket(HeadBucketRequest request) throws SdkClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+        return new HeadBucketResult();
+    }
+
+    @Override
+    public void deleteObject(final DeleteObjectRequest request) throws AmazonClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+        blobs.remove(request.getKey());
+    }
+
+    @Override
+    public void shutdown() {
+        // TODO check close
+    }
+
+    @Override
+    public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) throws SdkClientException {
+        assertThat(request.getBucketName(), equalTo(bucket));
+
+        final List<DeleteObjectsResult.DeletedObject> deletions = new ArrayList<>();
+        for (DeleteObjectsRequest.KeyVersion key : request.getKeys()) {
+            if (blobs.remove(key.getKey()) != null) {
+                DeleteObjectsResult.DeletedObject deletion = new DeleteObjectsResult.DeletedObject();
+                deletion.setKey(key.getKey());
+                deletions.add(deletion);
+            }
+        }
+        return new DeleteObjectsResult(deletions);
+    }
+}

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.repositories.s3.S3BlobStoreTests.randomMockS3BlobStore;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    protected BlobStore newBlobStore() {
+        return randomMockS3BlobStore();
+    }
+
+    @Override
+    @Test
+    public void testDeleteBlob() {
+        assumeFalse("not implemented because of S3's weak consistency model", true);
+    }
+
+    @Override
+    @Test
+    public void testVerifyOverwriteFails() {
+        assumeFalse("not implemented because of S3's weak consistency model", true);
+    }
+
+    @Test
+    public void testExecuteSingleUploadBlobSizeTooLarge() throws IOException {
+        final long blobSize = ByteSizeUnit.GB.toBytes(randomIntBetween(6, 10));
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("can't be larger than 5gb"));
+        blobContainer.executeSingleUpload(blobStore, randomAlphaOfLengthBetween(1, 10), null, blobSize);
+    }
+
+    @Test
+    public void testExecuteSingleUploadBlobSizeLargerThanBufferSize() throws IOException {
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bufferSizeInBytes()).thenReturn(ByteSizeUnit.MB.toBytes(1));
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("can't be larger than buffer size"));
+        blobContainer.executeSingleUpload(blobStore, blobName, new ByteArrayInputStream(new byte[0]), ByteSizeUnit.MB.toBytes(2));
+    }
+
+    @Test
+    public void testExecuteSingleUpload() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+
+        final BlobPath blobPath = new BlobPath();
+        if (randomBoolean()) {
+            IntStream.of(randomIntBetween(1, 5)).forEach(value -> blobPath.add("path_" + value));
+        }
+
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final int blobSize = randomIntBetween(0, bufferSize);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        final boolean serverSideEncryption = randomBoolean();
+        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+
+        final StorageClass storageClass = randomFrom(StorageClass.values());
+        when(blobStore.getStorageClass()).thenReturn(storageClass);
+
+        final CannedAccessControlList cannedAccessControlList = randomBoolean() ? randomFrom(CannedAccessControlList.values()) : null;
+        if (cannedAccessControlList != null) {
+            when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
+        }
+
+        final AmazonS3 client = mock(AmazonS3.class);
+        final AmazonS3Reference clientReference = new AmazonS3Reference(client);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+
+        final ArgumentCaptor<PutObjectRequest> argumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        when(client.putObject(argumentCaptor.capture())).thenReturn(new PutObjectResult());
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[blobSize]);
+        blobContainer.executeSingleUpload(blobStore, blobName, inputStream, blobSize);
+
+        final PutObjectRequest request = argumentCaptor.getValue();
+        assertEquals(bucketName, request.getBucketName());
+        assertEquals(blobPath.buildAsString() + blobName, request.getKey());
+        assertEquals(inputStream, request.getInputStream());
+        assertEquals(blobSize, request.getMetadata().getContentLength());
+        assertEquals(storageClass.toString(), request.getStorageClass());
+        assertEquals(cannedAccessControlList, request.getCannedAcl());
+        if (serverSideEncryption) {
+            assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, request.getMetadata().getSSEAlgorithm());
+        }
+    }
+
+    @Test
+    public void testExecuteMultipartUploadBlobSizeTooLarge() throws IOException {
+        final long blobSize = ByteSizeUnit.TB.toBytes(randomIntBetween(6, 10));
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("can't be larger than 5tb"));
+        blobContainer.executeMultipartUpload(blobStore, randomAlphaOfLengthBetween(1, 10), null, blobSize);
+    }
+
+    @Test
+    public void testExecuteMultipartUploadBlobSizeTooSmall() throws IOException {
+        final long blobSize = ByteSizeUnit.MB.toBytes(randomIntBetween(1, 4));
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("can't be smaller than 5mb"));
+        blobContainer.executeMultipartUpload(blobStore, randomAlphaOfLengthBetween(1, 10), null, blobSize);
+    }
+
+    @Test
+    public void testExecuteMultipartUpload() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+
+        final BlobPath blobPath = new BlobPath();
+        if (randomBoolean()) {
+            IntStream.of(randomIntBetween(1, 5)).forEach(value -> blobPath.add("path_" + value));
+        }
+
+        final long blobSize = ByteSizeUnit.GB.toBytes(randomIntBetween(1, 128));
+        final long bufferSize =  ByteSizeUnit.MB.toBytes(randomIntBetween(5, 1024));
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
+
+        final boolean serverSideEncryption = randomBoolean();
+        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+
+        final StorageClass storageClass = randomFrom(StorageClass.values());
+        when(blobStore.getStorageClass()).thenReturn(storageClass);
+
+        final CannedAccessControlList cannedAccessControlList = randomBoolean() ? randomFrom(CannedAccessControlList.values()) : null;
+        if (cannedAccessControlList != null) {
+            when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
+        }
+
+        final AmazonS3 client = mock(AmazonS3.class);
+        final AmazonS3Reference clientReference = new AmazonS3Reference(client);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+
+        final ArgumentCaptor<InitiateMultipartUploadRequest> initArgCaptor = ArgumentCaptor.forClass(InitiateMultipartUploadRequest.class);
+        final InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
+        initResult.setUploadId(randomAlphaOfLength(10));
+        when(client.initiateMultipartUpload(initArgCaptor.capture())).thenReturn(initResult);
+
+        final ArgumentCaptor<UploadPartRequest> uploadArgCaptor = ArgumentCaptor.forClass(UploadPartRequest.class);
+
+        final List<String> expectedEtags = new ArrayList<>();
+        final long partSize = Math.min(bufferSize, blobSize);
+        long totalBytes = 0;
+        do {
+            expectedEtags.add(randomAlphaOfLength(50));
+            totalBytes += partSize;
+        } while (totalBytes < blobSize);
+
+        when(client.uploadPart(uploadArgCaptor.capture())).thenAnswer(invocationOnMock -> {
+            final UploadPartRequest request = (UploadPartRequest) invocationOnMock.getArguments()[0];
+            final UploadPartResult response = new UploadPartResult();
+            response.setPartNumber(request.getPartNumber());
+            response.setETag(expectedEtags.get(request.getPartNumber() - 1));
+            return response;
+        });
+
+        final ArgumentCaptor<CompleteMultipartUploadRequest> compArgCaptor = ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+        when(client.completeMultipartUpload(compArgCaptor.capture())).thenReturn(new CompleteMultipartUploadResult());
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+        blobContainer.executeMultipartUpload(blobStore, blobName, inputStream, blobSize);
+
+        final InitiateMultipartUploadRequest initRequest = initArgCaptor.getValue();
+        assertEquals(bucketName, initRequest.getBucketName());
+        assertEquals(blobPath.buildAsString() + blobName, initRequest.getKey());
+        assertEquals(storageClass, initRequest.getStorageClass());
+        assertEquals(cannedAccessControlList, initRequest.getCannedACL());
+        if (serverSideEncryption) {
+            assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, initRequest.getObjectMetadata().getSSEAlgorithm());
+        }
+
+        final Tuple<Long, Long> numberOfParts = S3BlobContainer.numberOfMultiparts(blobSize, bufferSize);
+
+        final List<UploadPartRequest> uploadRequests = uploadArgCaptor.getAllValues();
+        assertEquals(numberOfParts.v1().intValue(), uploadRequests.size());
+
+        for (int i = 0; i < uploadRequests.size(); i++) {
+            final UploadPartRequest uploadRequest = uploadRequests.get(i);
+
+            assertEquals(bucketName, uploadRequest.getBucketName());
+            assertEquals(blobPath.buildAsString() + blobName, uploadRequest.getKey());
+            assertEquals(initResult.getUploadId(), uploadRequest.getUploadId());
+            assertEquals(i + 1, uploadRequest.getPartNumber());
+            assertEquals(inputStream, uploadRequest.getInputStream());
+
+            if (i == (uploadRequests.size() -1)) {
+                assertTrue(uploadRequest.isLastPart());
+                assertEquals(numberOfParts.v2().longValue(), uploadRequest.getPartSize());
+            } else {
+                assertFalse(uploadRequest.isLastPart());
+                assertEquals(bufferSize, uploadRequest.getPartSize());
+            }
+        }
+
+        final CompleteMultipartUploadRequest compRequest = compArgCaptor.getValue();
+        assertEquals(bucketName, compRequest.getBucketName());
+        assertEquals(blobPath.buildAsString() + blobName, compRequest.getKey());
+        assertEquals(initResult.getUploadId(), compRequest.getUploadId());
+
+        final List<String> actualETags = compRequest.getPartETags().stream().map(PartETag::getETag).collect(Collectors.toList());
+        assertEquals(expectedEtags, actualETags);
+    }
+
+    @Test
+    public void testExecuteMultipartUploadAborted() {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final BlobPath blobPath = new BlobPath();
+
+        final long blobSize = ByteSizeUnit.MB.toBytes(765);
+        final long bufferSize =  ByteSizeUnit.MB.toBytes(150);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
+        when(blobStore.getStorageClass()).thenReturn(randomFrom(StorageClass.values()));
+
+        final AmazonS3 client = mock(AmazonS3.class);
+        final AmazonS3Reference clientReference = new AmazonS3Reference(client);
+        doAnswer(invocation -> {
+            clientReference.incRef();
+            return clientReference;
+        }).when(blobStore).clientReference();
+
+        final String uploadId = randomAlphaOfLength(25);
+
+        final int stage = randomInt(2);
+        final List<AmazonClientException> exceptions = Arrays.asList(
+            new AmazonClientException("Expected initialization request to fail"),
+            new AmazonClientException("Expected upload part request to fail"),
+            new AmazonClientException("Expected completion request to fail")
+        );
+
+        if (stage == 0) {
+            // Fail the initialization request
+            when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+                .thenThrow(exceptions.get(stage));
+
+        } else if (stage == 1) {
+            final InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
+            initResult.setUploadId(uploadId);
+            when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenReturn(initResult);
+
+            // Fail the upload part request
+            when(client.uploadPart(any(UploadPartRequest.class)))
+                .thenThrow(exceptions.get(stage));
+
+        } else {
+            final InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
+            initResult.setUploadId(uploadId);
+            when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenReturn(initResult);
+
+            when(client.uploadPart(any(UploadPartRequest.class))).thenAnswer(invocationOnMock -> {
+                final UploadPartRequest request = (UploadPartRequest) invocationOnMock.getArguments()[0];
+                final UploadPartResult response = new UploadPartResult();
+                response.setPartNumber(request.getPartNumber());
+                response.setETag(randomAlphaOfLength(20));
+                return response;
+            });
+
+            // Fail the completion request
+            when(client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenThrow(exceptions.get(stage));
+        }
+
+        final ArgumentCaptor<AbortMultipartUploadRequest> argumentCaptor = ArgumentCaptor.forClass(AbortMultipartUploadRequest.class);
+        doNothing().when(client).abortMultipartUpload(argumentCaptor.capture());
+
+        final IOException e = expectThrows(IOException.class, () -> {
+            final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+            blobContainer.executeMultipartUpload(blobStore, blobName, new ByteArrayInputStream(new byte[0]), blobSize);
+        });
+
+        assertEquals("Unable to upload object [" + blobName + "] using multipart upload", e.getMessage());
+        assertThat(e.getCause(), instanceOf(AmazonClientException.class));
+        assertEquals(exceptions.get(stage).getMessage(), e.getCause().getMessage());
+
+        if (stage == 0) {
+            verify(client, times(1)).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+            verify(client, times(0)).uploadPart(any(UploadPartRequest.class));
+            verify(client, times(0)).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+            verify(client, times(0)).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+        } else {
+            verify(client, times(1)).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+
+            if (stage == 1) {
+                verify(client, times(1)).uploadPart(any(UploadPartRequest.class));
+                verify(client, times(0)).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+            } else {
+                verify(client, times(6)).uploadPart(any(UploadPartRequest.class));
+                verify(client, times(1)).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+            }
+
+            verify(client, times(1)).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+            final AbortMultipartUploadRequest abortRequest = argumentCaptor.getValue();
+            assertEquals(bucketName, abortRequest.getBucketName());
+            assertEquals(blobName, abortRequest.getKey());
+            assertEquals(uploadId, abortRequest.getUploadId());
+        }
+    }
+
+    @Test
+    public void testNumberOfMultipartsWithZeroPartSize() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("Part size must be greater than zero"));
+        S3BlobContainer.numberOfMultiparts(randomNonNegativeLong(), 0L);
+    }
+
+    @Test
+    public void testNumberOfMultiparts() {
+        final ByteSizeUnit unit = randomFrom(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB, ByteSizeUnit.GB);
+        final long size = unit.toBytes(randomIntBetween(2, 1000));
+        final int factor = randomIntBetween(2, 10);
+
+        // Fits in 1 empty part
+        assertNumberOfMultiparts(1, 0L, 0L, size);
+
+        // Fits in 1 part exactly
+        assertNumberOfMultiparts(1, size, size, size);
+        assertNumberOfMultiparts(1, size, size, size * factor);
+
+        // Fits in N parts exactly
+        assertNumberOfMultiparts(factor, size, size * factor, size);
+
+        // Fits in N parts plus a bit more
+        final long remaining = randomIntBetween(1, (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size - 1);
+        assertNumberOfMultiparts(factor + 1, remaining, (size * factor) + remaining, size);
+    }
+
+    private static void assertNumberOfMultiparts(final int expectedParts, final long expectedRemaining, long totalSize, long partSize) {
+        final Tuple<Long, Long> result = S3BlobContainer.numberOfMultiparts(totalSize, partSize);
+
+        assertEquals("Expected number of parts [" + expectedParts + "] but got [" + result.v1() + "]", expectedParts, (long) result.v1());
+        assertEquals("Expected remaining [" + expectedRemaining + "] but got [" + result.v2() + "]", expectedRemaining, (long) result.v2());
+    }
+}

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.StorageClass;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.blobstore.BlobStoreException;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.repositories.ESBlobStoreTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class S3BlobStoreTests extends ESBlobStoreTestCase {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Override
+    protected BlobStore newBlobStore() {
+        return randomMockS3BlobStore();
+    }
+
+    @Test
+    public void testInitCannedACL() {
+        String[] aclList = new String[]{
+                "private", "public-read", "public-read-write", "authenticated-read",
+                "log-delivery-write", "bucket-owner-read", "bucket-owner-full-control"};
+
+        //empty acl
+        assertThat(S3BlobStore.initCannedACL(null), equalTo(CannedAccessControlList.Private));
+        assertThat(S3BlobStore.initCannedACL(""), equalTo(CannedAccessControlList.Private));
+
+        // it should init cannedACL correctly
+        for (String aclString : aclList) {
+            CannedAccessControlList acl = S3BlobStore.initCannedACL(aclString);
+            assertThat(acl.toString(), equalTo(aclString));
+        }
+
+        // it should accept all aws cannedACLs
+        for (CannedAccessControlList awsList : CannedAccessControlList.values()) {
+            CannedAccessControlList acl = S3BlobStore.initCannedACL(awsList.toString());
+            assertThat(acl, equalTo(awsList));
+        }
+    }
+
+    @Test
+    public void testInvalidCannedACL() {
+        expectedException.expect(BlobStoreException.class);
+        expectedException.expectMessage("cannedACL is not valid: [test_invalid]");
+        S3BlobStore.initCannedACL("test_invalid");
+    }
+
+    @Test
+    public void testInitStorageClass() {
+        // it should default to `standard`
+        assertThat(S3BlobStore.initStorageClass(null), equalTo(StorageClass.Standard));
+        assertThat(S3BlobStore.initStorageClass(""), equalTo(StorageClass.Standard));
+
+        // it should accept [standard, standard_ia, reduced_redundancy]
+        assertThat(S3BlobStore.initStorageClass("standard"), equalTo(StorageClass.Standard));
+        assertThat(S3BlobStore.initStorageClass("standard_ia"), equalTo(StorageClass.StandardInfrequentAccess));
+        assertThat(S3BlobStore.initStorageClass("reduced_redundancy"), equalTo(StorageClass.ReducedRedundancy));
+    }
+
+    @Test
+    public void testCaseInsensitiveStorageClass() {
+        assertThat(S3BlobStore.initStorageClass("sTandaRd"), equalTo(StorageClass.Standard));
+        assertThat(S3BlobStore.initStorageClass("sTandaRd_Ia"), equalTo(StorageClass.StandardInfrequentAccess));
+        assertThat(S3BlobStore.initStorageClass("reduCED_redundancy"), equalTo(StorageClass.ReducedRedundancy));
+    }
+
+    @Test
+    public void testInvalidStorageClass() {
+        expectedException.expect(BlobStoreException.class);
+        expectedException.expectMessage("`whatever` is not a valid S3 Storage Class.");
+        S3BlobStore.initStorageClass("whatever");
+    }
+
+    @Test
+    public void testRejectGlacierStorageClass() {
+        expectedException.expect(BlobStoreException.class);
+        expectedException.expectMessage("Glacier storage class is not supported");
+        S3BlobStore.initStorageClass("glacier");
+    }
+
+    /**
+     * Creates a new {@link S3BlobStore} with random settings.
+     * <p>
+     * The blobstore uses a {@link MockAmazonS3} client.
+     */
+    public static S3BlobStore randomMockS3BlobStore() {
+        String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        ByteSizeValue bufferSize = new ByteSizeValue(randomIntBetween(5, 100), ByteSizeUnit.MB);
+        boolean serverSideEncryption = randomBoolean();
+
+        String cannedACL = null;
+        if (randomBoolean()) {
+            cannedACL = randomFrom(CannedAccessControlList.values()).toString();
+        }
+
+        String storageClass = null;
+        if (randomBoolean()) {
+            storageClass = randomValueOtherThan(
+                StorageClass.Glacier,
+                () -> randomFrom(StorageClass.values())).toString();
+        }
+
+        final AmazonS3 client = new MockAmazonS3(new ConcurrentHashMap<>(), bucket, serverSideEncryption, cannedACL, storageClass);
+        final S3Service service = new S3Service() {
+            @Override
+            public synchronized AmazonS3Reference client(String name) {
+                return new AmazonS3Reference(client);
+            }
+        };
+        return new S3BlobStore(
+            service, "default", bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
+    }
+}

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.services.s3.AbstractAmazonS3;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.repositories.RepositoryException;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class S3RepositoryTests extends ESTestCase {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static class DummyS3Client extends AbstractAmazonS3 {
+
+        @Override
+        public void shutdown() {
+            // TODO check is closed
+        }
+    }
+
+    private static class DummyS3Service extends S3Service {
+        @Override
+        public AmazonS3Reference client(String repositoryMetaData) {
+            return new AmazonS3Reference(new DummyS3Client());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    @Test
+    public void testCreateRepositoryWithValidChunkBufferSizeSettings() {
+        // chunk > buffer should pass
+        final Settings s2 = bufferAndChunkSettings(5, 10);
+        createS3Repo(getRepositoryMetaData(s2)).close();
+        // chunk = buffer should pass
+        final Settings s3 = bufferAndChunkSettings(5, 5);
+        createS3Repo(getRepositoryMetaData(s3)).close();
+    }
+
+    @Test
+    public void testCreateRepositoryWithChunkSmallerThanBufferSize() {
+        expectedException.expect(RepositoryException.class);
+        expectedException.expectMessage("chunk_size (5mb) can't be lower than buffer_size (10mb)");
+        createS3Repo(getRepositoryMetaData(bufferAndChunkSettings(10, 5)));
+    }
+
+    @Test
+    public void testCreateRepositoryWithBufferSizeSmallerThan5mb() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("failed to parse value [4mb] for setting [buffer_size], must be >= [5mb]");
+        createS3Repo(getRepositoryMetaData(bufferAndChunkSettings(4, 10)));
+    }
+
+    @Test
+    public void testCreateRepositoryWithChunkSizeGreaterThan5tb() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("failed to parse value [6000000mb] for setting [chunk_size], must be <= [5tb]");
+        createS3Repo(getRepositoryMetaData(bufferAndChunkSettings(5, 6000000)));
+    }
+
+    private Settings bufferAndChunkSettings(long buffer, long chunk) {
+        return Settings.builder()
+            .put(S3RepositorySettings.BUFFER_SIZE_SETTING.getKey(),
+                 new ByteSizeValue(buffer, ByteSizeUnit.MB).getStringRep())
+            .put(S3RepositorySettings.CHUNK_SIZE_SETTING.getKey(),
+                 new ByteSizeValue(chunk, ByteSizeUnit.MB).getStringRep())
+            .build();
+    }
+
+    private RepositoryMetaData getRepositoryMetaData(Settings settings) {
+        return new RepositoryMetaData("dummy-repo", "mock", Settings.builder().put(settings).build());
+    }
+
+    @Test
+    public void testBasePathSetting() {
+        final RepositoryMetaData metadata = new RepositoryMetaData("dummy-repo", "mock", Settings.builder()
+            .put(S3RepositorySettings.BASE_PATH_SETTING.getKey(), "foo/bar").build());
+        try (S3Repository s3repo = createS3Repo(metadata)) {
+            assertEquals("foo/bar/", s3repo.basePath().buildAsString());
+        }
+    }
+
+    private S3Repository createS3Repo(RepositoryMetaData metadata) {
+        return new S3Repository(metadata, Settings.EMPTY, NamedXContentRegistry.EMPTY, new DummyS3Service()) {
+            @Override
+            protected void assertSnapshotOrGenericThread() {
+                // eliminate thread name check as we create repo manually on test/main threads
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of some tests for s3 blob store, blob store container, and repository.
We have only tests for the repository client settings, it would be nice to have some
additional test before cleaning up some obsolete code in s3 repository impl.



## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
