### PR TITLE
Docs: Cross-ref from wait_for_active_shards to promote replica

### DIFF
--- a/blackbox/docs/sql/statements/alter-table.rst
+++ b/blackbox/docs/sql/statements/alter-table.rst
@@ -195,6 +195,8 @@ where ``reroute_option`` is::
 **ALLOCATE REPLICA**
   Allows to force allocation of an unassigned replica shard on a specific node.
 
+.. _alter-table-reroute-promote-replica:
+
 **PROMOTE REPLICA**
   Force promote a stale replica shard to a primary.
   In case a node holding a primary copy of a shard had a failure and the

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -345,7 +345,10 @@ Replica shard copies that missed some writes will be brought up to date by the
 system eventually, but in case a node holding the primary copy has a system
 failure, the replica copy couldn't be promoted automatically as it would lead
 to data loss since the system is aware that the replica shard didn't receive
-all writes.
+all writes. In such a scenario, :ref:`ALTER TABLE .. REROUTE PROMOTE REPLICA
+<alter-table-reroute-promote-replica>` can be used to force the allocation of a
+stale replica copy to at least recover the data that is available in the stale
+replica copy.
 
 Say you've a 3 node cluster and a table with 1 configured replica. With
 ``write.wait_for_active_shards=1`` and ``number_of_replicas=1`` a node in the


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)