### PR TITLE
Add VALUES as top level relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __pycache__/
 *.pyc
 *.pyo
 blackbox/get-pip.py
+blackbox/.mypy_cache/
 develop-eggs/
 eggs/
 parts/

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for using :ref:`ref-values` as top-level relation.
+
 - Added an optimization that allows to run `WHERE` clauses on top of
   derived tables containing :ref:`table functions <ref-table-functions>`
   more efficiently in some cases.

--- a/blackbox/docs/sql/statements/index.rst
+++ b/blackbox/docs/sql/statements/index.rst
@@ -50,3 +50,4 @@ SQL Statements
     show-tables
     show
     update
+    values

--- a/blackbox/docs/sql/statements/values.rst
+++ b/blackbox/docs/sql/statements/values.rst
@@ -1,0 +1,43 @@
+.. highlight:: psql
+.. _ref-values:
+
+==========
+``VALUES``
+==========
+
+``VALUES`` computes a set of rows.
+
+
+Synopsis
+========
+
+::
+
+    VALUES ( expression [, ...] ) [, ...]
+
+
+Description
+===========
+
+``VALUES`` can be used to generate a result set containing constant values.
+
+When more than 1 row is specified, all rows must have the same number of
+elements.
+
+An example::
+
+   cr> VALUES (1, 'one'), (2, 'two'), (3, 'three');
+   +------+-------+
+   | col1 | col2  |
+   +------+-------+
+   |    1 | one   |
+   |    2 | two   |
+   |    3 | three |
+   +------+-------+
+   VALUES 3 rows in set (... sec)
+
+
+It is commonly used in :ref:`ref-insert` to provide values to insert into a
+table.
+
+All expressions within the same column must have the same type.

--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -489,7 +489,8 @@ def load_tests(loader, suite, ignore):
                             'interfaces/postgres.rst',
                             'general/ddl/views.rst',
                             'sql/general/value-expressions.rst',
-                            'sql/general/lexical-structure.rst'):
+                            'sql/general/lexical-structure.rst',
+                            'sql/statements/values.rst'):
         tests.append(docsuite(fn, setUp=setUpLocationsAndQuotes))
 
     for fn in doctest_files('general/dql/geo.rst',):

