### PR TITLE
Make sure nested columns default expressions are considered

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that led to DEFAULT constraints of inner columns of object
+  columns to be ignored.
+
 - The values provided in INSERT or UPDATE statements for object columns which
   contain generated expressions are now validated. The computed expression must
   match the provided value. This makes the behavior consistent with how top

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -136,7 +136,7 @@ final class UpdateSourceGen {
     }
 
     private void injectGeneratedColumns(HashMap<String, Object> updatedSource) {
-        for (Map.Entry<Reference, Input<?>> entry : generatedColumns.toInject()) {
+        for (Map.Entry<Reference, Input<?>> entry : generatedColumns.generatedToInject()) {
             ColumnIdent column = entry.getKey().column();
             Object value = entry.getValue().value();
             Maps.mergeInto(updatedSource, column.name(), column.path(), value);

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -194,7 +194,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.supportedOperations = supportedOperations;
         // scale the fetchrouting timeout by n# of partitions
         this.docColumn = new TableColumn(DocSysColumns.DOC, references);
-        this.defaultExpressionColumns = columns
+        this.defaultExpressionColumns = references.values()
             .stream()
             .filter(r -> r.defaultExpression() != null)
             .collect(Collectors.toList());

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -82,7 +82,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
             XContentHelper.convertToMap(bytes, false, XContentType.JSON).v2(),
             bytes::utf8ToString
         ));
-        Map.Entry<Reference, Input<?>> generatedColumn = generatedColumns.toInject().iterator().next();
+        Map.Entry<Reference, Input<?>> generatedColumn = generatedColumns.generatedToInject().iterator().next();
         assertThat(generatedColumn.getValue().value(), is(new Object[] { 10, 20 }));
     }
 }

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -765,7 +765,7 @@ public class SQLExecutor {
         return sessionContext;
     }
 
-    public <T> T resolveTableInfo(String tableName) {
+    public <T extends TableInfo> T resolveTableInfo(String tableName) {
         IndexParts indexParts = new IndexParts(tableName);
         QualifiedName qualifiedName = QualifiedName.of(indexParts.getSchema(), indexParts.getTable());
         return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionContext.searchPath());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `defaultExpressionColumns` in the `DocTableInfo` didn't contain
entries for nested columns, which caused other parts to not fill in
missing values properly.

We also need to distinguish default expressions and generated column expressions because the former must only be applied if no user value is provided. Previously this distinction wasn't necessary because we simply didn't add any columns to `toInject` that the user specified explicitly in the statement. But for nested columns it is necessary because we don't know up-front if the values will be specified by the user or not - and we must only apply the defaults if the values are null.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)