### PR TITLE
Fix `build_snapshot` value inside version JSON payload

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue with the version payload returned by HTTP, which resulted in
+  falsely displaying CrateDB's version as a ``-SNAPSHOT`` version at the AdminUI.
+
 - Fixed parsing of timestamps with a time zone offset of `+0000`.
 
 - Fixed an issue that could cause startup to fail with early access builds of

--- a/http/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/http/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -181,7 +181,7 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
             .field("number", Version.CURRENT.externalNumber())
             .field("build_hash", Build.CURRENT.hash())
             .field("build_timestamp", Build.CURRENT.timestamp())
-            .field("build_snapshot", Version.CURRENT.build)
+            .field("build_snapshot", Version.CURRENT.isSnapshot())
             .field("lucene_version", org.apache.lucene.util.Version.LATEST.toString())
             .endObject();
         builder.endObject();


### PR DESCRIPTION
The build number was used instead of the `isSnapshot()` boolean.
This results in falsely displaying CrateDB’s version as a ``—-SNAPSHOT`` version at the AdminUI.