### PR TITLE
Add execution and planner support for the filter clause in aggregate expressions.

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -29,6 +29,7 @@ import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
@@ -75,7 +76,8 @@ public class AggregateCollectorBenchmark {
             new AggregationFunction[] { sumAggregation },
             Version.CURRENT,
             BigArrays.NON_RECYCLING_INSTANCE,
-            new Input[] { inExpr0 }
+            new Input[][] { {inExpr0 } },
+            new Input[] { Literal.BOOLEAN_TRUE }
         );
     }
 

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -36,6 +36,7 @@ import io.crate.execution.engine.collect.collectors.LuceneBatchIterator;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LongColumnReference;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.types.DataTypes;
@@ -133,6 +134,7 @@ public class GroupingLongCollectorBenchmark {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAgg },
             new Input[][] { new Input[] { keyInput }},
+            new Input[] { Literal.BOOLEAN_TRUE },
             RAM_ACCOUNTING_CONTEXT,
             keyInput,
             Version.CURRENT,
@@ -150,6 +152,7 @@ public class GroupingLongCollectorBenchmark {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAgg },
             new Input[][] { new Input[] { keyInput }},
+            new Input[] { Literal.BOOLEAN_TRUE },
             RAM_ACCOUNTING_CONTEXT,
             keyInputs.get(0),
             DataTypes.LONG,

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -34,6 +34,7 @@ import io.crate.execution.engine.aggregation.impl.MinimumAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.types.DataTypes;
@@ -101,6 +102,7 @@ public class GroupingStringCollectorBenchmark {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { minAgg },
             new Input[][] { new Input[] { keyInput }},
+            new Input[] { Literal.BOOLEAN_TRUE },
             RAM_ACCOUNTING_CONTEXT,
             keyInputs.get(0),
             DataTypes.STRING,

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -30,6 +30,7 @@ import io.crate.execution.engine.aggregation.AggregateCollector;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.module.EnterpriseFunctionsModule;
@@ -85,7 +86,8 @@ public class HyperLogLogDistinctAggregationBenchmark {
             new AggregationFunction[] { hllAggregation },
             Version.CURRENT,
             BigArrays.NON_RECYCLING_INSTANCE,
-            new Input[] { inExpr0 }
+            new Input[][] { {inExpr0 } },
+            new Input[] { Literal.BOOLEAN_TRUE }
         );
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -63,6 +63,7 @@ import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -63,7 +63,6 @@ import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.symbol.Field;
-import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
@@ -31,9 +31,11 @@ public class AggregationContext {
 
     private final AggregationFunction impl;
     private final List<Input<?>> inputs = new ArrayList<>();
+    private final Input<?> filter;
 
-    public AggregationContext(AggregationFunction aggregationFunction) {
+    public AggregationContext(AggregationFunction aggregationFunction, Input<?> filter) {
         this.impl = aggregationFunction;
+        this.filter = filter;
     }
 
     public void addInput(Input<?> input) {
@@ -45,6 +47,10 @@ public class AggregationContext {
     }
 
     public Input<?>[] inputs() {
-        return inputs.toArray(new Input[inputs.size()]);
+        return inputs.toArray(new Input[0]);
+    }
+
+    public Input<?> filter() {
+        return filter;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -47,11 +47,14 @@ public class AggregationPipe implements Projector {
                            BigArrays bigArrays) {
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
         Input[][] inputs = new Input[aggregations.length][];
+        Input[] filters = new Input[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationContext aggregation = aggregations[i];
             functions[i] = aggregation.function();
             inputs[i] = aggregation.inputs();
+            filters[i] = aggregation.filter();
         }
+
         collector = new AggregateCollector(
             expressions,
             ramAccountingContext,
@@ -59,7 +62,8 @@ public class AggregationPipe implements Projector {
             functions,
             indexVersionCreated,
             bigArrays,
-            inputs
+            inputs,
+            filters
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -60,10 +60,12 @@ public class GroupingProjector implements Projector {
 
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
         Input[][] inputs = new Input[aggregations.length][];
+        Input[] filters = new Input[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationContext aggregation = aggregations[i];
             functions[i] = aggregation.function();
             inputs[i] = aggregation.inputs();
+            filters[i] = aggregation.filter();
         }
         if (keys.size() == 1) {
             Symbol key = keys.get(0);
@@ -74,6 +76,7 @@ public class GroupingProjector implements Projector {
                     mode,
                     functions,
                     inputs,
+                    filters,
                     ramAccountingContext,
                     keyInputs.get(0),
                     indexVersionCreated,
@@ -85,6 +88,7 @@ public class GroupingProjector implements Projector {
                     mode,
                     functions,
                     inputs,
+                    filters,
                     ramAccountingContext,
                     keyInputs.get(0),
                     key.valueType(),
@@ -99,6 +103,7 @@ public class GroupingProjector implements Projector {
                 mode,
                 functions,
                 inputs,
+                filters,
                 ramAccountingContext,
                 keyInputs,
                 typeView(keys),

--- a/sql/src/main/java/io/crate/expression/InputFactory.java
+++ b/sql/src/main/java/io/crate/expression/InputFactory.java
@@ -202,7 +202,8 @@ public class InputFactory {
         @Override
         public Input<?> visitAggregation(Aggregation symbol, Void context) {
             FunctionImplementation impl = functions.getQualified(symbol.functionIdent());
-            AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl);
+            Input<?> filter = process(symbol.filter(), context);
+            AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl, filter);
             for (Symbol aggInput : symbol.inputs()) {
                 aggregationContext.addInput(process(aggInput, context));
             }

--- a/sql/src/main/java/io/crate/expression/symbol/Aggregation.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Aggregation.java
@@ -27,30 +27,47 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 public class Aggregation extends Symbol {
 
     public Aggregation(StreamInput in) throws IOException {
         functionInfo = new FunctionInfo(in);
         valueType = DataTypes.fromStream(in);
+        if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
+            filter = Symbols.fromStream(in);
+        } else {
+            filter = Literal.BOOLEAN_TRUE;
+        }
         inputs = Symbols.listFromStream(in);
     }
 
     private final FunctionInfo functionInfo;
     private final List<Symbol> inputs;
     private final DataType valueType;
+    private final Symbol filter;
 
     public Aggregation(FunctionInfo functionInfo, DataType valueType, List<Symbol> inputs) {
-        Preconditions.checkNotNull(inputs, "inputs are null");
+        this(functionInfo, valueType, inputs, Literal.BOOLEAN_TRUE);
+    }
+
+    public Aggregation(FunctionInfo functionInfo,
+                       DataType valueType,
+                       List<Symbol> inputs,
+                       Symbol filter) {
+        Preconditions.checkNotNull(inputs, "inputs must not be null");
+        Preconditions.checkNotNull(filter, "filter must not be null");
 
         this.valueType = valueType;
         this.functionInfo = functionInfo;
         this.inputs = inputs;
+        this.filter = filter;
     }
 
     @Override
@@ -76,12 +93,19 @@ public class Aggregation extends Symbol {
         return inputs;
     }
 
+    public Symbol filter() {
+        return filter;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         functionInfo.writeTo(out);
-
         DataTypes.toStream(valueType, out);
+        if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
+            Symbols.toStream(filter, out);
+        }
         Symbols.toStream(inputs, out);
+
     }
 
     @Override
@@ -92,6 +116,27 @@ public class Aggregation extends Symbol {
     @Override
     public String representation() {
         return "Aggregation{" + functionInfo.ident().name() +
-               ", args=[" + ExplainLeaf.printList(inputs) + "]}";
+               ", args=[" + ExplainLeaf.printList(inputs) + "]" +
+               ", filter=" + filter.representation() + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Aggregation that = (Aggregation) o;
+        return Objects.equals(functionInfo, that.functionInfo) &&
+               Objects.equals(inputs, that.inputs) &&
+               Objects.equals(valueType, that.valueType) &&
+               Objects.equals(filter, that.filter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(functionInfo, inputs, valueType, filter);
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
@@ -38,6 +38,10 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
         for (Symbol arg : symbol.arguments()) {
             process(arg, context);
         }
+        var filter = symbol.filter();
+        if (filter != null) {
+            process(filter, context);
+        }
         return null;
     }
 

--- a/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -62,7 +62,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         ArrayList<Symbol> newArgs = new ArrayList<>(args.size());
 
         Symbol filter = func.filter();
-        Symbol newFilter = processSafe(filter, context);
+        Symbol newFilter = processNullable(filter, context);
 
         boolean changed = false;
         for (Symbol arg : args) {
@@ -90,7 +90,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         Symbol newArg2 = requireNonNull(process(arg2, context), "function arguments must never be NULL");
 
         Symbol filter = func.filter();
-        Symbol newFilter = processSafe(filter, context);
+        Symbol newFilter = processNullable(filter, context);
 
         if (arg1 == newArg1 && arg2 == newArg2 && filter == newFilter) {
             return func;
@@ -104,7 +104,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         Symbol newArg = requireNonNull(process(arg, context), "function arguments must never be NULL");
 
         Symbol filter = func.filter();
-        Symbol newFilter = processSafe(filter, context);
+        Symbol newFilter = processNullable(filter, context);
 
         if (arg == newArg && filter == newFilter) {
             return func;
@@ -113,9 +113,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
     }
 
     @Nullable
-    private Symbol processSafe(@Nullable Symbol symbol, C context) {
+    private Symbol processNullable(@Nullable Symbol symbol, C context) {
         if (symbol != null) {
-            return process(symbol, context);
+            return symbol.accept(this, context);
         }
         return null;
     }

--- a/sql/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
@@ -107,7 +107,7 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(splitPoints.toCollect(), contains(
             isReference("i"),
-            isFunction("op_>", isField("x"), isLiteral(1)))
+            isFunction("op_>", isReference("x"), isLiteral(1)))
         );
         assertThat(splitPoints.aggregates(), contains(isFunction("sum")));
     }

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/GroupBySingleNumberCollectorTest.java
@@ -34,6 +34,7 @@ import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.test.integration.CrateUnitTest;
@@ -72,6 +73,7 @@ public class GroupBySingleNumberCollectorTest extends CrateUnitTest {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[]{sumAgg},
             new Input[][]{new Input[]{keyInput}},
+            new Input[] {Literal.BOOLEAN_TRUE},
             RAM_ACCOUNTING_CONTEXT,
             keyInput,
             Version.CURRENT,

--- a/sql/src/test/java/io/crate/expression/symbol/AggregationTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/AggregationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class AggregationTest extends CrateUnitTest {
+
+    @Test
+    public void test_serialization_with_filter() throws Exception {
+        Aggregation actual = new Aggregation(
+            CountAggregation.COUNT_STAR_FUNCTION,
+            CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+            List.of(),
+            Literal.BOOLEAN_FALSE
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+        Symbols.toStream(actual, output);
+
+        StreamInput input = output.bytes().streamInput();
+        Aggregation expected = (Aggregation) Symbols.fromStream(input);
+
+        assertThat(expected.filter(), is(Literal.BOOLEAN_FALSE));
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void test_serialization_with_filter_before_version_4_1_0() throws Exception {
+        Aggregation actual = new Aggregation(
+            CountAggregation.COUNT_STAR_FUNCTION,
+            CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+            List.of()
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(Version.V_4_0_0);
+        Symbols.toStream(actual, output);
+
+        StreamInput input = output.bytes().streamInput();
+        input.setVersion(Version.V_4_0_0);
+
+        Aggregation expected = (Aggregation) Symbols.fromStream(input);
+
+        assertThat(expected.filter(), is(Literal.BOOLEAN_TRUE));
+        assertThat(expected, is(actual));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static io.crate.testing.TestingHelpers.printedTable;
+
+public class AggregateExpressionIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void test_filter_in_aggregate_expr_with_group_by() {
+        execute("SELECT" +
+                "   y, " +
+                "   COLLECT_SET(x) FILTER (WHERE x > 3), " +
+                "   COLLECT_SET(x) FILTER (WHERE x > 2) " +
+                "FROM UNNEST(" +
+                "   [1, 3, 4, 3, 5, 4]," +
+                "   ['a', 'a', 'a', 'b', 'b', 'b']) as t(x, y) " +
+                "GROUP BY y " +
+                "ORDER BY y");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("a| [4]| [3, 4]\n" +
+                               "b| [4, 5]| [3, 4, 5]\n")
+        );
+    }
+
+    @Test
+    public void test_filter_in_aggregate_expr_with_group_by_column_with_nulls() {
+        execute("SELECT" +
+                "   y, " +
+                "   COLLECT_SET(x) FILTER (WHERE x > 3) " +
+                "FROM UNNEST(" +
+                "   [1, 4, 3, 5, 4]," +
+                "   ['a', 'a', null, null, null]) AS t(x, y) " +
+                "GROUP BY y " +
+                "ORDER BY y");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("a| [4]\n" +
+                               "NULL| [4, 5]\n")
+        );
+    }
+
+    @Test
+    public void test_filter_in_aggregate_expr_for_global_aggregate() {
+        execute("SELECT" +
+                "   COLLECT_SET(x) FILTER (WHERE x > 3), " +
+                "   collect_set(x) FILTER (WHERE x > 2) " +
+                "FROM UNNEST([1, 3, 4, 2, 5, 4]) AS t(x, y)");
+        assertThat(printedTable(response.rows()), Matchers.is("[4, 5]| [3, 4, 5]\n"));
+    }
+
+    // grouping by a single numeric value would result in a different
+    // code path where the optimized version of the grouping collector is used
+    @Test
+    public void test_filter_in_aggregate_expr_with_group_by_single_number() {
+        execute("SELECT" +
+                "   COLLECT_SET(x) FILTER (WHERE x > 1) " +
+                "FROM UNNEST(" +
+                "   [1, 2, 1, 3]," +
+                "   [1, 1, 2, 2]) AS t(x, y) " +
+                "GROUP BY y");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("[2]\n" +
+                               "[3]\n"));
+    }
+
+    @Test
+    public void test_filter_in_aggregate_expr_with_group_by_single_numeric_column_with_nulls() {
+        execute("SELECT" +
+                "   COLLECT_SET(x) FILTER (WHERE x > 1) " +
+                "FROM unnest(" +
+                "   [1, 2, 1, 3]," +
+                "   [1, 1, null, null]) AS t(x, y) " +
+                "GROUP BY y");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("[2]\n" +
+                               "[3]\n"));
+    }
+
+    @Test
+    public void test_filter_with_subquery_in_aggregate_expr_for_global_aggregate() {
+        execute("SELECT" +
+                "   COLLECT_SET(x) FILTER (WHERE x in (SELECT UNNEST([1, 3]))) " +
+                "FROM UNNEST([1, 2]) AS t(x)");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("[1]\n"));
+    }
+
+    @Test
+    public void test_filter_with_subquery_in_aggregate_expr_for_group_by_aggregates() {
+        execute("SELECT" +
+                "   y, " +
+                "   COLLECT_SET(x) FILTER (WHERE x in (SELECT UNNEST([1, 4]))), " +
+                "   COLLECT_SET(x) FILTER (WHERE x in (SELECT UNNEST([3, 5]))) " +
+                "FROM UNNEST(" +
+                "   [1, 3, 4, 3, 5, 4]," +
+                "   ['a', 'a', 'a', 'b', 'b', 'b']) as t(x, y) " +
+                "GROUP BY y " +
+                "ORDER BY y");
+        assertThat(printedTable(response.rows()),
+                   Matchers.is("a| [1, 4]| [3]\n" +
+                               "b| [4]| [3, 5]\n"));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -82,8 +82,8 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                "collectPhase={COLLECT={type=executionPhase, id=0, executionNodes=[n1], " +
                    "distribution={distributedByColumn=0, type=BROADCAST}, toCollect=Ref{doc.t1.x, integer}, Ref{doc.t1.a, text}, " +
                    "projections=[" +
-                       "{type=HashAggregation, keys=IC{1, text}, aggregations=Aggregation{max, args=[IC{0, integer}]}}, " +
-                       "{type=HashAggregation, keys=IC{0, text}, aggregations=Aggregation{max, args=[IC{1, integer}]}}, " +
+                       "{type=HashAggregation, keys=IC{1, text}, aggregations=Aggregation{max, args=[IC{0, integer}], filter=true}}, " +
+                       "{type=HashAggregation, keys=IC{0, text}, aggregations=Aggregation{max, args=[IC{1, integer}], filter=true}}, " +
                        "{type=Filter, filter=IC{1, integer} > 10}, " +
                        "{type=OrderByTopN, limit=-1, offset=0, outputs=IC{0, text}, IC{1, integer}, orderBy=[IC{0, text} ASC]}], " +
                     "routing={n1={t1=[0, 1, 2, 3]}}, where=true}}}}"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
