### PR TITLE
Fix table swapping on left/right outer joins

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -383,6 +383,9 @@ Changes
 Fixes
 =====
 
+- Fixes an issue that caused wrong results when running ``LEFT`` or ``RIGHT``
+  outer joins on a single node cluster and the rows inside each table differs.
+
 - Fixed an issue in the PostgreSQL wire protocol implementation that could
   cause clients to receive a ``Only write operations are allowed in Batch
   statements`` if the client relied on the behavior that closing prepared

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -164,6 +164,7 @@ public class NestedLoopJoin implements LogicalPlan {
                         (!left.resultDescription().nodeIds().isEmpty() && !right.resultDescription().nodeIds().isEmpty());
         boolean blockNlPossible = !isDistributed && isBlockNlPossible(left, right);
 
+        JoinType joinType = this.joinType;
         if (!orderByWasPushedDown && joinType.supportsInversion() &&
             (isDistributed && lhs.numExpectedRows() < rhs.numExpectedRows() && orderByFromLeft == null) ||
             (blockNlPossible && lhs.numExpectedRows() > rhs.numExpectedRows())) {
@@ -177,6 +178,7 @@ public class NestedLoopJoin implements LogicalPlan {
             right = tmpExecutionPlan;
             leftLogicalPlan = rhs;
             rightLogicalPlan = lhs;
+            joinType = joinType.invert();
         }
         Tuple<Collection<String>, List<MergePhase>> joinExecutionNodesAndMergePhases =
             configureExecution(left, right, plannerContext, isDistributed);


### PR DESCRIPTION
When tables are switched the join type must be inverted as well.
This is important for LEFT/RIGHT joins and otherwise results in wrong join execution.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests