### PR TITLE
Extend generate_series to support timestamp / intervals

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ Breaking Changes
 Changes
 =======
 
+- Extended :ref:`table-functions-generate-series` to work with timestamp and
+  interval types.
+
 - Added support for the filter clause in the
   :ref:`aggregate expressions <aggregate-expressions>`.
 

--- a/blackbox/docs/general/builtins/table-functions.rst
+++ b/blackbox/docs/general/builtins/table-functions.rst
@@ -100,17 +100,23 @@ possible to access values of the object using the subscript notation::
     cr> select col1['x'] from unnest([{x=10}]);
     SQLActionException[ColumnUnknownException: Column col1['x'] unknown]
 
-.. table-functions-generate-series:
+.. _table-functions-generate-series:
 
 ``generate_series(start, stop, [step])``
 ========================================
 
 Generate a series of values from inclusive start to inclusive stop with
 ``step`` increments.
-The ``step`` parameter is optional and defaults to 1.
 
-The arguments can be either of type ``integer`` or ``bigint`` and the return
-value will match the argument types.
+The argument can be ``integer`` or ``bigint``, in which case ``step`` is
+optional and defaults to ``1``.
+
+``start`` and ``stop`` can also be of type ``timestamp with time zone`` or
+``timestamp without time zone`` in which case ``step`` is required and must be
+of type ``interval``.
+
+The return value always matches the ``start`` / ``stop`` types.
+
 
 ::
 
@@ -124,3 +130,18 @@ value will match the argument types.
     |    4 |
     +------+
     SELECT 4 rows in set (... sec)
+
+::
+
+    cr> SELECT 
+    ...     x,
+    ...     date_format('%Y-%m-%d, %H:%i', x) 
+    ...     FROM generate_series('2019-01-01 00:00'::timestamp, '2019-01-04 00:00'::timestamp, '30 hours'::interval) AS t(x);
+    +---------------+-----------------------------------+
+    |             x | date_format('%Y-%m-%d, %H:%i', x) |
+    +---------------+-----------------------------------+
+    | 1546300800000 | 2019-01-01, 00:00                 |
+    | 1546408800000 | 2019-01-02, 06:00                 |
+    | 1546516800000 | 2019-01-03, 12:00                 |
+    +---------------+-----------------------------------+
+    SELECT 3 rows in set (... sec)

--- a/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -47,9 +47,16 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.IntegerType;
+import io.crate.types.LongType;
+import io.crate.types.TimestampType;
 import org.elasticsearch.cluster.ClusterState;
