### PR TITLE
Jenkins: Update openjdk 12 version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   environment {
     CI_RUN = "true"
     JDK_11 = 'openjdk@1.11.0-2'
-    JDK_12 = 'openjdk@1.12.0-1'
+    JDK_12 = 'openjdk@1.12.0-2'
     ADOPT_JDK_12 = 'adopt@1.12.33-0'
   }
   stages {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`-1` is no longer available


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)