### PR TITLE
Add timezone scalar function

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,8 @@ Breaking Changes
 Changes
 =======
 
+- Added :ref:`TIMEZONE <scalar-timezone>` scalar function.
+
 - Added support for the filter clause in the
   :ref:`aggregate expressions <aggregate-expressions>`.
 

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -706,6 +706,7 @@ If no ``format_string`` is given the default format will be used::
     +-----------------------------+
     SELECT 1 row in set (... sec)
 
+
 Timezone
 ........
 
@@ -732,6 +733,74 @@ The ``timezone`` will be ``UTC`` if not provided::
     +------------------+
     | 1969/12/31 19:00 |
     +------------------+
+    SELECT 1 row in set (... sec)
+
+.. _scalar-timezone:
+
+``timezone(timezone, timestamp)``
+---------------------------------
+
+The timezone scalar function converts values of ``timestamp`` without time zone to/from
+timestamp with time zone.
+
+Synopsis
+........
+
+::
+
+    TIMEZONE(timezone, timestamp)
+
+It has two variants depending on the type of ``timestamp``:
+
+.. csv-table::
+   :header: "Type of timestamp", "Return Type", "Description"
+
+   "timestamp without time zone OR bigint", "timestamp with time zone", "Treat \
+   given timestamp without time zone as located in the specified timezone"
+   "timestamp with time zone", "timestamp without time zone", "Convert given \
+   timestamp with time zone to the new timezone with no time zone designation"
+
+::
+
+    cr> select
+    ... 257504400000 as no_tz,
+    ... date_format('%Y-%m-%d %h:%i', 257504400000) as no_tz_str,
+    ... timezone('Europe/Madrid', 257504400000) as in_madrid,
+    ... date_format('%Y-%m-%d %h:%i', timezone('Europe/Madrid',
+    ... 257504400000)) as in_madrid_str;
+    +--------------+------------------+--------------+------------------+
+    |        no_tz | no_tz_str        |    in_madrid | in_madrid_str    |
+    +--------------+------------------+--------------+------------------+
+    | 257504400000 | 1978-02-28 09:00 | 257500800000 | 1978-02-28 08:00 |
+    +--------------+------------------+--------------+------------------+
+    SELECT 1 row in set (... sec)
+
+::
+
+    cr> select
+    ... timezone('Europe/Madrid',
+    ... '1978-02-28T10:00:00.000+01:00'::timestamp with time zone) as epoque,
+    ... date_format('%Y-%m-%d %h:%i', timezone('Europe/Madrid',
+    ... '1978-02-28T10:00:00.000+01:00'::timestamp with time zone)) as epoque_str;
+    +--------------+------------------+
+    |       epoque | epoque_str       |
+    +--------------+------------------+
+    | 257508000000 | 1978-02-28 10:00 |
+    +--------------+------------------+
+    SELECT 1 row in set (... sec)
+
+::
+
+    cr> select
+    ... timezone('Europe/Madrid',
+    ... '1978-02-28T10:00:00.000+01:00'::timestamp without time zone) as epoque,
+    ... date_format('%Y-%m-%d %h:%i', timezone('Europe/Madrid',
+    ... '1978-02-28T10:00:00.000+01:00'::timestamp without time zone)) as epoque_str;
+    +--------------+------------------+
+    |       epoque | epoque_str       |
+    +--------------+------------------+
+    | 257504400000 | 1978-02-28 09:00 |
+    +--------------+------------------+
     SELECT 1 row in set (... sec)
 
 Geo functions

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -62,6 +62,7 @@ import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
+import io.crate.expression.scalar.timestamp.TimezoneFunction;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
@@ -124,6 +125,7 @@ public class ScalarFunctionModule extends AbstractModule {
         DateTruncFunction.register(this);
         ExtractFunctions.register(this);
         CurrentTimestampFunction.register(this);
+        TimezoneFunction.register(this);
         DateFormatFunction.register(this);
         CastFunction.register(this);
         TryCastScalarFunction.register(this);

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.timestamp;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.BaseFunctionResolver;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.params.FuncParams;
+import io.crate.metadata.functions.params.Param;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.TimestampType;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+
+public class TimezoneFunction extends Scalar<Long, Object> {
+
+    public static final String NAME = "timezone";
+    private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final FuncParams FUNCTION_PARAMS = FuncParams.builder(Param.STRING,
+                                                                         Param.of(DataTypes.TIMESTAMPZ,
+                                                                                  DataTypes.TIMESTAMP)).build();
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(NAME, new BaseFunctionResolver(FUNCTION_PARAMS) {
+            @Override
+            public FunctionImplementation getForTypes(List<DataType> signatureTypes) throws IllegalArgumentException {
+                DataType returnType =
+                    signatureTypes.get(1).id() == TimestampType.ID_WITH_TZ ? DataTypes.TIMESTAMP : DataTypes.TIMESTAMPZ;
+                return new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, signatureTypes), returnType));
+            }
+        });
+    }
+
+    private final FunctionInfo info;
+
+    private TimezoneFunction(FunctionInfo info) {
+        this.info = info;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return info;
+    }
+
+    @Override
+    public Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        assert args.length == 2 : String.format(Locale.ENGLISH,
+                                                "number of arguments must be 2, got %d instead",
+                                                args.length);
+        String zoneStr = (String) args[0].value();
+        if (zoneStr == null) {
+            return null;
+        }
+        ZoneId zoneId;
+        try {
+            zoneId = ZoneId.of(zoneStr);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                             " time zone \"%s\" not recognized",
+                                                             zoneStr));
+        }
+        Number utcTimestamp = (Number) args[1].value();
+        if (utcTimestamp == null) {
+            return null;
+        }
+
+        Instant instant = Instant.ofEpochMilli(utcTimestamp.longValue());
+        boolean paramHadTimezone = info.returnType() == DataTypes.TIMESTAMP;
+        ZoneId srcZoneId = paramHadTimezone ? zoneId : UTC;
+        ZoneId dstZoneId = paramHadTimezone ? UTC : zoneId;
+        ZonedDateTime zonedDateTime = instant.atZone(srcZoneId).withZoneSameLocal(dstZoneId);
+        return zonedDateTime.toEpochSecond() * 1000;
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.timestamp;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.format.DateTimeParseException;
+
+import static java.lang.String.format;
+
+public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final Long TIMESTAMP = 257504400000L;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testEvaluateInvalidZoneIsNull() {
+        assertEvaluate(format("timezone(null, %d)", TIMESTAMP), null);
+    }
+
+    @Test
+    public void testEvaluateInvalidTimestampIsNull() {
+        assertEvaluate("timezone('Europe/Madrid', null)", null);
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsBlanc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \" \" not recognized");
+        assertEvaluate(format("timezone(' ', %d)", TIMESTAMP), null);
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsRandom() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \"Random/Location\" not recognized");
+        assertEvaluate(format("timezone('Random/Location', %d)", TIMESTAMP), null);
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsRandomNumeric() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \"+31:97\" not recognized");
+        assertEvaluate(format("timezone('+31:97', %d)", TIMESTAMP), null);
+    }
+
+    @Test
+    public void testEvaluateInvalidTimestamp() {
+        expectedException.expect(DateTimeParseException.class);
+        expectedException.expectMessage(
+            "Text 'not_a_timestamp' could not be parsed at index 0");
+        assertEvaluate("timezone('Europe/Madrid', 'not_a_timestamp')", null);
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsNullFromColumn() {
+        assertEvaluate(format("timezone(name, %d)", TIMESTAMP), null, Literal.of((Long) null));
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsBlancFromColumn() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \" \" not recognized");
+        assertEvaluate(format("timezone(name, %d)", TIMESTAMP), null, Literal.of(" "));
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsRandomFromColumn() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \"Random/Location\" not recognized");
+        assertEvaluate(format("timezone(name, %d)", TIMESTAMP), null, Literal.of("Random/Location"));
+    }
+
+    @Test
+    public void testEvaluateInvalidZoneIsRandomNumericFromColumn() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("time zone \"+31:97\" not recognized");
+        assertEvaluate(format("timezone(name, %d)", TIMESTAMP), null, Literal.of("+31:97"));
+    }
+
+    @Test
+    public void testEvaluateValidTimestamp() {
+        assertEvaluate(format("timezone('UTC', %d)", TIMESTAMP), TIMESTAMP);
+        assertEvaluate("timezone('UTC', x)", TIMESTAMP, Literal.of(TIMESTAMP));
+        assertEvaluate(format("timezone(name, %d)", TIMESTAMP), TIMESTAMP, Literal.of("UTC"));
+        assertEvaluate(format("timezone('Europe/Madrid', %d)", 257491800000L), 257488200000L);
+        assertEvaluate("timezone('Europe/Madrid', '1978-02-28T14:30+05:30'::timestamp with time zone)",
+                       257508000000L);
+        assertEvaluate("timezone('Europe/Madrid', '1978-02-28T14:30+05:30'::timestamp without time zone)",
+                       257520600000L);
+        assertEvaluate("timezone(name, '1978-02-28T14:30+05:30'::timestamp with time zone)",
+                       257508000000L,
+                       Literal.of("Europe/Madrid"));
+        assertEvaluate("timezone(name, '1978-02-28T14:30+05:30'::timestamp without time zone)",
+                       257520600000L,
+                       Literal.of("Europe/Madrid"));
+        assertEvaluate("timezone('Europe/Madrid', timestamp_tz)",
+                       257508000000L,
+                       Literal.of(DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMPZ.value("1978-02-28T14:30+05:30")));
+        assertEvaluate("timezone('Europe/Madrid', timestamp)",
+                       257520600000L,
+                       Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("1978-02-28T14:30+05:30")));
+        assertEvaluate("timezone('Europe/Madrid', x)", 257484600000L, Literal.of(257488200000L));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a draft, to check that I understood the requirements so far and to continue
the specification of the At TIME ZONE parser syntax, which will be built atop

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
