### PR TITLE
Extend the write.wait_for_active_shards docs

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -45,7 +45,9 @@ Changes
 - Added support for the ``lag`` window function as enterprise features.
 
 - Changed the default for :ref:`sql_ref_write_wait_for_active_shards` from
-  ``ALL`` to ``1``.
+  ``ALL`` to ``1``. This will improve the out of box experience as it allows a
+  subset of nodes to become unavailable without blocking write operations. See
+  the documentation for more details about the implications.
 
 Fixes
 =====


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)