### PR TITLE
Extend JMH benchmarks for group by operations

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/NumericDocValuesReference.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/NumericDocValuesReference.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+
+import java.io.IOException;
+
+public class NumericDocValuesReference extends LuceneCollectorExpression<Long> {
+
+    private final String columnName;
+    private NumericDocValues values;
+    private Long value;
+
+    public NumericDocValuesReference(String columnName) {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public Long value() {
+        return value;
+    }
+
+    @Override
+    public void setNextDocId(int doc) throws IOException {
+        value = values.advanceExact(doc) ? values.longValue() : null;
+    }
+
+    @Override
+    public void setNextReader(LeafReaderContext context) throws IOException {
+        super.setNextReader(context);
+        values = DocValues.getNumeric(context.reader(), columnName);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits. This adds some new benchmarks to get a better idea on what
kind of overheads we have.


    measureGroupBySumLong                                avgt   10  710.172 ± 40.041  ms/op
    measureGroupBySumLongOptimized                       avgt   10  606.413 ±  1.816  ms/op
    measureGroupBySumLongOptimizedOnLuceneBatchIterator  avgt   10  878.274 ±  8.251  ms/op
    measureGroupingOnDocValues                           avgt   10  414.473 ±  8.890  ms/op
    measureGroupingOnLongArray                           avgt   10  227.142 ±  0.268  ms/op

    measureGroupingOnNumericDocValues                                              avgt   10  361.522 ±  3.135  ms/op
    measureGroupingOnSortedNumericDocValues                                        avgt   10  417.842 ±  2.199  ms/op

    measureGroupBySumLongOptimizedOnLuceneBatchIteratorWithNumericDocValues        avgt   10  848.663 ± 15.214  ms/op
    measureGroupBySumLongOptimizedOnLuceneBatchIteratorWithSortedNumericDocValues  avgt   10  944.336 ± 81.760  ms/op


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
