### PR TITLE
Remove the offset start/end value from window function test framework

### DIFF
--- a/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
@@ -36,7 +36,6 @@ public class WindowFrameDefinition implements Writeable {
 
     private final Type type;
     private final FrameBoundDefinition start;
-    @Nullable
     private final FrameBoundDefinition end;
 
     public WindowFrameDefinition(StreamInput in) throws IOException {

--- a/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -193,14 +193,11 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             26.0,
             22.0
         };
-
         assertEvaluate("sum(d) OVER(" +
                             "ORDER BY d RANGE BETWEEN 3 PRECEDING and CURRENT ROW" +
                        ")",
             contains(expected),
             Collections.singletonMap(new ColumnIdent("d"), 0),
-            3L,
-            null,
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -229,8 +226,6 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                        ")",
             contains(expected),
             Collections.singletonMap(new ColumnIdent("d"), 0),
-            3L,
-            null,
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -259,8 +254,6 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                        ")",
                        contains(expected),
                        Collections.singletonMap(new ColumnIdent("d"), 0),
-                       null,
-                       3L,
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},
@@ -289,8 +282,6 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                        ")",
                        contains(expected),
                        Collections.singletonMap(new ColumnIdent("d"), 0),
-                       null,
-                       3L,
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

These values can be inferred from the window definition and don't have
to be passed in separately.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)