### PR TITLE
Change return type of table functions to Iterable

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -25,7 +25,6 @@ package io.crate.execution.engine.collect.sources;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.OrderBy;
 import io.crate.data.BatchIterator;
-import io.crate.data.Bucket;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -39,9 +38,9 @@ import io.crate.execution.engine.collect.ValueAndInputRow;
 import io.crate.expression.InputCondition;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import org.elasticsearch.common.inject.Inject;
@@ -80,9 +79,9 @@ public class TableFunctionCollectSource implements CollectSource {
             topLevelInputs.add(ctx.add(symbol));
         }
 
-        Bucket buckets = functionImplementation.evaluate(txnCtx, inputs.toArray(new Input[0]));
+        Iterable<Row> result = functionImplementation.evaluate(txnCtx, inputs.toArray(new Input[0]));
         Iterable<Row> rows = Iterables.transform(
-            buckets,
+            result,
             new ValueAndInputRow<>(topLevelInputs, ctx.expressions()));
         Input<Boolean> condition = (Input<Boolean>) ctx.add(phase.where());
         rows = Iterables.filter(rows, InputCondition.asPredicate(condition));

--- a/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
@@ -22,18 +22,18 @@
 
 package io.crate.metadata.tablefunctions;
 
-import io.crate.data.Bucket;
+import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 
 /**
  * Interface which needs to be implemented by functions returning whole tables as result.
  */
-public abstract class TableFunctionImplementation<T> extends Scalar<Bucket, T> {
+public abstract class TableFunctionImplementation<T> extends Scalar<Iterable<Row>, T> {
 
     @Override
     public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {

--- a/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -24,8 +24,10 @@ package io.crate.expression.tablefunctions;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.data.ArrayBucket;
 import io.crate.data.Bucket;
 import io.crate.data.Input;
+import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -54,13 +56,15 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
         functions = sqlExpressions.getInstance(Functions.class);
     }
 
-    protected Bucket execute(String expr) {
+    protected Iterable<Row> execute(String expr) {
         Symbol functionSymbol = sqlExpressions.asSymbol(expr);
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
         TableFunctionImplementation<?> tableFunction = (TableFunctionImplementation) functions.getQualified(ident);
-        return tableFunction.evaluate(txnCtx, function.arguments().stream().map(a -> (Input) a).toArray(Input[]::new));
+        return tableFunction.evaluate(
+            txnCtx,
+            function.arguments().stream().map(a -> (Input) a).toArray(Input[]::new));
     }
 
     protected void assertExecute(String expr, String expected) {

--- a/sql/src/test/java/io/crate/expression/tablefunctions/EmptyRowTableFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/EmptyRowTableFunctionTest.java
@@ -22,7 +22,8 @@
 
 package io.crate.expression.tablefunctions;
 
-import io.crate.data.Bucket;
+import com.google.common.collect.Iterables;
+import io.crate.data.Row;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -36,7 +37,7 @@ public class EmptyRowTableFunctionTest extends AbstractTableFunctionsTest {
 
     @Test
     public void testEmptyRowReturnsOneRow() {
-        Bucket result = execute("empty_row()");
-        assertThat(result.size(), is(1));
+        Iterable<Row> result = execute("empty_row()");
+        assertThat(Iterables.size(result), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -26,8 +26,6 @@ import com.google.common.collect.Ordering;
 import io.crate.analyze.where.DocKeys;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Sorted;
-import io.crate.data.Bucket;
-import io.crate.data.Buckets;
 import io.crate.data.Row;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.window.WindowFunctionModule;
@@ -72,6 +70,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -92,8 +91,11 @@ public class TestingHelpers {
         return printRows(Arrays.asList(result));
     }
 
-    public static String printedTable(Bucket result) {
-        return printRows(Arrays.asList(Buckets.materialize(result)));
+    public static String printedTable(Iterable<Row> result) {
+        return printRows(StreamSupport.stream(result.spliterator(), false)
+            .map(Row::materialize)
+            ::iterator
+        );
     }
 
     public static String printRows(Iterable<Object[]> rows) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We don't need the `Bucket`s `size` property, so we can change the return
type to `Iterable`, which will allow us to make some implementations a
bit simpler as we do not have to calculate the final result-size
up-front.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)