### PR TITLE
Replace CompletableFutures.failedFuture with JDK failedFuture

### DIFF
--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -23,13 +23,13 @@
 package io.crate.data;
 
 import com.google.common.collect.Iterators;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -120,7 +120,7 @@ public class AsyncOperationBatchIterator<T> implements BatchIterator<T> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (sourceExhausted) {
-            return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
+            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
         }
         return uncheckedLoadNextBatch();
     }
@@ -153,7 +153,7 @@ public class AsyncOperationBatchIterator<T> implements BatchIterator<T> {
                 }
             }
         } catch (Throwable t) {
-            return CompletableFutures.failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
         return null;
     }

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -22,10 +22,10 @@
 
 package io.crate.data;
 
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
@@ -64,7 +64,7 @@ public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (closed) {
-            return CompletableFutures.failedFuture(new IllegalStateException("Iterator is closed"));
+            return CompletableFuture.failedFuture(new IllegalStateException("Iterator is closed"));
         }
         return delegate.loadNextBatch();
     }

--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -22,8 +22,6 @@
 
 package io.crate.data;
 
-import io.crate.concurrent.CompletableFutures;
-
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Iterator;
@@ -151,7 +149,7 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
                 });
             return resultFuture;
         }
-        return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already loaded"));
+        return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already loaded"));
     }
 
     @Override

--- a/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
@@ -157,7 +157,7 @@ public final class CompositeBatchIterator {
                 }
                 return iterator.loadNextBatch();
             }
-            return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
+            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
         }
     }
 
