### PR TITLE
Fix value removal logic in `collect_set`

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue with the ``collect_set`` function. It could compute an
+  incorrect result if used as a window function with shrinking window frames.
+
 - Fixed an issue with the version payload returned by HTTP, which resulted in
   falsely displaying CrateDB's version as a ``-SNAPSHOT`` version at the AdminUI.
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -218,8 +218,11 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
             if (value == null) {
                 return previousAggState;
             }
-            Long occurrencesCountForValue = previousAggState.get(value);
-            if (occurrencesCountForValue == 1) {
+            Long numTimesValueSeen = previousAggState.get(value);
+            if (numTimesValueSeen == null) {
+                return previousAggState;
+            }
+            if (numTimesValueSeen == 1) {
                 previousAggState.remove(value);
                 ramAccountingContext.addBytes(
                     // we initially accounted for values size + 32 bytes for entry, 4 bytes for increased capacity
@@ -227,7 +230,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
                     -RamAccountingContext.roundUp(innerTypeEstimator.estimateSize(value) + 48L)
                 );
             } else {
-                occurrencesCountForValue--;
+                previousAggState.put(value, numTimesValueSeen - 1);
             }
             return previousAggState;
         }

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
@@ -73,6 +74,24 @@ public class CollectSetAggregationTest extends AggregationTest {
 
         Object newState = impl.partialType().streamer().readValueFrom(streamOutput.bytes().streamInput());
         assertEquals(state, newState);
+    }
+
+    @Test
+    public void test_value_adding_and_removal() {
+        AggregationFunction impl = (AggregationFunction) functions.get(
+            null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+        AggregationFunction aggregationFunction = impl.optimizeForExecutionAsWindowFunction();
+
+        Object state = aggregationFunction.newState(
+            ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+        state = aggregationFunction.iterate(ramAccountingContext, state, Literal.of(10));
+        state = aggregationFunction.iterate(ramAccountingContext, state, Literal.of(10));
+
+        aggregationFunction.removeFromAggregatedState(ramAccountingContext, state, new Input[] { Literal.of(10) });
+        aggregationFunction.removeFromAggregatedState(ramAccountingContext, state, new Input[] { Literal.of(10) });
+
+        Object values = aggregationFunction.terminatePartial(ramAccountingContext, state);
+        assertThat((List<Object>) values, Matchers.empty());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If a value was collected more than once and removed the same number of
times it still appeared in the result.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)