### PR TITLE
Avoid redundant streaming of offest start/end values

### DIFF
--- a/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -41,7 +41,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLastValueWithEmptyOver() throws Exception {
+    public void testLastValueWithEmptyOver() throws Throwable {
         assertEvaluate("last_value(x) over()",
             contains(new Object[] {4, 4, 4, 4}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -53,7 +53,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLastValueWithOrderByClause() throws Exception {
+    public void testLastValueWithOrderByClause() throws Throwable {
         Map<ColumnIdent, Integer> mapping = new HashMap<>();
         mapping.put(new ColumnIdent("x"), 0);
         mapping.put(new ColumnIdent("y"), 1);
@@ -69,7 +69,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLastValueUseSymbolMultipleTimes() throws Exception {
+    public void testLastValueUseSymbolMultipleTimes() throws Throwable {
         Map<ColumnIdent, Integer> mapping = new HashMap<>();
         mapping.put(new ColumnIdent("x"), 0);
         mapping.put(new ColumnIdent("y"), 1);
@@ -85,7 +85,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testFirstValueWithEmptyOver() throws Exception {
+    public void testFirstValueWithEmptyOver() throws Throwable {
         assertEvaluate("first_value(x) over()",
             contains(new Object[] {1, 1, 1, 1}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -97,7 +97,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testFirstValueWithOrderByClause() throws Exception {
+    public void testFirstValueWithOrderByClause() throws Throwable {
         Map<ColumnIdent, Integer> mapping = new HashMap<>();
         mapping.put(new ColumnIdent("x"), 0);
         mapping.put(new ColumnIdent("y"), 1);
@@ -113,7 +113,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
         @Test
-    public void testNthValueWithEmptyOver() throws Exception {
+    public void testNthValueWithEmptyOver() throws Throwable {
         assertEvaluate("nth_value(x, 3) over()",
             contains(new Object[] {3, 3, 3, 3}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -125,7 +125,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueWithOrderByClause() throws Exception {
+    public void testNthValueWithOrderByClause() throws Throwable {
         Map<ColumnIdent, Integer> mapping = new HashMap<>();
         mapping.put(new ColumnIdent("x"), 0);
         mapping.put(new ColumnIdent("y"), 1);
@@ -141,7 +141,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueWithNullPositionReturnsNull() throws Exception {
+    public void testNthValueWithNullPositionReturnsNull() throws Throwable {
         Map<ColumnIdent, Integer> mapping = new HashMap<>();
         mapping.put(new ColumnIdent("x"), 0);
         mapping.put(new ColumnIdent("y"), 1);
@@ -157,7 +157,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testRowNthValueOverPartitionedWindow() throws Exception {
+    public void testRowNthValueOverPartitionedWindow() throws Throwable {
         Object[] expected = new Object[]{2, 2, 2, 4, 4, 4, null};
         assertEvaluate("nth_value(x, 2) over(partition by x > 2)",
                        contains(expected),
@@ -172,7 +172,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueOverPartitionedOrderedWindow() throws Exception {
+    public void testNthValueOverPartitionedOrderedWindow() throws Throwable {
         Object[] expected = new Object[]{null, 2, 2, null, 4, 4, null};
         assertEvaluate("nth_value(x, 2) over(partition by x > 2 order by x)",
                        contains(expected),
@@ -187,7 +187,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueOverUnboundedFollowingWindow() throws Exception {
+    public void testNthValueOverUnboundedFollowingWindow() throws Throwable {
         Object[] expected = new Object[]{2, 2, 2, 4, 5, null, null};
         assertEvaluate("nth_value(x, 2) OVER(PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
                        contains(expected),
@@ -202,7 +202,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueOverRangeModeOneRowFrames() throws Exception {
+    public void testNthValueOverRangeModeOneRowFrames() throws Throwable {
         Object[] expected = new Object[]{1, 1};
         assertEvaluate("nth_value(x, 1) OVER(ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             contains(expected),
@@ -212,7 +212,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testNthValueOverRowsModeOneRowFrames() throws Exception {
+    public void testNthValueOverRowsModeOneRowFrames() throws Throwable {
         Object[] expected = new Object[]{1, 1};
         assertEvaluate("nth_value(x, 1) OVER(ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             contains(expected),

--- a/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -39,7 +39,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithSingleArgumentAndEmptyOver() throws Exception {
+    public void testLagWithSingleArgumentAndEmptyOver() throws Throwable {
         assertEvaluate("lag(x) over()",
             contains(new Object[]{null, 1, null, 2}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -51,7 +51,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithOffsetAndEmptyOver() throws Exception {
+    public void testLagWithOffsetAndEmptyOver() throws Throwable {
         assertEvaluate("lag(x, 2) over()",
             contains(new Object[]{null, null, 1, 2}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -63,7 +63,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithNullOffset() throws Exception {
+    public void testLagWithNullOffset() throws Throwable {
         assertEvaluate("lag(x, null) over()",
             contains(new Object[]{null, null, null}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -74,7 +74,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagZeroOffsetAndEmptyOver() throws Exception {
+    public void testLagZeroOffsetAndEmptyOver() throws Throwable {
         assertEvaluate("lag(x, 0) over()",
             contains(new Object[]{1, 2}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -84,7 +84,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagNegativeOffsetAndEmptyOver() throws Exception {
+    public void testLagNegativeOffsetAndEmptyOver() throws Throwable {
         assertEvaluate("lag(x, -1) over()",
             contains(new Object[]{2, null}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -94,7 +94,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithDefaultValueAndEmptyOver() throws Exception {
+    public void testLagWithDefaultValueAndEmptyOver() throws Throwable {
         assertEvaluate("lag(x, 1, -1) over()",
             contains(new Object[]{-1, 1, 2, 3}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -106,7 +106,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithExpressionAsArgumentAndEmptyOver() throws Exception {
+    public void testLagWithExpressionAsArgumentAndEmptyOver() throws Throwable {
         assertEvaluate("lag(coalesce(x, 1), 1, -1) over()",
             contains(new Object[]{-1, 1, 1}),
             Map.of(new ColumnIdent("x"), 0),
@@ -117,7 +117,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithOrderBy() throws Exception {
+    public void testLagWithOrderBy() throws Throwable {
         assertEvaluate("lag(x) over(order by y)",
             contains(new Object[]{null, 1, 3, 1}),
             Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
@@ -129,7 +129,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagWithOrderByReferenceUsedInFunction() throws Exception {
+    public void testLagWithOrderByReferenceUsedInFunction() throws Throwable {
         assertEvaluate("lag(x) over(order by y, x)",
             contains(new Object[]{null, 1, 1, 3}),
             Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
@@ -141,7 +141,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagOverPartitionedWindow() throws Exception {
+    public void testLagOverPartitionedWindow() throws Throwable {
         assertEvaluate("lag(x) over(partition by x > 2)",
             contains(new Object[]{null, 1, 2, null, 3, 4}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -154,7 +154,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLagOperatesOnPartitionAndIgnoresFrameRange() throws Exception {
+    public void testLagOperatesOnPartitionAndIgnoresFrameRange() throws Throwable {
         assertEvaluate("lag(x) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             contains(new Object[]{null, 1, 2, 3}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -166,7 +166,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLeadOverPartitionedWindow() throws Exception {
+    public void testLeadOverPartitionedWindow() throws Throwable {
         assertEvaluate("lead(x) over(partition by x > 2)",
             contains(new Object[]{2, 2, null, 4, 5, null}),
             Collections.singletonMap(new ColumnIdent("x"), 0),
@@ -179,7 +179,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLeadWithOrderBy() throws Exception {
+    public void testLeadWithOrderBy() throws Throwable {
         assertEvaluate("lead(x) over(order by y)",
                        contains(new Object[]{3, 1, 2, null}),
                        Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
@@ -191,7 +191,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Exception {
+    public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Throwable {
         assertEvaluate("lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             contains(new Object[]{2, 3, 4, 42, 42}),
             Collections.singletonMap(new ColumnIdent("x"), 0),

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -354,7 +354,7 @@ public final class ExpressionFormatter {
         public String visitWindowFrame(WindowFrame node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder(" ");
 
-            builder.append(node.getType().toString()).append(' ');
+            builder.append(node.mode().toString()).append(' ');
 
             if (node.getEnd().isPresent()) {
                 builder.append("BETWEEN ")

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -874,7 +874,7 @@ public final class SqlFormatter {
         @Override
         public Void visitWindowFrame(WindowFrame frame, Integer indent) {
             append(indent, " ");
-            append(indent, frame.getType().name());
+            append(indent, frame.mode().name());
 
             append(indent, " ");
             Expression startOffset = frame.getStart().getValue();

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1910,12 +1910,12 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         }
     }
 
-    private static WindowFrame.Type getFrameType(Token type) {
+    private static WindowFrame.Mode getFrameType(Token type) {
         switch (type.getType()) {
             case SqlBaseLexer.RANGE:
-                return WindowFrame.Type.RANGE;
+                return WindowFrame.Mode.RANGE;
             case SqlBaseLexer.ROWS:
-                return WindowFrame.Type.ROWS;
+                return WindowFrame.Mode.ROWS;
             default:
                 throw new IllegalArgumentException("Unsupported frame type: " + type.getText());
         }

--- a/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
@@ -30,14 +30,14 @@ import static io.crate.common.collections.Lists2.findFirstGTEProbeValue;
 import static io.crate.common.collections.Lists2.findFirstLTEProbeValue;
 import static io.crate.common.collections.Lists2.findFirstNonPeer;
 import static io.crate.common.collections.Lists2.findFirstPreviousPeer;
-import static io.crate.sql.tree.WindowFrame.Type.ROWS;
+import static io.crate.sql.tree.WindowFrame.Mode.ROWS;
 
 public class FrameBound extends Node {
 
     public enum Type {
         UNBOUNDED_PRECEDING {
             @Override
-            public <T> int getStart(WindowFrame.Type frameType,
+            public <T> int getStart(WindowFrame.Mode mode,
                                     int pStart,
                                     int pEnd,
                                     int currentRowIdx,
@@ -49,7 +49,7 @@ public class FrameBound extends Node {
             }
 
             @Override
-            public <T> int getEnd(WindowFrame.Type frameType,
+            public <T> int getEnd(WindowFrame.Mode mode,
                                   int pStart,
                                   int pEnd,
                                   int currentRowIdx,
@@ -62,7 +62,7 @@ public class FrameBound extends Node {
         },
         PRECEDING {
             @Override
-            public <T> int getStart(WindowFrame.Type frameType,
+            public <T> int getStart(WindowFrame.Mode mode,
                                     int pStart,
                                     int pEnd,
                                     int currentRowIdx,
@@ -70,7 +70,7 @@ public class FrameBound extends Node {
                                     @Nullable T offsetProbeValue,
                                     @Nullable Comparator<T> cmp,
                                     List<T> rows) {
-                if (frameType == ROWS) {
+                if (mode == ROWS) {
                     assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
                     int startIndex = Math.max(pStart, currentRowIdx - ((Long) offset).intValue());
                     return startIndex > 0 ? startIndex : 0;
@@ -85,7 +85,7 @@ public class FrameBound extends Node {
             }
 
             @Override
-            public <T> int getEnd(WindowFrame.Type frameType,
+            public <T> int getEnd(WindowFrame.Mode mode,
                                   int pStart,
                                   int pEnd,
                                   int currentRowIdx,
@@ -105,7 +105,7 @@ public class FrameBound extends Node {
          */
         CURRENT_ROW {
             @Override
-            public <T> int getStart(WindowFrame.Type frameType,
+            public <T> int getStart(WindowFrame.Mode mode,
                                     int pStart,
                                     int pEnd,
                                     int currentRowIdx,
@@ -113,7 +113,7 @@ public class FrameBound extends Node {
                                     @Nullable T offsetProbeValue,
                                     @Nullable Comparator<T> cmp,
                                     List<T> rows) {
-                if (frameType == ROWS) {
+                if (mode == ROWS) {
                     return currentRowIdx;
                 }
 
@@ -129,7 +129,7 @@ public class FrameBound extends Node {
             }
 
             @Override
-            public <T> int getEnd(WindowFrame.Type frameType,
+            public <T> int getEnd(WindowFrame.Mode mode,
                                   int pStart,
                                   int pEnd,
                                   int currentRowIdx,
@@ -137,7 +137,7 @@ public class FrameBound extends Node {
                                   @Nullable T offsetProbeValue,
                                   @Nullable Comparator<T> cmp,
                                   List<T> rows) {
-                if (frameType == ROWS) {
+                if (mode == ROWS) {
                     return currentRowIdx + 1;
                 }
 
@@ -146,7 +146,7 @@ public class FrameBound extends Node {
         },
         FOLLOWING {
             @Override
-            public <T> int getStart(WindowFrame.Type frameType,
+            public <T> int getStart(WindowFrame.Mode mode,
                                     int pStart,
                                     int pEnd,
                                     int currentRowIdx,
@@ -158,7 +158,7 @@ public class FrameBound extends Node {
             }
 
             @Override
-            public <T> int getEnd(WindowFrame.Type frameType,
+            public <T> int getEnd(WindowFrame.Mode mode,
                                   int pStart,
                                   int pEnd,
                                   int currentRowIdx,
@@ -167,7 +167,7 @@ public class FrameBound extends Node {
                                   @Nullable Comparator<T> cmp,
                                   List<T> rows) {
                 // end index is exclusive so we increment it by one when finding the interval end index
-                if (frameType == ROWS) {
+                if (mode == ROWS) {
                     assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
                     return Math.min(pEnd, currentRowIdx + ((Long) offset).intValue() + 1);
                 } else {
@@ -177,7 +177,7 @@ public class FrameBound extends Node {
         },
         UNBOUNDED_FOLLOWING {
             @Override
-            public <T> int getStart(WindowFrame.Type frameType,
+            public <T> int getStart(WindowFrame.Mode mode,
                                     int pStart,
                                     int pEnd,
                                     int currentRowIdx,
@@ -189,7 +189,7 @@ public class FrameBound extends Node {
             }
 
             @Override
-            public <T> int getEnd(WindowFrame.Type frameType,
+            public <T> int getEnd(WindowFrame.Mode mode,
                                   int pStart,
                                   int pEnd,
                                   int currentRowIdx,
@@ -201,7 +201,7 @@ public class FrameBound extends Node {
             }
         };
 
-        public abstract <T> int getStart(WindowFrame.Type frameType,
+        public abstract <T> int getStart(WindowFrame.Mode mode,
                                          int pStart,
                                          int pEnd,
                                          int currentRowIdx,
@@ -210,7 +210,7 @@ public class FrameBound extends Node {
                                          @Nullable Comparator<T> cmp,
                                          List<T> rows);
 
-        public abstract <T> int getEnd(WindowFrame.Type frameType,
+        public abstract <T> int getEnd(WindowFrame.Mode mode,
                                        int pStart,
                                        int pEnd,
                                        int currentRowIdx,

--- a/sql-parser/src/main/java/io/crate/sql/tree/WindowFrame.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/WindowFrame.java
@@ -26,23 +26,23 @@ import java.util.Optional;
 
 public class WindowFrame extends Node {
 
-    public enum Type {
+    public enum Mode {
         RANGE,
         ROWS
     }
 
-    private final Type frameType;
+    private final Mode mode;
     private final FrameBound start;
     private final Optional<FrameBound> end;
 
-    public WindowFrame(Type frameType, FrameBound start, Optional<FrameBound> end) {
-        this.frameType = frameType;
+    public WindowFrame(Mode mode, FrameBound start, Optional<FrameBound> end) {
+        this.mode = mode;
         this.start = start;
         this.end = end;
     }
 
-    public Type getType() {
-        return frameType;
+    public Mode mode() {
+        return mode;
     }
 
     public FrameBound getStart() {
@@ -60,14 +60,14 @@ public class WindowFrame extends Node {
 
         WindowFrame that = (WindowFrame) o;
 
-        if (frameType != that.frameType) return false;
+        if (mode != that.mode) return false;
         if (!start.equals(that.start)) return false;
         return end.equals(that.end);
     }
 
     @Override
     public int hashCode() {
-        int result = frameType.hashCode();
+        int result = mode.hashCode();
         result = 31 * result + start.hashCode();
         result = 31 * result + end.hashCode();
         return result;
@@ -76,7 +76,7 @@ public class WindowFrame extends Node {
     @Override
     public String toString() {
         return "WindowFrame{" +
-               "frameType=" + frameType +
+               "frameType=" + mode +
                ", start=" + start +
                ", end=" + end +
                '}';

--- a/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 

--- a/sql/src/main/java/io/crate/analyze/WindowDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowDefinition.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
 
 import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 
 /**
  * Representation of a window used to describe the window function calls target.

--- a/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
@@ -25,7 +25,7 @@ package io.crate.analyze;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.FrameBound;
-import io.crate.sql.tree.WindowFrame.Type;
+import io.crate.sql.tree.WindowFrame.Mode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -37,17 +37,17 @@ import java.util.function.Function;
 
 public class WindowFrameDefinition implements Writeable {
 
-    private final Type type;
+    private final Mode type;
     private final FrameBoundDefinition start;
     private final FrameBoundDefinition end;
 
     public WindowFrameDefinition(StreamInput in) throws IOException {
-        type = in.readEnum(Type.class);
+        type = in.readEnum(Mode.class);
         start = new FrameBoundDefinition(in);
         end = in.readOptionalWriteable(FrameBoundDefinition::new);
     }
 
-    public WindowFrameDefinition(Type type, FrameBoundDefinition start, @Nullable FrameBoundDefinition end) {
+    public WindowFrameDefinition(Mode type, FrameBoundDefinition start, @Nullable FrameBoundDefinition end) {
         this.type = type;
         this.start = start;
         if (end != null) {
@@ -57,7 +57,7 @@ public class WindowFrameDefinition implements Writeable {
         }
     }
 
-    public Type type() {
+    public Mode type() {
         return type;
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -306,7 +306,7 @@ public class ExpressionAnalyzer {
             FrameBoundDefinition endBound = windowFrame.getEnd()
                 .map(end -> convertToAnalyzedFrameBound(context, end))
                 .orElse(new FrameBoundDefinition(FrameBound.Type.CURRENT_ROW, Literal.NULL));
-            windowFrameDefinition = new WindowFrameDefinition(windowFrame.getType(), startBound, endBound);
+            windowFrameDefinition = new WindowFrameDefinition(windowFrame.mode(), startBound, endBound);
         }
 
         return new WindowDefinition(partitionSymbols, orderBy, windowFrameDefinition);
@@ -346,7 +346,7 @@ public class ExpressionAnalyzer {
             throw new IllegalStateException("Frame start cannot be " + startType);
         }
 
-        if (windowFrame.getType() == WindowFrame.Type.RANGE) {
+        if (windowFrame.mode() == WindowFrame.Mode.RANGE) {
             if (startType.equals(FrameBound.Type.PRECEDING) && windowFrame.getStart().getValue() != null) {
                 if (window.getOrderBy().size() != 1) {
                     throw new IllegalStateException("RANGE with offset PRECEDING/FOLLOWING requires exactly one ORDER BY column");
@@ -361,7 +361,7 @@ public class ExpressionAnalyzer {
                 throw new IllegalStateException("Frame end cannot be " + endType);
             }
 
-            if (windowFrame.getType() == WindowFrame.Type.RANGE) {
+            if (windowFrame.mode() == WindowFrame.Mode.RANGE) {
                 if (endType.equals(FrameBound.Type.FOLLOWING) && windowFrame.getEnd().get().getValue() != null) {
                     if (window.getOrderBy().size() != 1) {
                         throw new IllegalStateException("RANGE with offset PRECEDING/FOLLOWING requires exactly one ORDER BY column");

--- a/sql/src/main/java/io/crate/execution/dsl/projection/WindowAggProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/WindowAggProjection.java
@@ -28,11 +28,9 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.planner.ExplainLeaf;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -47,14 +45,8 @@ public class WindowAggProjection extends Projection {
     private final List<Symbol> standaloneWithInputs;
     private final LinkedHashMap<WindowFunction, List<Symbol>> functionsWithInputs;
     private final ArrayList<Symbol> outputs;
-    @Nullable
-    private Object startFrameOffset;
-    @Nullable
-    private Object endFrameOffset;
 
     public WindowAggProjection(WindowDefinition windowDefinition,
-                               @Nullable Object startFrameOffset,
-                               @Nullable Object endFrameOffset,
                                LinkedHashMap<WindowFunction, List<Symbol>> functionsWithInputs,
                                List<Symbol> standaloneWithInputs) {
         Set<WindowFunction> windowFunctions = functionsWithInputs.keySet();
@@ -63,8 +55,6 @@ public class WindowAggProjection extends Projection {
         assert standaloneWithInputs.stream().noneMatch(Symbols.IS_COLUMN)
             : "Cannot operate on Reference or Field: " + standaloneWithInputs;
         this.windowDefinition = windowDefinition;
-        this.startFrameOffset = startFrameOffset;
-        this.endFrameOffset = endFrameOffset;
         this.functionsWithInputs = functionsWithInputs;
         this.standaloneWithInputs = standaloneWithInputs;
         outputs = new ArrayList<>(windowFunctions);
@@ -73,10 +63,6 @@ public class WindowAggProjection extends Projection {
 
     public WindowAggProjection(StreamInput in) throws IOException {
         windowDefinition = new WindowDefinition(in);
-        if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
-            startFrameOffset = in.readGenericValue();
-            endFrameOffset = in.readGenericValue();
-        }
         standaloneWithInputs = Symbols.listFromStream(in);
         int functionsCount = in.readVInt();
         functionsWithInputs = new LinkedHashMap<>(functionsCount, 1f);
@@ -90,16 +76,6 @@ public class WindowAggProjection extends Projection {
 
     public WindowDefinition windowDefinition() {
         return windowDefinition;
-    }
-
-    @Nullable
-    public Object startFrameOffset() {
-        return startFrameOffset;
-    }
-
-    @Nullable
-    public Object endFrameOffset() {
-        return endFrameOffset;
     }
 
     public LinkedHashMap<WindowFunction, List<Symbol>> functionsWithInputs() {
@@ -142,10 +118,6 @@ public class WindowAggProjection extends Projection {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         windowDefinition.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
-            out.writeGenericValue(startFrameOffset);
-            out.writeGenericValue(endFrameOffset);
-        }
         Symbols.toStream(standaloneWithInputs, out);
         out.writeVInt(functionsWithInputs.size());
         for (Map.Entry<WindowFunction, List<Symbol>> functionWithInputs : functionsWithInputs.entrySet()) {

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -56,7 +56,7 @@ import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
 import static io.crate.common.collections.Lists2.findFirstNonPeer;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 
 /**
  * BatchIterator which computes window functions (incl. partitioning + ordering)

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.window;
 
 import io.crate.analyze.OrderBy;
+import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.WindowDefinition;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.RowAccounting;
@@ -40,6 +41,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.SubQueryResults;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.util.BigArrays;
 
@@ -118,8 +120,8 @@ public class WindowProjector implements Projector {
         return new WindowProjector(
             accounting,
             windowDefinition,
-            projection.startFrameOffset(),
-            projection.endFrameOffset(),
+            SymbolEvaluator.evaluate(txnCtx, functions, windowDefinition.windowFrameDefinition().start().value(), Row.EMPTY, SubQueryResults.EMPTY),
+            SymbolEvaluator.evaluate(txnCtx, functions, windowDefinition.windowFrameDefinition().end().value(), Row.EMPTY, SubQueryResults.EMPTY),
             partitions.isEmpty() ? null : createComparator(createInputFactoryContext, new OrderBy(windowDefinition.partitions())),
             createComparator(createInputFactoryContext, windowDefinition.orderBy()),
             projection.standalone().size(),

--- a/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
@@ -140,7 +140,7 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
         assertThat(windowFunction.arguments().size(), is(1));
         WindowFrameDefinition frameDefinition = windowFunction.windowDefinition().windowFrameDefinition();
-        assertThat(frameDefinition.type(), is(WindowFrame.Type.RANGE));
+        assertThat(frameDefinition.type(), is(WindowFrame.Mode.RANGE));
         assertThat(frameDefinition.start().type(), is(FrameBound.Type.UNBOUNDED_PRECEDING));
         assertThat(frameDefinition.end().type(), is(FrameBound.Type.UNBOUNDED_FOLLOWING));
     }

--- a/sql/src/test/java/io/crate/analyze/WindowDefinitionSerialisationTest.java
+++ b/sql/src/test/java/io/crate/analyze/WindowDefinitionSerialisationTest.java
@@ -41,7 +41,7 @@ public class WindowDefinitionSerialisationTest {
     @Test
     public void testSerialisationWithMissingFields() throws IOException {
         FrameBoundDefinition start = new FrameBoundDefinition(FrameBound.Type.UNBOUNDED_PRECEDING, Literal.NULL);
-        WindowFrameDefinition frameDefinition = new WindowFrameDefinition(WindowFrame.Type.RANGE, start, null);
+        WindowFrameDefinition frameDefinition = new WindowFrameDefinition(WindowFrame.Mode.RANGE, start, null);
         WindowDefinition windowDefinition = new WindowDefinition(singletonList(Literal.of(2L)), null, frameDefinition);
 
         BytesStreamOutput output = new BytesStreamOutput();
@@ -58,7 +58,7 @@ public class WindowDefinitionSerialisationTest {
     public void testFullyConstructedWindowDefinitionSerialisation() throws IOException {
         FrameBoundDefinition start = new FrameBoundDefinition(FrameBound.Type.UNBOUNDED_PRECEDING, Literal.of(5L));
         FrameBoundDefinition end = new FrameBoundDefinition(FrameBound.Type.FOLLOWING, Literal.of(3L));
-        WindowFrameDefinition frameDefinition = new WindowFrameDefinition(WindowFrame.Type.RANGE, start, end);
+        WindowFrameDefinition frameDefinition = new WindowFrameDefinition(WindowFrame.Mode.RANGE, start, end);
         OrderBy orderBy = new OrderBy(singletonList(Literal.of(1L)), new boolean[]{true}, new boolean[]{true});
         WindowDefinition windowDefinition = new WindowDefinition(singletonList(Literal.of(2L)), orderBy, frameDefinition);
 

--- a/sql/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -60,17 +60,18 @@ public class WindowAggProjectionSerialisationTest {
         WindowDefinition partitionByTwoWindowDef =
             new WindowDefinition(singletonList(Literal.of(2L)), null, null);
 
-        WindowFunction firstWindowFunction = new WindowFunction(sumFunctionImpl.info(), Arrays.asList(Literal.of(1L)), partitionByOneWindowDef);
-        WindowFunction secondWindowFunction = new WindowFunction(sumFunctionImpl.info(), Arrays.asList(Literal.of(2L)), partitionByTwoWindowDef);
+        WindowFunction firstWindowFunction = new WindowFunction(
+            sumFunctionImpl.info(), singletonList(Literal.of(1L)), partitionByOneWindowDef);
+        WindowFunction secondWindowFunction = new WindowFunction(
+            sumFunctionImpl.info(), singletonList(Literal.of(2L)), partitionByTwoWindowDef);
 
         LinkedHashMap<WindowFunction, List<Symbol>> functionsWithInputs = new LinkedHashMap<>(2, 1f);
-        functionsWithInputs.put(firstWindowFunction, Arrays.asList(Literal.of(1L)));
-        functionsWithInputs.put(secondWindowFunction, Arrays.asList(Literal.of(2L)));
+        functionsWithInputs.put(firstWindowFunction, singletonList(Literal.of(1L)));
+        functionsWithInputs.put(secondWindowFunction, singletonList(Literal.of(2L)));
 
         WindowAggProjection windowAggProjection =
-            new WindowAggProjection(partitionByOneWindowDef,
-                null,
-                null,
+            new WindowAggProjection(
+                partitionByOneWindowDef,
                 functionsWithInputs,
                 Collections.singletonList(Literal.of(42L)));
         BytesStreamOutput output = new BytesStreamOutput();

--- a/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -77,7 +77,7 @@ import static io.crate.data.SentinelRow.SENTINEL;
 import static io.crate.execution.engine.sort.Comparators.createComparator;
 import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.elasticsearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
 import static org.hamcrest.Matchers.instanceOf;
 

--- a/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -43,7 +43,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     };
 
     @Test
-    public void testSumOverUnboundedPrecedingToUnboundedFollowingFrames() throws Exception {
+    public void testSumOverUnboundedPrecedingToUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{5L, 5L, 5L, 12L, 12L, 12L, null};
         assertEvaluate("sum(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING" +
@@ -54,7 +54,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testCountOverUnboundedFollowingFrames() throws Exception {
+    public void testCountOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{3L, 2L, 2L, 3L, 2L, 1L, 0L};
         assertEvaluate("count(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -65,7 +65,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testAvgOverUnboundedFollowingFrames() throws Exception {
+    public void testAvgOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{1.6666666666666667, 2.0, 2.0, 4.0, 4.5, 5.0, null};
         assertEvaluate("avg(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -76,7 +76,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testSumOverUnboundedFollowingFrames() throws Exception {
+    public void testSumOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{5L, 4L, 4L, 12L, 9L, 5L, null};
         assertEvaluate("sum(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -87,7 +87,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testVarianceOverUnboundedFollowingFrames() throws Exception {
+    public void testVarianceOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{0.22222222222222202, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
         assertEvaluate("variance(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -98,7 +98,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testStdDevOverUnboundedFollowingFrames() throws Exception {
+    public void testStdDevOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
         assertEvaluate("stddev(x) OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -109,7 +109,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testStringAggOverUnboundedFollowingFrames() throws Exception {
+    public void testStringAggOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{"a,b,b", "b,b", "b,b", "c,d,e", "d,e", "e", null};
         assertEvaluate("string_agg(z, ',') OVER(" +
                             "PARTITION BY z>'b' ORDER BY z RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -126,7 +126,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testCollectSetOverUnboundedFollowingFrames() throws Exception {
+    public void testCollectSetOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{
             List.of(1, 2),
             List.of(2),
@@ -155,7 +155,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testCollectSetOverRowsUnboundedPrecedingCurrentRowFrame() throws Exception {
+    public void testCollectSetOverRowsUnboundedPrecedingCurrentRowFrame() throws Throwable {
         Object[] expected = new Object[]{
             List.of(1),
             List.of(1, 2),
@@ -182,7 +182,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void test_agg_over_range_offset_preceding() throws Exception {
+    public void test_agg_over_range_offset_preceding() throws Throwable {
         Object[] expected = new Object[]{
             2.5,
             6.5,
@@ -209,7 +209,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void test_agg_over_rows_offset_preceding() throws Exception {
+    public void test_agg_over_rows_offset_preceding() throws Throwable {
         Object[] expected = new Object[]{
             2.5,
             6.5,
@@ -237,7 +237,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void test_agg_over_range_following() throws Exception {
+    public void test_agg_over_range_following() throws Throwable {
         Object[] expected = new Object[]{
             11.5,
             15.0,
@@ -265,7 +265,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void test_agg_over_rows_offset_following() throws Exception {
+    public void test_agg_over_rows_offset_following() throws Throwable {
         Object[] expected = new Object[]{
             17.5,
             22.5,

--- a/sql/src/test/java/io/crate/execution/engine/window/CurrentRowFrameBoundTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/CurrentRowFrameBoundTest.java
@@ -30,8 +30,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
-import static io.crate.sql.tree.WindowFrame.Type.ROWS;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.ROWS;
 import static org.hamcrest.core.Is.is;
 
 public class CurrentRowFrameBoundTest extends CrateUnitTest {

--- a/sql/src/test/java/io/crate/execution/engine/window/OffsetFollowingFrameBoundTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/OffsetFollowingFrameBoundTest.java
@@ -30,8 +30,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import static io.crate.sql.tree.FrameBound.Type.FOLLOWING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
-import static io.crate.sql.tree.WindowFrame.Type.ROWS;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.ROWS;
 import static org.hamcrest.core.Is.is;
 
 public class OffsetFollowingFrameBoundTest extends CrateUnitTest {

--- a/sql/src/test/java/io/crate/execution/engine/window/OffsetPrecedingFrameBoundTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/OffsetPrecedingFrameBoundTest.java
@@ -29,10 +29,9 @@ import org.junit.Test;
 import java.util.Comparator;
 import java.util.List;
 
-import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.crate.sql.tree.FrameBound.Type.PRECEDING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
-import static io.crate.sql.tree.WindowFrame.Type.ROWS;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.ROWS;
 import static org.hamcrest.core.Is.is;
 
 public class OffsetPrecedingFrameBoundTest extends CrateUnitTest {

--- a/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.contains;
 public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
     @Test
-    public void testRowNumberFunction() throws Exception {
+    public void testRowNumberFunction() throws Throwable {
         Object[] expected = new Object[] {1, 2, 3, 4};
 
         assertEvaluate("row_number() over(order by x)",
@@ -46,7 +46,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testRowNumberOverPartitionedWindow() throws Exception {
+    public void testRowNumberOverPartitionedWindow() throws Throwable {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2)",
                        contains(expected),
@@ -61,7 +61,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testRowNumberOverPartitionedOrderedWindow() throws Exception {
+    public void testRowNumberOverPartitionedOrderedWindow() throws Throwable {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2 order by x)",
                        contains(expected),
@@ -76,7 +76,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testRowNumberOverUnboundedFollowingFrames() throws Exception {
+    public void testRowNumberOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() OVER(" +
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +

--- a/sql/src/test/java/io/crate/execution/engine/window/UnboundedFollowingFrameBoundTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/UnboundedFollowingFrameBoundTest.java
@@ -30,7 +30,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
 
 public class UnboundedFollowingFrameBoundTest extends CrateUnitTest {

--- a/sql/src/test/java/io/crate/execution/engine/window/UnboundedPrecedingFrameBoundTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/UnboundedPrecedingFrameBoundTest.java
@@ -30,7 +30,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
-import static io.crate.sql.tree.WindowFrame.Type.RANGE;
+import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
 
 public class UnboundedPrecedingFrameBoundTest extends CrateUnitTest {

--- a/sql/src/test/java/io/crate/execution/engine/window/WindowFunctionsTestingFrameworkTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/WindowFunctionsTestingFrameworkTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.anything;
 public class WindowFunctionsTestingFrameworkTest extends AbstractWindowFunctionTest {
 
     @Test
-    public void testInputOfDifferentSizeRaiseException() throws Exception {
+    public void testInputOfDifferentSizeRaiseException() throws Throwable {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Inputs need to be of equal size");
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See individual commits


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)