--- a/shared/src/main/java/io/crate/common/collections/Lists2.java
+++ b/shared/src/main/java/io/crate/common/collections/Lists2.java
@@ -66,6 +66,42 @@ public final class Lists2 {
     }
 
     /**
+     * Change the layout from rows to column oriented.
+     *
+     * <pre>
+     *
+     * rows: [
+     *  [a, 1],
+     *  [b, 2]
+     * ]
+     *
+     * to
+     *
+     * columnValues: [
+     *  [a, b],
+     *  [1, 2]
+     * ]
+     * </pre>
+     */
+    public static <T> List<List<T>> toColumnOrientation(List<? extends List<T>> rows) {
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+        List<T> firstRow = rows.get(0);
+        int numColumns = firstRow.size();
+        ArrayList<List<T>> columns = new ArrayList<>();
+        for (int c = 0; c < numColumns; c++) {
+            ArrayList<T> columnValues = new ArrayList<>(rows.size());
+            for (int r = 0; r < rows.size(); r++) {
+                List<T> row = rows.get(r);
+                columnValues.add(row.get(c));
+            }
+            columns.add(columnValues);
+        }
+        return columns;
+    }
+
+    /**
      * Apply the replace function on each item of the list and replaces the item.
      *
      * This is similar to Guava's com.google.common.collect.Lists#transform(List, com.google.common.base.Function),

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -121,7 +121,8 @@ querySpec
       where?
       (GROUP BY expr (',' expr)*)?
       (HAVING having=booleanExpression)?
-      (WINDOW windows+=namedWindow (',' windows+=namedWindow)*)?
+      (WINDOW windows+=namedWindow (',' windows+=namedWindow)*)?                     #defaultQuerySpec
+    | VALUES values (',' values)*                                                    #valuesRelation
     ;
 
 selectItem

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -86,6 +86,8 @@ import io.crate.sql.tree.Table;
 import io.crate.sql.tree.TableFunction;
 import io.crate.sql.tree.TableSubquery;
 import io.crate.sql.tree.Union;
+import io.crate.sql.tree.Values;
+import io.crate.sql.tree.ValuesList;
 import io.crate.sql.tree.Window;
 import io.crate.sql.tree.WindowFrame;
 
@@ -101,6 +103,7 @@ import java.util.TreeMap;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static io.crate.sql.ExpressionFormatter.formatExpression;
 import static io.crate.sql.ExpressionFormatter.formatStandaloneExpression;
 
 public final class SqlFormatter {
@@ -300,6 +303,32 @@ public final class SqlFormatter {
             if (node.getOffset().isPresent()) {
                 append(indent, "OFFSET " + node.getOffset().get())
                     .append('\n');
+            }
+            return null;
+        }
+
+
+        @Override
+        public Void visitValues(Values values, Integer indent) {
+            append(indent, "VALUES ");
+            List<ValuesList> rows = values.rows();
+            for (int i = 0; i < rows.size(); i++) {
+                ValuesList row = rows.get(i);
+
+                append(indent, "(");
+                List<Expression> expressions = row.values();
+                for (int j = 0; j < expressions.size(); j++) {
+                    Expression value = expressions.get(j);
+                    append(indent, formatExpression(value));
+                    if (j + 1 < expressions.size()) {
+                        append(indent, ", ");
+                    }
+                }
+                append(indent, ")");
+
+                if (i + 1 < rows.size()) {
+                    append(indent, ", ");
+                }
             }
             return null;
         }

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -174,6 +174,7 @@ import io.crate.sql.tree.TrimMode;
 import io.crate.sql.tree.TryCast;
 import io.crate.sql.tree.Union;
 import io.crate.sql.tree.Update;
+import io.crate.sql.tree.Values;
 import io.crate.sql.tree.ValuesList;
 import io.crate.sql.tree.WhenClause;
 import io.crate.sql.tree.Window;
@@ -956,7 +957,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitQuerySpec(SqlBaseParser.QuerySpecContext context) {
+    public Node visitDefaultQuerySpec(SqlBaseParser.DefaultQuerySpecContext context) {
         List<SelectItem> selectItems = visitCollection(context.selectItem(), SelectItem.class);
         return new QuerySpecification(
             new Select(isDistinct(context.setQuant()), selectItems),
@@ -969,6 +970,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             Optional.empty(),
             Optional.empty()
         );
+    }
+
+    @Override
+    public Node visitValuesRelation(SqlBaseParser.ValuesRelationContext ctx) {
+        return new Values(visitCollection(ctx.values(), ValuesList.class));
     }
 
     private Map<String, Window> getWindowDefinitions(List<SqlBaseParser.NamedWindowContext> windowContexts) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -600,4 +600,8 @@ public abstract class AstVisitor<R, C> {
     public R visitReroutePromoteReplica(PromoteReplica promoteReplica, C context) {
         return visitNode(promoteReplica, context);
     }
+
+    public R visitValues(Values values, C context) {
+        return visitRelation(values, context);
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Values.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Values.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.List;
+
+public final class Values extends QueryBody {
+
+    private List<ValuesList> rows;
+
+    public Values(List<ValuesList> rows) {
+        this.rows = rows;
+    }
+
+    public List<ValuesList> rows() {
+        return rows;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitValues(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Values values = (Values) o;
+
+        return rows.equals(values.rows);
+    }
+
+    @Override
+    public int hashCode() {
+        return rows.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Values{" +
+               "rows=" + rows +
+               '}';
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -22,7 +22,6 @@
 
 package io.crate.sql.parser;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import io.crate.sql.Literals;
 import io.crate.sql.SqlFormatter;
@@ -75,6 +74,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Strings.repeat;
@@ -192,7 +193,7 @@ public class TestStatementBuilder {
     @Test
     public void testNullNotAllowedAsArgToExtractField() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("viable alternative at input 'select extract(null'");
+        expectedException.expectMessage("no viable alternative at input 'select extract(null'");
         printStatement("select extract(null from x)");
     }
 
@@ -1533,6 +1534,13 @@ public class TestStatementBuilder {
         printStatement("DROP VIEW IF EXISTS v1, x.v2, y.v3");
     }
 
+    @Test
+    public void test_values_as_top_relation_parsing() {
+        printStatement("VALUES (1, 2), (2, 3), (3, 4)");
+        printStatement("VALUES (1), (2), (3)");
+        printStatement("VALUES (1, 2, 3 + 3, (SELECT 1))");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");
@@ -1597,7 +1605,7 @@ public class TestStatementBuilder {
 
     private static String readResource(String name)
         throws IOException {
-        return Resources.toString(Resources.getResource(name), Charsets.UTF_8);
+        return Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);
     }
 
     private static String fixTpchQuery(String s) {

--- a/sql/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -22,14 +22,17 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Function;
-import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.sql.tree.QualifiedName;
+
+import java.util.function.Consumer;
 
 public class TableFunctionRelation extends TableRelation {
 
@@ -64,5 +67,12 @@ public class TableFunctionRelation extends TableRelation {
             return getField(path);
         }
         throw new UnsupportedOperationException("Table functions don't support write operations");
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (Symbol argument : function.arguments()) {
+            consumer.accept(argument);
+        }
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/NodeOperationTreeGenerator.java
+++ b/sql/src/main/java/io/crate/execution/engine/NodeOperationTreeGenerator.java
@@ -22,13 +22,13 @@
 
 package io.crate.execution.engine;
 
+import io.crate.data.Paging;
 import io.crate.execution.dsl.phases.ExecutionPhase;
 import io.crate.execution.dsl.phases.ExecutionPhases;
 import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.dsl.phases.UpstreamPhase;
 import io.crate.execution.engine.distribution.DistributingConsumerFactory;
-import io.crate.data.Paging;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.ExecutionPlanVisitor;
 import io.crate.planner.Merge;

--- a/sql/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -38,7 +38,7 @@ public abstract class Symbol implements FuncArg, Writeable, ExplainLeaf {
 
     public abstract <C, R> R accept(SymbolVisitor<C, R> visitor, C context);
 
-    public abstract DataType valueType();
+    public abstract DataType<?> valueType();
 
     /**
      * Casts this Symbol to a new {@link DataType} by wrapping a cast function around it.

--- a/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -63,7 +63,7 @@ import static io.crate.metadata.functions.params.Param.ANY_ARRAY;
 
 public class UnnestFunction {
 
-    private static final String NAME = "unnest";
+    public static final String NAME = "unnest";
     public static final RelationName TABLE_IDENT = new RelationName("", NAME);
 
     static class UnnestTableFunctionImplementation extends TableFunctionImplementation<List<Object>> {

--- a/sql/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.relations.AliasedAnalyzedRelation;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SymbolMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+
+public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        e = SQLExecutor.builder(clusterService).build();
+    }
+
+    @Test
+    public void test_error_is_raised_if_number_of_items_within_rows_are_not_equal() {
+        expectedException.expectMessage("VALUES lists must all be the same length");
+        e.analyze("VALUES (1), (2, 3)");
+    }
+
+    @Test
+    public void test_error_is_raised_if_the_types_of_the_rows_are_not_compatible() {
+        expectedException.expectMessage(
+            "The types of the columns within VALUES lists must match. Found `bigint` and `text` at position: 0");
+        e.analyze("VALUES (1), ('foo')");
+    }
+
+    @Test
+    public void test_values_used_in_sub_query_can_be_analyzed() {
+        AliasedAnalyzedRelation rel = e.analyze("SELECT x, y FROM (VALUES (1, 2)) AS t (x, y)");
+        assertThat(rel.fields(), contains(
+            SymbolMatchers.isField("x"),
+            SymbolMatchers.isField("y")
+        ));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1681,4 +1681,15 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
                "Hello World\n")
         );
     }
+
+    @Test
+    public void test_values_as_top_level_relation() {
+        execute("VALUES (1, 'a'), (2, 'b'), (3, (SELECT 'c'))");
+        assertThat(
+            printedTable(response.rows()),
+            is("1| a\n" +
+               "2| b\n" +
+               "3| c\n")
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
-@SuppressWarnings("ConstantConditions")
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Besides improving SQL Standard compatiblity, this will allow us to
de-duplicate the INSERT FROM VALUES / INSERT FROM query logic by
treating VALUES as a regular relation.

Internally it is currently being re-written to ``UNNEST`` as it lets us
avoid having to add a new operator, execution phase, execution plan and
execution task. The downside is that we've a row-orientation ->
column-orientation -> row-orientation roundrip.

We can later on optimize that if it turns out to be necessary.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)