### PR TITLE
Extend timestamp without time zone support

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -67,4 +67,6 @@ Changes
 Fixes
 =====
 
-None
+- Arithmetic operations now work on expressions of type :ref:`timestamp without
+  time zone <date-time-types>`, to make it consistent with ``timestamp with time
+  zone``.

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -37,12 +37,14 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
+import io.crate.types.IpType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
@@ -224,7 +226,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
      * to replace NULLs which can lead to ClassCastException when the original type was for example Integer.
      */
     @Nullable
-    private static Object missingObject(DataType dataType, Object missingValue, boolean reversed) {
+    static Object missingObject(DataType dataType, Object missingValue, boolean reversed) {
         boolean min = sortMissingFirst(missingValue) ^ reversed;
         switch (dataType.id()) {
             case ByteType.ID:
@@ -233,15 +235,17 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                 return min ? Short.MIN_VALUE : Short.MAX_VALUE;
             case IntegerType.ID:
                 return min ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+            case BooleanType.ID:
             case LongType.ID:
+            case TimestampType.ID_WITH_TZ:
+            case TimestampType.ID_WITHOUT_TZ:
                 return min ? Long.MIN_VALUE : Long.MAX_VALUE;
             case FloatType.ID:
                 return min ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
             case DoubleType.ID:
                 return min ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-            case TimestampType.ID_WITH_TZ:
-                return min ? Long.MIN_VALUE : Long.MAX_VALUE;
             case StringType.ID:
+            case IpType.ID:
                 return null;
             default:
                 throw new UnsupportedOperationException("Unsupported data type: " + dataType);

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -50,6 +50,9 @@ import java.util.function.BinaryOperator;
 
 public class ArithmeticFunctions {
 
+    private static final Param ARITHMETIC_TYPE = Param.of(
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP);
+
     public static class Names {
         public static final String ADD = "add";
         public static final String SUBTRACT = "subtract";
@@ -64,10 +67,10 @@ public class ArithmeticFunctions {
             Names.ADD,
             "+",
             FunctionInfo.DETERMINISTIC_AND_COMPARISON_REPLACEMENT,
-            (arg0, arg1) -> arg0 + arg1,
-            (arg0, arg1) -> arg0 + arg1,
-            (arg0, arg1) -> arg0 + arg1,
-            (arg0, arg1) -> arg0 + arg1
+            Integer::sum,
+            Double::sum,
+            Long::sum,
+            Float::sum
         ));
         module.register(Names.SUBTRACT, new ArithmeticFunctionResolver(
             Names.SUBTRACT,
@@ -107,14 +110,11 @@ public class ArithmeticFunctions {
         ));
         module.register(Names.POWER, new DoubleFunctionResolver(
             Names.POWER,
-            (arg0, arg1) -> Math.pow(arg0, arg1)
+            Math::pow
         ));
     }
 
     static final class DoubleFunctionResolver extends BaseFunctionResolver {
-
-        private static final Param ARITHMETIC_TYPE = Param.of(
-            DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
         private final String name;
         private final BinaryOperator<Double> doubleFunction;
@@ -133,9 +133,6 @@ public class ArithmeticFunctions {
 
 
     static final class ArithmeticFunctionResolver extends BaseFunctionResolver {
-
-        private static final Param ARITHMETIC_TYPE = Param.of(
-            DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
         private final String name;
         private final String operator;
@@ -187,6 +184,7 @@ public class ArithmeticFunctions {
 
                 case LongType.ID:
                 case TimestampType.ID_WITH_TZ:
+                case TimestampType.ID_WITHOUT_TZ:
                     scalar = new BinaryScalar<>(longFunction, name, DataTypes.LONG, features);
                     break;
 

--- a/sql/src/test/java/io/crate/execution/engine/sort/SortSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/SortSymbolVisitorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.sort;
+
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+public class SortSymbolVisitorTest {
+
+    @Test
+    public void test_missing_object_is_implemented_for_all_primitives() {
+        for (DataType primitiveType : DataTypes.PRIMITIVE_TYPES) {
+            SortSymbolVisitor.missingObject(primitiveType, "_first", false);
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -338,10 +338,10 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
                 "   l long, " +
                 "   f float, " +
                 "   d double, " +
-                "   t timestamp with time zone" +
+                "   tz timestamp with time zone, " +
+                "   t timestamp without time zone " +
                 ") with (number_of_replicas=0)");
-        ensureYellow();
-        execute("insert into t (b, s, i, l, f, d, t) values (1, 2, 3, 4, 5.7, 6.3, '2014-07-30')");
+        execute("insert into t (b, s, i, l, f, d, tz, t) values (1, 2, 3, 4, 5.7, 6.3, '2014-07-30', '2018-07-30')");
         refresh();
 
         String[] functionCalls = new String[]{
@@ -355,7 +355,7 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
             "round(%s)",
             "sqrt(%s)"
         };
-        execute("select b + b, s + s, i + i, l + l, f + f, d + d, t + t from t");
+        execute("select b + b, s + s, i + i, l + l, f + f, d + d, tz + tz, t + t from t");
 
         for (String functionCall : functionCalls) {
             String byteCall = String.format(Locale.ENGLISH, functionCall, "b");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commit messages

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)