### PR TITLE
Fix selecting columns twice under different output name

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -95,6 +95,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue with using the same column under a different name/alias inside
+  more complex queries. Example:
+  ``SELECT count(*), t.x, t.x AS tx FROM t GROUP BY t.x``
+
 - Fixed an issue with the ``collect_set`` function. It could compute an
   incorrect result if used as a window function with shrinking window frames.
 

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -271,22 +271,4 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             (QueriedSelectRelation<AbstractTableRelation<?>>) ((AliasedAnalyzedRelation) relation.subRelation()).relation();
         assertThat(queriedTable.subRelation().tableInfo(), is(t1Info));
     }
-
-    @Test
-    public void testPreserveMultipleAliasesOnSubSelect() throws Exception {
-        QueriedSelectRelation<?> relation =
-            analyze("SELECT tt1.i, i as ii, tt1.ii + 2, ii as iii, abs(x), abs(tt1.x) as absx " +
-                    "FROM (select i, i+1 as ii, x from t1) as tt1");
-        assertThat(relation.fields().size(), is(6));
-        assertThat(relation.fields().get(0), isField("i"));
-        assertThat(relation.fields().get(1), isField("ii"));
-        assertThat(relation.fields().get(2), isField("(ii + 2)"));
-        assertThat(relation.fields().get(3), isField("iii"));
-        assertThat(relation.fields().get(4), isField("abs(x)"));
-        assertThat(relation.fields().get(5), isField("absx"));
-
-        QueriedSelectRelation<AbstractTableRelation<?>> queriedTable =
-            (QueriedSelectRelation<AbstractTableRelation<?>>) ((AliasedAnalyzedRelation) relation.subRelation()).relation();
-        assertThat(queriedTable.subRelation().tableInfo(), is(t1Info));
-    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/RelationAliasITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RelationAliasITest.java
@@ -60,4 +60,17 @@ public class RelationAliasITest extends SQLTransportIntegrationTest {
                                                      "40| 2.5| 40.0\n" +
                                                      "50| 3.0| 40.0\n"));
     }
+
+    @Test
+    public void testSameColumnWithDifferentOutputNamesAndARelationBoundary() {
+        execute("create table t1 (id int, a text)");
+        execute("insert into t1 (id, a) values (1, 'foo'), (2, 'foo'), (3, 'bar')");
+        refresh();
+        execute("select count(*) as cnt, t.a as a_alias, t.a" +
+                " from t1 t" +
+                " group by 2" +
+                " order by 1");
+        assertThat(printedTable(response.rows()), is("1| bar| bar\n" +
+                                                     "2| foo| foo\n"));
+    }
 }


### PR DESCRIPTION
If a column is selected multiple times using different identifiers (e.g. once using the real column identifier and second using an alias), one of the columns wasn’t found if a relation boundary exists.
