### PR TITLE
Use partition instead of frame end in getRowInPartitionAtIndexOrNull.

### DIFF
--- a/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -181,6 +181,18 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
+    public void testLeadWithOrderBy() throws Exception {
+        assertEvaluate("lead(x) over(order by y)",
+                       contains(new Object[]{3, 1, 2, null}),
+                       Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
+                       new Object[]{1, 1},
+                       new Object[]{1, 3},
+                       new Object[]{3, 2},
+                       new Object[]{2, 5}
+        );
+    }
+
+    @Test
     public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Exception {
         assertEvaluate("lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             contains(new Object[]{2, 3, 4, 42, 42}),

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
@@ -34,6 +34,7 @@ public final class WindowFrameState {
     private int lowerBound;
     private int upperBoundExclusive;
     private int partitionStart;
+    private int partitionEnd;
 
     WindowFrameState(int lowerBound, int upperBoundExclusive, List<Object[]> rows) {
         this.lowerBound = lowerBound;
@@ -78,15 +79,15 @@ public final class WindowFrameState {
      */
     public Object[] getRowInPartitionAtIndexOrNull(int index) {
         int idxInPartition = partitionStart + index;
-        int partitionEnd = upperBoundExclusive + partitionStart;
         if (idxInPartition < partitionStart || idxInPartition >= partitionEnd) {
             return null;
         }
         return rows.get(idxInPartition);
     }
 
-    void updateBounds(int pStart, int wBegin, int wEnd) {
+    void updateBounds(int pStart, int pEnd, int wBegin, int wEnd) {
         this.partitionStart = pStart;
+        this.partitionEnd = pEnd;
         this.lowerBound = wBegin - pStart;
         this.upperBoundExclusive = wEnd - pStart;
     }
@@ -97,6 +98,7 @@ public final class WindowFrameState {
                "lowerBound=" + lowerBound +
                ", upperBoundExclusive=" + upperBoundExclusive +
                ", partitionStart=" + partitionStart +
+               ", partitionEnd=" + partitionEnd +
                '}';
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -204,7 +204,7 @@ public final class WindowFunctionBatchIterator {
                                                                cmpOrderBy,
                                                                sortedRows);
 
-                frame.updateBounds(pStart, wBegin, wEnd);
+                frame.updateBounds(pStart, pEnd, wBegin, wEnd);
                 final Object[] row = computeAndInjectResults(
                     sortedRows, numCellsInSourceRow, windowFunctions, frame, i, idxInPartition, argsExpressions, args);
 

--- a/sql/src/test/java/io/crate/execution/engine/window/WindowFrameStateTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/WindowFrameStateTest.java
@@ -44,39 +44,39 @@ public class WindowFrameStateTest {
 
     @Test
     public void testGetRowWithinRangeInSinglePartition() {
-        wfs.updateBounds(0, 0, 6);
+        wfs.updateBounds(0, 6, 0, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(1), is(rows.get(1)));
     }
 
     @Test
     public void testGetRowOutOfRangeInSinglePartition() {
-        wfs.updateBounds(0, 0, 6);
+        wfs.updateBounds(0, 6, 0, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1), is(nullValue()));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(rows.size()), is(nullValue()));
     }
 
     @Test
     public void testGetRowsWithinRangeInTwoPartitionReturnsNull() {
-        // Partition 1 index range: [0, 3)
-        wfs.updateBounds(0, 0, 3);
+        // Partition 1 index range: [0, 3); frame [0, 1)
+        wfs.updateBounds(0, 3, 0, 1);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(0), is(rows.get(0)));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(2), is(rows.get(2)));
 
-        // Partition 2 index range: [3, 6)
-        wfs.updateBounds(3, 3, 6);
+        // Partition 2 index range: [3, 6); frame [3, 6)
+        wfs.updateBounds(3, 6, 3, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(0), is(rows.get(3)));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(2), is(rows.get(5)));
     }
 
     @Test
     public void testGetRowsOutOfRangeInTwoPartitionReturnsNull() {
-        // Partition 1 index range: [0, 3)
-        wfs.updateBounds(0, 0, 3);
+        // Partition 1 index range: [0, 3); frame [0, 1)
+        wfs.updateBounds(0, 3, 0, 1);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1), is(nullValue()));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(3), is(nullValue()));
 
-        // Partition 2 index range: [3, 6)
-        wfs.updateBounds(3, 3, 6);
+        // Partition 2 index range: [3, 6); frame [3, 6)
+        wfs.updateBounds(3, 6, 3, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1), is(nullValue()));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(3), is(nullValue()));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The method relied on the upper frame bound to get calculate
index of a partition end. It could lead to incorrect behaviour
In case when the end of frame has the ``current_row`` type.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
