### PR TITLE
docs: remove fix entry from unreleased 

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -445,8 +445,5 @@ Fixes
 - Fixed a bug that led to failures of group by a single text column queries
   on columns with the cardinality ration lower than ``0.5``.
 
-- Fixed ``NullPointerException`` that could occur when a column is defined as a
-  :ref:`Base Column<ref-base-columns>` and the type is missing from the column definition.
-
 - Fixed function resolution for function :ref:`scalar_current_schema` when the schema prefix
   ``pg_catalog`` is included.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This regression was introduced by bd56b2e which is not released yet
so there is no need for a fix entry.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
