### PR TITLE
Add optimizer rules pre-grouping by root plan type.

### DIFF
--- a/sql/src/main/java/io/crate/planner/optimizer/RulesGrouper.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/RulesGrouper.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer;
+
+import com.google.common.reflect.TypeToken;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.matcher.TypeOfPattern;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+class RulesGrouper {
+
+    private final Map<Class<?>, List<Rule<?>>> rulesByRootType;
+
+    private RulesGrouper(Map<Class<?>, List<Rule<?>>> rulesByRootType) {
+        this.rulesByRootType = Map.copyOf(rulesByRootType);
+    }
+
+    Stream<Rule<?>> getCandidates(Object object) {
+        return supertypes(object.getClass())
+            .map(rulesByRootType::get)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream);
+    }
+
+    private static Stream<Class<?>> supertypes(Class<?> type) {
+        return TypeToken.of(type).getTypes().stream()
+            .map(TypeToken::getRawType);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static class Builder {
+
+        private final Map<Class<?>, List<Rule<?>>> rulesByRootType = new HashMap<>();
+
+        Builder registerAll(List<Rule<?>> rules) {
+            for (Rule<?> rule : rules) {
+                register(rule);
+            }
+            return this;
+        }
+
+        Builder register(Rule<?> rule) {
+            Pattern pattern = getFirstPattern(rule.pattern());
+            if (pattern instanceof TypeOfPattern<?>) {
+                Class<?> patternType = ((TypeOfPattern<?>) pattern).expectedClass();
+                rulesByRootType
+                    .computeIfAbsent(patternType, k -> new ArrayList<>())
+                    .add(rule);
+            } else {
+                throw new IllegalArgumentException("Unexpected Pattern: " + pattern);
+            }
+            return this;
+        }
+
+        private Pattern<?> getFirstPattern(Pattern<?> pattern) {
+            while (pattern.previous() != null) {
+                pattern = pattern.previous();
+            }
+            return pattern;
+        }
+
+        RulesGrouper build() {
+            return new RulesGrouper(rulesByRootType);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
@@ -22,11 +22,23 @@
 
 package io.crate.planner.optimizer.matcher;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 public abstract class Pattern<T> {
+
+    @Nullable
+    private final Pattern<?> previous;
+
+    protected Pattern() {
+        this(null);
+    }
+
+    protected Pattern(@Nullable Pattern<?> previous) {
+        this.previous = previous;
+    }
 
     public static <T> Pattern<T> typeOf(Class<T> expectedClass) {
         return new TypeOfPattern<>(expectedClass);
@@ -45,4 +57,9 @@ public abstract class Pattern<T> {
     }
 
     public abstract Match<T> accept(Object object, Captures captures);
+
+    @Nullable
+    public Pattern<?> previous() {
+        return previous;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
@@ -22,12 +22,16 @@
 
 package io.crate.planner.optimizer.matcher;
 
-class TypeOfPattern<T> extends Pattern<T> {
+public class TypeOfPattern<T> extends Pattern<T> {
 
     private Class<T> expectedClass;
 
     TypeOfPattern(Class<T> expectedClass) {
         this.expectedClass = expectedClass;
+    }
+
+    public Class<T> expectedClass() {
+        return expectedClass;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
@@ -27,19 +27,22 @@ import java.util.function.Function;
 
 class WithPattern<T, U, V> extends Pattern<T> {
 
-    private final Pattern<T> firstPattern;
+    private final Pattern<T> previous;
     private final Function<? super T, Optional<U>> getProperty;
     private final Pattern<V> propertyPattern;
 
-    WithPattern(Pattern<T> firstPattern, Function<? super T, Optional<U>> getProperty, Pattern<V> propertyPattern) {
-        this.firstPattern = firstPattern;
+    WithPattern(Pattern<T> previous,
+                Function<? super T, Optional<U>> getProperty,
+                Pattern<V> propertyPattern) {
+        super(previous);
+        this.previous = previous;
         this.getProperty = getProperty;
         this.propertyPattern = propertyPattern;
     }
 
     @Override
     public Match<T> accept(Object object, Captures captures) {
-        Match<T> match = firstPattern.accept(object, captures);
+        Match<T> match = previous.accept(object, captures);
         return match.flatMap(matchedValue -> {
             Optional<?> optProperty = getProperty.apply(matchedValue);
             Match<V> propertyMatch = optProperty

--- a/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
@@ -26,17 +26,18 @@ import java.util.function.Predicate;
 
 public class WithPropertyPattern<T> extends Pattern<T> {
 
-    private final Pattern<T> pattern;
+    private final Pattern<T> previous;
     private final Predicate<? super T> propertyPredicate;
 
-    WithPropertyPattern(Pattern<T> pattern, Predicate<? super T> propertyPredicate) {
-        this.pattern = pattern;
+    WithPropertyPattern(Pattern<T> previous, Predicate<? super T> propertyPredicate) {
+        super(previous);
+        this.previous = previous;
         this.propertyPredicate = propertyPredicate;
     }
 
     @Override
     public Match<T> accept(Object object, Captures captures) {
-        Match<T> match = pattern.accept(object, captures);
+        Match<T> match = previous.accept(object, captures);
         return match.flatMap(matchedValue -> {
             if (propertyPredicate.test(matchedValue)) {
                 return match;

--- a/sql/src/test/java/io/crate/planner/optimizer/RulesGrouperTest.java
+++ b/sql/src/test/java/io/crate/planner/optimizer/RulesGrouperTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer;
+
+import io.crate.analyze.OrderBy;
+import io.crate.expression.symbol.Literal;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanner;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Mockito.mock;
+
+public class RulesGrouperTest extends CrateUnitTest {
+
+    @Test
+    public void testWithLogicalPlanHierarchy() {
+        Rule orderRule = new NoOpRule(Pattern.typeOf(Order.class));
+        Rule otherOrderRule = new NoOpRule(Pattern.typeOf(Order.class));
+        Rule filterRule = new NoOpRule(Pattern.typeOf(Filter.class));
+        Rule limitRule = new NoOpRule(Pattern.typeOf(Limit.class));
+
+        RulesGrouper rulesGrouper = RulesGrouper.builder()
+            .register(orderRule)
+            .register(otherOrderRule)
+            .register(filterRule)
+            .register(limitRule)
+            .build();
+
+        Filter filter = new Filter(mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
+        Order order = new Order(filter, mock(OrderBy.class));
+
+        assertThat(
+            rulesGrouper.getCandidates(filter).collect(toSet()),
+            contains(filterRule));
+        assertThat(
+            rulesGrouper.getCandidates(order).collect(toSet()),
+            containsInAnyOrder(orderRule, otherOrderRule));
+    }
+
+    @Test
+    public void testInterfacesHierarchy() {
+        Rule a = new NoOpRule(Pattern.typeOf(A.class));
+        Rule b = new NoOpRule(Pattern.typeOf(B.class));
+        Rule ab = new NoOpRule(Pattern.typeOf(AB.class));
+
+        RulesGrouper rulesGrouper = RulesGrouper.builder()
+            .register(a)
+            .register(b)
+            .register(ab)
+            .build();
+
+        assertThat(
+            rulesGrouper.getCandidates(new A() {}).collect(toSet()),
+            contains(a));
+        assertThat(
+            rulesGrouper.getCandidates(new B() {}).collect(toSet()),
+            contains(b));
+        assertThat(
+            rulesGrouper.getCandidates(new AB()).collect(toSet()),
+            containsInAnyOrder(ab, a, b));
+    }
+
+    private static class NoOpRule implements Rule<LogicalPlanner> {
+        private final Pattern pattern;
+
+        private NoOpRule(Pattern pattern) {
+            this.pattern = pattern;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Pattern pattern() {
+            return pattern;
+        }
+
+        @Override
+        public LogicalPlan apply(LogicalPlanner plan, Captures captures) {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return toStringHelper(this)
+                .add("pattern", pattern)
+                .toString();
+        }
+    }
+
+    private interface A {}
+
+    private interface B {}
+
+    private static class AB
+        implements A, B {}
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It improves the performance of the rule application by
pre-grouping rules by the root plan instance type they operate on,
due filtering out all rules except potentially applicable once.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
