### PR TITLE
Remove Setting definition indirections

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
@@ -46,12 +46,12 @@ class AlterBlobTableAnalyzer {
         if (!node.genericProperties().isEmpty()) {
             TablePropertiesAnalyzer.analyze(
                 tableParameter,
-                tableInfo.tableParameterInfo(),
+                tableInfo.tableParameters(),
                 node.genericProperties(),
                 parameters
             );
         } else if (!node.resetProperties().isEmpty()) {
-            TablePropertiesAnalyzer.analyzeResetProperties(tableParameter, tableInfo.tableParameterInfo(), node.resetProperties());
+            TablePropertiesAnalyzer.analyzeResetProperties(tableParameter, tableInfo.tableParameters(), node.resetProperties());
         }
         return new AlterBlobTableAnalyzedStatement(tableInfo, tableParameter);
     }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -53,7 +53,7 @@ public class AlterTableAnalyzer {
         DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(), Operation.ALTER_BLOCKS,
             sessionContext.searchPath());
         PartitionName partitionName = createPartitionName(table.partitionProperties(), docTableInfo, parameters);
-        TableParameterInfo tableParameters = getTableParameterInfo(table, partitionName);
+        TableParameters tableParameters = getTableParameterInfo(table, partitionName);
         TableParameter tableParameter = getTableParameter(node, parameters, tableParameters);
         maybeRaiseBlockedException(docTableInfo, tableParameter.settings());
         return new AlterTableAnalyzedStatement(docTableInfo, partitionName, tableParameter, table.excludePartitions());
@@ -84,16 +84,16 @@ public class AlterTableAnalyzer {
         return new AlterTableRenameAnalyzedStatement(tableInfo, newRelationName);
     }
 
