### PR TITLE
Jenkins: Update openjdk 12 version (bp #8940)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ pipeline {
   }
   environment {
     CI_RUN = "true"
-    JDK_11 = 'openjdk@1.11.0-2'
-    JDK_12 = 'openjdk@1.12.0-1'
+    JDK_11 = 'openjdk@1.11.0'
+    JDK_12 = 'openjdk@1.12.0'
     ADOPT_JDK_12 = 'adopt@1.12.33-0'
   }
   stages {


### PR DESCRIPTION
`-1` is no longer available.

(cherry picked from commit 3ede9c1edefe75ae58c75cdb6ec2b672f682ad7b)