### PR TITLE
Fix a possible NPE on the `sys.allocations` table.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Changes
 Fixes
 =====
 
+- Fixed a possible NPE which could occur when querying the ``sys.allocations``
+  table.
+
 - Fixed the tables compatibility check to correctly indicate when tables need
   to be recreated in preparation for a CrateDB upgrade towards the next major
   version of CrateDB.

--- a/enterprise/users/src/main/java/io/crate/metadata/sys/SysPrivilegesTableInfo.java
+++ b/enterprise/users/src/main/java/io/crate/metadata/sys/SysPrivilegesTableInfo.java
@@ -38,11 +38,12 @@ import java.util.stream.StreamSupport;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.STRING;
 
-public class SysPrivilegesTableInfo extends StaticTableInfo {
+public class SysPrivilegesTableInfo extends StaticTableInfo<SysPrivilegesTableInfo.PrivilegeRow> {
 
     private static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "privileges");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;
 
+    @SuppressWarnings("WeakerAccess")
     public static class PrivilegeRow {
         private final String grantee;
         private final Privilege privilege;

--- a/enterprise/users/src/main/java/io/crate/metadata/sys/SysUsersTableInfo.java
+++ b/enterprise/users/src/main/java/io/crate/metadata/sys/SysUsersTableInfo.java
@@ -37,7 +37,7 @@ import static io.crate.execution.engine.collect.NestableCollectExpression.forFun
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.BOOLEAN;
 
-public class SysUsersTableInfo extends StaticTableInfo {
+public class SysUsersTableInfo extends StaticTableInfo<User> {
 
     private static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "users");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -48,7 +48,7 @@ import static io.crate.execution.engine.collect.NestableCollectExpression.forFun
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
 
 
-public class InformationColumnsTableInfo extends InformationTableInfo {
+public class InformationColumnsTableInfo extends InformationTableInfo<ColumnContext> {
 
     public static final String NAME = "columns";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
@@ -39,7 +39,7 @@ import static io.crate.types.DataTypes.INTEGER;
 /**
  * Table which contains the primary keys of all user tables.
  */
-public class InformationKeyColumnUsageTableInfo extends InformationTableInfo {
+public class InformationKeyColumnUsageTableInfo extends InformationTableInfo<InformationSchemaIterables.KeyColumnUsage> {
 
     public static final String NAME = "key_column_usage";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -49,7 +49,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.STRING;
 
-public class InformationPartitionsTableInfo extends InformationTableInfo {
+public class InformationPartitionsTableInfo extends InformationTableInfo<PartitionInfo> {
 
     public static final String NAME = "table_partitions";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
 import static io.crate.types.DataTypes.STRING;
 
-public class InformationReferentialConstraintsTableInfo extends InformationTableInfo {
+public class InformationReferentialConstraintsTableInfo extends InformationTableInfo<Void> {
 
     public static final String NAME = "referential_constraints";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationRoutinesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationRoutinesTableInfo.java
@@ -33,7 +33,7 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 
-public class InformationRoutinesTableInfo extends InformationTableInfo {
+public class InformationRoutinesTableInfo extends InformationTableInfo<RoutineInfo> {
 
     public static final String NAME = "routines";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
@@ -28,12 +28,12 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.SchemaInfo;
 
+import java.util.Map;
+
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.STRING;
 
-import java.util.Map;
-
-public class InformationSchemataTableInfo extends InformationTableInfo {
+public class InformationSchemataTableInfo extends InformationTableInfo<SchemaInfo> {
 
     public static final String NAME = "schemata";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationSqlFeaturesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSqlFeaturesTableInfo.java
@@ -22,21 +22,21 @@
 
 package io.crate.metadata.information;
 
+import io.crate.execution.engine.collect.files.SqlFeatureContext;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.execution.engine.collect.files.SqlFeatureContext;
 import io.crate.metadata.table.ColumnRegistrar;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.BOOLEAN;
 
 import java.util.Map;
 
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.STRING;
 
-public class InformationSqlFeaturesTableInfo extends InformationTableInfo {
+
+public class InformationSqlFeaturesTableInfo extends InformationTableInfo<SqlFeatureContext> {
 
     public static final String NAME = "sql_features";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
@@ -28,14 +28,13 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.ConstraintInfo;
 
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-
-
 import java.util.Map;
 
-public class InformationTableConstraintsTableInfo extends InformationTableInfo {
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.STRING;
+
+public class InformationTableConstraintsTableInfo extends InformationTableInfo<ConstraintInfo> {
 
     public static final String NAME = "table_constraints";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
@@ -34,16 +34,16 @@ import io.crate.metadata.table.StaticTableInfo;
 import org.elasticsearch.cluster.ClusterState;
 
 
-public class InformationTableInfo extends StaticTableInfo {
+public abstract class InformationTableInfo<T> extends StaticTableInfo<T> {
 
     InformationTableInfo(RelationName ident,
-                         ColumnRegistrar columnRegistrar,
+                         ColumnRegistrar<T> columnRegistrar,
                          ImmutableList<ColumnIdent> primaryKey) {
         super(ident, columnRegistrar, primaryKey);
     }
 
     InformationTableInfo(RelationName ident,
-                         ColumnRegistrar columnRegistrar,
+                         ColumnRegistrar<T> columnRegistrar,
                          String... primaryKey) {
         super(ident, columnRegistrar, primaryKey);
     }

--- a/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -47,7 +47,7 @@ import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class InformationTablesTableInfo extends InformationTableInfo {
+public class InformationTablesTableInfo extends InformationTableInfo<RelationInfo> {
 
     public static final String NAME = "tables";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/information/InformationViewsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationViewsTableInfo.java
@@ -35,7 +35,7 @@ import static io.crate.execution.engine.collect.NestableCollectExpression.forFun
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING;
 
-public class InformationViewsTableInfo extends InformationTableInfo {
+public class InformationViewsTableInfo extends InformationTableInfo<ViewInfo> {
 
     public static final String NAME = "views";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
@@ -41,7 +41,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
 
 
-public class PgAttrDefTable extends StaticTableInfo {
+public class PgAttrDefTable extends StaticTableInfo<Void> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attrdef");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -50,7 +50,7 @@ import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgAttributeTable extends StaticTableInfo {
+public class PgAttributeTable extends StaticTableInfo<ColumnContext> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attribute");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -49,7 +49,7 @@ import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgClassTable extends StaticTableInfo {
+public class PgClassTable extends StaticTableInfo<RelationInfo> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_class");
     private static final String KIND_TABLE = "r";

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
@@ -49,7 +49,7 @@ import static io.crate.types.DataTypes.SHORT_ARRAY;
 import static io.crate.types.DataTypes.INTEGER_ARRAY;
 import static io.crate.types.DataTypes.INTEGER;
 
-public class PgConstraintTable extends StaticTableInfo {
+public class PgConstraintTable extends StaticTableInfo<ConstraintInfo> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_constraint");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
@@ -43,7 +43,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgDatabaseTable extends StaticTableInfo {
+public class PgDatabaseTable extends StaticTableInfo<Void> {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_database");
 
@@ -71,7 +71,7 @@ public class PgDatabaseTable extends StaticTableInfo {
             .register("datacl", STRING_ARRAY, () -> constant(null));
     }
 
-    public PgDatabaseTable() {
+    PgDatabaseTable() {
         super(NAME, columnRegistrar());
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
@@ -40,7 +40,7 @@ import static io.crate.execution.engine.collect.NestableCollectExpression.consta
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.INTEGER;
 
-public final class PgDescriptionTable extends StaticTableInfo {
+public final class PgDescriptionTable extends StaticTableInfo<Void> {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_description");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -44,7 +44,7 @@ import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.SHORT_ARRAY;
 import static io.crate.types.DataTypes.INTEGER_ARRAY;
 
-public class PgIndexTable extends StaticTableInfo {
+public class PgIndexTable extends StaticTableInfo<Void> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_index");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
@@ -44,7 +44,7 @@ import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.INTEGER;
 
-public class PgNamespaceTable extends StaticTableInfo {
+public class PgNamespaceTable extends StaticTableInfo<SchemaInfo> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_namespace");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
@@ -45,7 +45,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
 
 
-public class PgSettingsTable extends StaticTableInfo {
+public class PgSettingsTable extends StaticTableInfo<NamedSessionSetting> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_settings");
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -45,7 +45,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.SHORT;
 
-public class PgTypeTable extends StaticTableInfo {
+public class PgTypeTable extends StaticTableInfo<PGType> {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_type");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -37,13 +37,14 @@ import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.ObjectType;
 import org.elasticsearch.cluster.ClusterState;
 
+import java.util.HashMap;
 import java.util.Map;
 
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.STRING_ARRAY;
-import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 
 public class SysAllocationsTableInfo extends StaticTableInfo {
 
@@ -78,14 +79,13 @@ public class SysAllocationsTableInfo extends StaticTableInfo {
             .build(), () -> new SysAllocationDecisionsExpression<Map<String, Object>>() {
                 @Override
                 protected Map<String, Object> valueForItem(SysAllocation.SysAllocationNodeDecision input) {
-                    return Map.of(
-                        Columns.DECISIONS_NODE_ID.path().get(0), input.nodeId(),
-                        Columns.DECISIONS_NODE_NAME.path().get(0), input.nodeName(),
-                        Columns.DECISIONS_EXPLANATIONS.path().get(0), input.explanations()
-                    );
+                    var decision = new HashMap<String, Object>(3);
+                    decision.put(Columns.DECISIONS_NODE_ID.path().get(0), input.nodeId());
+                    decision.put(Columns.DECISIONS_NODE_NAME.path().get(0), input.nodeName());
+                    decision.put(Columns.DECISIONS_EXPLANATIONS.path().get(0), input.explanations());
+                    return decision;
                 }
-                }
-             )
+            })
             .register("decisions","node_id", STRING, () -> new SysAllocationDecisionsExpression<String>() {
 
                 @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -46,7 +46,7 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class SysAllocationsTableInfo extends StaticTableInfo {
+public class SysAllocationsTableInfo extends StaticTableInfo<SysAllocation> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "allocations");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
@@ -34,14 +34,14 @@ import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import org.elasticsearch.cluster.ClusterState;
 
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.BOOLEAN;
-
 import java.util.Map;
 
-public class SysChecksTableInfo extends StaticTableInfo {
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+
+public class SysChecksTableInfo extends StaticTableInfo<SysCheck> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "checks");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -50,7 +50,7 @@ import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.ISSUED_TO;
 import static io.crate.expression.reference.sys.cluster.ClusterLicenseExpression.MAX_NODES;
 
-public class SysClusterTableInfo extends StaticTableInfo {
+public class SysClusterTableInfo extends StaticTableInfo<Void> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "cluster");
 
@@ -72,8 +72,8 @@ public class SysClusterTableInfo extends StaticTableInfo {
         return RowGranularity.CLUSTER;
     }
 
-    private static ColumnRegistrar buildColumnRegistrar() {
-        return new ColumnRegistrar(IDENT, RowGranularity.CLUSTER)
+    private static ColumnRegistrar<Void> buildColumnRegistrar() {
+        return new ColumnRegistrar<Void>(IDENT, RowGranularity.CLUSTER)
             .register("id", DataTypes.STRING)
             .register("name", DataTypes.STRING)
             .register("master_node", DataTypes.STRING)

--- a/sql/src/main/java/io/crate/metadata/sys/SysHealthTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysHealthTableInfo.java
@@ -41,7 +41,7 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.LONG;
 
-public class SysHealthTableInfo extends StaticTableInfo {
+public class SysHealthTableInfo extends StaticTableInfo<TableHealth> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "health");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -44,7 +44,7 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class SysJobsLogTableInfo extends StaticTableInfo {
+public class SysJobsLogTableInfo extends StaticTableInfo<JobContextLog> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "jobs_log");
     public static final TableInfo INSTANCE = new SysJobsLogTableInfo();

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 
-public class SysJobsTableInfo extends StaticTableInfo {
+public class SysJobsTableInfo extends StaticTableInfo<JobContext> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "jobs");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -46,7 +46,7 @@ import static io.crate.types.DataTypes.DOUBLE;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.UNDEFINED;
 
-public class SysMetricsTableInfo extends StaticTableInfo {
+public class SysMetricsTableInfo extends StaticTableInfo<MetricsView> {
 
     public static final RelationName NAME = new RelationName(SysSchemaInfo.NAME, "jobs_metrics");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
@@ -47,7 +47,7 @@ import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 
 
-public class SysNodeChecksTableInfo extends StaticTableInfo {
+public class SysNodeChecksTableInfo extends StaticTableInfo<SysNodeCheck> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "node_checks");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -73,10 +73,9 @@ import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 import static io.crate.types.DataTypes.INTEGER;
 
-public class SysNodesTableInfo extends StaticTableInfo {
+public class SysNodesTableInfo extends StaticTableInfo<NodeStatsContext> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "nodes");
-    private static final ImmutableList<ColumnIdent> PRIMARY_KEY = ImmutableList.of(new ColumnIdent("id"));
 
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
@@ -41,7 +41,7 @@ import static io.crate.types.DataTypes.TIMESTAMPZ;
 import static io.crate.types.DataTypes.LONG;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 
-public class SysOperationsLogTableInfo extends StaticTableInfo {
+public class SysOperationsLogTableInfo extends StaticTableInfo<OperationContextLog> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "operations_log");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
@@ -45,7 +45,7 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 import static io.crate.types.DataTypes.LONG;
 
-public class SysOperationsTableInfo extends StaticTableInfo {
+public class SysOperationsTableInfo extends StaticTableInfo<OperationContext> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "operations");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.STRING;
 
-public class SysRepositoriesTableInfo extends StaticTableInfo {
+public class SysRepositoriesTableInfo extends StaticTableInfo<Repository> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "repositories");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -69,7 +69,7 @@ import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
 
-public class SysShardsTableInfo extends StaticTableInfo {
+public class SysShardsTableInfo extends StaticTableInfo<ShardRowContext> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "shards");
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
@@ -42,7 +42,7 @@ import static io.crate.types.DataTypes.TIMESTAMPZ;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 
-public class SysSnapshotsTableInfo extends StaticTableInfo {
+public class SysSnapshotsTableInfo extends StaticTableInfo<SysSnapshot> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "snapshots");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
@@ -42,7 +42,7 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.GEO_POINT;
 
-public class SysSummitsTableInfo extends StaticTableInfo {
+public class SysSummitsTableInfo extends StaticTableInfo<SummitsContext> {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "summits");
     private static final RowGranularity GRANULARITY = RowGranularity.DOC;

--- a/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
@@ -26,6 +26,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import static io.crate.common.collections.Lists2.map;
 
-public abstract class StaticTableInfo implements TableInfo {
+public abstract class StaticTableInfo<T> implements TableInfo {
 
     private final RelationName ident;
     private final List<ColumnIdent> primaryKey;
@@ -57,11 +58,11 @@ public abstract class StaticTableInfo implements TableInfo {
         this.primaryKey = primaryKey;
     }
 
-    public StaticTableInfo(RelationName ident, ColumnRegistrar columnRegistrar, List<ColumnIdent> primaryKey) {
+    public StaticTableInfo(RelationName ident, ColumnRegistrar<T> columnRegistrar, List<ColumnIdent> primaryKey) {
         this(ident, columnRegistrar.infos(), columnRegistrar.columns(), primaryKey);
     }
 
-    public StaticTableInfo(RelationName ident, ColumnRegistrar columnRegistrar, String... primaryKey) {
+    public StaticTableInfo(RelationName ident, ColumnRegistrar<T> columnRegistrar, String... primaryKey) {
         this(ident, columnRegistrar.infos(), columnRegistrar.columns(), map(Arrays.asList(primaryKey), ColumnIdent::new));
     }
 
@@ -96,6 +97,7 @@ public abstract class StaticTableInfo implements TableInfo {
         return ident.fqn();
     }
 
+    @Nonnull
     @Override
     public Iterator<Reference> iterator() {
         return columnMap.values().iterator();


### PR DESCRIPTION
`explanations` can be null which must be supported by the used map implementation.
Also fix a generics type issue at the StaticTableInfo.
    
Follow ups of fa99398c12f25b2799f86ba0f60e63f24b06c31b.