### PR TITLE
Inline AstVisitor.process

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -22,12 +22,7 @@
 package io.crate.sql.tree;
 
 
-import javax.annotation.Nullable;
-
 public abstract class AstVisitor<R, C> {
-    public R process(Node node, @Nullable C context) {
-        return node.accept(this, context);
-    }
 
     protected R visitNode(Node node, C context) {
         return null;

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -21,53 +21,53 @@
 
 package io.crate.sql.tree;
 
-public abstract class DefaultTraversalVisitor<R, C>
-    extends AstVisitor<R, C> {
+public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
+
     @Override
     protected R visitExtract(Extract node, C context) {
-        return process(node.getExpression(), context);
+        return node.getExpression().accept(this, context);
     }
 
     @Override
     protected R visitCast(Cast node, C context) {
-        return process(node.getExpression(), context);
+        return node.getExpression().accept(this, context);
     }
 
     @Override
     protected R visitTryCast(TryCast node, C context) {
-        return process(node.getExpression(), context);
+        return node.getExpression().accept(this, context);
     }
 
     @Override
     protected R visitArithmeticExpression(ArithmeticExpression node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitBetweenPredicate(BetweenPredicate node, C context) {
-        process(node.getValue(), context);
-        process(node.getMin(), context);
-        process(node.getMax(), context);
+        node.getValue().accept(this, context);
+        node.getMin().accept(this, context);
+        node.getMax().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitComparisonExpression(ComparisonExpression node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitQuery(Query node, C context) {
-        process(node.getQueryBody(), context);
+        node.getQueryBody().accept(this, context);
         for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+            sortItem.accept(this, context);
         }
 
         return null;
@@ -76,7 +76,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitSelect(Select node, C context) {
         for (SelectItem item : node.getSelectItems()) {
-            process(item, context);
+            item.accept(this, context);
         }
 
         return null;
@@ -84,23 +84,23 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitSingleColumn(SingleColumn node, C context) {
-        process(node.getExpression(), context);
+        node.getExpression().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitWhenClause(WhenClause node, C context) {
-        process(node.getOperand(), context);
-        process(node.getResult(), context);
+        node.getOperand().accept(this, context);
+        node.getResult().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitInPredicate(InPredicate node, C context) {
-        process(node.getValue(), context);
-        process(node.getValueList(), context);
+        node.getValue().accept(this, context);
+        node.getValueList().accept(this, context);
 
         return null;
     }
@@ -108,7 +108,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitFunctionCall(FunctionCall node, C context) {
         for (Expression argument : node.getArguments()) {
-            process(argument, context);
+            argument.accept(this, context);
         }
 
         return null;
@@ -116,12 +116,12 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitSimpleCaseExpression(SimpleCaseExpression node, C context) {
-        process(node.getOperand(), context);
+        node.getOperand().accept(this, context);
         for (WhenClause clause : node.getWhenClauses()) {
-            process(clause, context);
+            clause.accept(this, context);
         }
         if (node.getDefaultValue() != null) {
-            process(node.getDefaultValue(), context);
+            node.getDefaultValue().accept(this, context);
         }
 
         return null;
@@ -130,7 +130,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitInListExpression(InListExpression node, C context) {
         for (Expression value : node.getValues()) {
-            process(value, context);
+            value.accept(this, context);
         }
 
         return null;
@@ -138,10 +138,10 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitIfExpression(IfExpression node, C context) {
-        process(node.getCondition(), context);
-        process(node.getTrueValue(), context);
+        node.getCondition().accept(this, context);
+        node.getTrueValue().accept(this, context);
         if (node.getFalseValue().isPresent()) {
-            process(node.getFalseValue().get(), context);
+            node.getFalseValue().get().accept(this, context);
         }
 
         return null;
@@ -149,21 +149,22 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitNegativeExpression(NegativeExpression node, C context) {
-        return process(node.getValue(), context);
+        return node.getValue().accept(this, context);
     }
 
     @Override
     protected R visitNotExpression(NotExpression node, C context) {
-        return process(node.getValue(), context);
+        return node.getValue().accept(this, context);
     }
 
     @Override
     protected R visitSearchedCaseExpression(SearchedCaseExpression node, C context) {
         for (WhenClause clause : node.getWhenClauses()) {
-            process(clause, context);
+            clause.accept(this, context);
         }
-        if (node.getDefaultValue() != null) {
-            process(node.getDefaultValue(), context);
+        Expression defaultValue = node.getDefaultValue();
+        if (defaultValue != null) {
+            defaultValue.accept(this, context);
         }
 
         return null;
@@ -171,10 +172,11 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitLikePredicate(LikePredicate node, C context) {
-        process(node.getValue(), context);
-        process(node.getPattern(), context);
-        if (node.getEscape() != null) {
-            process(node.getEscape(), context);
+        node.getValue().accept(this, context);
+        node.getPattern().accept(this, context);
+        Expression escape = node.getEscape();
+        if (escape != null) {
+            escape.accept(this, context);
         }
 
         return null;
@@ -182,30 +184,30 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitIsNotNullPredicate(IsNotNullPredicate node, C context) {
-        return process(node.getValue(), context);
+        return node.getValue().accept(this, context);
     }
 
     @Override
     protected R visitIsNullPredicate(IsNullPredicate node, C context) {
-        return process(node.getValue(), context);
+        return node.getValue().accept(this, context);
     }
 
     @Override
     protected R visitLogicalBinaryExpression(LogicalBinaryExpression node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
 
         return null;
     }
 
     @Override
     protected R visitSubqueryExpression(SubqueryExpression node, C context) {
-        return process(node.getQuery(), context);
+        return node.getQuery().accept(this, context);
     }
 
     @Override
     protected R visitSortItem(SortItem node, C context) {
-        return process(node.getSortKey(), context);
+        return node.getSortKey().accept(this, context);
     }
 
     @Override
@@ -213,63 +215,63 @@ public abstract class DefaultTraversalVisitor<R, C>
 
         // visit the from first, since this qualifies the select
         for (Relation relation : node.getFrom()) {
-            process(relation, context);
+            relation.accept(this, context);
         }
 
-        process(node.getSelect(), context);
+        node.getSelect().accept(this, context);
         if (node.getWhere().isPresent()) {
-            process(node.getWhere().get(), context);
+            node.getWhere().get().accept(this, context);
         }
         for (Expression expression : node.getGroupBy()) {
-            process(expression, context);
+            expression.accept(this, context);
         }
         if (node.getHaving().isPresent()) {
-            process(node.getHaving().get(), context);
+            node.getHaving().get().accept(this, context);
         }
         for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+            sortItem.accept(this, context);
         }
         return null;
     }
 
     @Override
     protected R visitUnion(Union node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
         return null;
     }
 
     @Override
     protected R visitIntersect(Intersect node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
         return null;
     }
 
     @Override
     protected R visitExcept(Except node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
         return null;
     }
 
     @Override
     protected R visitTableSubquery(TableSubquery node, C context) {
-        return process(node.getQuery(), context);
+        return node.getQuery().accept(this, context);
     }
 
     @Override
     protected R visitAliasedRelation(AliasedRelation node, C context) {
-        return process(node.getRelation(), context);
+        return node.getRelation().accept(this, context);
     }
 
     @Override
     protected R visitJoin(Join node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        node.getLeft().accept(this, context);
+        node.getRight().accept(this, context);
 
         if (node.getCriteria().isPresent() && node.getCriteria().get() instanceof JoinOn) {
-            process(((JoinOn) node.getCriteria().get()).getExpression(), context);
+            ((JoinOn) node.getCriteria().get()).getExpression().accept(this, context);
         }
 
         return null;
@@ -277,9 +279,9 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     public R visitInsertFromValues(InsertFromValues node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         for (ValuesList valuesList : node.valuesLists()) {
-            process(valuesList, context);
+            valuesList.accept(this, context);
         }
         return null;
     }
@@ -287,76 +289,76 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     public R visitValuesList(ValuesList node, C context) {
         for (Expression value : node.values()) {
-            process(value, context);
+            value.accept(this, context);
         }
         return null;
     }
 
     @Override
     public R visitUpdate(Update node, C context) {
-        process(node.relation(), context);
+        node.relation().accept(this, context);
         for (Assignment assignment : node.assignements()) {
-            process(assignment, context);
+            assignment.accept(this, context);
         }
         if (node.whereClause().isPresent()) {
-            process(node.whereClause().get(), context);
+            node.whereClause().get().accept(this, context);
         }
         return null;
     }
 
     @Override
     public R visitDelete(Delete node, C context) {
-        process(node.getRelation(), context);
+        node.getRelation().accept(this, context);
         return null;
     }
 
     @Override
     public R visitCopyFrom(CopyFrom node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         return null;
     }
 
     @Override
     public R visitCopyTo(CopyTo node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         return null;
     }
 
     @Override
     public R visitAlterTable(AlterTable node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         return null;
     }
 
     @Override
     public R visitInsertFromSubquery(InsertFromSubquery node, C context) {
-        process(node.table(), context);
-        process(node.subQuery(), context);
+        node.table().accept(this, context);
+        node.subQuery().accept(this, context);
         return null;
     }
 
     @Override
     public R visitDropTable(DropTable node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         return super.visitDropTable(node, context);
     }
 
     @Override
     public R visitCreateTable(CreateTable node, C context) {
-        process(node.name(), context);
+        node.name().accept(this, context);
         return null;
     }
 
     @Override
     public R visitShowCreateTable(ShowCreateTable node, C context) {
-        process(node.table(), context);
+        node.table().accept(this, context);
         return null;
     }
 
     @Override
     public R visitRefreshStatement(RefreshStatement node, C context) {
         for (Table nodeTable : node.tables()) {
-            process(nodeTable, context);
+            nodeTable.accept(this, context);
         }
         return null;
     }
@@ -364,10 +366,10 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     public R visitMatchPredicate(MatchPredicate node, C context) {
         for (MatchPredicateColumnIdent columnIdent : node.idents()) {
-            process(columnIdent.columnIdent(), context);
-            process(columnIdent.boost(), context);
+            columnIdent.columnIdent().accept(this, context);
+            columnIdent.boost().accept(this, context);
         }
-        process(node.value(), context);
+        node.value().accept(this, context);
 
         return null;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
@@ -21,16 +21,14 @@
 
 package io.crate.sql.tree;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-
 import java.util.Locale;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Immutable
-public class Extract
-    extends Expression {
+public class Extract extends Expression {
+
     private final Expression expression;
     private final Field field;
 
@@ -54,14 +52,13 @@ public class Extract
         EPOCH
     }
 
-    public Extract(@Nullable Expression expression, StringLiteral field) {
+    public Extract(Expression expression, StringLiteral field) {
         checkNotNull(expression, "expression is null");
         // field: ident is converted to StringLiteral in SqlBase.g
         this.expression = expression;
         this.field = Field.valueOf(field.getValue().toUpperCase(Locale.ENGLISH));
     }
 
-    @Nullable
     public Expression getExpression() {
         return expression;
     }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
@@ -67,9 +67,8 @@ final class TreeAssertions {
     private static List<Node> linearizeTree(Node tree) {
         final ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         new DefaultTraversalVisitor<Node, Void>() {
-            @Override
             public Node process(Node node, @Nullable Void context) {
-                Node result = super.process(node, context);
+                Node result = node.accept(this, context);
                 nodes.add(node);
                 return result;
             }

--- a/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -67,9 +67,7 @@ public class AlterTableRerouteAnalyzer {
             relationName = schemas.resolveRelation(node.table().getName(), context.sessionContext().searchPath());
         }
         tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_REROUTE);
-        return rerouteOptionVisitor.process(
-            node.rerouteOption(),
-            new Context(
+        return node.rerouteOption().accept(rerouteOptionVisitor, new Context(
                 tableInfo,
                 node.table().partitionProperties(),
                 context.transactionContext(),

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -226,7 +226,7 @@ public class Analyzer {
     }
 
     AnalyzedStatement analyzedStatement(Statement statement, Analysis analysis) {
-        AnalyzedStatement analyzedStatement = dispatcher.process(statement, analysis);
+        AnalyzedStatement analyzedStatement = statement.accept(dispatcher, analysis);
         assert analyzedStatement != null : "analyzed statement must not be null";
         return analyzedStatement;
     }

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -57,7 +57,7 @@ class CreateAnalyzerStatementAnalyzer
     }
 
     public CreateAnalyzerAnalyzedStatement analyze(Node node, Analysis analysis) {
-        return super.process(node, new Context(analysis));
+        return node.accept(this, new Context(analysis));
     }
 
     static class Context {
@@ -80,7 +80,7 @@ class CreateAnalyzerStatementAnalyzer
         }
 
         for (AnalyzerElement element : node.elements()) {
-            process(element, context);
+            element.accept(this, context);
         }
 
         return context.statement;

--- a/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
+++ b/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
@@ -36,7 +36,7 @@ public class OutputNameFormatter {
     private static final InnerOutputNameFormatter INSTANCE = new InnerOutputNameFormatter();
 
     public static String format(Expression expression) {
-        return INSTANCE.process(expression, null);
+        return expression.accept(INSTANCE, null);
     }
 
     private static class InnerOutputNameFormatter extends ExpressionFormatter.Formatter {
@@ -51,15 +51,15 @@ public class OutputNameFormatter {
 
         @Override
         protected String visitSubscriptExpression(SubscriptExpression node, List<Expression> parameters) {
-            return process(node.name(), null) + '[' + process(node.index(), null) + ']';
+            return node.name().accept(this, null) + '[' + node.index().accept(this, null) + ']';
         }
 
         @Override
         public String visitArrayComparisonExpression(ArrayComparisonExpression node, List<Expression> parameters) {
-            return process(node.getLeft(), null) + ' ' +
+            return node.getLeft().accept(this, null) + ' ' +
                    node.getType().getValue() + ' ' +
                    node.quantifier().name() + '(' +
-                   process(node.getRight(), null) + ')';
+                   node.getRight().accept(this, null) + ')';
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -116,7 +116,7 @@ class SetStatementAnalyzer {
         private static final ExpressionToSettingNameListVisitor INSTANCE = new ExpressionToSettingNameListVisitor();
 
         public static Collection<String> convert(Node node) {
-            return INSTANCE.process(node, null);
+            return node.accept(INSTANCE, null);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
+++ b/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
@@ -47,7 +47,7 @@ public final class SubscriptValidator {
     }
 
     public static void validate(SubscriptExpression node, SubscriptContext subscriptContext) {
-        SubscriptNameVisitor.INSTANCE.process(node, subscriptContext);
+        node.accept(SubscriptNameVisitor.INSTANCE, subscriptContext);
     }
 
     private static class SubscriptNameVisitor extends AstVisitor<Void, SubscriptContext> {

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -74,7 +74,7 @@ public class TableElementsAnalyzer {
             int position = positionOffset + i + 1;
             ColumnDefinitionContext ctx = new ColumnDefinitionContext(
                 position, null, parameters, fulltextAnalyzerResolver, analyzedTableElements, relationName, tableInfo);
-            ANALYZER.process(tableElement, ctx);
+            tableElement.accept(ANALYZER, ctx);
             if (ctx.analyzedColumnDefinition.ident() != null) {
                 analyzedTableElements.add(ctx.analyzedColumnDefinition);
             }
@@ -121,10 +121,11 @@ public class TableElementsAnalyzer {
         public Void visitColumnDefinition(ColumnDefinition node, ColumnDefinitionContext context) {
             context.analyzedColumnDefinition.name(node.ident());
             for (ColumnConstraint columnConstraint : node.constraints()) {
-                process(columnConstraint, context);
+                columnConstraint.accept(this, context);
             }
-            if (node.type() != null) {
-                process(node.type(), context);
+            ColumnType type = node.type();
+            if (type != null) {
+                type.accept(this, context);
             }
             if (node.defaultExpression() != null) {
                 context.analyzedColumnDefinition.defaultExpression(node.defaultExpression());
@@ -173,10 +174,11 @@ public class TableElementsAnalyzer {
             }
 
             for (ColumnConstraint columnConstraint : node.constraints()) {
-                process(columnConstraint, context);
+                columnConstraint.accept(this, context);
             }
-            if (node.type() != null) {
-                process(node.type(), context);
+            ColumnType type = node.type();
+            if (type != null) {
+                type.accept(this, context);
             }
             if (node.generatedExpression() != null) {
                 context.analyzedColumnDefinition.generatedExpression(node.generatedExpression());
@@ -207,7 +209,7 @@ public class TableElementsAnalyzer {
                     context.relationName,
                     context.tableInfo
                 );
-                process(columnDefinition, childContext);
+                columnDefinition.accept(this, childContext);
                 context.analyzedColumnDefinition.addChild(childContext.analyzedColumnDefinition);
             }
 
@@ -222,7 +224,7 @@ public class TableElementsAnalyzer {
                 throw new UnsupportedOperationException("Nesting ARRAY or SET types is not supported");
             }
 
-            process(node.innerType(), context);
+            node.innerType().accept(this, context);
             return null;
         }
 

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -73,7 +73,8 @@ class UnboundAnalyzer {
 
     public AnalyzedStatement analyze(Statement statement, SessionContext sessionContext, ParamTypeHints paramTypeHints) {
         CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
-        return dispatcher.process(statement, new Analysis(coordinatorTxnCtx, ParameterContext.EMPTY, paramTypeHints));
+        return statement.accept(dispatcher,
+                                new Analysis(coordinatorTxnCtx, ParameterContext.EMPTY, paramTypeHints));
     }
 
     private static class UnboundDispatcher extends AstVisitor<AnalyzedStatement, Analysis> {

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -182,12 +182,12 @@ public final class UpdateAnalyzer {
         private static final AssignmentNameValidator INSTANCE = new AssignmentNameValidator();
 
         static void ensureNoArrayElementUpdate(Expression expression) {
-            INSTANCE.process(expression, false);
+            expression.accept(INSTANCE, false);
         }
 
         @Override
         protected Void visitSubscriptExpression(SubscriptExpression node, Boolean childOfSubscript) {
-            process(node.index(), true);
+            node.index().accept(this, true);
             return super.visitSubscriptExpression(node, childOfSubscript);
         }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -74,7 +74,7 @@ public class ExpressionAnalysisContext {
      * @param arrayExpressionChild the expression to register
      */
     void registerArrayChild(Expression arrayExpressionChild) {
-        arrayChildVisitor.process(arrayExpressionChild, null);
+        arrayExpressionChild.accept(arrayChildVisitor, null);
     }
 
     /**

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
@@ -42,7 +42,7 @@ public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List
     }
 
     public static ColumnIdent convert(Node node) {
-        return INSTANCE.process(node, null);
+        return node.accept(INSTANCE, null);
     }
 
     @Override
@@ -86,8 +86,8 @@ public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List
         if (context == null) {
             context = new ArrayList<>();
         }
-        ColumnIdent colIdent = process(node.name(), context);
-        process(node.index(), context);
+        ColumnIdent colIdent = node.name().accept(this, context);
+        node.index().accept(this, context);
 
 
         return colIdent;

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToNumberVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToNumberVisitor.java
@@ -41,7 +41,7 @@ public class ExpressionToNumberVisitor extends AstVisitor<Number, Row> {
     }
 
     public static Number convert(Node node, Row parameters) {
-        return INSTANCE.process(node, parameters);
+        return node.accept(INSTANCE, parameters);
     }
 
     private static Number parseString(String value) {
@@ -96,7 +96,7 @@ public class ExpressionToNumberVisitor extends AstVisitor<Number, Row> {
 
     @Override
     protected Number visitNegativeExpression(NegativeExpression node, Row context) {
-        Number n = process(node.getValue(), context);
+        Number n = node.getValue().accept(this, context);
         return NegativeExpression.negate(n);
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToObjectVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToObjectVisitor.java
@@ -50,7 +50,7 @@ public class ExpressionToObjectVisitor extends AstVisitor<Object, Row> {
     }
 
     public static Object convert(Node node, Row parameters) {
-        return INSTANCE.process(node, parameters);
+        return node.accept(INSTANCE, parameters);
     }
 
     @Override
@@ -90,7 +90,9 @@ public class ExpressionToObjectVisitor extends AstVisitor<Object, Row> {
 
     @Override
     protected String visitSubscriptExpression(SubscriptExpression node, Row context) {
-        return String.format(Locale.ENGLISH, "%s.%s", process(node.name(), context), process(node.index(), context));
+        return String.format(Locale.ENGLISH, "%s.%s",
+                             node.name().accept(this, context),
+                             node.index().accept(this, context));
     }
 
     @Override
@@ -119,7 +121,7 @@ public class ExpressionToObjectVisitor extends AstVisitor<Object, Row> {
 
     @Override
     protected Object visitNegativeExpression(NegativeExpression node, Row context) {
-        Object o = process(node.getValue(), context);
+        Object o = node.getValue().accept(this, context);
         return NegativeExpression.negate(o);
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
@@ -48,7 +48,7 @@ public class ExpressionToStringVisitor extends AstVisitor<String, Row> {
     }
 
     public static String convert(Node node, @Nullable Row context) {
-        return INSTANCE.process(node, context);
+        return node.accept(INSTANCE, context);
     }
 
     @Override
@@ -93,12 +93,14 @@ public class ExpressionToStringVisitor extends AstVisitor<String, Row> {
 
     @Override
     protected String visitNegativeExpression(NegativeExpression node, Row context) {
-        return "-" + process(node.getValue(), context);
+        return "-" + node.getValue().accept(this, context);
     }
 
     @Override
     protected String visitSubscriptExpression(SubscriptExpression node, Row context) {
-        return String.format(Locale.ENGLISH, "%s.%s", process(node.name(), context), process(node.index(), context));
+        return String.format(Locale.ENGLISH, "%s.%s",
+                             node.name().accept(this, context),
+                             node.index().accept(this, context));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -49,7 +49,7 @@ public class SelectAnalyzer {
                                                ExpressionAnalysisContext expressionAnalysisContext) {
         SelectAnalysis selectAnalysis = new SelectAnalysis(
             select.getSelectItems().size(), sources, expressionAnalyzer, expressionAnalysisContext);
-        INSTANCE.process(select, selectAnalysis);
+        select.accept(INSTANCE, selectAnalysis);
         SelectSymbolValidator.validate(selectAnalysis.outputSymbols());
         return selectAnalysis;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The method delegated to `node.accept(..)`. We can avoid that
redirection.

It made stepping through visitors with the debugger more troublesome
than it needs to be.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)