### PR TITLE
Add support for default clause on 'Alter table add column' statement

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -250,7 +250,8 @@ Deprecations
 Changes
 =======
 
-- Added support for column :ref:`ref-default-clause` for :ref:`ref-create-table`.
+- Added support for column :ref:`ref-default-clause` for statements:
+  :ref:`ref-create-table` and :ref:`ref-alter-table`.
 
 - Added support for ``CURRENT ROW -> UNBOUNDED FOLLOWING`` window frame
   definitions in the context of :ref:`window-functions`.

--- a/blackbox/docs/sql/statements/alter-table.rst
+++ b/blackbox/docs/sql/statements/alter-table.rst
@@ -116,8 +116,9 @@ can be used. For more more info on that, see :ref:`alter_change_number_of_shard`
 --------------
 
 Can be used to add an additional column to a table. While columns can be added
-at any time, adding a new :ref:`generated column <ref-generated-columns>` is
-only possible if the table is empty.
+at any time, adding a new :ref:`generated column <ref-generated-columns>` or a
+base column with :ref:`ref-default-clause` is only possible if the table is
+empty.
 
 :data_type:
   Data type of the column which should be added.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -491,11 +491,15 @@ tableElement
     ;
 
 columnDefinition
-    : ident dataType? (DEFAULT defaultExpr=expr)? ((GENERATED ALWAYS)? AS generatedExpr=expr)? columnConstraint*
+    : ident columnElements
     ;
 
 addColumnDefinition
-    : subscriptSafe dataType? ((GENERATED ALWAYS)? AS expr)? columnConstraint*
+    : subscriptSafe columnElements
+    ;
+
+columnElements
+    : dataType? (DEFAULT defaultExpr=expr)? ((GENERATED ALWAYS)? AS generatedExpr=expr)? columnConstraint*
     ;
 
 rerouteOption

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -31,6 +31,7 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnElements;
 import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CopyFrom;
