### PR TITLE
Fix row count reporting for `on conflict.. do nothing` conflicts.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -383,6 +383,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused conflicting rows in an ``INSERT INTO .. ON
+  CONFLICT (..) DO NOTHING`` statement to be reported as failed.
+
 - Fixes an issue that caused wrong results when running ``LEFT`` or ``RIGHT``
   outer joins on a single node cluster and the rows inside each table differs.
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -56,7 +56,6 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -124,7 +123,7 @@ public class LegacyUpsertByIdTask {
     public void execute(final RowConsumer consumer) {
         doExecute().whenComplete((r, f) -> {
             if (f == null) {
-                consumer.accept(InMemoryBatchIterator.of(new Row1((long) r.cardinality()), SENTINEL), null);
+                consumer.accept(InMemoryBatchIterator.of(new Row1((long) r.numSuccessfulWrites()), SENTINEL), null);
             } else {
                 consumer.accept(null, f);
             }
@@ -132,7 +131,7 @@ public class LegacyUpsertByIdTask {
     }
 
     public List<CompletableFuture<Long>> executeBulk() {
-        final List<CompletableFuture<Long>> results = prepareResultList(numBulkResponses);
+        final List<CompletableFuture<Long>> results = createUnsetFutures(numBulkResponses);
         doExecute().whenComplete((responses, f) -> {
             if (f == null) {
                 long[] resultRowCount = createBulkResponse(responses);
@@ -151,7 +150,9 @@ public class LegacyUpsertByIdTask {
     /**
      * Create bulk-response depending on number of bulk responses
      * <pre>
-     *     responses BitSet: [1, 1, 1, 1]
+     *     compressedResult
+     *          success: [1, 1, 1, 1]
+     *          failure: []
      *
      *     insert into t (x) values (?), (?)   -- bulkParams: [[1, 2], [3, 4]]
      *     Response:
@@ -162,29 +163,29 @@ public class LegacyUpsertByIdTask {
      *      [1, 1, 1, 1]
      * </pre>
      */
-    private long[] createBulkResponse(BitSet responses) {
+    private long[] createBulkResponse(ShardResponse.CompressedResult compressedResult) {
         long[] resultRowCount = new long[numBulkResponses];
         Arrays.fill(resultRowCount, 0L);
         for (int i = 0; i < items.size(); i++) {
             int resultIdx = bulkIndices.get(i);
-            if (responses.get(i)) {
+            if (compressedResult.successfulWrites(i)) {
                 resultRowCount[resultIdx]++;
-            } else {
+            } else if (compressedResult.failed(i)) {
                 resultRowCount[resultIdx] = Row1.ERROR;
             }
         }
         return resultRowCount;
     }
 
-    private static List<CompletableFuture<Long>> prepareResultList(int numResponses) {
-        ArrayList<CompletableFuture<Long>> results = new ArrayList<>(numResponses);
-        for (int i = 0; i < numResponses; i++) {
+    private static <T> List<CompletableFuture<T>> createUnsetFutures(int num) {
+        ArrayList<CompletableFuture<T>> results = new ArrayList<>(num);
+        for (int i = 0; i < num; i++) {
             results.add(new CompletableFuture<>());
         }
         return results;
     }
 
-    private CompletableFuture<BitSet> doExecute() {
+    private CompletableFuture<ShardResponse.CompressedResult> doExecute() {
         MetaData metaData = clusterService.state().getMetaData();
         List<String> indicesToCreate = new ArrayList<>();
         for (LegacyUpsertById.Item item : items) {
@@ -200,33 +201,33 @@ public class LegacyUpsertByIdTask {
         }
     }
 
-    private CompletableFuture<BitSet> createAndSendRequests() {
+    private CompletableFuture<ShardResponse.CompressedResult> createAndSendRequests() {
         Map<ShardId, ShardUpsertRequest> requestsByShard;
         try {
             requestsByShard = groupRequests();
         } catch (Throwable t) {
             return failedFuture(t);
         }
+        final ShardResponse.CompressedResult compressedResult = new ShardResponse.CompressedResult();
         if (requestsByShard.isEmpty()) {
-            return CompletableFuture.completedFuture(new BitSet(0));
+            return CompletableFuture.completedFuture(compressedResult);
         }
-        CompletableFuture<BitSet> result = new CompletableFuture<>();
+        CompletableFuture<ShardResponse.CompressedResult> result = new CompletableFuture<>();
         AtomicInteger numRequests = new AtomicInteger(requestsByShard.size());
         AtomicReference<Throwable> lastFailure = new AtomicReference<>(null);
-        final BitSet responses = new BitSet();
 
         for (Iterator<Map.Entry<ShardId, ShardUpsertRequest>> it = requestsByShard.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<ShardId, ShardUpsertRequest> entry = it.next();
             ShardUpsertRequest request = entry.getValue();
             it.remove();
 
-            ActionListener<ShardResponse> listener = new ActionListener<ShardResponse>() {
+            ActionListener<ShardResponse> listener = new ActionListener<>() {
                 @Override
                 public void onResponse(ShardResponse shardResponse) {
                     Throwable failure = shardResponse.failure();
                     if (failure == null) {
-                        synchronized (responses) {
-                            ShardResponse.markResponseItemsAndFailures(shardResponse, responses);
+                        synchronized (compressedResult) {
+                            compressedResult.update(shardResponse);
                         }
                     } else {
                         lastFailure.set(failure);
@@ -236,6 +237,11 @@ public class LegacyUpsertByIdTask {
 
                 @Override
                 public void onFailure(Exception e) {
+                    if (!updateAffectedNoRows(e) && !partitionWasDeleted(e, request.index())) {
+                        synchronized (compressedResult) {
+                            compressedResult.markAsFailed(request.items());
+                        }
+                    }
                     lastFailure.set(e);
                     countdown();
                 }
@@ -244,7 +250,7 @@ public class LegacyUpsertByIdTask {
                     if (numRequests.decrementAndGet() == 0) {
                         Throwable throwable = lastFailure.get();
                         if (throwable == null) {
-                            result.complete(responses);
+                            result.complete(compressedResult);
                         } else {
                             throwable = SQLExceptions.unwrap(throwable, t -> t instanceof RuntimeException);
                             // we want to report duplicate key exceptions
@@ -252,7 +258,7 @@ public class LegacyUpsertByIdTask {
                                 (updateAffectedNoRows(throwable)
                                  || partitionWasDeleted(throwable, request.index())
                                  || mixedArgumentTypesFailure(throwable, request.items()))) {
-                                result.complete(responses);
+                                result.complete(compressedResult);
                             } else {
                                 result.completeExceptionally(throwable);
                             }

--- a/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
@@ -25,8 +25,6 @@ package io.crate.execution.dml;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
-import java.util.BitSet;
-
 import static org.hamcrest.core.Is.is;
 
 public class ShardResponseTest extends CrateUnitTest {
@@ -38,11 +36,16 @@ public class ShardResponseTest extends CrateUnitTest {
         shardResponse.add(1);
         shardResponse.add(2, new ShardResponse.Failure());
 
-        BitSet bitSet = new BitSet();
-        ShardResponse.markResponseItemsAndFailures(shardResponse, bitSet);
+        var result = new ShardResponse.CompressedResult();
+        result.update(shardResponse);
 
-        assertThat(bitSet.get(0), is(true));
-        assertThat(bitSet.get(1), is(true));
-        assertThat(bitSet.get(2), is(false));
+        assertThat(result.successfulWrites(0), is(true));
+        assertThat(result.failed(0), is(false));
+
+        assertThat(result.successfulWrites(1), is(true));
+        assertThat(result.failed(1), is(false));
+
+        assertThat(result.successfulWrites(2), is(false));
+        assertThat(result.failed(2), is(true));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -750,6 +750,25 @@ public class PostgresITest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void test_insert_with_on_conflict_do_nothing_batch_error_resp_is_0_for_conflicting_items() throws Exception {
+        try (Connection conn = DriverManager.getConnection(url(RW))) {
+            conn.prepareStatement("create table t (id int primary key) clustered into 1 shards").execute();
+            conn.prepareStatement("insert into t (id) (select col1 from generate_series(1, 3))").execute();
+
+            PreparedStatement stmt = conn.prepareStatement("insert into t (id) values (?) on conflict (id) do nothing");
+            stmt.setInt(1, 4);
+            stmt.addBatch();
+            stmt.setInt(1, 1);
+            stmt.addBatch();
+
+            int[] result = stmt.executeBatch();
+            assertThat(result.length, is(2));
+            assertThat(result[0], is(1));
+            assertThat(result[1], is(0));
+        }
+    }
+
+    @Test
     @UseJdbc(0) // Simulate explicit call by a user through HTTP iface
     public void test_proper_termination_of_deallocate_through_http_call() throws Exception {
        execute("DEALLOCATE ALL");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes an issue where bulk requests with `ON CONFLICT (id) DO
NOTHING` would get an error response for the items that had a conflict.

We used a BitSet to represent the successful responses. This limited us
to 2 states: Write happened (rowCount 1) or write failed (rowCount -2)

We also need to take care of the third state: Write was ignored (rowCount
0).

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)