### PR TITLE
Revert "Do not move Order below Union if ordered by literals"

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -420,7 +420,3 @@ Others
 Fixes
 =====
 
-- Fixed an issue on ``UNION`` statements when the ``ORDER BY`` points to
-  literals of the subrelations which resulted in an exception.
-  Example query:
-  ``SELECT * FROM (SELECT 5, x FROM t UNION ALL SELECT 6, y FROM t) ORDER BY 1``

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -22,9 +22,6 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
-import io.crate.expression.symbol.Field;
-import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -47,8 +44,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
     public MoveOrderBeneathUnion() {
         this.unionCapture = new Capture<>();
         this.pattern = typeOf(Order.class)
-            .with(source(), typeOf(Union.class).capturedAs(unionCapture))
-            .with(MoveOrderBeneathUnion::orderDoesNotContainAnyLiteral);
+            .with(source(), typeOf(Union.class).capturedAs(unionCapture));
     }
 
     @Override
@@ -66,60 +62,15 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
         return union.replaceSources(List.of(lhsOrder, rhsOrder));
     }
 
-    private static Order updateSources(Order order, LogicalPlan source) {
+    private static Order updateSources(Order order, LogicalPlan rhs) {
         List<Symbol> sourceOutputs = order.source().outputs();
-        return new Order(source, order.orderBy().map(s -> {
+        return new Order(rhs, order.orderBy().map(s -> {
             int idx = sourceOutputs.indexOf(s);
             if (idx < 0) {
                 throw new IllegalArgumentException(
                     "The ORDER BY expression " + s + " must be part of the child union: " + sourceOutputs);
             }
-            return source.outputs().get(idx);
+            return rhs.outputs().get(idx);
         }));
-    }
-
-    /**
-     * An order on a union always references to the position on each sub relations outputs.
-     * If one symbol is a literal, it must be applied after the union as each sub relation may return different literals.
-     * In such cases, the push down must be prevented.
-     * (Pushing down parts of the order by could be done but requires order symbols splitting)
-     *
-     * Example query:
-     *
-     *  SELECT * FROM (
-     *     SELECT 1 AS x, y FROM t1
-     *     UNION ALL
-     *     SELECT 2, z FROM t2
-     *  ) c
-     *  ORDER BY x
-     *
-     */
-    private static boolean orderDoesNotContainAnyLiteral(Order order) {
-        for (Symbol symbol : order.orderBy().orderBySymbols()) {
-            if (ContainsOrPointsToAnyLiteralSymbol.INSTANCE.process(symbol, null)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static class ContainsOrPointsToAnyLiteralSymbol extends DefaultTraversalSymbolVisitor<Void, Boolean> {
-
-        private static final ContainsOrPointsToAnyLiteralSymbol INSTANCE = new ContainsOrPointsToAnyLiteralSymbol();
-
-        @Override
-        protected Boolean visitSymbol(Symbol symbol, Void context) {
-            return false;
-        }
-
-        @Override
-        public Boolean visitLiteral(Literal symbol, Void context) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitField(Field field, Void context) {
-            return process(field.pointer(), context);
-        }
     }
 }

--- a/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -26,13 +26,11 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.planner.node.dql.Collect;
-import io.crate.planner.operators.LogicalPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -100,26 +98,5 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         Merge merge = (Merge) unionExecutionPlan.left();
         assertThat(merge.subPlan(), instanceOf(Collect.class));
         assertThat(unionExecutionPlan.right(), instanceOf(Collect.class));
-    }
-
-    @Test
-    public void testOrderByOnUnionPointingToLiteralsMustNotPushedDown() {
-        LogicalPlan plan = e.logicalPlan(
-            "select * from (" +
-            "   select 1 as x, id from users" +
-            "   union all" +
-            "   select 2, id from users" +
-            ") u " +
-            "order by 1, id");
-        assertThat(plan, isPlan(e.functions(),
-            "RootBoundary[x, id]\n" +
-            "Boundary[x, id]\n" +
-            "Boundary[x, id]\n" +
-            "OrderBy[x ASC id ASC]\n" +
-            "Union[\n" +
-            "Collect[doc.users | [1, id] | All]\n" +
-            "---\n" +
-            "Collect[doc.users | [2, id] | All]\n" +
-            "]\n"));
     }
 }


### PR DESCRIPTION
This reverts commit 33ece05e4dd88afc551317df3c028e2b9ce6f660.
The fix was wrong as it only solved this special union case
while ordering by literal on simple selects still raises errors.