### PR TITLE
Validate values for nested object column that contain generated expressions

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,5 +46,10 @@ None
 Fixes
 =====
 
+- The values provided in INSERT or UPDATE statements for object columns which
+  contain generated expressions are now validated. The computed expression must
+  match the provided value. This makes the behavior consistent with how top
+  level columns of a table are treated.
+
 - Fixed support for ordering by literal constants.
   Example: ``SELECT 1, * FROM t ORDER BY 1"``

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -99,9 +99,9 @@ public final class InsertSourceFromCells implements InsertSourceGen {
             if (target.granularity() == RowGranularity.DOC) {
                 ColumnIdent column = target.column();
                 Maps.mergeInto(source, column.name(), column.path(), value);
-                generatedColumns.validateValue(target, value);
             }
         }
+        generatedColumns.validateValues(source);
         for (Map.Entry<Reference, Input<?>> entry : generatedColumns.toInject()) {
             ColumnIdent column = entry.getKey().column();
             Maps.mergeInto(source, column.name(), column.path(), entry.getValue().value());

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -127,9 +127,9 @@ final class UpdateSourceGen {
             Object value = eval.process(updateAssignments[i], values).value();
             ColumnIdent column = ref.column();
             Maps.mergeInto(updatedSource, column.name(), column.path(), value);
-            generatedColumns.setNextRow(updatedDoc);
-            generatedColumns.validateValue(ref, value);
         }
+        generatedColumns.setNextRow(updatedDoc);
+        generatedColumns.validateValues(updatedSource);
         injectGeneratedColumns(updatedSource);
         checks.validate(updatedDoc);
         return BytesReference.bytes(XContentFactory.jsonBuilder().map(updatedSource));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously in a table like:

    CREATE TABLE t (obj object as (x int, y as x + 1));

With an INSERT like:

    INSERT INTO t (obj) VALUES ({x=1, y=3});

We silently overrode the `y` value with `2` (the result of the generated
expression). This was inconsistent with the behavior of top-level
generated expressions where we throw an error if the provided value
doesn't match the computed value.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)


Co-authored-by: Savvas Makalias <savvas@crate.io>