### PR TITLE
Remove the orphans handling from create table

### DIFF
--- a/shared/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/shared/src/main/java/io/crate/exceptions/Exceptions.java
@@ -36,6 +36,14 @@ public final class Exceptions {
         Exceptions.rethrow(ex);
     }
 
+    public static <T> T rethrowRuntimeException(Throwable t) {
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        } else {
+            throw new RuntimeException(t);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private static <T extends Throwable> void rethrow(final Throwable t) throws T {
         throw (T) t;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -22,222 +22,83 @@
 
 package io.crate.execution.ddl.tables;
 
-import com.google.common.base.Joiner;
 import io.crate.Constants;
 import io.crate.analyze.CreateTableAnalyzedStatement;
+import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.SQLExceptions;
-import io.crate.metadata.IndexParts;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
+import io.crate.execution.support.Transports;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.cluster.metadata.AliasOrIndex;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Locale;
-import java.util.SortedMap;
 import java.util.concurrent.CompletableFuture;
 
 @Singleton
 public class TableCreator {
 
-    private static final Long SUCCESS_RESULT = 1L;
-
     protected static final Logger LOGGER = LogManager.getLogger(TableCreator.class);
 
-    private final ClusterService clusterService;
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final TransportCreateTableAction transportCreateTableAction;
-    private final TransportDeleteIndexAction transportDeleteIndexAction;
 
     @Inject
-    public TableCreator(ClusterService clusterService,
-                        IndexNameExpressionResolver indexNameExpressionResolver,
-                        TransportCreateTableAction transportCreateIndexAction,
-                        TransportDeleteIndexAction transportDeleteIndexAction) {
-        this.clusterService = clusterService;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
+    public TableCreator(TransportCreateTableAction transportCreateIndexAction) {
         this.transportCreateTableAction = transportCreateIndexAction;
-        this.transportDeleteIndexAction = transportDeleteIndexAction;
     }
 
-
-    public CompletableFuture<Long> create(CreateTableAnalyzedStatement statement) {
-        final CompletableFuture<Long> result = new CompletableFuture<>();
-
-        // real work done in createTable()
-        deleteOrphans(new CreateTableResponseListener(result, statement), statement.tableIdent());
-        return result;
-    }
-
-    private CreateIndexRequest createIndexRequest(CreateTableAnalyzedStatement statement) {
-        return new CreateIndexRequest(statement.tableIdent().indexNameOrAlias(), settings(statement))
-            .mapping(Constants.DEFAULT_MAPPING_TYPE, statement.mapping());
-    }
-
-    private Settings settings(CreateTableAnalyzedStatement statement) {
-        return statement.tableParameter().settings();
-    }
-
-    private PutIndexTemplateRequest createTemplateRequest(CreateTableAnalyzedStatement statement) {
-        return new PutIndexTemplateRequest(statement.templateName())
-            .mapping(Constants.DEFAULT_MAPPING_TYPE, statement.mapping())
-            .create(true)
-            .settings(settings(statement))
-            .patterns(Collections.singletonList(statement.templatePrefix()))
-            .order(100)
-            .alias(new Alias(statement.tableIdent().indexNameOrAlias()));
-    }
-
-    private void createTable(final CompletableFuture<Long> result, final CreateTableAnalyzedStatement statement) {
-        final CreateTableRequest createTableRequest;
-        if (statement.templateName() != null) {
-            createTableRequest = new CreateTableRequest(createTemplateRequest(statement));
-        } else {
-            createTableRequest = new CreateTableRequest(createIndexRequest(statement));
-        }
-        transportCreateTableAction.execute(createTableRequest, new ActionListener<CreateTableResponse>() {
-            @Override
-            public void onResponse(CreateTableResponse response) {
-                if (!response.isAllShardsAcked()) {
-                    warnNotAcknowledged(String.format(Locale.ENGLISH, "creating table '%s'", statement.tableIdent().fqn()));
-                }
-                result.complete(SUCCESS_RESULT);
+    public CompletableFuture<Long> create(CreateTableAnalyzedStatement createTable) {
+        var templateName = createTable.templateName();
+        var relationName = createTable.tableIdent();
+        var createTableRequest = templateName == null
+            ? new CreateTableRequest(
+                new CreateIndexRequest(
+                    relationName.indexNameOrAlias(),
+                    createTable.tableParameter().settings()
+                ).mapping(Constants.DEFAULT_MAPPING_TYPE, createTable.mapping())
+            )
+            : new CreateTableRequest(
+                new PutIndexTemplateRequest(templateName)
+                    .mapping(Constants.DEFAULT_MAPPING_TYPE, createTable.mapping())
+                    .create(true)
+                    .settings(createTable.tableParameter().settings())
+                    .patterns(Collections.singletonList(createTable.templatePrefix()))
+                    .order(100)
+                    .alias(new Alias(relationName.indexNameOrAlias()))
+        );
+        return Transports.execute(transportCreateTableAction, createTableRequest, resp -> {
+            if (!resp.isAllShardsAcked() && LOGGER.isWarnEnabled()) {
+                LOGGER.warn("CREATE TABLE `{}` was not acknowledged. This could lead to inconsistent state.", relationName.fqn());
             }
-
-            @Override
-            public void onFailure(Exception e) {
-                setException(result, e, statement);
+            return 1L;
+        }).exceptionally(error -> {
+            Throwable t = SQLExceptions.unwrap(error);
+            String message = t.getMessage();
+            Throwable cause = t.getCause();
+            if ("mapping [default]".equals(message) && cause != null) {
+                // this is a generic mapping parse exception,
+                // the cause has usually a better more detailed error message
+                return Exceptions.rethrowRuntimeException(cause);
+            } else if (createTable.ifNotExists() && isTableExistsError(t, templateName)) {
+                return 0L;
+            } else {
+                return Exceptions.rethrowRuntimeException(t);
             }
         });
     }
 
-
-    private static void setException(CompletableFuture<Long> result, Throwable e, CreateTableAnalyzedStatement statement) {
-        e = SQLExceptions.unwrap(e);
-        String message = e.getMessage();
-        if ("mapping [default]".equals(message) && e.getCause() != null) {
-            // this is a generic mapping parse exception,
-            // the cause has usually a better more detailed error message
-            result.completeExceptionally(e.getCause());
-        } else if (statement.ifNotExists() && (e instanceof ResourceAlreadyExistsException ||
-                                               (statement.templateName() != null && isTemplateAlreadyExistsException(e)))) {
-            result.complete(null);
-        } else {
-            result.completeExceptionally(e);
-        }
+    private static boolean isTableExistsError(Throwable e, @Nullable String templateName) {
+        return e instanceof ResourceAlreadyExistsException
+               || (templateName != null && isTemplateAlreadyExistsException(e));
     }
 
     private static boolean isTemplateAlreadyExistsException(Throwable e) {
         return e instanceof IllegalArgumentException
             && e.getMessage() != null && e.getMessage().endsWith("already exists");
-    }
-
-    private void deleteOrphans(final CreateTableResponseListener listener, RelationName relationName) {
-        MetaData metaData = clusterService.state().getMetaData();
-        String fqn = relationName.fqn();
-
-        if (metaData.hasAlias(fqn) && isPartition(metaData, fqn)) {
-            LOGGER.debug("Deleting orphaned partitions with alias: {}", fqn);
-            transportDeleteIndexAction.execute(new DeleteIndexRequest(fqn), new ActionListener<AcknowledgedResponse>() {
-                @Override
-                public void onResponse(AcknowledgedResponse response) {
-                    if (!response.isAcknowledged()) {
-                        warnNotAcknowledged("deleting orphaned alias");
-                    }
-                    deleteOrphanedPartitions(listener, relationName);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            });
-        } else {
-            deleteOrphanedPartitions(listener, relationName);
-        }
-    }
-
-    private static boolean isPartition(MetaData metaData, String fqn) {
-        SortedMap<String, AliasOrIndex> aliasAndIndexLookup = metaData.getAliasAndIndexLookup();
-        AliasOrIndex aliasOrIndex = aliasAndIndexLookup.get(fqn);
-        return IndexParts.isPartitioned(
-            aliasOrIndex.getIndices().iterator().next().getIndex().getName());
-    }
-
-    /**
-     * if some orphaned partition with the same table name still exist,
-     * delete them beforehand as they would create unwanted and maybe invalid
-     * initial data.
-     * <p>
-     * should never delete partitions of existing partitioned tables
-     */
-    private void deleteOrphanedPartitions(final CreateTableResponseListener listener, RelationName relationName) {
-        String partitionWildCard = PartitionName.templateName(relationName.schema(), relationName.name()) + "*";
-        String[] orphans = indexNameExpressionResolver.concreteIndexNames(
-            clusterService.state(), IndicesOptions.strictExpand(), partitionWildCard);
-        if (orphans.length > 0) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Deleting orphaned partitions: {}", Joiner.on(", ").join(orphans));
-            }
-            transportDeleteIndexAction.execute(new DeleteIndexRequest(orphans), new ActionListener<AcknowledgedResponse>() {
-                @Override
-                public void onResponse(AcknowledgedResponse response) {
-                    if (!response.isAcknowledged()) {
-                        warnNotAcknowledged("deleting orphans");
-                    }
-                    listener.onResponse(SUCCESS_RESULT);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            });
-        } else {
-            listener.onResponse(SUCCESS_RESULT);
-        }
-    }
-
-    protected void warnNotAcknowledged(String operationName) {
-        LOGGER.warn("{} was not acknowledged. This could lead to inconsistent state.",
-                    operationName);
-    }
-
-    class CreateTableResponseListener implements ActionListener<Long> {
-
-        final CompletableFuture<Long> result;
-        final CreateTableAnalyzedStatement statement;
-
-        public CreateTableResponseListener(CompletableFuture<Long> result, CreateTableAnalyzedStatement statement) {
-            this.result = result;
-            this.statement = statement;
-
-        }
-
-        @Override
-        public void onResponse(Long ignored) {
-            createTable(result, statement);
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            result.completeExceptionally(e);
-        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We made DROP TABLE an atomic cluster state update a while ago, so there
shouldn't be cases anymore that can result in orphaned indices or
aliases.

Removing the logic that deleted those orphans on a CREATE TABLE should
therefore be safe. (And if not, it should expose any bugs and we can
then fix the root causes)


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)