### PR TITLE
Change TablesNeedUpgradeSysCheck to check for re-index requirement

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1398,7 +1398,7 @@ Here's an example query::
   | id | description                                                      |
   +----+--------------------------------------------------------------...-+
   |  2 | The total number of partitions of one or more partitioned tab... |
-  |  3 | The following tables need to be upgraded for compatibility wi... |
+  |  3 | The following tables need to be recreated for compatibility w... |
   |  6 | Your CrateDB license is valid. Enjoy CrateDB!                    |
   +----+--------------------------------------------------------------...-+
   SELECT 3 rows in set (... sec)
@@ -1423,28 +1423,58 @@ This check warns if any :ref:`partitioned table <partitioned_tables>` has more
 than 1000 partitions to detect the usage of a high cardinality field for
 partitioning.
 
-Tables need to be upgraded
-..........................
+Tables need to be recreated
+...........................
 
 .. WARNING::
 
-   Do not attempt to upgrade your cluster if this cluster check is failing.
-   Follow the instructions below to get this cluster check passing.
+   Do not attempt to upgrade your cluster to a newer major version if this
+   cluster check is failing. Follow the instructions below to get this cluster
+   check passing.
 
-This check warns you if there are tables that need to be upgraded for
-compatibility with future versions of CrateDB.
+This check warns you if there are tables that need to be recreated for
+compatibility with future major versions of CrateDB.
 
-For tables that need upgrading, use the :ref:`sql_ref_optimize` command to
-perform a :ref:`optimize_segments_upgrade`.
+If you try to upgrade to the next major version of CrateDB with tables that
+have not been recreated, CrateDB will refuse to start.
 
-For each table, run a command like so::
+To recreate a table, you have to create new tables, copy over the data and
+rename or remove the old table.
 
-  OPTIMIZE TABLE table_ident WITH (upgrade_segments=true);
+1) Use :ref:`ref-show-create-table` to get the schema required to create an
+empty copy of the table to recreate::
 
-Here, replace ``table_ident`` with the name of the table you are upgrading.
+    SHOW CREATE TABLE your_table;
 
-When all tables that needed upgrading have been upgraded, this cluster check
-should pass.
+2) Create a new temporary table, using the schema returned from
+:ref:`ref-show-create-table`::
+
+    CREATE TABLE tmp_your_table (...);
+
+3) Prevent inserts to the original table::
+
+    ALTER TABLE your_table SET ("blocks.read_only" = true);
+
+4) Copy the data::
+
+    INSERT INTO tmp_your_table (...) (SELECT ... FROM your_table);
+
+5) Swap the tables::
+
+    ALTER CLUSTER SWAP TABLE tmp_your_table TO your_table;
+
+6) Confirm the new ``your_table`` contains all data and has the new version::
+
+    SELECT count(*) FROM your_table;
+    SELECT version FROM information_schema.tables where table_name = 'your_table';
+
+7) Drop the now obsolete old table::
+
+    ALTER TABLE tmp_your_table SET ("blocks.read_only" = false);
+    DROP TABLE tmp_your_table;
+
+
+When all tables have been recreated, this cluster check will pass.
 
 .. NOTE::
 
@@ -1832,60 +1862,6 @@ table, either directly or inherited from the ``SCHEMA`` or ``CLUSTER``.
 A user that doesn't have superuser privileges is allowed to retrieve only
 their own job logs entries, while a user with superuser privileges has access
 to all.
-
-Before upgrading
-================
-
-In certain cases, for compatibility with future versions of CrateDB,
-you need to perform some actions before upgrading to a new CrateDB version.
-
-Tables need to be recreated
----------------------------
-
-The following should be performed if there are tables
-that need to be recreated for compatibility with future versions of CrateDB.
-
-For tables that need recreating, use :ref:`ref-show-create-table` to get the
-SQL statement needed to restore the table, like so::
-
-  SHOW CREATE TABLE table_ident;
-
-Here, ``table_ident`` is the name of the table you want to recreate.
-
-Copy the output of this command, replace the ``table_ident`` with
-``table_ident_new``, and execute it to create a new table identical to the one
-you want to recreate.
-
-Make sure you stop inserting data to the original ``table_ident`` by
-executing::
-
-  ALTER TABLE table_ident SET ("blocks.read_only" = true);
-
-Copy the data from the original table to the new one by executing::
-
-  INSERT INTO table_ident_new (col1, col2, ...)
-     (SELECT col1, col2, ... FROM table_ident);
-
-Make sure that you include all columns and that the columns appear in the same
-order in both lists.
-
-Execute refresh on the new table like so::
-
-  REFRESH TABLE table_ident_new;
-
-Make sure table the new table and the old table have the same data.
-
-Drop the original table by executing::
-
-  ALTER TABLE table_ident SET ("blocks.read_only" = false);
-
-::
-
-  DROP TABLE table_ident;
-
-Rename the new table back to its original name::
-
-  ALTER TABLE table_ident_new RENAME TO table_ident;
 
 
 .. _configuration: ../configuration.html

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,10 @@ None
 Fixes
 =====
 
+- Fixed the tables compatibility check to correctly indicate when tables need
+  to be recreated in preparation for a CrateDB upgrade towards the next major
+  version of CrateDB.
+
 - Fixed an issue that led to DEFAULT constraints of inner columns of object
   columns to be ignored.
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -22,23 +22,16 @@
 
 package io.crate.expression.reference.sys.check.cluster;
 
-import io.crate.action.sql.ResultReceiver;
-import io.crate.action.sql.SQLOperations;
-import io.crate.action.sql.Session;
-import io.crate.data.Row;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.crate.expression.reference.sys.check.AbstractSysCheck;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Statement;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.Version;
+import io.crate.metadata.RelationName;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
 
