### PR TITLE
Push filters beneath ProjectSet if they target `standalone` outputs.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Unreleased Changes
 Changes
 =======
 
+- Added an optimization that allows to run `WHERE` clauses on top of
+  derived tables containing :ref:`table functions <ref-table-functions>`
+  more efficiently in some cases.
+
 - Statements containing limits, filters, window functions or table functions
   will now be labelled accordingly in :ref:`sys-jobs-metrics`.
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -75,6 +75,7 @@ import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathHashJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathProjectSet;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathUnion;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathWindowAgg;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathBoundary;
@@ -117,6 +118,7 @@ public class LogicalPlanner {
             new MoveFilterBeneathBoundary(),
             new MoveFilterBeneathFetchOrEval(),
             new MoveFilterBeneathOrder(),
+            new MoveFilterBeneathProjectSet(),
             new MoveFilterBeneathHashJoin(),
             new MoveFilterBeneathNestedLoop(),
             new MoveFilterBeneathUnion(),

--- a/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -115,6 +115,10 @@ public class ProjectSet extends ForwardingLogicalPlan {
         return outputs;
     }
 
+    public List<Symbol> standaloneOutputs() {
+        return standalone;
+    }
+
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return new ProjectSet(Lists2.getOnlyElement(sources), tableFunctions, standalone);

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.metadata.FunctionInfo;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.ProjectSet;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
+
+    private final Capture<ProjectSet> projectSetCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathProjectSet() {
+        this.projectSetCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(ProjectSet.class).capturedAs(projectSetCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter, Captures captures) {
+        var projectSet = captures.get(projectSetCapture);
+
+        var queryParts = AndOperator.split(filter.query());
+        ArrayList<Symbol> toPushDown = new ArrayList<>();
+        ArrayList<Symbol> toKeep = new ArrayList<>();
+        for (var part : queryParts) {
+            if (!SymbolVisitors.any(MoveFilterBeneathProjectSet::isTableFunction, part)
+                && projectSet.standaloneOutputs().containsAll(extractColumns(part))) {
+                toPushDown.add(part);
+            } else {
+                toKeep.add(part);
+            }
+        }
+
+        if (toPushDown.isEmpty()) {
+            return null;
+        } else if (toKeep.isEmpty()) {
+            return transpose(filter, projectSet);
+        } else {
+            var newProjectSet = projectSet.replaceSources(
+                List.of(new Filter(projectSet.source(), AndOperator.join(toPushDown))));
+            return new Filter(newProjectSet, AndOperator.join(toKeep));
+        }
+    }
+
+    private static boolean isTableFunction(Symbol s) {
+        return s instanceof Function && ((Function) s).info().type() == FunctionInfo.Type.TABLE;
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