+import org.joda.time.Period;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -57,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
 
 /**
  * <pre>
@@ -83,19 +91,41 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
     private final Comparator<T> comparator;
 
     public static void register(TableFunctionModule module) {
-        Param longOrInt = Param.of(DataTypes.LONG, DataTypes.INTEGER);
+        Param startAndEnd = Param.of(DataTypes.LONG, DataTypes.INTEGER, DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP);
+        Param stepType = Param.of(DataTypes.LONG, DataTypes.INTEGER, DataTypes.INTERVAL);
         FuncParams.Builder paramsBuilder = FuncParams
-            .builder(longOrInt, longOrInt)
-            .withVarArgs(longOrInt)
+            .builder(startAndEnd, startAndEnd)
+            .withVarArgs(stepType)
             .limitVarArgOccurrences(1);
         module.register(NAME, new BaseFunctionResolver(paramsBuilder.build()) {
             @Override
             public FunctionImplementation getForTypes(List<DataType> types) throws IllegalArgumentException {
-                DataType dataType = types.get(0);
-                if (dataType.equals(DataTypes.INTEGER)) {
-                    return new GenerateSeries<>(types, 1, (x, y) -> x - y, (x, y) -> x + y, (x, y) -> x / y, Integer::compare);
-                } else {
-                    return new GenerateSeries<>(types, 1L, (x, y) -> x - y, (x, y) -> x + y, (x, y) -> x / y, Long::compare);
+                DataType startType = types.get(0);
+                DataType stopType = types.get(1);
+                assert startType.equals(stopType) : "Start and stop type must be the same, got: " + startType + " and " + stopType;
+                if (types.size() == 2 && !startType.equals(DataTypes.INTEGER) && !startType.equals(DataTypes.LONG)) {
+                    throw new IllegalArgumentException(
+                        "generate_series(start, stop) has type `" + startType.getName() +
+                        "` for start, but requires long/int values for start and stop, " +
+                        "or if used with timestamps, it requires a third argument for the step (interval)");
+                }
+                switch (stopType.id()) {
+                    case IntegerType.ID:
+                        return new GenerateSeries<>(types, 1, (x, y) -> x - y, Integer::sum, (x, y) -> x / y, Integer::compare);
+
+                    case LongType.ID:
+                        return new GenerateSeries<>(types, 1L, (x, y) -> x - y, Long::sum, (x, y) -> x / y, Long::compare);
+
+                    case TimestampType.ID_WITH_TZ:
+                    case TimestampType.ID_WITHOUT_TZ:
+                        return new GenerateSeriesIntervals(types);
+
+                    default:
+                        var typeNames = types.stream()
+                            .map(DataType::getName)
+                            .collect(Collectors.joining(", "));
+                        throw new IllegalArgumentException(
+                            "Couldn't find variant of generate_series(start, stop [, step]) that matches the given types: " + typeNames);
                 }
             }
         });
@@ -119,28 +149,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
 
     @Override
     public TableInfo createTableInfo() {
-        ColumnIdent col1 = new ColumnIdent("col1");
-        Reference reference = new Reference(new ReferenceIdent(RELATION_NAME, col1),
-                                            RowGranularity.DOC,
-                                            info.returnType(),
-                                            1,
-                                            null);
-        Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col1, reference);
-        return new StaticTableInfo(RELATION_NAME, referenceByColumn, Collections.singletonList(reference), Collections.emptyList()) {
-            @Override
-            public Routing getRouting(ClusterState state,
-                                      RoutingProvider routingProvider,
-                                      WhereClause whereClause,
-                                      RoutingProvider.ShardSelection shardSelection,
-                                      SessionContext sessionContext) {
-                return Routing.forTableOnSingleNode(RELATION_NAME, state.getNodes().getLocalNodeId());
-            }
-
-            @Override
-            public RowGranularity rowGranularity() {
-                return RowGranularity.DOC;
-            }
-        };
+        return tableWith1Col(info.returnType());
     }
 
     @Override
@@ -201,5 +210,107 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    private static TableInfo tableWith1Col(DataType<?> returnType) {
+        ColumnIdent col1 = new ColumnIdent("col1");
+        Reference reference = new Reference(
+            new ReferenceIdent(RELATION_NAME, col1),
+            RowGranularity.DOC,
+            returnType,
+            1,
+            null
+        );
+        Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col1, reference);
+        return new StaticTableInfo(RELATION_NAME, referenceByColumn, Collections.singletonList(reference), Collections.emptyList()) {
+            @Override
+            public Routing getRouting(ClusterState state,
+                                      RoutingProvider routingProvider,
+                                      WhereClause whereClause,
+                                      RoutingProvider.ShardSelection shardSelection,
+                                      SessionContext sessionContext) {
+                return Routing.forTableOnSingleNode(RELATION_NAME, state.getNodes().getLocalNodeId());
+            }
+
+            @Override
+            public RowGranularity rowGranularity() {
+                return RowGranularity.DOC;
+            }
+        };
+    }
+
+    private static class GenerateSeriesIntervals extends TableFunctionImplementation<Object> {
+
+        private final FunctionInfo info;
+
+        public GenerateSeriesIntervals(List<DataType> types) {
+            FunctionIdent functionIdent = new FunctionIdent(NAME, types);
+            DataType returnType = types.get(0);
+            this.info = new FunctionInfo(functionIdent, returnType, FunctionInfo.Type.TABLE);
+        }
+
+        @Override
+        public FunctionInfo info() {
+            return info;
+        }
+
+
+        @Override
+        public TableInfo createTableInfo() {
+            return tableWith1Col(info.returnType());
+        }
+
+        @Override
+        public Iterable<Row> evaluate(TransactionContext txnCtx, Input<Object>... args) {
+            Long startInclusive = (Long) args[0].value();
+            Long stopInclusive = (Long) args[1].value();
+            Period step = (Period) args[2].value();
+            if (startInclusive == null || stopInclusive == null || step == null) {
+                return Bucket.EMPTY;
+            }
+            ZonedDateTime start = Instant.ofEpochMilli(startInclusive).atZone(ZoneOffset.UTC);
+            ZonedDateTime stop = Instant.ofEpochMilli(stopInclusive).atZone(ZoneOffset.UTC);
+
+            boolean reverse = start.compareTo(stop) > 0;
+
+            return () -> new Iterator<>() {
+
+                final Object[] cells = new Object[1];
+                final RowN rowN = new RowN(cells);
+
+                ZonedDateTime value = start;
+                boolean doStep = false;
+
+                @Override
+                public boolean hasNext() {
+                    if (doStep) {
+                        value = value
+                            .plusYears(step.getYears())
+                            .plusMonths(step.getMonths())
+                            .plusWeeks(step.getWeeks())
+                            .plusDays(step.getDays())
+                            .plusHours(step.getHours())
+                            .plusMinutes(step.getMinutes())
+                            .plusSeconds(step.getSeconds())
+                            .plusNanos(step.getMillis() * 1000_0000);
+                        doStep = false;
+                    }
+                    int compare = value.compareTo(stop);
+                    return reverse
+                        ? compare >= 0
+                        : compare <= 0;
+                }
+
+                @Override
+                public Row next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException("No more element in generate_series");
+                    }
+                    doStep = true;
+                    cells[0] = (value.toEpochSecond() * 1000);
+                    return rowN;
+                }
+            };
+        }
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
@@ -100,4 +100,44 @@ public class GenerateSeriesTest extends AbstractTableFunctionsTest {
             "2\n"
         );
     }
+
+    @Test
+    public void test_generate_interval_from_start_date_to_end_date_with_10_hours_interval() {
+        assertExecute(
+            "generate_series('2008-03-01 00:00'::timestamp, '2008-03-04 12:00'::timestamp, '10 hours'::interval)",
+            "1204329600000\n" +
+            "1204365600000\n" +
+            "1204401600000\n" +
+            "1204437600000\n" +
+            "1204473600000\n" +
+            "1204509600000\n" +
+            "1204545600000\n" +
+            "1204581600000\n" +
+            "1204617600000\n"
+        );
+    }
+
+    @Test
+    public void test_generate_interval_from_start_date_to_end_date_with_minus_10_hours_interval() {
+        assertExecute(
+            "generate_series('2008-03-05 00:00'::timestamp, '2008-03-04 12:00'::timestamp, '-10 hours'::interval)",
+            "1204675200000\n" +
+            "1204639200000\n"
+        );
+    }
+
+    @Test
+    public void test_generate_series_with_interval_and_null_values_results_in_empty_result() {
+        assertExecute(
+            "generate_series(null::timestamp, '2019-03-04'::timestamp, '1 days'::interval)",
+            ""
+        );
+    }
+
+    @Test
+    public void test_step_is_mandatory_for_timestamps() {
+        expectedException.expectMessage(
+            "generate_series(start, stop) has type `timestamp with time zone` for start, but requires long/int values for start and stop, or if used with timestamps, it requires a third argument for the step (interval)");
+        assertExecute("generate_series(null::timestamp, '2019-03-04'::timestamp)", "");
+    }
 }


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)