@@ -188,7 +188,7 @@ public final class CompositeBatchIterator {
         @Override
         public CompletionStage<?> loadNextBatch() {
             if (allLoaded()) {
-                return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already loaded"));
+                return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already loaded"));
             }
             int availableThreads = this.availableThreads.getAsInt();
             List<BatchIterator<T>> itToLoad = getIteratorsToLoad(iterators);

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -23,12 +23,12 @@
 package io.crate.data;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.concurrent.CompletableFutures;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -93,7 +93,7 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
 
     @Override
     public CompletionStage<?> loadNextBatch() {
-        return CompletableFutures.failedFuture(new IllegalStateException("All batches already loaded"));
+        return CompletableFuture.failedFuture(new IllegalStateException("All batches already loaded"));
     }
 
     @Override

--- a/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
@@ -22,8 +22,7 @@
 
 package io.crate.data;
 
-import io.crate.concurrent.CompletableFutures;
-
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public final class LimitingBatchIterator<T> extends ForwardingBatchIterator<T> {
@@ -67,7 +66,7 @@ public final class LimitingBatchIterator<T> extends ForwardingBatchIterator<T> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (allLoaded()) {
-            return CompletableFutures.failedFuture(new IllegalStateException("Iterator already fully loaded"));
+            return CompletableFuture.failedFuture(new IllegalStateException("Iterator already fully loaded"));
         }
         return super.loadNextBatch();
     }

--- a/dex/src/test/java/io/crate/testing/BatchIteratorTester.java
+++ b/dex/src/test/java/io/crate/testing/BatchIteratorTester.java
@@ -40,7 +40,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -187,7 +186,7 @@ public class BatchIteratorTester {
             return CompletableFuture.completedFuture(it.currentElement());
         }
         if (it.allLoaded()) {
-            return failedFuture(new IllegalStateException("Iterator is exhausted"));
+            return CompletableFuture.failedFuture(new IllegalStateException("Iterator is exhausted"));
         }
         return it.loadNextBatch()
             .thenCompose(r -> getFirstElementFuture(it))

--- a/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
+++ b/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
@@ -22,7 +22,6 @@
 
 package io.crate.testing;
 
-import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 
 import javax.annotation.Nonnull;
@@ -117,13 +116,13 @@ public class BatchSimulatingIterator<T> implements BatchIterator<T> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (!currentlyLoading.compareAndSet(false, true)) {
-            return CompletableFutures.failedFuture(new IllegalStateException("loadNextBatch call during load operation"));
+            return CompletableFuture.failedFuture(new IllegalStateException("loadNextBatch call during load operation"));
         }
         if (delegate.allLoaded()) {
             currentBatch++;
             if (currentBatch > numBatches) {
                 currentlyLoading.compareAndSet(true, false);
-                return CompletableFutures.failedFuture(new IllegalStateException("Iterator already fully loaded"));
+                return CompletableFuture.failedFuture(new IllegalStateException("Iterator already fully loaded"));
             }
             return CompletableFuture.runAsync(() -> {
                 try {

--- a/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
+++ b/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
@@ -36,16 +36,6 @@ public final class CompletableFutures {
     private CompletableFutures() {
     }
 
-    /**
-     * Creates a {@code CompletableFuture} which will throw the given exception on the invocations
-     * of get()
-     */
-    public static <T> CompletableFuture<T> failedFuture(Throwable t) {
-        CompletableFuture<T> future = new CompletableFuture<>();
-        future.completeExceptionally(t);
-        return future;
-    }
-
     public static <T> CompletableFuture<List<T>> allAsList(Collection<? extends CompletableFuture<? extends T>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
             .thenApply(aVoid -> {
@@ -63,7 +53,7 @@ public final class CompletableFutures {
         try {
             return CompletableFuture.supplyAsync(supplier, executor);
         } catch (Exception e) {
-            return failedFuture(e);
+            return CompletableFuture.failedFuture(e);
         }
     }
 

--- a/shared/src/test/java/io/crate/concurrent/CompletableFuturesTest.java
+++ b/shared/src/test/java/io/crate/concurrent/CompletableFuturesTest.java
@@ -43,13 +43,6 @@ public class CompletableFuturesTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void failedFutureIsCompletedExceptionally() {
-        Exception exception = new Exception("failed future");
-        CompletableFuture<Object> failedFuture = CompletableFutures.failedFuture(exception);
-        assertThat(failedFuture.isCompletedExceptionally(), is(true));
-    }
-
-    @Test
     public void testAllAsListFailurePropagation() throws Exception {
         CompletableFuture<Integer> f1 = new CompletableFuture<>();
         CompletableFuture<Integer> f2 = new CompletableFuture<>();

--- a/sql/src/main/java/io/crate/action/sql/DCLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DCLStatementDispatcher.java
@@ -26,7 +26,6 @@ import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.PrivilegesAnalyzedStatement;
 import io.crate.auth.user.UserManager;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.data.Row;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
@@ -61,8 +60,7 @@ public class DCLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
 
         @Override
         protected CompletableFuture<Long> visitAnalyzedStatement(AnalyzedStatement analyzedStatement, UserManager userManager) {
-            return CompletableFutures.failedFuture(
-                new UnsupportedOperationException(String.format(Locale.ENGLISH, "Can't handle \"%s\"", analyzedStatement)));
+            return CompletableFuture.failedFuture(new UnsupportedOperationException(String.format(Locale.ENGLISH, "Can't handle \"%s\"", analyzedStatement)));
         }
 
         @Override

--- a/sql/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
+++ b/sql/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
@@ -23,7 +23,6 @@
 package io.crate.cluster.decommission;
 
 import io.crate.cluster.gracefulstop.DecommissioningService;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.execution.support.NodeAction;
 import io.crate.execution.support.NodeActionRequestHandler;
 import io.crate.execution.support.Transports;
@@ -77,7 +76,7 @@ public class TransportDecommissionNodeAction implements NodeAction<DecommissionN
         try {
             return decommissioningService.decommission().thenApply(aVoid -> new AcknowledgedResponse(true));
         } catch (Throwable t) {
-            return CompletableFutures.failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
@@ -83,7 +83,6 @@ import static io.crate.analyze.OptimizeTableAnalyzer.FLUSH;
 import static io.crate.analyze.OptimizeTableAnalyzer.MAX_NUM_SEGMENTS;
 import static io.crate.analyze.OptimizeTableAnalyzer.ONLY_EXPUNGE_DELETES;
 import static io.crate.analyze.OptimizeTableAnalyzer.UPGRADE_SEGMENTS;
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 
 /**
  * visitor that dispatches requests based on Analysis class to different actions.
@@ -274,7 +273,7 @@ public class DDLStatementDispatcher {
             try {
                 secureHash = UserActions.generateSecureHash(analysis.properties(), ctx.parameters, ctx.txnCtx, functions);
             } catch (GeneralSecurityException | IllegalArgumentException e) {
-                return failedFuture(e);
+                return CompletableFuture.failedFuture(e);
             }
             return userManager.createUser(analysis.userName(), secureHash);
         }
@@ -285,7 +284,7 @@ public class DDLStatementDispatcher {
             try {
                 newPassword = UserActions.generateSecureHash(analysis.properties(), ctx.parameters, ctx.txnCtx, functions);
             } catch (GeneralSecurityException | IllegalArgumentException e) {
-                return failedFuture(e);
+                return CompletableFuture.failedFuture(e);
             }
             return userManager.alterUser(analysis.userName(), newPassword);
         }

--- a/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
+++ b/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
@@ -52,8 +52,6 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
-
 public final class RerouteActions {
 
     private RerouteActions() {
@@ -69,7 +67,7 @@ public final class RerouteActions {
         try {
             request = prepareRequest(stmt, parameters);
         } catch (Throwable t) {
-            return failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
         FutureActionListener<ClusterRerouteResponse, Long> listener =
             new FutureActionListener<>(r -> r.isAcknowledged() ? 1L : -1L);

--- a/sql/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static org.elasticsearch.index.mapper.MapperService.parseMapping;
 
 @Singleton
@@ -158,7 +157,7 @@ public class TransportSchemaUpdateAction extends TransportMasterNodeAction<Schem
                 return CompletableFuture.completedFuture(new SchemaUpdateResponse(true));
             }
         } catch (Exception e) {
-            return failedFuture(e);
+            return CompletableFuture.failedFuture(e);
         }
         clusterService.submitStateUpdateTask("update-template-mapping", new ClusterStateUpdateTask(Priority.HIGH) {
             @Override

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -35,7 +35,6 @@ import io.crate.analyze.AlterTableOpenCloseAnalyzedStatement;
 import io.crate.analyze.AlterTableRenameAnalyzedStatement;
 import io.crate.analyze.TableParameter;
 import io.crate.analyze.TableParameterInfo;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.concurrent.MultiBiConsumer;
 import io.crate.data.Row;
 import io.crate.execution.ddl.index.SwapAndDropIndexRequest;
@@ -423,7 +422,7 @@ public class AlterTableOperation {
         IndexTemplateMetaData indexTemplateMetaData =
             clusterService.state().metaData().templates().get(templateName);
         if (indexTemplateMetaData == null) {
-            return CompletableFutures.failedFuture(new RuntimeException("Template '" + templateName + "' for partitioned table is missing"));
+            return CompletableFuture.failedFuture(new RuntimeException("Template '" + templateName + "' for partitioned table is missing"));
         }
 
         PutIndexTemplateRequest request = preparePutIndexTemplateRequest(indexScopedSettings, indexTemplateMetaData,
@@ -505,7 +504,7 @@ public class AlterTableOperation {
             String index = indices[0];
             mapping = metaData.index(index).mapping(Constants.DEFAULT_MAPPING_TYPE).getSourceAsMap();
         } catch (ElasticsearchParseException e) {
-            return CompletableFutures.failedFuture(e);
+            return CompletableFuture.failedFuture(e);
         }
 
         FutureActionListener<AcknowledgedResponse, Long> listener = new FutureActionListener<>(r -> 0L);

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -67,7 +67,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static io.crate.data.SentinelRow.SENTINEL;
 
 public class LegacyUpsertByIdTask {
@@ -206,7 +205,7 @@ public class LegacyUpsertByIdTask {
         try {
             requestsByShard = groupRequests();
         } catch (Throwable t) {
-            return failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
         final ShardResponse.CompressedResult compressedResult = new ShardResponse.CompressedResult();
         if (requestsByShard.isEmpty()) {

--- a/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -176,7 +176,7 @@ public final class JobLauncher {
         try {
             setupTasks(txnCtx, operationByServer, handlerPhases, handlerConsumers);
         } catch (Throwable throwable) {
-            return Collections.singletonList(CompletableFutures.failedFuture(throwable));
+            return Collections.singletonList(CompletableFuture.failedFuture(throwable));
         }
         return results;
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -80,7 +80,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.crate.breaker.RamAccountingContext.roundUp;
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static io.crate.execution.dsl.projection.Projections.shardProjections;
 import static io.crate.execution.engine.collect.LuceneShardCollectorProvider.getCollectorContext;
 
@@ -194,7 +193,7 @@ final class GroupByOptimizedIterator {
                             )
                         );
                     } catch (Throwable t) {
-                        return failedFuture(t);
+                        return CompletableFuture.failedFuture(t);
                     }
                 },
                 true

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -24,7 +24,6 @@ package io.crate.execution.engine.collect.collectors;
 
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -49,6 +48,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -185,9 +185,9 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (closed) {
-            return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator is closed"));
+            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator is closed"));
         }
-        return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
+        return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
     }
 
     private Weight createWeight() throws IOException {

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactory.java
@@ -44,7 +44,6 @@ import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static java.util.Collections.singletonList;
 
 /**
@@ -108,7 +107,7 @@ public class OrderedLuceneBatchIteratorFactory {
 
         private CompletableFuture<List<KeyIterable<ShardId, Row>>> tryFetchMore(ShardId shardId) {
             if (allExhausted()) {
-                return failedFuture(new IllegalStateException("Cannot fetch more if source is exhausted"));
+                return CompletableFuture.failedFuture(new IllegalStateException("Cannot fetch more if source is exhausted"));
             }
             if (shardId == null) {
                 return ThreadPools.runWithAvailableThreads(
@@ -125,7 +124,7 @@ public class OrderedLuceneBatchIteratorFactory {
             try {
                 return CompletableFuture.completedFuture(singletonList(collector.get()));
             } catch (Exception e) {
-                return failedFuture(e);
+                return CompletableFuture.failedFuture(e);
             }
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -23,7 +23,6 @@ package io.crate.execution.engine.collect.files;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.CloseAssertingBatchIterator;
 import io.crate.data.Input;
@@ -261,7 +260,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
 
     @Override
     public CompletableFuture<?> loadNextBatch() {
-        return CompletableFutures.failedFuture(new IllegalStateException("All batches already loaded"));
+        return CompletableFuture.failedFuture(new IllegalStateException("All batches already loaded"));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.collect.stats;
 
-import io.crate.concurrent.CompletableFutures;
 import io.crate.execution.support.NodeAction;
 import io.crate.execution.support.NodeActionRequestHandler;
 import io.crate.execution.support.Transports;
@@ -85,7 +84,7 @@ public class TransportNodeStatsAction implements NodeAction<NodeStatsRequest, No
             NodeStatsContext context = nodeContextFieldsResolver.forTopColumnIdents(request.columnIdents());
             return CompletableFuture.completedFuture(new NodeStatsResponse(context));
         } catch (Throwable t) {
-            return CompletableFutures.failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -34,8 +34,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
-
 /**
  * BatchIterator implementation that is backed by a {@link PagingIterator}.
  *
@@ -106,10 +104,10 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
     @Override
     public CompletionStage<?> loadNextBatch() {
         if (closed) {
-            return failedFuture(new IllegalStateException("BatchIterator already closed"));
+            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already closed"));
         }
         if (allLoaded()) {
-            return failedFuture(new IllegalStateException("All data already loaded"));
+            return CompletableFuture.failedFuture(new IllegalStateException("All data already loaded"));
         }
         Throwable err;
         CompletableFuture<? extends Iterable<? extends KeyIterable<Key, Row>>> future;
@@ -118,7 +116,7 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
             if (err == null) {
                 currentlyLoading = future = fetchMore.apply(pagingIterator.exhaustedIterable());
             } else {
-                future = failedFuture(err);
+                future = CompletableFuture.failedFuture(err);
             }
         }
         if (err == null) {

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
@@ -106,7 +106,7 @@ public class FetchBatchAccumulator implements BatchAccumulator<Row, Iterator<? e
             try {
                 futures.add(fetchOperation.fetch(nodeId, toFetch, isLastBatch));
             } catch (Throwable t) {
-                futures.add(CompletableFutures.failedFuture(t));
+                futures.add(CompletableFuture.failedFuture(t));
             }
             if (isLastBatch) {
                 it.remove();

--- a/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -47,8 +47,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
-
 /**
  * A {@link PageBucketReceiver} which receives buckets from upstreams, wait to receive the page from all upstreams
  * and forwards the merged bucket results to the consumers for further processing. It then continues to receive
@@ -231,7 +229,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
 
     private CompletableFuture<? extends Iterable<? extends KeyIterable<Integer, Row>>> fetchMore(Integer exhaustedBucket) {
         if (allUpstreamsExhausted()) {
-            return failedFuture(new IllegalStateException("Source is exhausted"));
+            return CompletableFuture.failedFuture(new IllegalStateException("Source is exhausted"));
         }
         currentPage = new CompletableFuture<>();
         if (exhaustedBucket == null || exhausted.contains(exhaustedBucket)) {

--- a/sql/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -24,7 +24,6 @@ package io.crate.execution.jobs;
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.exceptions.JobKilledException;
 import io.crate.exceptions.SQLExceptions;
@@ -295,7 +294,7 @@ public class RootTask implements CompletionListenable<Void> {
             // sanity check
             IllegalStateException stateException = new IllegalStateException(
                 String.format(Locale.ENGLISH, "Tried to finish profiling job [id=%s], but profiling is not enabled.", jobId));
-            return CompletableFutures.failedFuture(stateException);
+            return CompletableFuture.failedFuture(stateException);
         }
         assert profilingFuture != null : "profilingFuture must not be null";
         return profilingFuture.whenComplete((o, t) -> close());

--- a/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -98,7 +98,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
             RootTask context = tasksService.createTask(contextBuilder);
             context.start();
         } catch (Throwable t) {
-            return CompletableFutures.failedFuture(t);
+            return CompletableFuture.failedFuture(t);
         }
 
         if (directResponseFutures.size() == 0) {

--- a/sql/src/main/java/io/crate/execution/support/ChainableActions.java
+++ b/sql/src/main/java/io/crate/execution/support/ChainableActions.java
@@ -23,7 +23,6 @@
 package io.crate.execution.support;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.MultiException;
 
@@ -87,7 +86,7 @@ public class ChainableActions {
             // Only undo the chain once
             if (result.undoDone) {
                 Exceptions.rethrowUnchecked(result.error);
-                return CompletableFutures.failedFuture(result.error);
+                return CompletableFuture.failedFuture(result.error);
             }
             int previousActionsSize = previousActions.size();
             assert previousActionsSize > 0 : "previous actions cannot be empty. " +
@@ -111,7 +110,7 @@ public class ChainableActions {
                 .handle(result::addResultAndError)
                 .thenCompose(r -> {
                     Exceptions.rethrowUnchecked(result.error);
-                    return CompletableFutures.failedFuture(result.error);
+                    return CompletableFuture.failedFuture(result.error);
                 });
         }
         return CompletableFuture.completedFuture(result.result);

--- a/sql/src/main/java/io/crate/user/StubUserManager.java
+++ b/sql/src/main/java/io/crate/user/StubUserManager.java
@@ -27,7 +27,6 @@ import io.crate.analyze.user.Privilege;
 import io.crate.auth.user.AccessControl;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.UnsupportedFeatureException;
 
 import javax.annotation.Nullable;
@@ -38,30 +37,22 @@ public class StubUserManager implements UserManager {
 
     @Override
     public CompletableFuture<Long> createUser(String userName, @Nullable SecureHash hashedPw) {
-        return CompletableFutures.failedFuture(
-            new UnsupportedFeatureException("CREATE USER is only supported in enterprise version")
-        );
+        return CompletableFuture.failedFuture(new UnsupportedFeatureException("CREATE USER is only supported in enterprise version"));
     }
 
     @Override
     public CompletableFuture<Long> dropUser(String userName, boolean suppressNotFoundError) {
-        return CompletableFutures.failedFuture(
-            new UnsupportedFeatureException("DROP USER is only supported in enterprise version")
-        );
+        return CompletableFuture.failedFuture(new UnsupportedFeatureException("DROP USER is only supported in enterprise version"));
     }
 
     @Override
     public CompletableFuture<Long> alterUser(String userName, @Nullable SecureHash newHashedPw) {
-        return CompletableFutures.failedFuture(
-            new UnsupportedFeatureException("ALTER USER is only supported in enterprise version")
-        );
+        return CompletableFuture.failedFuture(new UnsupportedFeatureException("ALTER USER is only supported in enterprise version"));
     }
 
     @Override
     public CompletableFuture<Long> applyPrivileges(Collection<String> userNames, Collection<Privilege> privileges) {
-        return CompletableFutures.failedFuture(
-            new UnsupportedFeatureException("GRANT or REVOKE privileges is only supported in enterprise version")
-        );
+        return CompletableFuture.failedFuture(new UnsupportedFeatureException("GRANT or REVOKE privileges is only supported in enterprise version"));
     }
 
     @Nullable

--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
@@ -45,7 +45,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -76,7 +75,7 @@ public class BatchPagingIteratorTest {
             pagingIterator.merge(singletonList(new KeyIterable<>(0, rows)));
             return new BatchPagingIterator<>(
                 pagingIterator,
-                exhaustedIt -> failedFuture(new IllegalStateException("upstreams exhausted")),
+                exhaustedIt -> CompletableFuture.failedFuture(new IllegalStateException("upstreams exhausted")),
                 () -> true,
                 throwable -> {}
             );
@@ -132,7 +131,7 @@ public class BatchPagingIteratorTest {
         TestPagingIterator pagingIterator = new TestPagingIterator();
         BatchPagingIterator<Integer> iterator = new BatchPagingIterator<>(
             pagingIterator,
-            exhaustedIt -> failedFuture(new IllegalStateException("upstreams exhausted")),
+            exhaustedIt -> CompletableFuture.failedFuture(new IllegalStateException("upstreams exhausted")),
             () -> true,
             throwable -> {}
         );

--- a/sql/src/test/java/io/crate/execution/support/ChainableActionsTest.java
+++ b/sql/src/test/java/io/crate/execution/support/ChainableActionsTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.support;
 
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.MultiException;
 import io.crate.exceptions.SQLExceptions;
 import org.junit.Test;
@@ -121,7 +120,7 @@ public class ChainableActionsTest {
             numActions - 1,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         CompletableFuture<Integer> result = ChainableActions.run(actions);
@@ -143,7 +142,7 @@ public class ChainableActionsTest {
             numActions - 1,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         CompletableFuture<Integer> result = ChainableActions.run(actions);
@@ -169,7 +168,7 @@ public class ChainableActionsTest {
             numActions - 1,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         for (int i = 0; i < numActions - 1; i++) {
@@ -214,14 +213,14 @@ public class ChainableActionsTest {
             doCalls,
             undoCalls,
             () -> CompletableFuture.completedFuture(0),
-            () -> CompletableFutures.failedFuture(new RuntimeException("the undo operation failed"))));
+            () -> CompletableFuture.failedFuture(new RuntimeException("the undo operation failed"))));
 
         // last one which will throw an error, undo() on all previous actions must be called in reverse order
         actions.add(new TrackedChainableAction(
             numActions - 1,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("the do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("the do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         CompletableFuture<Integer> result = ChainableActions.run(actions);
@@ -257,7 +256,7 @@ public class ChainableActionsTest {
             0,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("the first do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("the first do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         // 2nd one will throw an error on rollback
@@ -266,14 +265,14 @@ public class ChainableActionsTest {
             doCalls,
             undoCalls,
             () -> CompletableFuture.completedFuture(0),
-            () -> CompletableFutures.failedFuture(new RuntimeException("the undo operation failed"))));
+            () -> CompletableFuture.failedFuture(new RuntimeException("the undo operation failed"))));
 
         // last one which will throw an error, undo() on all previous actions must be called in reverse order
         actions.add(new TrackedChainableAction(
             2,
             doCalls,
             undoCalls,
-            () -> CompletableFutures.failedFuture(new RuntimeException("the do operation failed")),
+            () -> CompletableFuture.failedFuture(new RuntimeException("the do operation failed")),
             () -> CompletableFuture.completedFuture(0)));
 
         CompletableFuture<Integer> result = ChainableActions.run(actions);

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -32,7 +32,6 @@ import io.crate.auth.AuthenticationMethod;
 import io.crate.auth.user.AccessControl;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.planner.DependencyCarrier;
@@ -498,7 +497,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         if (failure != null) {
             when(session.sync()).thenAnswer(invocationOnMock -> {
                 Messages.sendErrorResponse(channel, failure);
-                return CompletableFutures.failedFuture(failure);
+                return CompletableFuture.failedFuture(failure);
             });
         } else {
             when(session.sync()).thenReturn(CompletableFuture.completedFuture(null));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Since we're no longer on JDK8 we can get rid of our custom failedFuture.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)