### PR TITLE
Use optimized bulk execution if applicable for batched deferredExecutions

### DIFF
--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -294,13 +294,13 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(session.portals.size(), is(2));
         assertThat(session.preparedStatements.size(), is(2));
-        assertThat(session.deferredExecutions.size(), is(1));
+        assertThat(session.deferredExecutionsByStmt.size(), is(1));
 
         session.close();
 
         assertThat(session.portals.size(), is(0));
         assertThat(session.preparedStatements.size(), is(0));
-        assertThat(session.deferredExecutions.size(), is(0));
+        assertThat(session.deferredExecutionsByStmt.size(), is(0));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.Session;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.auth.user.AccessControl;
+import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.engine.collect.stats.JobsLogs;
@@ -42,20 +43,25 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 import org.mockito.Answers;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
-    public void testEachStatementReceivesCorrectParams() throws IOException {
-        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+    public void testEachStatementReceivesCorrectParams() throws Throwable {
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (x int)")
+            .build();
 
-        AtomicReference<Row> lastParams = new AtomicReference<>();
         Plan insertPlan = new Plan() {
             @Override
             public StatementType type() {
@@ -68,7 +74,7 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
                                       RowConsumer consumer,
                                       Row params,
                                       SubQueryResults subQueryResults) {
-                lastParams.set(params);
+                consumer.accept(InMemoryBatchIterator.of(params, null), null);
             }
         };
         Planner planner = new Planner(Settings.EMPTY, clusterService, sqlExecutor.functions(), new TableStats(), () -> true) {
@@ -90,13 +96,26 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
 
         session.parse("S_1", "insert into t1(x) values(1)", Collections.emptyList());
         session.bind("Portal", "S_1", Collections.emptyList(), null);
-        session.execute("Portal", 0, new BaseResultReceiver());
+        final ArrayList<Object[]> s1Rows = new ArrayList<>();
+        session.execute("Portal", 0, new BaseResultReceiver() {
+            @Override
+            public void setNextRow(Row row) {
+                s1Rows.add(row.materialize());
+            }
+        });
 
         session.parse("S_2", "insert into t1(x) values(?)", Collections.emptyList());
         session.bind("Portal", "S_2", Collections.singletonList(2), null);
-        session.execute("Portal", 0, new BaseResultReceiver());
-        session.sync();
+        final ArrayList<Object[]> s2Rows = new ArrayList<>();
+        session.execute("Portal", 0, new BaseResultReceiver() {
+            @Override
+            public void setNextRow(Row row) {
+                s2Rows.add(row.materialize());
+            }
+        });
+        session.sync().get(5, TimeUnit.SECONDS);
 
-        assertThat(lastParams.get().get(0), is(2));
+        assertThat(s1Rows, contains(emptyArray()));
+        assertThat(s2Rows, contains(arrayContaining(is(2))));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If we have a case like:

    addBatch(STMT1, args1)
    addBatch(STMT2, args2)
    addBatch(STMT2, args3)

We can execute STMT2 using the bulk processing functionality.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
