### PR TITLE
Bump version of admin-ui to 1.15.1

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue in the admin ui that prevented partitions from showing up in
+  the table detail view.
+
 - Fixed an issue in the version handling that would prevent rolling upgrades to
   future versions of CrateDB.
 

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -19,7 +19,7 @@ jacksondatabind=2.0.1
 jacksondataformatcsv=2.5.1
 
 # Admin UI
-crate_admin_ui = 1.15.0
+crate_admin_ui = 1.15.1
 
 # Crate JDBC
 crate_jdbc=2.5.1


### PR DESCRIPTION
The admin-ui 1.15.1 has the queries adapted to crateBD 4.0 breaking
changes in information_schema.table_partitions.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [X] User relevant changes are recorded in ``CHANGES.txt``
 - [X] Touched code is covered by tests
 - [X] Documentation has been updated if necessary
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
