### PR TITLE
Fix offset preceding/following calculations for windows with partitions

### DIFF
--- a/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -27,9 +27,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.module.EnterpriseFunctionsModule;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
 
@@ -42,9 +40,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLastValueWithEmptyOver() throws Throwable {
-        assertEvaluate("last_value(x) over()",
+        assertEvaluate(
+            "last_value(x) over()",
             contains(new Object[] {4, 4, 4, 4}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -54,13 +53,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLastValueWithOrderByClause() throws Throwable {
-        Map<ColumnIdent, Integer> mapping = new HashMap<>();
-        mapping.put(new ColumnIdent("x"), 0);
-        mapping.put(new ColumnIdent("y"), 1);
-
-        assertEvaluate("last_value(x) over(order by y)",
+        assertEvaluate(
+            "last_value(x) over(order by y)",
             contains(new Object[] {1, 3, 3, 2}),
-            mapping,
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -70,13 +66,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLastValueUseSymbolMultipleTimes() throws Throwable {
-        Map<ColumnIdent, Integer> mapping = new HashMap<>();
-        mapping.put(new ColumnIdent("x"), 0);
-        mapping.put(new ColumnIdent("y"), 1);
-
-        assertEvaluate("last_value(x) over(order by y, x)",
+        assertEvaluate(
+            "last_value(x) over(order by y, x)",
             contains(new Object[] {1, 1, 3, 2}),
-            mapping,
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -86,9 +79,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testFirstValueWithEmptyOver() throws Throwable {
-        assertEvaluate("first_value(x) over()",
+        assertEvaluate(
+            "first_value(x) over()",
             contains(new Object[] {1, 1, 1, 1}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -98,13 +92,9 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testFirstValueWithOrderByClause() throws Throwable {
-        Map<ColumnIdent, Integer> mapping = new HashMap<>();
-        mapping.put(new ColumnIdent("x"), 0);
-        mapping.put(new ColumnIdent("y"), 1);
-
         assertEvaluate("first_value(x) over(order by y)",
             contains(new Object[] {1, 1, 1, 1}),
-            mapping,
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -116,7 +106,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testNthValueWithEmptyOver() throws Throwable {
         assertEvaluate("nth_value(x, 3) over()",
             contains(new Object[] {3, 3, 3, 3}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -126,13 +116,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testNthValueWithOrderByClause() throws Throwable {
-        Map<ColumnIdent, Integer> mapping = new HashMap<>();
-        mapping.put(new ColumnIdent("x"), 0);
-        mapping.put(new ColumnIdent("y"), 1);
-
-        assertEvaluate("nth_value(x, 3) over(order by y)",
+        assertEvaluate(
+            "nth_value(x, 3) over(order by y)",
             contains(new Object[] {null, 3, 3, 3}),
-            mapping,
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -142,13 +129,9 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testNthValueWithNullPositionReturnsNull() throws Throwable {
-        Map<ColumnIdent, Integer> mapping = new HashMap<>();
-        mapping.put(new ColumnIdent("x"), 0);
-        mapping.put(new ColumnIdent("y"), 1);
-
         assertEvaluate("nth_value(x,null) over(order by y)",
             contains(new Object[] {null, null, null, null}),
-            mapping,
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -159,54 +142,58 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     @Test
     public void testRowNthValueOverPartitionedWindow() throws Throwable {
         Object[] expected = new Object[]{2, 2, 2, 4, 4, 4, null};
-        assertEvaluate("nth_value(x, 2) over(partition by x > 2)",
-                       contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
-                       new Object[]{1, 1},
-                       new Object[]{2, 2},
-                       new Object[]{2, 2},
-                       new Object[]{3, 3},
-                       new Object[]{4, 4},
-                       new Object[]{5, 5},
-                       new Object[]{null, null});
+        assertEvaluate(
+            "nth_value(x, 2) over(partition by x > 2)",
+            contains(expected),
+            List.of(new ColumnIdent("x")),
+            new Object[]{1, 1},
+            new Object[]{2, 2},
+            new Object[]{2, 2},
+            new Object[]{3, 3},
+            new Object[]{4, 4},
+            new Object[]{5, 5},
+            new Object[]{null, null});
     }
 
     @Test
     public void testNthValueOverPartitionedOrderedWindow() throws Throwable {
         Object[] expected = new Object[]{null, 2, 2, null, 4, 4, null};
-        assertEvaluate("nth_value(x, 2) over(partition by x > 2 order by x)",
-                       contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
-                       new Object[]{1},
-                       new Object[]{2},
-                       new Object[]{2},
-                       new Object[]{3},
-                       new Object[]{4},
-                       new Object[]{5},
-                       new Object[]{null});
+        assertEvaluate(
+            "nth_value(x, 2) over(partition by x > 2 order by x)",
+            contains(expected),
+            List.of(new ColumnIdent("x")),
+            new Object[]{1},
+            new Object[]{2},
+            new Object[]{2},
+            new Object[]{3},
+            new Object[]{4},
+            new Object[]{5},
+            new Object[]{null});
     }
 
     @Test
     public void testNthValueOverUnboundedFollowingWindow() throws Throwable {
         Object[] expected = new Object[]{2, 2, 2, 4, 5, null, null};
-        assertEvaluate("nth_value(x, 2) OVER(PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
-                       contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
-                       new Object[]{1},
-                       new Object[]{2},
-                       new Object[]{2},
-                       new Object[]{3},
-                       new Object[]{4},
-                       new Object[]{5},
-                       new Object[]{null});
+        assertEvaluate(
+            "nth_value(x, 2) OVER(PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
+            contains(expected),
+            List.of(new ColumnIdent("x")),
+            new Object[]{1},
+            new Object[]{2},
+            new Object[]{2},
+            new Object[]{3},
+            new Object[]{4},
+            new Object[]{5},
+            new Object[]{null});
     }
 
     @Test
     public void testNthValueOverRangeModeOneRowFrames() throws Throwable {
         Object[] expected = new Object[]{1, 1};
-        assertEvaluate("nth_value(x, 1) OVER(ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
+        assertEvaluate(
+            "nth_value(x, 1) OVER(ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2});
     }
@@ -214,9 +201,10 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     @Test
     public void testNthValueOverRowsModeOneRowFrames() throws Throwable {
         Object[] expected = new Object[]{1, 1};
-        assertEvaluate("nth_value(x, 1) OVER(ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
+        assertEvaluate(
+            "nth_value(x, 1) OVER(ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2});
     }

--- a/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -27,8 +27,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.module.EnterpriseFunctionsModule;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
 
@@ -40,9 +39,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithSingleArgumentAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(x) over()",
+        assertEvaluate(
+            "lag(x) over()",
             contains(new Object[]{null, 1, null, 2}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2},
@@ -52,9 +52,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithOffsetAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(x, 2) over()",
+        assertEvaluate(
+            "lag(x, 2) over()",
             contains(new Object[]{null, null, 1, 2}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -64,9 +65,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithNullOffset() throws Throwable {
-        assertEvaluate("lag(x, null) over()",
+        assertEvaluate(
+            "lag(x, null) over()",
             contains(new Object[]{null, null, null}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2}
@@ -75,9 +77,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagZeroOffsetAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(x, 0) over()",
+        assertEvaluate(
+            "lag(x, 0) over()",
             contains(new Object[]{1, 2}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2}
         );
@@ -85,9 +88,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagNegativeOffsetAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(x, -1) over()",
+        assertEvaluate(
+            "lag(x, -1) over()",
             contains(new Object[]{2, null}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2}
         );
@@ -95,9 +99,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithDefaultValueAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(x, 1, -1) over()",
+        assertEvaluate(
+            "lag(x, 1, -1) over()",
             contains(new Object[]{-1, 1, 2, 3}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -107,9 +112,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithExpressionAsArgumentAndEmptyOver() throws Throwable {
-        assertEvaluate("lag(coalesce(x, 1), 1, -1) over()",
+        assertEvaluate(
+            "lag(coalesce(x, 1), 1, -1) over()",
             contains(new Object[]{-1, 1, 1}),
-            Map.of(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2}
@@ -118,9 +124,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithOrderBy() throws Throwable {
-        assertEvaluate("lag(x) over(order by y)",
+        assertEvaluate(
+            "lag(x) over(order by y)",
             contains(new Object[]{null, 1, 3, 1}),
-            Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[]{1, 1},
             new Object[]{1, 3},
             new Object[]{3, 2},
@@ -130,9 +137,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithOrderByReferenceUsedInFunction() throws Throwable {
-        assertEvaluate("lag(x) over(order by y, x)",
+        assertEvaluate(
+            "lag(x) over(order by y, x)",
             contains(new Object[]{null, 1, 1, 3}),
-            Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[]{1, 1},
             new Object[]{1, 2},
             new Object[]{3, 2},
@@ -144,7 +152,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagOverPartitionedWindow() throws Throwable {
         assertEvaluate("lag(x) over(partition by x > 2)",
             contains(new Object[]{null, 1, 2, null, 3, 4}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -155,9 +163,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagOperatesOnPartitionAndIgnoresFrameRange() throws Throwable {
-        assertEvaluate("lag(x) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
+        assertEvaluate(
+            "lag(x) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             contains(new Object[]{null, 1, 2, 3}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -167,9 +176,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLeadOverPartitionedWindow() throws Throwable {
-        assertEvaluate("lead(x) over(partition by x > 2)",
+        assertEvaluate(
+            "lead(x) over(partition by x > 2)",
             contains(new Object[]{2, 2, null, 4, 5, null}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -182,7 +192,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLeadWithOrderBy() throws Throwable {
         assertEvaluate("lead(x) over(order by y)",
                        contains(new Object[]{3, 1, 2, null}),
-                       Map.of(new ColumnIdent("x"), 0, new ColumnIdent("y"), 1),
+                       List.of(new ColumnIdent("x"), new ColumnIdent("y")),
                        new Object[]{1, 1},
                        new Object[]{1, 3},
                        new Object[]{3, 2},
@@ -192,9 +202,10 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Throwable {
-        assertEvaluate("lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
+        assertEvaluate(
+            "lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             contains(new Object[]{2, 3, 4, 42, 42}),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},

--- a/shared/src/main/java/io/crate/common/collections/Lists2.java
+++ b/shared/src/main/java/io/crate/common/collections/Lists2.java
@@ -246,9 +246,13 @@ public final class Lists2 {
      * specified by @param itemIdx, according to the provided comparator.
      * @return the index of the first LTE item, or -1 if there isn't any (eg. probe is less than all items)
      */
-    public static <T> int findFirstLTEProbeValue(List<T> sortedItems, int itemIdx, T probe, Comparator<T> cmp) {
+    public static <T> int findFirstLTEProbeValue(List<T> sortedItems,
+                                                 int upperBoundary,
+                                                 int itemIdx,
+                                                 T probe,
+                                                 Comparator<T> cmp) {
         int start = itemIdx;
-        int end = sortedItems.size() - 1;
+        int end = upperBoundary - 1;
 
         int firstLTEProbeIdx = -1;
         while (start <= end) {
@@ -269,8 +273,8 @@ public final class Lists2 {
      * specified by @param itemIdx, according to the provided comparator.
      * @return the index of the first GTE item, or -1 if there isn't any (eg. probe is greater than all items)
      */
-    public static <T> int findFirstGTEProbeValue(List<T> sortedItems, int itemIdx, T probe, Comparator<T> cmp) {
-        int start = 0;
+    public static <T> int findFirstGTEProbeValue(List<T> sortedItems, int lowerBoundary, int itemIdx, T probe, Comparator<T> cmp) {
+        int start = lowerBoundary;
         int end = itemIdx - 1;
 
         int firstGTEProbeIdx = -1;

--- a/shared/src/test/java/io/crate/common/collections/Lists2Test.java
+++ b/shared/src/test/java/io/crate/common/collections/Lists2Test.java
@@ -129,24 +129,24 @@ public class Lists2Test {
     @Test
     public void test_find_first_gte_probe_when_exists_in_slice() {
         var numbers = List.of(1, 2, 3, 6, 7, 8);
-        assertThat(findFirstGTEProbeValue(numbers, 4, 4, integerComparator), is(3));
+        assertThat(findFirstGTEProbeValue(numbers, 0, 4, 4, integerComparator), is(3));
     }
 
     @Test
     public void test_find_first_gte_probe_when_greater_than_all_items_is_minus_one() {
         var numbers = List.of(1, 2, 3, 6, 7, 8);
-        assertThat(findFirstGTEProbeValue(numbers, 3, 4, integerComparator), is(-1));
+        assertThat(findFirstGTEProbeValue(numbers, 0, 3, 4, integerComparator), is(-1));
     }
 
     @Test
     public void test_find_first_lte_probe_when_exists_in_slice() {
         var numbers = List.of(1, 2, 3, 6, 7, 8);
-        assertThat(findFirstLTEProbeValue(numbers, 3, 7, integerComparator), is(4));
+        assertThat(findFirstLTEProbeValue(numbers, numbers.size(), 3, 7, integerComparator), is(4));
     }
 
     @Test
     public void test_find_first_lte_probe_when_less_than_all_items_is_minus_one() {
         var numbers = List.of(1, 2, 3, 4, 5, 6, 7, 8);
-        assertThat(findFirstLTEProbeValue(numbers, 5, 0, integerComparator), is(-1));
+        assertThat(findFirstLTEProbeValue(numbers, numbers.size(), 5, 0, integerComparator), is(-1));
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
@@ -72,14 +72,13 @@ public class FrameBound extends Node {
                                     List<T> rows) {
                 if (mode == ROWS) {
                     assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
-                    int startIndex = Math.max(pStart, currentRowIdx - ((Long) offset).intValue());
-                    return startIndex > 0 ? startIndex : 0;
+                    return Math.max(pStart, currentRowIdx - ((Long) offset).intValue());
                 } else {
-                    int firstGTEProbeValue = findFirstGTEProbeValue(rows, currentRowIdx, offsetProbeValue, cmp);
+                    int firstGTEProbeValue = findFirstGTEProbeValue(rows, pStart, currentRowIdx, offsetProbeValue, cmp);
                     if (firstGTEProbeValue == -1) {
                         return currentRowIdx;
                     } else {
-                        return Math.max(pStart, firstGTEProbeValue);
+                        return firstGTEProbeValue;
                     }
                 }
             }
@@ -171,7 +170,7 @@ public class FrameBound extends Node {
                     assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
                     return Math.min(pEnd, currentRowIdx + ((Long) offset).intValue() + 1);
                 } else {
-                    return Math.min(pEnd, findFirstLTEProbeValue(rows, currentRowIdx, offsetProbeValue, cmp) + 1);
+                    return findFirstLTEProbeValue(rows, pEnd, currentRowIdx, offsetProbeValue, cmp) + 1;
                 }
             }
         },

--- a/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/WindowFrameDefinition.java
@@ -37,18 +37,18 @@ import java.util.function.Function;
 
 public class WindowFrameDefinition implements Writeable {
 
-    private final Mode type;
+    private final Mode mode;
     private final FrameBoundDefinition start;
     private final FrameBoundDefinition end;
 
     public WindowFrameDefinition(StreamInput in) throws IOException {
-        type = in.readEnum(Mode.class);
+        mode = in.readEnum(Mode.class);
         start = new FrameBoundDefinition(in);
         end = in.readOptionalWriteable(FrameBoundDefinition::new);
     }
 
-    public WindowFrameDefinition(Mode type, FrameBoundDefinition start, @Nullable FrameBoundDefinition end) {
-        this.type = type;
+    public WindowFrameDefinition(Mode mode, FrameBoundDefinition start, @Nullable FrameBoundDefinition end) {
+        this.mode = mode;
         this.start = start;
         if (end != null) {
             this.end = end;
@@ -57,8 +57,8 @@ public class WindowFrameDefinition implements Writeable {
         }
     }
 
-    public Mode type() {
-        return type;
+    public Mode mode() {
+        return mode;
     }
 
     public FrameBoundDefinition start() {
@@ -75,13 +75,13 @@ public class WindowFrameDefinition implements Writeable {
         if (newStart == start && newEnd == end) {
             return this;
         } else {
-            return new WindowFrameDefinition(type, newStart, newEnd);
+            return new WindowFrameDefinition(mode, newStart, newEnd);
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeEnum(type);
+        out.writeEnum(mode);
         start.writeTo(out);
         out.writeOptionalWriteable(end);
     }
@@ -91,20 +91,20 @@ public class WindowFrameDefinition implements Writeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WindowFrameDefinition that = (WindowFrameDefinition) o;
-        return type == that.type &&
+        return mode == that.mode &&
                Objects.equals(start, that.start) &&
                Objects.equals(end, that.end);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, start, end);
+        return Objects.hash(mode, start, end);
     }
 
     @Override
     public String toString() {
         return "WindowFrame{" +
-               "type=" + type +
+               "type=" + mode +
                ", start=" + start +
                ", end=" + end +
                '}';

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -227,7 +227,7 @@ public final class WindowFunctionBatchIterator {
                     pEnd = findFirstNonPeer(sortedRows, pStart, end, cmpPartitionBy);
                 }
 
-                if (windowDefinition.windowFrameDefinition().type() == RANGE) {
+                if (windowDefinition.windowFrameDefinition().mode() == RANGE) {
                     // if the offsetCell position is -1 the window is ordered by a Literal so we leave the
                     // probe value to null so it doesn't impact ordering (ie. all values will be consistently GT or LT
                     // `null`)
@@ -247,7 +247,7 @@ public final class WindowFunctionBatchIterator {
                 }
 
                 int wBegin = frameDefinition.start().type().getStart(
-                    frameDefinition.type(),
+                    frameDefinition.mode(),
                     pStart,
                     pEnd,
                     i,
@@ -258,7 +258,7 @@ public final class WindowFunctionBatchIterator {
                 );
 
                 int wEnd = frameDefinition.end().type().getEnd(
-                    frameDefinition.type(),
+                    frameDefinition.mode(),
                     pStart,
                     pEnd,
                     i,
@@ -288,7 +288,7 @@ public final class WindowFunctionBatchIterator {
     private static BinaryOperator<Object> getFunctionForRangeCustomOffset(WindowDefinition windowDefinition,
                                                                           @Nullable Object frameOffset,
                                                                           Function<DataType, BinaryOperator<Object>> functionSupplier) {
-        if (windowDefinition.windowFrameDefinition().type() == RANGE && frameOffset != null) {
+        if (windowDefinition.windowFrameDefinition().mode() == RANGE && frameOffset != null) {
             assert windowDefinition.orderBy() !=
                    null : "The window definition must be ordered if custom offsets are specified";
             DataType orderByDataType = windowDefinition.orderBy().orderBySymbols().get(0).valueType();

--- a/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
@@ -140,7 +140,7 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
         WindowFunction windowFunction = (WindowFunction) outputSymbols.get(0);
         assertThat(windowFunction.arguments().size(), is(1));
         WindowFrameDefinition frameDefinition = windowFunction.windowDefinition().windowFrameDefinition();
-        assertThat(frameDefinition.type(), is(WindowFrame.Mode.RANGE));
+        assertThat(frameDefinition.mode(), is(WindowFrame.Mode.RANGE));
         assertThat(frameDefinition.start().type(), is(FrameBound.Type.UNBOUNDED_PRECEDING));
         assertThat(frameDefinition.end().type(), is(FrameBound.Type.UNBOUNDED_FOLLOWING));
     }

--- a/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -146,8 +146,8 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
         ReferenceResolver<InputCollectExpression> referenceResolver =
             r -> new InputCollectExpression(rowsColumnDescription.indexOf(r.column()));
 
-        List<Symbol> sourceSymbols = Lists2.map(rowsColumnDescription, x -> sqlExpressions.normalize(sqlExpressions.asSymbol(x.sqlFqn())));
-
+        var sourceSymbols = Lists2.map(rowsColumnDescription, x -> sqlExpressions.normalize(sqlExpressions.asSymbol(x.sqlFqn())));
+        ensureInputRowsHaveCorrectType(sourceSymbols, inputRows);
         var argsCtx = inputFactory.ctxForRefs(txnCtx, referenceResolver);
         argsCtx.add(windowFunctionSymbol.arguments());
 
@@ -197,5 +197,13 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
             throw e.getCause();
         }
         assertThat((T) actualResult, expectedValue);
+    }
+
+    private static void ensureInputRowsHaveCorrectType(List<Symbol> sourceSymbols, Object[][] inputRows) {
+        for (int i = 0; i < sourceSymbols.size(); i++) {
+            for (Object[] inputRow : inputRows) {
+                inputRow[i] = sourceSymbols.get(i).valueType().value(inputRow[i]);
+            }
+        }
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -299,4 +299,38 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                        new Object[]{10.0, 10.0},
                        new Object[]{12.0, 12.0});
     }
+
+    @Test
+    public void test_sum_with_range_offset_preceding_following_including_partitions() throws Throwable {
+        Object[][] rows = new Object[][] {
+            $("Male", 1000),
+            $("Male", 2000),
+            $("Female", 3000),
+            $("Female", 4000),
+            $("Male", 5000),
+            $("Female", 6000),
+            $("Male", 7000),
+            $("Female", 8000),
+            $("Male", 9000),
+            $("Male", 9500),
+        };
+        Object[] expected = new Object[] {
+            7000.0d,
+            7000.0d,
+            6000.0d,
+            8000.0d,
+            3000.0d,
+            3000.0d,
+            5000.0d,
+            7000.0d,
+            18500.0d,
+            18500.0d,
+        };
+        assertEvaluate(
+            "sum(d) over (partition by z order by d range between 1000 preceding and 1000 following)",
+            contains(expected),
+            List.of(new ColumnIdent("z"), new ColumnIdent("d")),
+            rows
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -25,9 +25,9 @@ package io.crate.execution.engine.window;
 import io.crate.metadata.ColumnIdent;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.hamcrest.Matchers.contains;
 
 public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
@@ -49,8 +49,9 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING" +
                        ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
-            INPUT_ROWS);
+            List.of(new ColumnIdent("x")),
+            INPUT_ROWS
+        );
     }
 
     @Test
@@ -60,69 +61,75 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
                        ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
-            INPUT_ROWS);
+            List.of(new ColumnIdent("x")),
+            INPUT_ROWS
+        );
     }
 
     @Test
     public void testAvgOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{1.6666666666666667, 2.0, 2.0, 4.0, 4.5, 5.0, null};
-        assertEvaluate("avg(x) OVER(" +
-                            "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
+        assertEvaluate(
+            "avg(x) OVER(" +
+            "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             INPUT_ROWS);
     }
 
     @Test
     public void testSumOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{5L, 4L, 4L, 12L, 9L, 5L, null};
-        assertEvaluate("sum(x) OVER(" +
-                            "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
+        assertEvaluate(
+            "sum(x) OVER(" +
+            "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             INPUT_ROWS);
     }
 
     @Test
     public void testVarianceOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{0.22222222222222202, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
-        assertEvaluate("variance(x) OVER(" +
-                            "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
+        assertEvaluate(
+            "variance(x) OVER(" +
+            "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             INPUT_ROWS);
     }
 
     @Test
     public void testStdDevOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
-        assertEvaluate("stddev(x) OVER(" +
-                            "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
+        assertEvaluate(
+            "stddev(x) OVER(" +
+            "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             INPUT_ROWS);
     }
 
     @Test
     public void testStringAggOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{"a,b,b", "b,b", "b,b", "c,d,e", "d,e", "e", null};
-        assertEvaluate("string_agg(z, ',') OVER(" +
-                            "PARTITION BY z>'b' ORDER BY z RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
+        assertEvaluate(
+            "string_agg(z, ',') OVER(" +
+            "   PARTITION BY z>'b' ORDER BY z RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("z"), 0),
-            new Object[]{"a", 1},
-            new Object[]{"b", 2},
-            new Object[]{"b", 2},
-            new Object[]{"c", 3},
-            new Object[]{"d", 4},
-            new Object[]{"e", 5},
-            new Object[]{null, null});
+            List.of(new ColumnIdent("z")),
+            new Object[]{"a"},
+            new Object[]{"b"},
+            new Object[]{"b"},
+            new Object[]{"c"},
+            new Object[]{"d"},
+            new Object[]{"e"},
+            new Object[]{null});
     }
 
     @Test
@@ -138,20 +145,21 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             List.of(5),
             List.of()
         };
-        assertEvaluate("collect_set(x) OVER(" +
-                            "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
-                       ")",
-                       contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
-            new Object[]{1, 1},
-            new Object[]{2, 2},
-            new Object[]{2, 2},
-            new Object[]{2, 2},
-            new Object[]{2, 2},
-            new Object[]{3, 3},
-            new Object[]{4, 4},
-            new Object[]{5, 5},
-            new Object[]{null, null});
+        assertEvaluate(
+            "collect_set(x) OVER(" +
+            "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
+            ")",
+            contains(expected),
+            List.of(new ColumnIdent("x")),
+            new Object[]{1},
+            new Object[]{2},
+            new Object[]{2},
+            new Object[]{2},
+            new Object[]{2},
+            new Object[]{3},
+            new Object[]{4},
+            new Object[]{5},
+            new Object[]{null});
     }
 
     @Test
@@ -170,7 +178,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW" +
                        ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+            List.of(new ColumnIdent("x")),
             new Object[]{1, 1},
             new Object[]{2, 2},
             new Object[]{2, 2},
@@ -197,7 +205,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d RANGE BETWEEN 3 PRECEDING and CURRENT ROW" +
                        ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("d"), 0),
+            List.of(new ColumnIdent("d")),
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -225,7 +233,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d ROWS BETWEEN 3 PRECEDING and CURRENT ROW" +
                        ")",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("d"), 0),
+            List.of(new ColumnIdent("d")),
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -253,7 +261,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                                "ORDER BY d RANGE BETWEEN CURRENT ROW and 3 FOLLOWING" +
                        ")",
                        contains(expected),
-                       Collections.singletonMap(new ColumnIdent("d"), 0),
+                       List.of(new ColumnIdent("d")),
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},
@@ -281,7 +289,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d ROWS BETWEEN CURRENT ROW and 3 FOLLOWING" +
                        ")",
                        contains(expected),
-                       Collections.singletonMap(new ColumnIdent("d"), 0),
+                       List.of(new ColumnIdent("d")),
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},
@@ -291,5 +299,4 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                        new Object[]{10.0, 10.0},
                        new Object[]{12.0, 12.0});
     }
-
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
@@ -25,7 +25,7 @@ package io.crate.execution.engine.window;
 import io.crate.metadata.ColumnIdent;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
 
@@ -37,7 +37,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
         assertEvaluate("row_number() over(order by x)",
             contains(expected),
-            Collections.singletonMap(new ColumnIdent("x"), 0),
+           List.of(new ColumnIdent("x")),
             new Object[] {4},
             new Object[] {3},
             new Object[] {2},
@@ -50,7 +50,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2)",
                        contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       List.of(new ColumnIdent("x")),
                        new Object[]{1},
                        new Object[]{2},
                        new Object[]{2},
@@ -65,7 +65,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2 order by x)",
                        contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       List.of(new ColumnIdent("x")),
                        new Object[]{1, 1},
                        new Object[]{2, 2},
                        new Object[]{2, 2},
@@ -82,7 +82,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
                        ")",
                        contains(expected),
-                       Collections.singletonMap(new ColumnIdent("x"), 0),
+                       List.of(new ColumnIdent("x")),
                        new Object[]{1, 1},
                        new Object[]{2, 2},
                        new Object[]{2, 2},

--- a/sql/src/test/java/io/crate/execution/engine/window/WindowFunctionsTestingFrameworkTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/WindowFunctionsTestingFrameworkTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.window;
 
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.anything;
 
@@ -36,9 +36,10 @@ public class WindowFunctionsTestingFrameworkTest extends AbstractWindowFunctionT
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Inputs need to be of equal size");
 
-        assertEvaluate("row_number() over()",
+        assertEvaluate(
+            "row_number() over()",
             anything("does not matter"),
-            Collections.emptyMap(),
+            List.of(),
             new Object[]{1},
             new Object[]{1, 2}
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The methods to calculate the frame boundaries were allowed to jump outside
a partition, which resulted in frame boundaries that were too large.

This is a fix for an unreleased feature, so no changes entry.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)