-    private static TableParameterInfo getTableParameterInfo(Table table,
-                                                            @Nullable PartitionName partitionName) {
+    private static TableParameters getTableParameterInfo(Table table,
+                                                         @Nullable PartitionName partitionName) {
         if (partitionName == null) {
-            return TableParameterInfo.TABLE_ALTER_PARAMETER_INFO;
+            return TableParameters.TABLE_ALTER_PARAMETER_INFO;
         }
         assert !table.excludePartitions() : "Alter table ONLY not supported when using a partition";
-        return TableParameterInfo.PARTITION_PARAMETER_INFO;
+        return TableParameters.PARTITION_PARAMETER_INFO;
     }
 
-    private static TableParameter getTableParameter(AlterTable node, Row parameters, TableParameterInfo tableParameters) {
+    private static TableParameter getTableParameter(AlterTable node, Row parameters, TableParameters tableParameters) {
         TableParameter tableParameter = new TableParameter();
         if (!node.genericProperties().isEmpty()) {
             TablePropertiesAnalyzer.analyze(tableParameter, tableParameters, node.genericProperties(), parameters);

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -53,8 +53,8 @@ public class AlterTableAnalyzer {
         DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(), Operation.ALTER_BLOCKS,
             sessionContext.searchPath());
         PartitionName partitionName = createPartitionName(table.partitionProperties(), docTableInfo, parameters);
-        TableParameterInfo tableParameterInfo = getTableParameterInfo(table, partitionName);
-        TableParameter tableParameter = getTableParameter(node, parameters, tableParameterInfo);
+        TableParameterInfo tableParameters = getTableParameterInfo(table, partitionName);
+        TableParameter tableParameter = getTableParameter(node, parameters, tableParameters);
         maybeRaiseBlockedException(docTableInfo, tableParameter.settings());
         return new AlterTableAnalyzedStatement(docTableInfo, partitionName, tableParameter, table.excludePartitions());
     }
@@ -93,12 +93,12 @@ public class AlterTableAnalyzer {
         return TableParameterInfo.PARTITION_PARAMETER_INFO;
     }
 
-    private static TableParameter getTableParameter(AlterTable node, Row parameters, TableParameterInfo tableParameterInfo) {
+    private static TableParameter getTableParameter(AlterTable node, Row parameters, TableParameterInfo tableParameters) {
         TableParameter tableParameter = new TableParameter();
         if (!node.genericProperties().isEmpty()) {
-            TablePropertiesAnalyzer.analyze(tableParameter, tableParameterInfo, node.genericProperties(), parameters);
+            TablePropertiesAnalyzer.analyze(tableParameter, tableParameters, node.genericProperties(), parameters);
         } else if (!node.resetProperties().isEmpty()) {
-            TablePropertiesAnalyzer.analyzeResetProperties(tableParameter, tableParameterInfo, node.resetProperties());
+            TablePropertiesAnalyzer.analyzeResetProperties(tableParameter, tableParameters, node.resetProperties());
         }
         return tableParameter;
     }

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
@@ -56,7 +56,7 @@ public class CreateBlobTableAnalyzer {
         // apply default in case it is not specified in the genericProperties,
         // if it is it will get overwritten afterwards.
         TablePropertiesAnalyzer.analyze(
-            statement.tableParameter(), TableParameterInfo.BLOB_TABLE_CREATE_PARAMETER_INFO,
+            statement.tableParameter(), TableParameterInfo.CREATE_BLOB_TABLE_PARAMETERS,
             node.genericProperties(), parameterContext.parameters(), true);
 
         return statement;

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
@@ -56,7 +56,7 @@ public class CreateBlobTableAnalyzer {
         // apply default in case it is not specified in the genericProperties,
         // if it is it will get overwritten afterwards.
         TablePropertiesAnalyzer.analyze(
-            statement.tableParameter(), TableParameterInfo.CREATE_BLOB_TABLE_PARAMETERS,
+            statement.tableParameter(), TableParameters.CREATE_BLOB_TABLE_PARAMETERS,
             node.genericProperties(), parameterContext.parameters(), true);
 
         return statement;

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -69,7 +69,7 @@ public final class CreateTableStatementAnalyzer {
         // if it is it will get overwritten afterwards.
         TablePropertiesAnalyzer.analyze(
             statement.tableParameter(),
-            TableParameterInfo.TABLE_CREATE_PARAMETER_INFO,
+            TableParameters.TABLE_CREATE_PARAMETER_INFO,
             createTable.properties(),
             parameters,
             true

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -146,7 +146,7 @@ public class GenericPropertiesConverter {
         for (Map.Entry<String, Setting<?>> entry : supportedSettings.entrySet()) {
             SettingHolder settingHolder = new SettingHolder(entry.getValue());
             // We'd set the "wrong" default for settings that base their default on other settings
-            if (TableParameterInfo.SETTINGS_WITH_OTHER_SETTING_FALLBACK.contains(settingHolder.setting)) {
+            if (TableParameterInfo.SETTINGS_WITH_COMPUTED_DEFAULT.contains(settingHolder.setting)) {
                 continue;
             }
             settingHolder.applyDefault(builder);

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -146,7 +146,7 @@ public class GenericPropertiesConverter {
         for (Map.Entry<String, Setting<?>> entry : supportedSettings.entrySet()) {
             SettingHolder settingHolder = new SettingHolder(entry.getValue());
             // We'd set the "wrong" default for settings that base their default on other settings
-            if (TableParameterInfo.SETTINGS_WITH_COMPUTED_DEFAULT.contains(settingHolder.setting)) {
+            if (TableParameters.SETTINGS_WITH_COMPUTED_DEFAULT.contains(settingHolder.setting)) {
                 continue;
             }
             settingHolder.applyDefault(builder);

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -245,8 +245,8 @@ public class MetaDataToASTNodeResolver {
             GenericProperties properties = new GenericProperties();
             Expression numReplicas = new StringLiteral(tableInfo.numberOfReplicas());
             properties.add(new GenericProperty(
-                    TableParameterInfo.NUMBER_OF_REPLICAS.getKey(),
-                    numReplicas
+                TableParameterInfo.NUMBER_OF_REPLICAS.getKey(),
+                numReplicas
                 )
             );
             // we want a sorted map of table parameters

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -68,7 +68,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
-import static io.crate.analyze.TableParameterInfo.stripIndexPrefix;
+import static io.crate.analyze.TableParameters.stripIndexPrefix;
 
 public class MetaDataToASTNodeResolver {
 
@@ -245,7 +245,7 @@ public class MetaDataToASTNodeResolver {
             GenericProperties properties = new GenericProperties();
             Expression numReplicas = new StringLiteral(tableInfo.numberOfReplicas());
             properties.add(new GenericProperty(
-                TableParameterInfo.NUMBER_OF_REPLICAS.getKey(),
+                TableParameters.NUMBER_OF_REPLICAS.getKey(),
                 numReplicas
                 )
             );

--- a/sql/src/main/java/io/crate/analyze/TableParameters.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameters.java
@@ -52,7 +52,7 @@ import java.util.Set;
  */
 @Immutable
 @ThreadSafe
-public class TableParameterInfo {
+public class TableParameters {
 
     // all available table settings
     static final NumberOfReplicasSetting NUMBER_OF_REPLICAS = new NumberOfReplicasSetting();
@@ -119,19 +119,19 @@ public class TableParameterInfo {
 
     private static final Map<String, Setting<?>> SUPPORTED_MAPPINGS_DEFAULT = Map.of("column_policy", COLUMN_POLICY);
 
-    static final TableParameterInfo TABLE_CREATE_PARAMETER_INFO
-        = new TableParameterInfo(SUPPORTED_SETTINGS_DEFAULT, SUPPORTED_MAPPINGS_DEFAULT);
+    static final TableParameters TABLE_CREATE_PARAMETER_INFO
+        = new TableParameters(SUPPORTED_SETTINGS_DEFAULT, SUPPORTED_MAPPINGS_DEFAULT);
 
-    static final TableParameterInfo TABLE_ALTER_PARAMETER_INFO
-        = new TableParameterInfo(SUPPORTED_SETTINGS_INCL_SHARDS, SUPPORTED_MAPPINGS_DEFAULT);
+    static final TableParameters TABLE_ALTER_PARAMETER_INFO
+        = new TableParameters(SUPPORTED_SETTINGS_INCL_SHARDS, SUPPORTED_MAPPINGS_DEFAULT);
 
-    public static final TableParameterInfo PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
-        = new TableParameterInfo(SUPPORTED_SETTINGS_DEFAULT, Map.of());
+    public static final TableParameters PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
+        = new TableParameters(SUPPORTED_SETTINGS_DEFAULT, Map.of());
 
-    static final TableParameterInfo PARTITION_PARAMETER_INFO
-        = new TableParameterInfo(SUPPORTED_SETTINGS_INCL_SHARDS, Map.of());
+    static final TableParameters PARTITION_PARAMETER_INFO
+        = new TableParameters(SUPPORTED_SETTINGS_INCL_SHARDS, Map.of());
 
-    static final TableParameterInfo CREATE_BLOB_TABLE_PARAMETERS = new TableParameterInfo(
+    static final TableParameters CREATE_BLOB_TABLE_PARAMETERS = new TableParameters(
         Map.of(
             NUMBER_OF_REPLICAS.getKey(), NUMBER_OF_REPLICAS,
             "blobs_path", Setting.simpleString(
@@ -140,7 +140,7 @@ public class TableParameterInfo {
         Map.of()
     );
 
-    public static final TableParameterInfo ALTER_BLOB_TABLE_PARAMETERS = new TableParameterInfo(
+    public static final TableParameters ALTER_BLOB_TABLE_PARAMETERS = new TableParameters(
         Map.of(NUMBER_OF_REPLICAS.getKey(), NUMBER_OF_REPLICAS),
         Map.of()
     );
@@ -148,7 +148,7 @@ public class TableParameterInfo {
     private final Map<String, Setting<?>> supportedSettings;
     private final Map<String, Setting<?>> supportedMappings;
 
-    protected TableParameterInfo(Map<String, Setting<?>> supportedSettings, Map<String, Setting<?>> supportedMappings) {
+    protected TableParameters(Map<String, Setting<?>> supportedSettings, Map<String, Setting<?>> supportedMappings) {
         this.supportedSettings = supportedSettings;
         this.supportedMappings = supportedMappings;
     }

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -36,14 +36,14 @@ public final class TablePropertiesAnalyzer {
     }
 
     public static void analyze(TableParameter tableParameter,
-                               TableParameterInfo tableParameters,
+                               TableParameters tableParameters,
                                GenericProperties properties,
                                Row parameters) {
         analyze(tableParameter, tableParameters, properties, parameters, false);
     }
 
     public static void analyze(TableParameter tableParameter,
-                               TableParameterInfo tableParameters,
+                               TableParameters tableParameters,
                                GenericProperties properties,
                                Row parameters,
                                boolean withDefaults) {
@@ -74,7 +74,7 @@ public final class TablePropertiesAnalyzer {
      * default value.
      */
     static void analyzeResetProperties(TableParameter tableParameter,
-                                       TableParameterInfo tableParameters,
+                                       TableParameters tableParameters,
                                        List<String> properties) {
         Map<String, Setting<?>> settingMap = tableParameters.supportedSettings();
         Map<String, Setting<?>> mappingsMap = tableParameters.supportedMappings();

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -36,19 +36,19 @@ public final class TablePropertiesAnalyzer {
     }
 
     public static void analyze(TableParameter tableParameter,
-                               TableParameterInfo tableParameterInfo,
+                               TableParameterInfo tableParameters,
                                GenericProperties properties,
                                Row parameters) {
-        analyze(tableParameter, tableParameterInfo, properties, parameters, false);
+        analyze(tableParameter, tableParameters, properties, parameters, false);
     }
 
     public static void analyze(TableParameter tableParameter,
-                               TableParameterInfo tableParameterInfo,
+                               TableParameterInfo tableParameters,
                                GenericProperties properties,
                                Row parameters,
                                boolean withDefaults) {
-        Map<String, Setting<?>> settingMap = tableParameterInfo.supportedSettings();
-        Map<String, Setting<?>> mappingsMap = tableParameterInfo.supportedMappings();
+        Map<String, Setting<?>> settingMap = tableParameters.supportedSettings();
+        Map<String, Setting<?>> mappingsMap = tableParameters.supportedMappings();
 
         GenericPropertiesConverter.settingsFromProperties(
             tableParameter.settingsBuilder(),
@@ -74,10 +74,10 @@ public final class TablePropertiesAnalyzer {
      * default value.
      */
     static void analyzeResetProperties(TableParameter tableParameter,
-                                       TableParameterInfo tableParameterInfo,
+                                       TableParameterInfo tableParameters,
                                        List<String> properties) {
-        Map<String, Setting<?>> settingMap = tableParameterInfo.supportedSettings();
-        Map<String, Setting<?>> mappingsMap = tableParameterInfo.supportedMappings();
+        Map<String, Setting<?>> settingMap = tableParameters.supportedSettings();
+        Map<String, Setting<?>> mappingsMap = tableParameters.supportedMappings();
 
         GenericPropertiesConverter.resetSettingsFromProperties(
             tableParameter.settingsBuilder(),

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -34,7 +34,7 @@ import io.crate.analyze.AlterTableAnalyzedStatement;
 import io.crate.analyze.AlterTableOpenCloseAnalyzedStatement;
 import io.crate.analyze.AlterTableRenameAnalyzedStatement;
 import io.crate.analyze.TableParameter;
-import io.crate.analyze.TableParameterInfo;
+import io.crate.analyze.TableParameters;
 import io.crate.concurrent.MultiBiConsumer;
 import io.crate.data.Row;
 import io.crate.execution.ddl.index.SwapAndDropIndexRequest;
@@ -213,7 +213,7 @@ public class AlterTableOperation {
 
                 if (!analysis.excludePartitions()) {
                     // create new filtered partition table settings
-                    List<String> supportedSettings = TableParameterInfo.PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
+                    List<String> supportedSettings = TableParameters.PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
                         .supportedSettings()
                         .values()
                         .stream()

--- a/sql/src/main/java/io/crate/expression/reference/information/TablesSettingsExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/information/TablesSettingsExpression.java
@@ -21,14 +21,20 @@
 
 package io.crate.expression.reference.information;
 
-import io.crate.analyze.TableParameterInfo;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
+import org.elasticsearch.index.IndexSettings;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
+import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
 
 public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
 
@@ -40,7 +46,7 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
 
     private void addChildImplementations() {
 
-        childImplementations.put(REFRESH_INTERVAL, new TableParameterExpression(TableParameterInfo.REFRESH_INTERVAL.getKey()));
+        childImplementations.put(REFRESH_INTERVAL, new TableParameterExpression(INDEX_REFRESH_INTERVAL_SETTING.getKey()));
         childImplementations.put(TablesSettingsBlocksExpression.NAME, new TablesSettingsBlocksExpression());
         childImplementations.put(TablesSettingsMappingExpression.NAME, new TablesSettingsMappingExpression());
         childImplementations.put(TablesSettingsRoutingExpression.NAME, new TablesSettingsRoutingExpression());
@@ -113,7 +119,7 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         public static final String LIMIT = "limit";
 
         TablesSettingsMappingTotalFieldsExpression() {
-            childImplementations.put(LIMIT, new TableParameterExpression(TableParameterInfo.MAPPING_TOTAL_FIELDS_LIMIT.getKey()));
+            childImplementations.put(LIMIT, new TableParameterExpression(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()));
         }
     }
 
@@ -131,10 +137,10 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         static final String METADATA = "metadata";
 
         private void addChildImplementations() {
-            childImplementations.put(READ_ONLY, new TableParameterExpression(TableParameterInfo.READ_ONLY.getKey()));
-            childImplementations.put(READ, new TableParameterExpression(TableParameterInfo.BLOCKS_READ.getKey()));
-            childImplementations.put(WRITE, new TableParameterExpression(TableParameterInfo.BLOCKS_WRITE.getKey()));
-            childImplementations.put(METADATA, new TableParameterExpression(TableParameterInfo.BLOCKS_METADATA.getKey()));
+            childImplementations.put(READ_ONLY, new TableParameterExpression(IndexMetaData.INDEX_READ_ONLY_SETTING.getKey()));
+            childImplementations.put(READ, new TableParameterExpression(IndexMetaData.INDEX_BLOCKS_READ_SETTING.getKey()));
+            childImplementations.put(WRITE, new TableParameterExpression(IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.getKey()));
+            childImplementations.put(METADATA, new TableParameterExpression(IndexMetaData.INDEX_BLOCKS_METADATA_SETTING.getKey()));
         }
     }
 
@@ -166,8 +172,8 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         static final String EXCLUDE = "exclude";
 
         private void addChildImplementations() {
-            childImplementations.put(ENABLE, new StringTableParameterExpression(TableParameterInfo.ROUTING_ALLOCATION_ENABLE.getKey()));
-            childImplementations.put(TOTAL_SHARDS_PER_NODE, new TableParameterExpression(TableParameterInfo.TOTAL_SHARDS_PER_NODE.getKey()));
+            childImplementations.put(ENABLE, new StringTableParameterExpression(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey()));
+            childImplementations.put(TOTAL_SHARDS_PER_NODE, new TableParameterExpression(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()));
             childImplementations.put(REQUIRE, NestableCollectExpression.<RelationInfo, Map<String, Object>>forFunction(
                 r -> mapOfDynamicGroupSetting(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_PREFIX, r)));
             childImplementations.put(INCLUDE, NestableCollectExpression.<RelationInfo, Map<String, Object>>forFunction(
@@ -204,7 +210,7 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         static final String ENABLED = "enabled";
 
         private void addChildImplementations() {
-            childImplementations.put(ENABLED, new TableParameterExpression(TableParameterInfo.WARMER_ENABLED.getKey()));
+            childImplementations.put(ENABLED, new TableParameterExpression(IndexSettings.INDEX_WARMER_ENABLED_SETTING.getKey()));
         }
     }
 
@@ -221,9 +227,9 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         static final String DURABILITY = "durability";
 
         private void addChildImplementations() {
-            childImplementations.put(FLUSH_THRESHOLD_SIZE, new TableParameterExpression(TableParameterInfo.FLUSH_THRESHOLD_SIZE.getKey()));
-            childImplementations.put(SYNC_INTERVAL, new TableParameterExpression(TableParameterInfo.TRANSLOG_SYNC_INTERVAL.getKey()));
-            childImplementations.put(DURABILITY, new TableParameterExpression(TableParameterInfo.TRANSLOG_DURABILITY.getKey()));
+            childImplementations.put(FLUSH_THRESHOLD_SIZE, new TableParameterExpression(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey()));
+            childImplementations.put(SYNC_INTERVAL, new TableParameterExpression(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
+            childImplementations.put(DURABILITY, new TableParameterExpression(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey()));
         }
     }
 
@@ -240,7 +246,7 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         private void addChildImplementations() {
             childImplementations.put(
                 WAIT_FOR_ACTIVE_SHARDS,
-                new StringTableParameterExpression(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()));
+                new StringTableParameterExpression(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()));
         }
     }
 
@@ -269,7 +275,7 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         static final String DELAYED_TIMEOUT = "delayed_timeout";
 
         private void addChildImplementations() {
-            childImplementations.put(DELAYED_TIMEOUT, new TableParameterExpression(TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT.getKey()));
+            childImplementations.put(DELAYED_TIMEOUT, new TableParameterExpression(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey()));
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/partitioned/PartitionsSettingsExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/partitioned/PartitionsSettingsExpression.java
@@ -21,10 +21,15 @@
 
 package io.crate.expression.reference.partitioned;
 
-import io.crate.analyze.TableParameterInfo;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.reference.ObjectCollectExpression;
 import io.crate.metadata.PartitionInfo;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperService;
 
 import java.util.Map;
 
@@ -44,7 +49,7 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
                 Map.of(
                     "wait_for_active_shards",
                     forFunction((PartitionInfo pi) ->
-                        pi.tableParameters().get(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey())))
+                        pi.tableParameters().get(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey())))
             )
         )));
     }
@@ -104,7 +109,7 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         public static final String LIMIT = "limit";
 
         PartitionSettingsMappingTotalFieldsExpression() {
-            childImplementations.put(LIMIT, new PartitionTableParameterExpression(TableParameterInfo.MAPPING_TOTAL_FIELDS_LIMIT.getKey()));
+            childImplementations.put(LIMIT, new PartitionTableParameterExpression(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()));
         }
     }
 
@@ -122,10 +127,10 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         static final String METADATA = "metadata";
 
         private void addChildImplementations() {
-            childImplementations.put(READ_ONLY, new PartitionTableParameterExpression(TableParameterInfo.READ_ONLY.getKey()));
-            childImplementations.put(READ, new PartitionTableParameterExpression(TableParameterInfo.BLOCKS_READ.getKey()));
-            childImplementations.put(WRITE, new PartitionTableParameterExpression(TableParameterInfo.BLOCKS_WRITE.getKey()));
-            childImplementations.put(METADATA, new PartitionTableParameterExpression(TableParameterInfo.BLOCKS_METADATA.getKey()));
+            childImplementations.put(READ_ONLY, new PartitionTableParameterExpression(IndexMetaData.INDEX_READ_ONLY_SETTING.getKey()));
+            childImplementations.put(READ, new PartitionTableParameterExpression(IndexMetaData.INDEX_BLOCKS_READ_SETTING.getKey()));
+            childImplementations.put(WRITE, new PartitionTableParameterExpression(IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.getKey()));
+            childImplementations.put(METADATA, new PartitionTableParameterExpression(IndexMetaData.INDEX_BLOCKS_METADATA_SETTING.getKey()));
         }
     }
 
@@ -154,8 +159,8 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         static final String TOTAL_SHARDS_PER_NODE = "total_shards_per_node";
 
         private void addChildImplementations() {
-            childImplementations.put(ENABLE, new StringPartitionTableParameterExpression(TableParameterInfo.ROUTING_ALLOCATION_ENABLE.getKey()));
-            childImplementations.put(TOTAL_SHARDS_PER_NODE, new PartitionTableParameterExpression(TableParameterInfo.TOTAL_SHARDS_PER_NODE.getKey()));
+            childImplementations.put(ENABLE, new StringPartitionTableParameterExpression(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey()));
+            childImplementations.put(TOTAL_SHARDS_PER_NODE, new PartitionTableParameterExpression(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()));
         }
     }
 
@@ -170,7 +175,7 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         static final String ENABLED = "enabled";
 
         private void addChildImplementations() {
-            childImplementations.put(ENABLED, new PartitionTableParameterExpression(TableParameterInfo.WARMER_ENABLED.getKey()));
+            childImplementations.put(ENABLED, new PartitionTableParameterExpression(IndexSettings.INDEX_WARMER_ENABLED_SETTING.getKey()));
         }
     }
 
@@ -187,9 +192,9 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         static final String DURABILITY = "durability";
 
         private void addChildImplementations() {
-            childImplementations.put(FLUSH_THRESHOLD_SIZE, new PartitionTableParameterExpression(TableParameterInfo.FLUSH_THRESHOLD_SIZE.getKey()));
-            childImplementations.put(SYNC_INTERVAL, new PartitionTableParameterExpression(TableParameterInfo.TRANSLOG_SYNC_INTERVAL.getKey()));
-            childImplementations.put(DURABILITY, new PartitionTableParameterExpression(TableParameterInfo.TRANSLOG_DURABILITY.getKey()));
+            childImplementations.put(FLUSH_THRESHOLD_SIZE, new PartitionTableParameterExpression(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey()));
+            childImplementations.put(SYNC_INTERVAL, new PartitionTableParameterExpression(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
+            childImplementations.put(DURABILITY, new PartitionTableParameterExpression(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey()));
         }
     }
 
@@ -218,7 +223,7 @@ public class PartitionsSettingsExpression extends ObjectCollectExpression<Partit
         static final String DELAYED_TIMEOUT = "delayed_timeout";
 
         private void addChildImplementations() {
-            childImplementations.put(DELAYED_TIMEOUT, new PartitionTableParameterExpression(TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT.getKey()));
+            childImplementations.put(DELAYED_TIMEOUT, new PartitionTableParameterExpression(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey()));
         }
     }
 }

--- a/sql/src/main/java/io/crate/metadata/PartitionInfo.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionInfo.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableMap;
 import io.crate.metadata.table.StoredTable;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
@@ -38,7 +37,7 @@ public class PartitionInfo implements StoredTable {
     private final Version versionUpgraded;
     private final boolean closed;
     private final Map<String, Object> values;
-    private final ImmutableMap<String, Object> tableParameters;
+    private final Map<String, Object> tableParameters;
 
     public PartitionInfo(PartitionName name,
                          int numberOfShards,
@@ -47,7 +46,7 @@ public class PartitionInfo implements StoredTable {
                          @Nullable Version versionUpgraded,
                          boolean closed,
                          Map<String, Object> values,
-                         ImmutableMap<String, Object> tableParameters) {
+                         Map<String, Object> tableParameters) {
         this.name = name;
         this.numberOfShards = numberOfShards;
         this.numberOfReplicas = numberOfReplicas;
@@ -112,7 +111,7 @@ public class PartitionInfo implements StoredTable {
             .toString();
     }
 
-    public ImmutableMap<String, Object> tableParameters() {
+    public Map<String, Object> tableParameters() {
         return tableParameters;
     }
 

--- a/sql/src/main/java/io/crate/metadata/PartitionInfos.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionInfos.java
@@ -24,7 +24,7 @@ package io.crate.metadata;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.Constants;
 import io.crate.analyze.NumberOfReplicas;
-import io.crate.analyze.TableParameterInfo;
+import io.crate.analyze.TableParameters;
 import io.crate.metadata.doc.DocIndexMetaData;
 import io.crate.metadata.doc.PartitionedByMappingExtractor;
 import io.crate.types.DataType;
@@ -79,7 +79,7 @@ public class PartitionInfos implements Iterable<PartitionInfo> {
                 settings.getAsVersion(IndexMetaData.SETTING_VERSION_UPGRADED, null),
                 DocIndexMetaData.isClosed(indexMetaData, mappingMap, false),
                 valuesMap,
-                TableParameterInfo.tableParametersFromIndexMetaData(indexMetaData));
+                TableParameters.tableParametersFromIndexMetaData(indexMetaData));
         } catch (Exception e) {
             LOGGER.trace("error extracting partition infos from index {}", e, indexMetaDataEntry.key);
             return null; // must filter on null

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -23,7 +23,7 @@ package io.crate.metadata.blob;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.TableParameterInfo;
+import io.crate.analyze.TableParameters;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -60,7 +60,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     private final String index;
     private final LinkedHashSet<Reference> columns = new LinkedHashSet<>();
     private final String blobsPath;
-    private final TableParameterInfo supportedTableParameters;
+    private final TableParameters supportedTableParameters;
     private final Map<String, Object> tableParameters;
     private final Version versionCreated;
     private final Version versionUpgraded;
@@ -89,7 +89,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.numberOfShards = numberOfShards;
         this.numberOfReplicas = numberOfReplicas;
         this.blobsPath = blobsPath;
-        this.supportedTableParameters = TableParameterInfo.ALTER_BLOB_TABLE_PARAMETERS;
+        this.supportedTableParameters = TableParameters.ALTER_BLOB_TABLE_PARAMETERS;
         this.tableParameters = tableParameters;
         this.versionCreated = versionCreated;
         this.versionUpgraded = versionUpgraded;
@@ -171,7 +171,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         return blobsPath;
     }
 
-    public TableParameterInfo tableParameters() {
+    public TableParameters tableParameters() {
         return supportedTableParameters;
     }
 

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -60,7 +60,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     private final String index;
     private final LinkedHashSet<Reference> columns = new LinkedHashSet<>();
     private final String blobsPath;
-    private final TableParameterInfo tableParameterInfo;
+    private final TableParameterInfo supportedTableParameters;
     private final Map<String, Object> tableParameters;
     private final Version versionCreated;
     private final Version versionUpgraded;
@@ -89,7 +89,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.numberOfShards = numberOfShards;
         this.numberOfReplicas = numberOfReplicas;
         this.blobsPath = blobsPath;
-        this.tableParameterInfo = TableParameterInfo.BLOB_TABLE_ALTER_PARAMETER_INFO;
+        this.supportedTableParameters = TableParameterInfo.ALTER_BLOB_TABLE_PARAMETERS;
         this.tableParameters = tableParameters;
         this.versionCreated = versionCreated;
         this.versionUpgraded = versionUpgraded;
@@ -171,8 +171,8 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         return blobsPath;
     }
 
-    public TableParameterInfo tableParameterInfo() {
-        return tableParameterInfo;
+    public TableParameterInfo tableParameters() {
+        return supportedTableParameters;
     }
 
     public Map<String, Object> parameters() {

--- a/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
@@ -22,7 +22,7 @@
 package io.crate.metadata.blob;
 
 import io.crate.analyze.NumberOfReplicas;
-import io.crate.analyze.TableParameterInfo;
+import io.crate.analyze.TableParameters;
 import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.exceptions.RelationUnknown;
@@ -84,7 +84,7 @@ public class InternalBlobTableInfoFactory implements BlobTableInfoFactory {
             indexMetaData.getIndex().getName(),
             indexMetaData.getNumberOfShards(),
             NumberOfReplicas.fromSettings(settings),
-            TableParameterInfo.tableParametersFromIndexMetaData(indexMetaData),
+            TableParameters.tableParametersFromIndexMetaData(indexMetaData),
             blobsPath(settings),
             IndexMetaData.SETTING_INDEX_VERSION_CREATED.get(settings),
             settings.getAsVersion(IndexMetaData.SETTING_VERSION_UPGRADED, null),

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -30,7 +30,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import io.crate.Constants;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.ParamTypeHints;
-import io.crate.analyze.TableParameterInfo;
+import io.crate.analyze.TableParameters;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
@@ -134,7 +134,7 @@ public class DocIndexMetaData {
         Settings settings = metaData.getSettings();
         this.numberOfReplicas = NumberOfReplicas.fromSettings(settings);
         this.mappingMap = getMappingMap(metaData);
-        this.tableParameters = TableParameterInfo.tableParametersFromIndexMetaData(metaData);
+        this.tableParameters = TableParameters.tableParametersFromIndexMetaData(metaData);
 
         Map<String, Object> metaMap = Maps.get(mappingMap, "_meta");
         indicesMap = Maps.getOrDefault(metaMap, "indices", ImmutableMap.of());

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -34,8 +34,8 @@ import io.crate.analyze.TableParameterInfo;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
-import io.crate.common.collections.Lists2;
 import io.crate.analyze.relations.FieldProvider;
+import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -99,7 +99,7 @@ public class DocIndexMetaData {
     private final RelationName ident;
     private final int numberOfShards;
     private final String numberOfReplicas;
-    private final ImmutableMap<String, Object> tableParameters;
+    private final Map<String, Object> tableParameters;
     private final Map<String, Object> indicesMap;
     private final ImmutableList<ColumnIdent> partitionedBy;
     private final Set<Operation> supportedOperations;
@@ -650,7 +650,7 @@ public class DocIndexMetaData {
         return columnPolicy;
     }
 
-    public ImmutableMap<String, Object> tableParameters() {
+    public Map<String, Object> tableParameters() {
         return tableParameters;
     }
 

--- a/sql/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.function.Function;
 
-import static io.crate.analyze.TableParameterInfo.stripIndexPrefix;
+import static io.crate.analyze.TableParameters.stripIndexPrefix;
 
 public class NumberOfReplicasSetting extends Setting<Settings> {
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -32,6 +32,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -307,7 +308,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             "alter table parted set (number_of_shards=10)");
         assertThat(analysis.partitionName().isPresent(), is(false));
         assertThat(analysis.table().isPartitioned(), is(true));
-        assertEquals("10", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
+        assertEquals("10", analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()));
     }
 
     @Test
@@ -316,7 +317,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             "alter table parted partition (date=1395874800000) set (number_of_shards=1)");
         assertThat(analysis.partitionName().isPresent(), is(true));
         assertThat(analysis.table().isPartitioned(), is(true));
-        assertEquals("1", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
+        assertEquals("1", analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()));
     }
 
     @Test
@@ -325,7 +326,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             "alter table parted partition (date=1395874800000) reset (number_of_shards)");
         assertThat(analysis.partitionName().isPresent(), is(true));
         assertThat(analysis.table().isPartitioned(), is(true));
-        assertEquals("5", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()));
+        assertEquals("5", analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()));
     }
 
     @Test
@@ -352,11 +353,11 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     public void testAlterTableWithWaitForActiveShards() {
         AlterTableAnalyzedStatement analyzedStatement = e.analyze(
             "ALTER TABLE parted SET (\"write.wait_for_active_shards\"= 'ALL')");
-        assertThat(analyzedStatement.tableParameter().settings().get(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()),
+        assertThat(analyzedStatement.tableParameter().settings().get(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()),
             is("ALL"));
 
         analyzedStatement = e.analyze("ALTER TABLE parted RESET (\"write.wait_for_active_shards\")");
-        assertThat(analyzedStatement.tableParameter().settings().get(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()),
+        assertThat(analyzedStatement.tableParameter().settings().get(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()),
             is("1"));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -246,7 +246,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "SET (column_policy = 'strict')");
         assertEquals(
             ColumnPolicy.STRICT.lowerCaseName(),
-            analysisSet.tableParameter().mappings().get(TableParameterInfo.COLUMN_POLICY.getKey()));
+            analysisSet.tableParameter().mappings().get(TableParameters.COLUMN_POLICY.getKey()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -47,8 +47,12 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -129,7 +133,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "create table foo (id integer primary key, name string not null) " +
             "clustered into 3 shards with (number_of_replicas=0)");
 
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("3"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("3"));
         assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()), is("0"));
 
         Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
@@ -156,7 +160,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void testCreateTableWithDefaultNumberOfShards() {
         CreateTableAnalyzedStatement analysis = e.analyze("create table foo (id integer primary key, name string)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("6"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("6"));
     }
 
     @Test
@@ -164,7 +168,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateTableAnalyzedStatement analysis = e.analyze(
             "create table foo (id integer primary key) clustered by (id)"
         );
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("6"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("6"));
     }
 
     @Test
@@ -173,7 +177,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "create table foo (id integer primary key) " +
             "clustered by (id) into 8 shards"
         );
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("8"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("8"));
     }
 
     @Test
@@ -181,7 +185,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateTableAnalyzedStatement analysis = e.analyze(
             "CREATE TABLE foo (id int primary key) " +
             "with (\"mapping.total_fields.limit\"=5000)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.MAPPING_TOTAL_FIELDS_LIMIT.getKey()), is("5000"));
+        assertThat(analysis.tableParameter().settings().get(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()), is("5000"));
     }
 
     @Test
@@ -189,7 +193,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateTableAnalyzedStatement analysis = e.analyze(
             "CREATE TABLE foo (id int primary key, content string) " +
             "with (refresh_interval='5000ms')");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.REFRESH_INTERVAL.getKey()), is("5s"));
+        assertThat(analysis.tableParameter().settings().get(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()), is("5s"));
     }
 
     @Test
@@ -212,13 +216,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysisSet = e.analyze(
             "ALTER TABLE user_refresh_interval " +
             "SET (refresh_interval = '5000ms')");
-        assertEquals("5s", analysisSet.tableParameter().settings().get(TableParameterInfo.REFRESH_INTERVAL.getKey()));
+        assertEquals("5s", analysisSet.tableParameter().settings().get(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()));
 
         // alter t reset
         AlterTableAnalyzedStatement analysisReset = e.analyze(
             "ALTER TABLE user_refresh_interval " +
             "RESET (refresh_interval)");
-        assertEquals("1s", analysisReset.tableParameter().settings().get(TableParameterInfo.REFRESH_INTERVAL.getKey()));
+        assertEquals("1s", analysisReset.tableParameter().settings().get(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()));
     }
 
     @Test
@@ -226,13 +230,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysisSet = e.analyze(
             "ALTER TABLE users " +
             "SET (\"mapping.total_fields.limit\" = '5000')");
-        assertEquals("5000", analysisSet.tableParameter().settings().get(TableParameterInfo.MAPPING_TOTAL_FIELDS_LIMIT.getKey()));
+        assertEquals("5000", analysisSet.tableParameter().settings().get(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()));
 
         // Check if resetting total_fields results in default value
         AlterTableAnalyzedStatement analysisReset = e.analyze(
             "ALTER TABLE users " +
             "RESET (\"mapping.total_fields.limit\")");
-        assertEquals("1000", analysisReset.tableParameter().settings().get(TableParameterInfo.MAPPING_TOTAL_FIELDS_LIMIT.getKey()));
+        assertEquals("1000", analysisReset.tableParameter().settings().get(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()));
     }
 
     @Test
@@ -258,7 +262,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysisSet = e.analyze(
             "ALTER TABLE users " +
             "SET (max_ngram_diff = 42)");
-        assertThat(analysisSet.tableParameter().settings().get(TableParameterInfo.MAX_NGRAM_DIFF.getKey()), is("42"));
+        assertThat(analysisSet.tableParameter().settings().get(IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey()), is("42"));
     }
 
     @Test
@@ -266,7 +270,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysisSet = e.analyze(
             "ALTER TABLE users " +
             "SET (max_shingle_diff = 43)");
-        assertThat(analysisSet.tableParameter().settings().get(TableParameterInfo.MAX_SHINGLE_DIFF.getKey()), is("43"));
+        assertThat(analysisSet.tableParameter().settings().get(IndexSettings.MAX_SHINGLE_DIFF_SETTING.getKey()), is("43"));
     }
 
     @Test
@@ -723,7 +727,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testCreateTableWithClusteredIntoShardsParameter() {
         CreateTableAnalyzedStatement analysis = e.analyze(
             "create table t (id int primary key) clustered into ? shards", new Object[]{2});
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("2"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("2"));
     }
 
     @Test
@@ -807,70 +811,70 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testChangeReadBlock() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"blocks.read\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.BLOCKS_READ.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_BLOCKS_READ_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeWriteBlock() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"blocks.write\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.BLOCKS_WRITE.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeMetadataBlock() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"blocks.metadata\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.BLOCKS_METADATA.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_BLOCKS_METADATA_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeReadOnlyBlock() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"blocks.read_only\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.READ_ONLY.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_READ_ONLY_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeBlockReadOnlyAllowDelete() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"blocks.read_only_allow_delete\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.READ_ONLY_ALLOW_DELETE.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeBlockReadOnlyAllowedDeletePartitionedTable() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table parted set (\"blocks.read_only_allow_delete\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.READ_ONLY_ALLOW_DELETE.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.getKey()), is("true"));
     }
 
     @Test
     public void testChangeFlushThresholdSize() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"translog.flush_threshold_size\"='300b')");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.FLUSH_THRESHOLD_SIZE.getKey()), is("300b"));
+        assertThat(analysis.tableParameter().settings().get(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey()), is("300b"));
     }
 
     @Test
     public void testChangeTranslogInterval() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"translog.sync_interval\"='100ms')");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.TRANSLOG_SYNC_INTERVAL.getKey()), is("100ms"));
+        assertThat(analysis.tableParameter().settings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()), is("100ms"));
     }
 
     @Test
     public void testChangeTranslogDurability() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"translog.durability\"='ASYNC')");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.TRANSLOG_DURABILITY.getKey()), is("ASYNC"));
+        assertThat(analysis.tableParameter().settings().get(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey()), is("ASYNC"));
     }
 
     @Test
     public void testRoutingAllocationEnable() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"routing.allocation.enable\"=\"none\")");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.ROUTING_ALLOCATION_ENABLE.getKey()), is("none"));
+        assertThat(analysis.tableParameter().settings().get(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey()), is("none"));
     }
 
     @Test
