### PR TITLE
Add parser support for filter clause in aggregate function calls.

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -135,6 +135,10 @@ where
     : WHERE condition=booleanExpression
     ;
 
+filter
+    : FILTER '(' where ')'
+    ;
+
 relation
     : left=relation
       ( CROSS JOIN right=aliasedRelation
@@ -222,9 +226,9 @@ valueExpression
 primaryExpression
     : parameterOrLiteral                                                             #defaultParamOrLiteral
     | explicitFunction                                                               #explicitFunctionDefault
-    | qname '(' ASTERISK ')' over?                                                   #functionCall
+    | qname '(' ASTERISK ')' filter? over?                                           #functionCall
     | ident                                                                          #columnReference
-    | qname '(' (setQuant? expr (',' expr)*)? ')' over?                              #functionCall
+    | qname '(' (setQuant? expr (',' expr)*)? ')' filter? over?                      #functionCall
     | subqueryExpression                                                             #subqueryExpressionDefault
     // This case handles a simple parenthesized expression.
     | '(' expr ')'                                                                   #nestedExpression
@@ -644,7 +648,7 @@ nonReserved
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN | COMMIT
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | PREPARE
-    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED
+    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED | FILTER
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | WINDOW | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN | PRECISION
@@ -864,6 +868,7 @@ SHARDS: 'SHARDS';
 PRIMARY_KEY: 'PRIMARY KEY';
 OFF: 'OFF';
 FULLTEXT: 'FULLTEXT';
+FILTER: 'FILTER';
 PLAIN: 'PLAIN';
 INDEX: 'INDEX';
 STORAGE: 'STORAGE';

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -314,9 +314,17 @@ public final class ExpressionFormatter {
                 builder.append('(').append(arguments).append(')');
             }
 
-            if (node.getWindow().isPresent()) {
-                builder.append(" OVER ").append(visitWindow(node.getWindow().get(), parameters));
-            }
+            node.filter()
+                .ifPresent(filter -> builder
+                    .append(" FILTER (WHERE ")
+                    .append(formatExpression(filter))
+                    .append(")"));
+
+            node.getWindow()
+                .ifPresent(window -> builder
+                    .append(" OVER ")
+                    .append(visitWindow(window, parameters)));
+
             return builder.toString();
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -364,10 +364,9 @@ public final class SqlFormatter {
         protected Void visitSingleColumn(SingleColumn node, Integer indent) {
             builder.append(formatStandaloneExpression(node.getExpression(), parameters));
             if (node.getAlias() != null) {
-                builder.append(' ')
-                    .append('"')
-                    .append(node.getAlias())
-                    .append('"'); // TODO: handle quoting properly
+                builder
+                    .append(' ')
+                    .append(quoteIdentifierIfNeeded(node.getAlias()));
             }
 
             return null;

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1552,8 +1552,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getQualifiedName(context.qname()),
             isDistinct(context.setQuant()),
             visitCollection(context.expr(), Expression.class),
-            visitIfPresent(context.over(), Window.class)
+            visitIfPresent(context.over(), Window.class),
+            visitIfPresent(context.filter(), Expression.class)
         );
+    }
+
+    @Override
+    public Node visitFilter(SqlBaseParser.FilterContext context) {
+        return visit(context.where());
     }
 
     // Literals

--- a/sql-parser/src/main/java/io/crate/sql/tree/FunctionCall.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/FunctionCall.java
@@ -22,6 +22,7 @@
 package io.crate.sql.tree;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class FunctionCall extends Expression {
@@ -30,16 +31,22 @@ public class FunctionCall extends Expression {
     private final boolean distinct;
     private final List<Expression> arguments;
     private final Optional<Window> window;
+    private final Optional<Expression> filter;
 
     public FunctionCall(QualifiedName name, List<Expression> arguments) {
-        this(name, false, arguments, Optional.empty());
+        this(name, false, arguments, Optional.empty(), Optional.empty());
     }
 
-    public FunctionCall(QualifiedName name, boolean distinct, List<Expression> arguments, Optional<Window> window) {
+    public FunctionCall(QualifiedName name,
+                        boolean distinct,
+                        List<Expression> arguments,
+                        Optional<Window> window,
+                        Optional<Expression> filter) {
         this.name = name;
         this.distinct = distinct;
         this.arguments = arguments;
         this.window = window;
+        this.filter = filter;
     }
 
     public QualifiedName getName() {
@@ -58,6 +65,10 @@ public class FunctionCall extends Expression {
         return window;
     }
 
+    public Optional<Expression> filter() {
+        return filter;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitFunctionCall(this, context);
@@ -65,23 +76,22 @@ public class FunctionCall extends Expression {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         FunctionCall that = (FunctionCall) o;
-
-        if (distinct != that.distinct) return false;
-        if (!name.equals(that.name)) return false;
-        if (!arguments.equals(that.arguments)) return false;
-        return window.equals(that.window);
+        return distinct == that.distinct &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(arguments, that.arguments) &&
+               Objects.equals(window, that.window) &&
+               Objects.equals(filter, that.filter);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + (distinct ? 1 : 0);
-        result = 31 * result + arguments.hashCode();
-        result = 31 * result + window.hashCode();
-        return result;
+        return Objects.hash(name, distinct, arguments, window, filter);
     }
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -75,7 +75,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Strings.repeat;
@@ -1539,6 +1538,25 @@ public class TestStatementBuilder {
         printStatement("VALUES (1, 2), (2, 3), (3, 4)");
         printStatement("VALUES (1), (2), (3)");
         printStatement("VALUES (1, 2, 3 + 3, (SELECT 1))");
+    }
+
+    @Test
+    public void test_wildcard_aggregate_with_filter_clause() {
+        printStatement("SELECT COUNT(*) FILTER (WHERE x > 10) FROM t");
+    }
+
+    @Test
+    public void test_distinct_aggregate_with_filter_clause() {
+        printStatement("SELECT AVG(DISTINCT x) FILTER (WHERE 1 = 1) FROM t");
+    }
+
+    @Test
+    public void test_multiple_aggregates_with_filter_clauses() {
+        printStatement(
+            "SELECT " +
+            "   SUM(x) FILTER (WHERE x > 10), " +
+            "   AVG(x) FILTER (WHERE 1 = 1) " +
+            "FROM t");
     }
 
     private static void printStatement(String sql) {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
@@ -27,7 +27,6 @@ import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.Statement;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.sql.SqlFormatter.formatSql;
@@ -67,12 +66,11 @@ final class TreeAssertions {
     private static List<Node> linearizeTree(Node tree) {
         final ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         new DefaultTraversalVisitor<Node, Void>() {
-            public Node process(Node node, @Nullable Void context) {
-                Node result = node.accept(this, context);
+            void process(Node node) {
+                node.accept(this, null);
                 nodes.add(node);
-                return result;
             }
-        }.process(tree, null);
+        }.process(tree);
         return nodes.build();
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds the parser support for the filter clause in aggregate function calls.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
