### PR TITLE
Don't use doc lookup in insert from sys-tables

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -338,7 +338,9 @@ public class Collect implements LogicalPlan {
                 RoutingProvider.ShardSelection.ANY,
                 sessionContext),
             tableInfo.rowGranularity(),
-            preferSourceLookup ? Lists2.map(boundOutputs, DocReferences::toSourceLookup) : boundOutputs,
+            preferSourceLookup && tableInfo instanceof DocTableInfo
+                ? Lists2.map(boundOutputs, DocReferences::toSourceLookup)
+                : boundOutputs,
             Collections.emptyList(),
             where.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST

--- a/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -499,4 +499,13 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             )
         );
     }
+
+    @Test
+    public void test_insert_from_sub_query_with_sys_tables_has_no_doc_lookup() {
+        Collect collect = e.plan("insert into users (id, name) (select oid, typname from pg_catalog.pg_type)");
+        assertThat(collect.collectPhase().toCollect(), contains(
+            isReference("oid"),
+            isReference("typname")
+        ));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Columns selected from sys tables in an INSERT INTO got re-written from
`x` to `_doc['x']` due to the change in
6e3e072b7b4f390a124993d32a94dd1d73f01233

This fixes the re-write.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)