@@ -884,7 +888,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"number_of_shards\"=1)");
         assertThat(analysis.table().ident().name(), is("users"));
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("1"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("1"));
     }
 
     @Test
@@ -892,7 +896,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users reset (\"number_of_shards\")");
         assertThat(analysis.table().ident().name(), is("users"));
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS.getKey()), is("5"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey()), is("5"));
     }
 
     @Test
@@ -900,14 +904,14 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"translog.sync_interval\"='1s')");
         assertThat(analysis.table().ident().name(), is("users"));
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.TRANSLOG_SYNC_INTERVAL.getKey()), is("1s"));
+        assertThat(analysis.tableParameter().settings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()), is("1s"));
     }
 
     @Test
     public void testAllocationMaxRetriesValidation() {
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"allocation.max_retries\"=1)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.ALLOCATION_MAX_RETRIES.getKey()), is("1"));
+        assertThat(analysis.tableParameter().settings().get(MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getKey()), is("1"));
     }
 
     @Test
@@ -915,7 +919,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateTableAnalyzedStatement analysis = e.analyze(
             "create table foo (id integer primary key, name string) "
             + "clustered into 3 shards with (\"blocks.read_only\"=true)");
-        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.READ_ONLY.getKey()), is("true"));
+        assertThat(analysis.tableParameter().settings().get(IndexMetaData.INDEX_READ_ONLY_SETTING.getKey()), is("true"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`TableParameterInfo` contained a lot of constant definitions for
settings that are defined elsewhere.

This removes them, as there is no real benefit by having them.

Also renames the class to `TableParameters`, as the `Info` seemed a bit
redundant and imho didn't convey any additional information.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)