### PR TITLE
Fix outer-to-inner-join plan optimization of FULL outer (bp #8826)

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -137,6 +137,28 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void test_filter_will_be_applied_after_outer_join() {
+        execute("create table t1 (id int, is_match int)");
+        execute("create table t2 (id int, t1_id int)");
+        execute("insert into t1 (id, is_match) values " +
+                "(1, 0),\n" +
+                "(2, 1),\n" +
+                "(36, 1)");
+        execute("insert into t2 (id, t1_id) values " +
+                "(1, 1),\n" +
+                "(2, 2),\n" +
+                "(3, null)");   // this row must be filtered out after the full join
+        refresh();
+
+        execute("SELECT t2.id, t2.t1_id, t1.id, t1.is_match " +
+                "FROM t2 " +
+                "FULL OUTER JOIN t1 ON (t1.id = t2.t1_id) " +
+                "WHERE (t1.is_match = 1) ");
+        assertThat(printedTable(response.rows()), is("2| 2| 2| 1\n" +
+                                                     "NULL| NULL| 36| 1\n"));
+    }
+
+    @Test
     public void testOuterJoinWithFunctionsInOrderBy() {
         execute("select coalesce(persons.name, ''), coalesce(offices.name, '') from" +
                 " offices full join employees as persons on office_id = offices.id" +


### PR DESCRIPTION
On full outer joins, filter must stay on top of the join phase even if they
are pushed down to the relevant source as both sides can generate NULL
which may be filtered out after the join.

Backport of https://github.com/crate/crate/pull/8826.