### PR TITLE
Support all drop statements in SqlFormatter.

### DIFF
--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -38,7 +38,14 @@ import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.DenyPrivilege;
+import io.crate.sql.tree.DropAnalyzer;
+import io.crate.sql.tree.DropBlobTable;
+import io.crate.sql.tree.DropFunction;
+import io.crate.sql.tree.DropRepository;
+import io.crate.sql.tree.DropSnapshot;
+import io.crate.sql.tree.DropTable;
 import io.crate.sql.tree.DropUser;
+import io.crate.sql.tree.DropView;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
@@ -1494,10 +1501,17 @@ public class TestStatementBuilder {
             statement instanceof GCDanglingArtifacts ||
             statement instanceof CreateFunction ||
             statement instanceof CreateUser ||
-            statement instanceof DropUser ||
             statement instanceof GrantPrivilege ||
             statement instanceof DenyPrivilege ||
-            statement instanceof RevokePrivilege) {
+            statement instanceof RevokePrivilege ||
+            statement instanceof DropUser ||
+            statement instanceof DropAnalyzer ||
+            statement instanceof DropFunction ||
+            statement instanceof DropTable ||
+            statement instanceof DropBlobTable ||
+            statement instanceof DropView ||
+            statement instanceof DropRepository ||
+            statement instanceof DropSnapshot) {
             println(SqlFormatter.formatSql(statement));
             println("");
             assertFormattedSql(statement);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So at some point we can get rid of https://github.com/crate/crate/blob/c8c332a16e2df90b7bb7637aa79bd3ac8c04e18a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java#L1489-L1501

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
