### PR TITLE
Add docs for the interval literal only.

### DIFF
--- a/blackbox/docs/general/ddl/data-types.rst
+++ b/blackbox/docs/general/ddl/data-types.rst
@@ -44,6 +44,7 @@ or collections.
 * `ip`_
 * `timestamp with time zone <timestamp with time zone_>`_
 * `timestamp without time zone <timestamp without time zone_>`_
+* `interval`_
 
 .. _sql_ddl_datatypes_geographic:
 
@@ -315,6 +316,114 @@ converted to UTC without considering the time zone indication.
     If a column is dynamically created the type detection won't recognize
     date time types. That means date type columns must always be declared
     beforehand.
+
+.. _interval_data_type:
+
+Interval
+--------
+
+
+.. _interval-literal:
+
+Interval literal
+................
+
+An interval literal represents a span of time and can be either
+a :ref:`year-month-literal` or :ref:`day-time-literal` literal. The generic
+literal synopsis defined as following
+
+::
+
+    <interval_literal> ::=
+        INTERVAL [ <sign> ] <string_literal> <interval_qualifier>
+
+    <interval_qualifier> ::=
+        <start_field> [ TO <end_field>]
+
+    <start_field> ::= <datetime_field>
+    <end_field> ::= <datetime_field>
+
+    <datetime_field> ::=
+          YEAR
+        | MONTH
+        | DAY
+        | HOUR
+        | MINUTE
+        | SECOND
+
+.. _year-month-literal:
+
+year-month
+^^^^^^^^^^
+
+A ``year-month`` literal includes either ``YEAR``, ``MONTH`` or a contiguous
+subset of these fields.
+
+::
+
+    <year_month_literal> ::=
+        INTERVAL [ {+ | -} ]'yy' <interval_qualifier> |
+        INTERVAL [ {+ | -} ]'[ yy- ] mm' <interval_qualifier>
+
+For example
+
+::
+
+    INTERVAL '01' YEAR              - 1 year
+    INTERVAL '02' MONTH             - 2 months
+    INTERVAL '01-02' YEAR TO MONTH  - 1 year and 2 months
+
+.. _day-time-literal:
+
+day-time
+^^^^^^^^
+
+A ``day-time`` literal includes either ``DAY``, ``HOUR``, ``MINUTE``,
+``SECOND`` or a contiguous subset of these fields.
+
+When using ``SECOND``, it is possible to define more digits representing
+a number of fractions of a seconds with ``.nn``. The allowed fractional
+seconds precision of ``SECOND`` ranges from 0 to 6 digits.
+
+::
+
+    <day_time_literal> ::=
+        INTERVAL [ {+ | -} ]'dd [ <space> hh [ :mm [ :ss ]]]' <interval_qualifier>
+        INTERVAL [ {+ | -} ]'hh [ :mm [ :ss [ .nn ]]]' <interval_qualifier>
+        INTERVAL [ {+ | -} ]'mm [ :ss [ .nn ]]' <interval_qualifier>
+        INTERVAL [ {+ | -} ]'ss [ .nn ]' <interval_qualifier>
+
+For example
+
+::
+
+    INTERVAL '100.123' SECOND         - 100.123 seconds
+    INTERVAL '40 23' DAY TO HOUR      - 40 days and 23 hours
+    INTERVAL '10 23:10' DAY TO MINUTE - 10 days, 23 hours and 10 minutes
+
+.. _temporal-arithmetic:
+
+Temporal arithmetic
+-------------------
+
+The following table specifies the declared types of
+:ref:`arithmetic <arithmetic>` expressions that involves temporal operands.
+
++---------------+----------+---------------+
+|       Operand | Operator |       Operand |
++===============+==========+===============+
+| ``timestamp`` |       \- | ``timestamp`` |
++---------------+----------+---------------+
+|  ``interval`` |       \+ | ``timestamp`` |
++---------------+----------+---------------+
+| ``timestamp`` | \+ or \- |  ``interval`` |
++---------------+----------+---------------+
+|  ``interval`` | \+ or \- |  ``interval`` |
++---------------+----------+---------------+
+|  ``interval`` |       \* |   ``numeric`` |
++---------------+----------+---------------+
+|  ``interval`` |  \* or / |   ``numeric`` |
++---------------+----------+---------------+
 
 .. _geo_point_data_type:
 

--- a/blackbox/docs/sql/general/value-expressions.rst
+++ b/blackbox/docs/sql/general/value-expressions.rst
@@ -22,10 +22,9 @@ A literal is a notation to represent a value within a statement.
 Different types have different notations. The simplest forms are:
 
 - boolean literals: ``true`` or ``false``
-
 - string literals: ``'this is a string literal'``
-
 - numeric literals: ``42``
+- interval literals: ``INTERVAL '1' SECOND``
 
 .. SEEALSO::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The documentation is `only` for the interval literal. 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