@@ -524,6 +525,13 @@ public final class SqlFormatter {
         public Void visitColumnDefinition(ColumnDefinition node, Integer indent) {
             builder.append(quoteIdentifierIfNeeded(node.ident()))
                 .append(" ");
+            ColumnElements columnElements = node.columnElements();
+            columnElements.accept(this, indent);
+            return null;
+        }
+
+        @Override
+        public Void visitColumnElements(ColumnElements node, Integer indent) {
             ColumnType type = node.type();
             if (type != null) {
                 type.accept(this, indent);

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -55,6 +55,7 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnElements;
 import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CommitStatement;
@@ -700,10 +701,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitColumnDefinition(SqlBaseParser.ColumnDefinitionContext context) {
         return new ColumnDefinition(
             getIdentText(context.ident()),
-            visitOptionalContext(context.defaultExpr, Expression.class),
-            visitOptionalContext(context.generatedExpr, Expression.class),
-            visitOptionalContext(context.dataType(), ColumnType.class),
-            visitCollection(context.columnConstraint(), ColumnConstraint.class));
+            (ColumnElements) visit(context.columnElements()));
     }
 
     @Override
@@ -846,7 +844,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAddColumnDefinition(SqlBaseParser.AddColumnDefinitionContext context) {
         return new AddColumnDefinition(
             (Expression) visit(context.subscriptSafe()),
-            visitOptionalContext(context.expr(), Expression.class),
+            (ColumnElements) visit(context.columnElements()));
+    }
+
+    @Override
+    public Node visitColumnElements(SqlBaseParser.ColumnElementsContext context) {
+        return new ColumnElements(
+            visitOptionalContext(context.defaultExpr, Expression.class),
+            visitOptionalContext(context.generatedExpr, Expression.class),
             visitOptionalContext(context.dataType(), ColumnType.class),
             visitCollection(context.columnConstraint(), ColumnConstraint.class));
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
@@ -23,52 +23,32 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
-import javax.annotation.Nullable;
-import java.util.List;
+import java.util.Objects;
 
 public class AddColumnDefinition extends TableElement {
 
     private final Expression name;
-    @Nullable
-    private final Expression generatedExpression;
-    @Nullable
-    private final ColumnType type;
-    private final List<ColumnConstraint> constraints;
+
+    private final ColumnElements columnElements;
 
     public AddColumnDefinition(Expression name,
-                               @Nullable Expression generatedExpression,
-                               @Nullable ColumnType type,
-                               List<ColumnConstraint> constraints) {
+                               ColumnElements columnElements) {
+
         this.name = name;
-        this.generatedExpression = generatedExpression;
-        this.type = type;
-        this.constraints = constraints;
-        validateColumnDefinition();
+        this.columnElements = columnElements;
+        validate();
     }
 
-    private void validateColumnDefinition() {
-        if (type == null && generatedExpression == null) {
-            throw new IllegalArgumentException("Column [" + name + "]: data type needs to be provided " +
-                                               "or column should be defined as a generated expression");
-        }
+    private void validate() {
+        columnElements.validate(name.toString());
     }
 
     public Expression name() {
         return name;
     }
 
-    @Nullable
-    public Expression generatedExpression() {
-        return generatedExpression;
-    }
-
-    @Nullable
-    public ColumnType type() {
-        return type;
-    }
-
-    public List<ColumnConstraint> constraints() {
-        return constraints;
+    public ColumnElements columnElements() {
+        return columnElements;
     }
 
     @Override
@@ -77,31 +57,20 @@ public class AddColumnDefinition extends TableElement {
         if (o == null || getClass() != o.getClass()) return false;
 
         AddColumnDefinition that = (AddColumnDefinition) o;
-
-        if (!name.equals(that.name)) return false;
-        if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
-            that.generatedExpression != null) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        return constraints.equals(that.constraints);
-
+        return Objects.equals(name, that.name) &&
+               Objects.equals(columnElements, that.columnElements);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + (generatedExpression != null ? generatedExpression.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + constraints.hashCode();
-        return result;
+        return Objects.hash(name, columnElements);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("name", name)
-            .add("generatedExpression", generatedExpression)
-            .add("type", type)
-            .add("constraints", constraints)
+            .add("columnElements", columnElements)
             .toString();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -497,6 +497,10 @@ public abstract class AstVisitor<R, C> {
         return visitTableElement(node, context);
     }
 
+    public R visitColumnElements(ColumnElements node, C context) {
+        return visitNode(node, context);
+    }
+
     public R visitInsertFromValues(InsertFromValues node, C context) {
         return visitInsert(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
@@ -22,77 +22,37 @@
 package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 
-import javax.annotation.Nullable;
-import java.util.List;
+import java.util.Objects;
 
 public class ColumnDefinition extends TableElement {
 
     private final String ident;
 
-    @Nullable
-    private final Expression defaultExpression;
-
-    @Nullable
-    private final Expression generatedExpression;
-
-    @Nullable
-    private final ColumnType type;
-
-    private final List<ColumnConstraint> constraints;
+    private final ColumnElements columnElements;
 
     public ColumnDefinition(String ident,
-                            @Nullable Expression defaultExpression,
-                            @Nullable Expression generatedExpression,
-                            @Nullable ColumnType type,
-                            List<ColumnConstraint> constraints) {
+                            ColumnElements columnElements) {
         this.ident = ident;
-        this.defaultExpression = defaultExpression;
-        this.generatedExpression = generatedExpression;
-        this.type = type;
-        this.constraints = constraints;
-        validateColumnDefinition();
+        this.columnElements = columnElements;
+        validate();
     }
 
-    private void validateColumnDefinition() {
-        if (type == null && generatedExpression == null) {
-            throw new IllegalArgumentException("Column [" + ident + "]: data type needs to be provided " +
-                                               "or column should be defined as a generated expression");
-        }
-
-        if (defaultExpression != null && generatedExpression != null) {
-            throw new IllegalArgumentException("Column [" + ident + "]: the default and generated expressions " +
-                                               "are mutually exclusive");
-        }
+    private void validate() {
+        columnElements.validate(ident);
     }
 
     public String ident() {
         return ident;
     }
 
-    @Nullable
-    public Expression generatedExpression() {
-        return generatedExpression;
-    }
-
-    @Nullable
-    public Expression defaultExpression() {
-        return defaultExpression;
-    }
-
-    @Nullable
-    public ColumnType type() {
-        return type;
-    }
-
-    public List<ColumnConstraint> constraints() {
-        return constraints;
+    public ColumnElements columnElements() {
+        return columnElements;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(ident, defaultExpression, generatedExpression, type, constraints);
+        return Objects.hash(ident, columnElements);
     }
 
     @Override
@@ -101,15 +61,8 @@ public class ColumnDefinition extends TableElement {
         if (o == null || getClass() != o.getClass()) return false;
 
         ColumnDefinition that = (ColumnDefinition) o;
-
-        if (!ident.equals(that.ident)) return false;
-        if (defaultExpression != null ? !defaultExpression.equals(that.defaultExpression) :
-            that.defaultExpression != null) return false;
-        if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
-            that.generatedExpression != null) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        return constraints.equals(that.constraints);
-
+        return Objects.equals(ident, that.ident) &&
+               Objects.equals(columnElements, that.columnElements);
     }
 
 
@@ -117,10 +70,7 @@ public class ColumnDefinition extends TableElement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("ident", ident)
-            .add("defaultExpression", defaultExpression)
-            .add("generatedExpression", generatedExpression)
-            .add("type", type)
-            .add("constraints", constraints)
+            .add("columnElements", columnElements)
             .toString();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnElements.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnElements.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ColumnElements extends Node {
+
+    @Nullable
+    private final ColumnType type;
+
+    @Nullable
+    private final Expression defaultExpression;
+
+    @Nullable
+    private final Expression generatedExpression;
+
+    private final List<ColumnConstraint> constraints;
+
+    public ColumnElements(@Nullable Expression defaultExpression,
+                          @Nullable Expression generatedExpression,
+                          @Nullable ColumnType type,
+                          List<ColumnConstraint> constraints) {
+        this.defaultExpression = defaultExpression;
+        this.generatedExpression = generatedExpression;
+        this.type = type;
+        this.constraints = constraints;
+    }
+
+    void validate(String column) {
+        if (type == null && generatedExpression == null) {
+            throw new IllegalArgumentException("Column [" + column + "]: data type needs to be provided " +
+                                               "or column should be defined as a generated expression");
+        }
+
+        if (defaultExpression != null && generatedExpression != null) {
+            throw new IllegalArgumentException("Column [" + column + "]: the default and generated expressions " +
+                                               "are mutually exclusive");
+        }
+    }
+
+    @Nullable
+    public Expression generatedExpression() {
+        return generatedExpression;
+    }
+
+    @Nullable
+    public Expression defaultExpression() {
+        return defaultExpression;
+    }
+
+    @Nullable
+    public ColumnType type() {
+        return type;
+    }
+
+    public List<ColumnConstraint> constraints() {
+        return constraints;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(defaultExpression, generatedExpression, type, constraints);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ColumnElements that = (ColumnElements) o;
+
+        if (defaultExpression != null ? !defaultExpression.equals(that.defaultExpression) :
+            that.defaultExpression != null) return false;
+        if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
+            that.generatedExpression != null) return false;
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        return constraints.equals(that.constraints);
+    }
+
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("defaultExpression", defaultExpression)
+            .add("generatedExpression", generatedExpression)
+            .add("type", type)
+            .add("constraints", constraints)
+            .toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitColumnElements(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1366,10 +1366,9 @@ public class TestStatementBuilder {
 
 
     @Test
-    public void testAddColumnWithDefaultExpressionIsNotSupported() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("mismatched input 'default'");
+    public void testAddColumnWithDefaultExpression() {
         printStatement("alter table t add col1 text default 'foo'");
+        printStatement("alter table t add col1 int default random()");
     }
 
 

--- a/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
@@ -28,16 +28,16 @@ public class AddColumnAnalyzedStatement implements DDLStatement {
     private final DocTableInfo tableInfo;
     private final AnalyzedTableElements analyzedTableElements;
     private final boolean newPrimaryKeys;
-    private final boolean hasNewGeneratedColumns;
+    private final boolean hasNewExpressionColumns;
 
     protected AddColumnAnalyzedStatement(DocTableInfo tableInfo,
                                          AnalyzedTableElements tableElements,
                                          boolean newPrimaryKeys,
-                                         boolean hasNewGeneratedColumns) {
+                                         boolean hasNewExpressionColumns) {
         this.tableInfo = tableInfo;
         analyzedTableElements = tableElements;
         this.newPrimaryKeys = newPrimaryKeys;
-        this.hasNewGeneratedColumns = hasNewGeneratedColumns;
+        this.hasNewExpressionColumns = hasNewExpressionColumns;
     }
 
     public DocTableInfo table() {
@@ -57,7 +57,7 @@ public class AddColumnAnalyzedStatement implements DDLStatement {
         return this.newPrimaryKeys;
     }
 
-    public boolean hasNewGeneratedColumns() {
-        return hasNewGeneratedColumns;
+    public boolean hasNewExpressionColumns() {
+        return hasNewExpressionColumns;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -80,12 +80,12 @@ class AlterTableAddColumnAnalyzer {
         }
 
         boolean hasNewPrimaryKeys = tableElements.primaryKeys().size() > numCurrentPks;
-        boolean hasGeneratedColumns = tableElements.hasGeneratedColumns();
+        boolean hasExpressionColumns = tableElements.hasExpressionColumns();
         return new AddColumnAnalyzedStatement(
             tableInfo,
             tableElements,
             hasNewPrimaryKeys,
-            hasGeneratedColumns
+            hasExpressionColumns
         );
     }
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -66,7 +66,7 @@ public class AnalyzedTableElements {
     private Set<String> primaryKeys;
     private Set<String> notNullColumns;
     private List<List<String>> partitionedBy;
-    private int numGeneratedColumns = 0;
+    private int numExpressionColumns = 0;
 
 
     /**
@@ -227,8 +227,9 @@ public class AnalyzedTableElements {
         columnIdents.add(analyzedColumnDefinition.ident());
         columns.add(analyzedColumnDefinition);
         columnTypes.put(analyzedColumnDefinition.ident(), analyzedColumnDefinition.dataType());
-        if (analyzedColumnDefinition.generatedExpression() != null) {
-            numGeneratedColumns++;
+        if (analyzedColumnDefinition.generatedExpression() != null ||
+            analyzedColumnDefinition.defaultExpression() != null) {
+            numExpressionColumns++;
         }
     }
 
@@ -517,7 +518,7 @@ public class AnalyzedTableElements {
         return columns;
     }
 
-    boolean hasGeneratedColumns() {
-        return numGeneratedColumns > 0;
+    boolean hasExpressionColumns() {
+        return numExpressionColumns > 0;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -57,7 +57,7 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType, Vo
     public DataType visitObjectColumnType(ObjectColumnType node, Void context) {
         ObjectType.Builder builder = ObjectType.builder();
         for (ColumnDefinition columnDefinition : node.nestedColumns()) {
-            builder.setInnerType(columnDefinition.ident(), process(columnDefinition.type(), context));
+            builder.setInnerType(columnDefinition.ident(), process(columnDefinition.columnElements().type(), context));
         }
         return builder.build();
     }

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -35,6 +35,7 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnElements;
 import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CreateTable;
@@ -182,10 +183,10 @@ public class MetaDataToASTNodeResolver {
                 String columnName = ident.isTopLevel() ? ident.name() : ident.path().get(ident.path().size() - 1);
                 elements.add(new ColumnDefinition(
                     columnName,
-                    defaultExpression,
-                    generatedExpression,
-                    columnType,
-                    constraints)
+                    new ColumnElements(defaultExpression,
+                                       generatedExpression,
+                                       columnType,
+                                       constraints))
                 );
             }
             return elements;

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -34,6 +34,7 @@ import io.crate.sql.tree.ArrayLiteral;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnElements;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
@@ -121,18 +122,7 @@ public class TableElementsAnalyzer {
         @Override
         public Void visitColumnDefinition(ColumnDefinition node, ColumnDefinitionContext context) {
             context.analyzedColumnDefinition.name(node.ident());
-            for (ColumnConstraint columnConstraint : node.constraints()) {
-                process(columnConstraint, context);
-            }
-            if (node.type() != null) {
-                process(node.type(), context);
-            }
-            if (node.defaultExpression() != null) {
-                context.analyzedColumnDefinition.defaultExpression(node.defaultExpression());
-            }
-            if (node.generatedExpression() != null) {
-                context.analyzedColumnDefinition.generatedExpression(node.generatedExpression());
-            }
+            process(node.columnElements(), context);
             return null;
         }
 
@@ -173,17 +163,26 @@ public class TableElementsAnalyzer {
                 context.analyzedColumnDefinition = leaf;
             }
 
+            process(node.columnElements(), context);
+
+            context.analyzedColumnDefinition = root;
+            return null;
+        }
+
+        @Override
+        public Void visitColumnElements(ColumnElements node, ColumnDefinitionContext context) {
             for (ColumnConstraint columnConstraint : node.constraints()) {
                 process(columnConstraint, context);
             }
             if (node.type() != null) {
                 process(node.type(), context);
             }
+            if (node.defaultExpression() != null) {
+                context.analyzedColumnDefinition.defaultExpression(node.defaultExpression());
+            }
             if (node.generatedExpression() != null) {
                 context.analyzedColumnDefinition.generatedExpression(node.generatedExpression());
             }
-
-            context.analyzedColumnDefinition = root;
             return null;
         }
 

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -147,7 +147,7 @@ public class AlterTableOperation {
 
     public CompletableFuture<Long> executeAlterTableAddColumn(final AddColumnAnalyzedStatement analysis) {
         final CompletableFuture<Long> result = new CompletableFuture<>();
-        if (analysis.newPrimaryKeys() || analysis.hasNewGeneratedColumns()) {
+        if (analysis.newPrimaryKeys() || analysis.hasNewExpressionColumns()) {
             RelationName ident = analysis.table().ident();
             String stmt =
                 String.format(Locale.ENGLISH, "SELECT COUNT(*) FROM \"%s\".\"%s\"", ident.schema(), ident.name());
@@ -658,9 +658,9 @@ public class AlterTableOperation {
             if (count == 0L) {
                 addColumnToTable(analysis, result);
             } else {
-                String columnFailure = analysis.newPrimaryKeys() ? "primary key" : "generated";
+                String columnFailure = analysis.newPrimaryKeys() ? "a primary key" : "an expression";
                 fail(new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "Cannot add a %s column to a table that isn't empty", columnFailure)));
+                    "Cannot add %s column to a table that isn't empty", columnFailure)));
             }
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I've started documenting that we do not support the default clause for ``alter table add column``
statement but realized that the generated expressions are supported but with the restriction
that the table needs to be empty.

This PR aligns this behavior for the base columns with `default clause` i.e. they are permitted for empty tables.
 
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
