### PR TITLE
Fix time zone offset parsing for value `+0000`

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -92,5 +92,7 @@ Changes
 Fixes
 =====
 
+- Fixed parsing of timestamps with a time zone offset of `+0000`.
+
 - Fixed an issue that could cause startup to fail with early access builds of
   Java.

--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -133,7 +133,7 @@ public final class TimestampType extends DataType<Long>
 
     static long parseTimestamp(String timestamp) {
         try {
-            return Long.valueOf(timestamp);
+            return Long.parseLong(timestamp);
         } catch (NumberFormatException e) {
             TemporalAccessor dt = TIMESTAMP_PARSER.parseBest(
                 timestamp, OffsetDateTime::from, LocalDateTime::from, LocalDate::from);
@@ -153,7 +153,7 @@ public final class TimestampType extends DataType<Long>
 
     static long parseTimestampIgnoreTimeZone(String timestamp) {
         try {
-            return Long.valueOf(timestamp);
+            return Long.parseLong(timestamp);
         } catch (NumberFormatException e) {
             TemporalAccessor dt = TIMESTAMP_PARSER.parseBest(
                 timestamp, LocalDateTime::from, LocalDate::from);
@@ -178,6 +178,6 @@ public final class TimestampType extends DataType<Long>
                 .optionalEnd()
             .append(ISO_LOCAL_TIME)
             .optionalStart()
-                .appendPattern("[VV][x][xx][xxx]")
+                .appendPattern("[Z][VV][x][xx][xxx]")
         .toFormatter(Locale.ENGLISH).withResolverStyle(ResolverStyle.STRICT);
 }

--- a/common/src/test/java/io/crate/types/TimestampTypesTest.java
+++ b/common/src/test/java/io/crate/types/TimestampTypesTest.java
@@ -22,6 +22,8 @@ public class TimestampTypesTest {
         assertThat(TimestampType.parseTimestamp("1999-01-08T04:00:00+0300"), is(915757200000L));
         assertThat(TimestampType.parseTimestamp("1999-01-08T04:00:00+03:00"), is(915757200000L));
         assertThat(TimestampType.parseTimestamp("1999-01-08T04:00:00.123456789+03:00"), is(915757200123L));
+        assertThat(TimestampType.parseTimestamp("1999-01-08T04:00:00+0000"), is(915768000000L));
+        assertThat(TimestampType.parseTimestamp("1999-01-08T04:00:00.123456789-0000"), is(915768000123L));
     }
 
     @Test


### PR DESCRIPTION
This special case wasn’t covered by existing offset patterns.