-import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 
 @Singleton
@@ -46,25 +39,15 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
     public static final int ID = 3;
     public static final String DESCRIPTION =
-        "The following tables need to be upgraded for compatibility with future versions of CrateDB: ";
+        "The following tables need to be recreated for compatibility with future major versions of CrateDB: ";
 
-    private static final String STMT = "SELECT schema_name || '.' || table_name, min_lucene_version " +
-                                       "FROM sys.shards " +
-                                       "WHERE min_lucene_version not like '" + Version.LATEST.major + ".%.%' " +
-                                       "GROUP BY 1, 2 " +
-                                       "ORDER BY 1";
-    private static final Statement PARSED_STMT = SqlParser.createStatement(STMT);
-
-    private final Logger logger;
-    private final Provider<SQLOperations> sqlOperationsProvider;
+    private final ClusterService clusterService;
     private volatile Collection<String> tablesNeedUpgrade;
-    private Session session;
 
     @Inject
-    public TablesNeedUpgradeSysCheck(Provider<SQLOperations> sqlOperationsProvider) {
-        super(ID, DESCRIPTION, Severity.MEDIUM);
-        this.sqlOperationsProvider = sqlOperationsProvider;
-        this.logger = LogManager.getLogger(TablesNeedUpgradeSysCheck.class);
+    public TablesNeedUpgradeSysCheck(ClusterService clusterService) {
+        super(ID, DESCRIPTION, Severity.LOW);
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -74,70 +57,22 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
     @Override
     public CompletableFuture<?> computeResult() {
-        final CompletableFuture<Collection<String>> result = new CompletableFuture<>();
-        try {
-            session().quickExec(STMT, stmt -> PARSED_STMT, new SycCheckResultReceiver(result), Row.EMPTY);
-        } catch (Throwable t) {
-            result.completeExceptionally(t);
-        }
-        return result.handle((tableNames, throwable) -> {
-            if (throwable == null) {
-                tablesNeedUpgrade = tableNames;
-            } else {
-                logger.error("error while checking for tables that need upgrade", throwable);
-            }
-            // `select * from sys.checks` should not fail if an error occurred here, so swallow exception
-            return null;
-        });
-    }
+        ArrayList<String> fqTables = new ArrayList<>();
+        for (ObjectCursor<IndexMetaData> cursor : clusterService.state()
+            .metaData()
+            .indices()
+            .values()) {
 
-    private Session session() {
-        if (session == null) {
-            session = sqlOperationsProvider.get().newSystemSession();
+            if (cursor.value.getCreationVersion().major < org.elasticsearch.Version.CURRENT.major) {
+                fqTables.add(RelationName.fqnFromIndexName(cursor.value.getIndex().getName()));
+            }
         }
-        return session;
+        tablesNeedUpgrade = fqTables;
+        return CompletableFuture.completedFuture(fqTables);
     }
 
     @Override
     public boolean isValid() {
         return tablesNeedUpgrade == null || tablesNeedUpgrade.isEmpty();
-    }
-
-    private class SycCheckResultReceiver implements ResultReceiver {
-
-        private final CompletableFuture<Collection<String>> result;
-        private final Collection<String> tables;
-
-        private SycCheckResultReceiver(CompletableFuture<Collection<String>> result) {
-            this.result = result;
-            this.tables = new HashSet<>();
-        }
-
-        @Override
-        public void setNextRow(Row row) {
-            // Row[0] = table_name, Row[1] = min_lucene_version
-            if (LuceneVersionChecks.isUpgradeRequired((String) row.get(1))) {
-                tables.add((String) row.get(0));
-            }
-        }
-
-        @Override
-        public void batchFinished() {
-        }
-
-        @Override
-        public void allFinished(boolean interrupted) {
-            result.complete(tables);
-        }
-
-        @Override
-        public void fail(@Nonnull Throwable t) {
-            result.completeExceptionally(t);
-        }
-
-        @Override
-        public CompletableFuture<Collection<String>> completionFuture() {
-            return result;
-        }
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -46,7 +46,7 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
         SQLResponse response = execute("select severity, passed from sys.checks order by id asc");
         assertThat(response.rowCount(), equalTo(2L));
         assertThat(response.rows()[0][0], is(Severity.MEDIUM.value()));
-        assertThat(response.rows()[1][0], is(Severity.MEDIUM.value()));
+        assertThat(response.rows()[1][0], is(Severity.LOW.value()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
@@ -56,6 +56,8 @@ public class TablesNeedUpgradeSysCheckTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(4L));
         execute("select * from sys.checks where id = 3");
         assertThat(response.rowCount(), is(1L));
-        assertThat(response.rows()[0][0], is("The following tables need to be upgraded for compatibility with future versions of CrateDB: [x.demo] https://cr8.is/d-cluster-check-3"));
+        assertThat(response.rows()[0][0], is(
+            "The following tables need to be recreated for compatibility with " +
+            "future major versions of CrateDB: [x.demo] https://cr8.is/d-cluster-check-3"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The check with ID 3 was initially the sys-check that checked for tables
that need to be re-created (See commit da9a66e918b57c487d56a6ec3ae6bbed60b7db93)

This changes the logic of the check back to check for the re-index
requirement as a segment upgrade alone isn't sufficient to make tables
compatible for the next major version.

It also changes the severity to low (given that no action has to be
taken if there are no immediate upgrade plans).

Within CrateDB 4.x this will trigger for tables created in 3.x.
With a backport to 3.3 this will trigger for tables created in 2.x.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)