### PR TITLE
Fix outer-to-inner-join plan optimization of FULL outer 

### DIFF
--- a/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -35,7 +35,6 @@ public class Optimizer {
 
     private static final Logger LOGGER = LogManager.getLogger(Optimizer.class);
 
-
     private List<Rule<?>> rules;
 
     public Optimizer(List<Rule<?>> rules) {

--- a/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -26,10 +26,15 @@ import io.crate.common.collections.Lists2;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
 public class Optimizer {
+
+    private static final Logger LOGGER = LogManager.getLogger(Optimizer.class);
+
 
     private List<Rule<?>> rules;
 
@@ -43,6 +48,7 @@ public class Optimizer {
     }
 
     private LogicalPlan tryApplyRules(LogicalPlan plan) {
+        final boolean isTraceEnabled = LOGGER.isTraceEnabled();
         LogicalPlan node = plan;
         // Some rules may only become applicable after another rule triggered, so we keep
         // trying to re-apply the rules as long as at least one plan was transformed.
@@ -52,9 +58,15 @@ public class Optimizer {
             for (Rule rule : rules) {
                 Match match = rule.pattern().accept(node, Captures.empty());
                 if (match.isPresent()) {
+                    if (isTraceEnabled) {
+                        LOGGER.trace("Rule '" + rule.getClass().getName() + "' matched");
+                    }
                     @SuppressWarnings("unchecked")
                     LogicalPlan transformedPlan = rule.apply(match.value(), match.captures());
                     if (transformedPlan != null) {
+                        if (isTraceEnabled) {
+                            LOGGER.trace("Rule '" + rule.getClass().getName() + "' transformed the logical plan");
+                        }
                         node = transformedPlan;
                         done = false;
                     }

--- a/sql/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -126,7 +126,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
         );
         var expectedPlan =
             "RootBoundary[x, x]\n" +
-            "Filter[(coalesce(x, 10) = 10)]\n" +
+            "Filter[((coalesce(x, 10) = 10) AND (x > 5))]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[x]\n" +
             "    Collect[doc.t1 | [x] | All]\n" +


### PR DESCRIPTION
On full outer joins, filter must stay on top of the join phase even if they
are pushed down to the relevant source as both sides can generate NULL
which may be filtered out after the join.

Relates https://github.com/crate/crate/issues/8815.