### PR TITLE
docs: 'Alter table add column' with default clause is not supported

### DIFF
--- a/blackbox/docs/sql/statements/alter-table.rst
+++ b/blackbox/docs/sql/statements/alter-table.rst
@@ -117,7 +117,8 @@ can be used. For more more info on that, see :ref:`alter_change_number_of_shard`
 
 Can be used to add an additional column to a table. While columns can be added
 at any time, adding a new :ref:`generated column <ref-generated-columns>` is
-only possible if the table is empty.
+only possible if the table is empty. In addition, adding a base column with
+:ref:`ref-default-clause` is not supported.
 
 :data_type:
   Data type of the column which should be added.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
