### PR TITLE
Fix ordering by literal contants.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,4 +46,5 @@ None
 Fixes
 =====
 
-None
+- Fixed support for ordering by literal constants.
+  Example: ``SELECT 1, * FROM t ORDER BY 1"``

--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * <pre>
@@ -175,6 +177,25 @@ public class OrderBy implements Writeable {
 
     public OrderBy map(Function<? super Symbol, ? extends Symbol> replaceFunction) {
         return new OrderBy(Lists2.map(orderBySymbols, replaceFunction), reverseFlags, nullsFirst);
+    }
+
+    @Nullable
+    public OrderBy exclude(Predicate<? super Symbol> predicate) {
+        ArrayList<Symbol> newOrderBySymbols = new ArrayList<>(orderBySymbols.size());
+        ArrayList<Boolean> newReverseFlags = new ArrayList<>(reverseFlags.length);
+        ArrayList<Boolean> newNullsFirst = new ArrayList<>(nullsFirst.length);
+        for (int i = 0; i < orderBySymbols.size(); i++) {
+            Symbol sortSymbol = orderBySymbols.get(i);
+            if (predicate.test(sortSymbol) == false) {
+                newOrderBySymbols.add(sortSymbol);
+                newReverseFlags.add(reverseFlags[i]);
+                newNullsFirst.add(nullsFirst[i]);
+            }
+        }
+        if (newOrderBySymbols.size() == 0) {
+            return null;
+        }
+        return new OrderBy(newOrderBySymbols, Booleans.toArray(newReverseFlags), Booleans.toArray(newNullsFirst));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -249,7 +249,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         if (orderBy != null) {
             orderBy = orderBy.map(normalize);
         }
-        changed = changed || newWhereClause != where;
+        changed = changed || newWhereClause != where || orderBy != this.orderBy;
         if (changed) {
             result = new RoutedCollectPhase(
                 jobId(),

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -200,7 +200,12 @@ public class Collect implements LogicalPlan {
         RoutedCollectPhase collectPhase = createPhase(plannerContext, params, subQueryResults);
         PositionalOrderBy positionalOrderBy = getPositionalOrderBy(order, outputs);
         if (positionalOrderBy != null) {
-            collectPhase.orderBy(order.map(s -> SubQueryAndParamBinder.convert(s, params, subQueryResults)));
+            collectPhase.orderBy(
+                order
+                    .map(s -> SubQueryAndParamBinder.convert(s, params, subQueryResults))
+                    // Filter out literal constants as ordering by constants is a NO-OP and also not supported
+                    // on the collect operation.
+                    .exclude(s -> s instanceof Literal));
         }
         int limitAndOffset = limitAndOffset(limit, offset);
         maybeApplyPageSize(limitAndOffset, pageSizeHint, collectPhase);

--- a/sql/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
@@ -24,9 +24,11 @@ package io.crate.integrationtests;
 
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
 public class SelectOrderByIntegrationTest extends SQLTransportIntegrationTest {
@@ -169,5 +171,15 @@ public class SelectOrderByIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select t from t1 order by date_trunc('year', 'Europe/London', t)");
         assertThat(response.rows()[0][0], is(1521479461L));
+    }
+
+    @Test
+    public void testOrderByLiteralConstant() {
+        execute("create table t1 (id int)");
+        execute("insert into t1 (id) values (1), (2)");
+        refresh();
+        execute("select 1 + 0, id from t1 order by 1, 2"); // add 2nd order by to get deterministic results
+        assertThat(printedTable(response.rows()), Matchers.is("1| 1\n" +
+                                                              "1| 2\n"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -359,15 +359,6 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testSubqueryInOrderResultsInAnError() throws Exception {
-        execute("create table t (x long primary key)");
-        ensureYellow();
-
-        expectedException.expectMessage("Using a non-integer constant in ORDER BY is not supported");
-        execute("select x from t order by (select 1)");
-    }
-
-    @Test
     public void testGlobalAggregatesOnSimpleSubQuery() throws Exception {
         execute("create table t (x int)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -99,4 +99,19 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(merge.subPlan(), instanceOf(Collect.class));
         assertThat(unionExecutionPlan.right(), instanceOf(Collect.class));
     }
+
+    @Test
+    public void testUnionWithOrderByLiteralConstant() {
+        ExecutionPlan plan = e.plan(
+            "select * from (" +
+            " select 1 as x, id from users" +
+            " union all" +
+            " select 2, id from users" +
+            ") o" +
+            " order by x");
+        assertThat(plan, instanceOf(UnionExecutionPlan.class));
+        UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
+        assertThat(unionExecutionPlan.mergePhase().orderByPositions(), instanceOf(PositionalOrderBy.class));
+        assertThat(unionExecutionPlan.mergePhase().orderByPositions().indices(), is(new int[]{0}));
+    }
 }


### PR DESCRIPTION
Ordering by literal constants is currently not supported by the (lucene)
collector and also result in a NO-OP. Thus literal symbols are filters
out of the ordering symbols.
The previous union-only wrong fix is reverted.
    
Relates https://github.com/crate/crate/issues/8851.