### PR TITLE
Validate deferred executions before triggering any

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -32,7 +32,6 @@ import io.crate.shade.org.postgresql.util.PSQLState;
 import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.BeforeClass;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`test_execute_batch_fails_with_read_operations` was flaky because we did
the validation ad-hoc on each statement. So we sometimes already
executed a valid subset of the batches.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)