### PR TITLE
Fix calculation of the mid index in binary search code of List2 methods.

### DIFF
--- a/shared/src/main/java/io/crate/common/collections/Lists2.java
+++ b/shared/src/main/java/io/crate/common/collections/Lists2.java
@@ -249,7 +249,7 @@ public final class Lists2 {
 
         int firstLTEProbeIdx = -1;
         while (start <= end) {
-            int mid = (start + end) / 2;
+            int mid = (start + end) >>> 1;
             // Move to left side if mid is greater than probe
             if (cmp.compare(sortedItems.get(mid), probe) > 0) {
                 end = mid - 1;
@@ -272,7 +272,7 @@ public final class Lists2 {
 
         int firstGTEProbeIdx = -1;
         while (start <= end) {
-            int mid = (start + end) / 2;
+            int mid = (start + end) >>> 1;
             // Move to right side if mid is less than probe
             if (cmp.compare(sortedItems.get(mid), probe) < 0) {
                 start = mid + 1;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The sum might overflow to a negative value for the large start
and end indexes.
See https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
