### PR TITLE
Remove subQuery planning logic from RelationBoundary

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -47,14 +47,17 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     private final Map<LogicalPlan, SelectSymbol> subQueries;
 
-    public static LogicalPlan createIfNeeded(LogicalPlan source,
-                                             AnalyzedRelation relation,
-                                             SubqueryPlanner subqueryPlanner) {
+    public static LogicalPlan.Builder createIfNeeded(LogicalPlan.Builder sourceBuilder,
+                                                     AnalyzedRelation relation,
+                                                     SubqueryPlanner subqueryPlanner) {
         Map<LogicalPlan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(relation);
         if (subQueries.isEmpty()) {
-            return source;
+            return sourceBuilder;
         }
-        return new MultiPhase(source, subQueries);
+        return (tableStats, hints, usedBeforeNextFetch) -> {
+            LogicalPlan source = sourceBuilder.build(tableStats, hints, usedBeforeNextFetch);
+            return new MultiPhase(source, subQueries);
+        };
     }
 
     private MultiPhase(LogicalPlan source, Map<LogicalPlan, SelectSymbol> subQueries) {

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -176,13 +176,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan("MultiPhase[\n" +
                                 "    subQueries[\n" +
                                 "        RootBoundary[1]\n" +
+                                "        Limit[2;0]\n" +
                                 "        MultiPhase[\n" +
                                 "            subQueries[\n" +
                                 "                RootBoundary[count(*)]\n" +
                                 "                Limit[1;0]\n" +
                                 "                Count[doc.t2 | All]\n" +
                                 "            ]\n" +
-                                "            Limit[2;0]\n" +
                                 "            Collect[doc.t1 | [1] | (x > cast(SelectSymbol{bigint_array} AS integer))]\n" +
                                 "        ]\n" +
                                 "    ]\n" +
@@ -366,9 +366,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         }
 
         private void startLine(String start) {
-            for (int i = 0; i < indentation; i++) {
-                sb.append(' ');
-            }
+            assert indentation >= 0 : "indentation must not get negative";
+            sb.append(" ".repeat(indentation));
             sb.append(start);
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We can re-use the existing MultiPhase operator instead for better
separation of concerns and it will open up the possibility to remove the
RelationBoundary in cases where relations do not introduce new scopes.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)