### PR TITLE
Fix java version parsing for EA builds

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -85,4 +85,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that could cause startup to fail with early access builds of
+  Java.

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheck.java
@@ -59,28 +59,28 @@ public final class JvmVersionNodeCheck extends AbstractSysNodeCheck {
      * Parse a Java version string into an array of [major, minor, hotfix]
      */
     static int[] parseVersion(String javaVersion) {
-        StringTokenizer stBuild = new StringTokenizer(javaVersion, "_");
-        String javaVersionWithoutBuildNumber = stBuild.nextToken();
-
-        StringTokenizer stVersionParts = new StringTokenizer(javaVersionWithoutBuildNumber, ".");
-        String firstToken = stVersionParts.nextToken();
-        try {
-            int major = Integer.parseInt(firstToken);
-            if (stVersionParts.hasMoreTokens()) {
-                int minor = Integer.parseInt(stVersionParts.nextToken());
-                int hotfix = Integer.parseInt(stVersionParts.nextToken());
-                return new int[] {major, minor, hotfix};
-            } else {
-                return new int[] {major, 0, 0};
-            }
-        } catch (NumberFormatException e) {
-            if (firstToken.endsWith("ea")) {
-                int offset = firstToken.endsWith("-ea") ? 3 : 2;
-                int major = Integer.parseInt(firstToken.substring(0, firstToken.length() - offset));
-                return new int[] {major, 0, 0};
-            }
-            throw e;
+        StringTokenizer tokenizer = new StringTokenizer(javaVersion, ".-_ea");
+        int major;
+        if (tokenizer.hasMoreTokens()) {
+            major = Integer.parseInt(tokenizer.nextToken());
+        } else {
+            throw new IllegalArgumentException("Cannot parse major version from java version: " + javaVersion);
         }
+        int minor = 0;
+        if (tokenizer.hasMoreTokens()) {
+            try {
+                minor = Integer.parseInt(tokenizer.nextToken());
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        int patch = 0;
+        if (tokenizer.hasMoreTokens()) {
+            try {
+                patch = Integer.parseInt(tokenizer.nextToken());
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return new int[] { major, minor, patch };
     }
 
     static boolean isOnOrAfter11(String javaVersion) {

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/node/JvmVersionNodeCheckTest.java
@@ -60,6 +60,11 @@ public class JvmVersionNodeCheckTest {
     }
 
     @Test
+    public void test_java11_ea_version_string_can_be_parsed() {
+        assertThat(JvmVersionNodeCheck.parseVersion("11.0.4-ea"), is(new int[] { 11, 0, 4 }));
+    }
+
+    @Test
     public void testEAVersionStringCanBeParsed() {
         assertThat(JvmVersionNodeCheck.parseVersion("12ea"), is(new int[] { 12, 0, 0 }));
     }


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)