### PR TITLE
Add Interval support

### DIFF
--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -184,8 +184,10 @@ CrateDB::
     | 1115 | _timestamp without time zone |        0 |    1114 |     -1 |
     | 1184 | timestamptz                  |     1185 |       0 |      8 |
     | 1185 | _timestamptz                 |        0 |    1184 |     -1 |
+    | 1186 | interval                     |     1187 |       0 |     16 |
+    | 1187 | _interval                    |        0 |    1186 |     -1 |
     +------+------------------------------+----------+---------+--------+
-    SELECT 25 rows in set (... sec)
+    SELECT 27 rows in set (... sec)
 
 
 .. NOTE::

--- a/common/src/main/java/io/crate/interval/IntervalParser.java
+++ b/common/src/main/java/io/crate/interval/IntervalParser.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import org.joda.time.Period;
+import org.joda.time.format.ISOPeriodFormat;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+
+public final class IntervalParser {
+
+    public enum Precision {
+        YEAR,
+        MONTH,
+        DAY,
+        HOUR,
+        MINUTE,
+        SECOND
+    }
+
+    private IntervalParser() { }
+
+    /**
+     * Parses a period from the given text, returning a new Period.
+     * The following text formats are supported:
+     * <p>
+     * SQL Standard 'Y-M D H:M:S'
+     * ISO 8601 'P1Y2M3DT4H5M6S'
+     * PostgreSQL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'
+     * Abbreviated PostgreSQL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'
+     *
+     * @param value  text to parse
+     * @return parsed value in a Period object
+     * @throws IllegalArgumentException if the text does not fulfill any of the format
+     */
+    public static Period apply(String value) {
+        return apply(value, null, null);
+    }
+
+    /**
+     * Parses a period from the given text, returning a new Period.
+     * The following text formats are supported:
+     * <p>
+     * SQL Standard 'Y-M D H:M:S'
+     * ISO 8601 'P1Y2M3DT4H5M6S'
+     * PostgreSQL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'
+     * Abbreviated PostgreSQL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'
+     *
+     * @param value  text to parse
+     * @param start  start of the precision
+     * @param end    end of the precision
+     * @return parsed value in a Period object
+     * @throws IllegalArgumentException if the text does not fulfill any of the format
+     */
+    public static Period apply(String value, @Nullable Precision start, @Nullable Precision end) {
+        if (value == null || value.isEmpty() || value.isBlank()) {
+            throw new IllegalArgumentException("Invalid interval format  " + value);
+        }
+
+        Period result;
+        try {
+            result = NumericalIntervalParser.apply(value, start, end);
+        } catch (IllegalArgumentException e1) {
+            try {
+                result = roundToPrecision(ISOPeriodFormat.standard().parsePeriod(value), start, end);
+            } catch (IllegalArgumentException e2) {
+                try {
+                    result = SQLStandardIntervalParser.apply(value, start, end);
+                } catch (IllegalArgumentException e3) {
+                    result = PGIntervalParser.apply(value, start, end);
+                }
+            }
+        }
+        return result.normalizedStandard();
+    }
+
+    static Period roundToPrecision(Period period, Precision start, Precision end) {
+        if (start == null && end == null) {
+            return period;
+        }
+        if (start == Precision.YEAR) {
+            if (end == null) {
+                return Period.years(period.getYears());
+            }
+            if (end == Precision.MONTH) {
+                return Period.years(period.getYears()).withMonths(period.getMonths());
+            }
+        }
+        if (start == Precision.MONTH && end == null) {
+            return Period.years(period.getYears()).withMonths(period.getMonths());
+        }
+        if (start == Precision.DAY) {
+            if (end == null) {
+                return period.withHours(0).withMinutes(0).withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.HOUR) {
+                return period.withMinutes(0).withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.MINUTE) {
+                return period.withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.SECOND) {
+                return period.withMillis(0);
+            }
+        }
+        if (start == Precision.HOUR) {
+            if (end == null) {
+                return period.withMinutes(0).withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.MINUTE) {
+                return period.withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.SECOND) {
+                return period.withMillis(0);
+            }
+        }
+        if (start == Precision.MINUTE) {
+            if (end == null) {
+                return period.withSeconds(0).withMillis(0);
+            }
+            if (end == Precision.SECOND) {
+                return period.withMillis(0);
+            }
+        }
+        if (start == Precision.SECOND && end == null) {
+            return period.withMillis(0);
+        }
+        throw new IllegalArgumentException("Invalid start and end combination");
+    }
+
+    static int parseMilliSeconds(String value) throws NumberFormatException {
+        BigDecimal decimal = new BigDecimal(value);
+        return decimal
+            .subtract(new BigDecimal(decimal.intValue()))
+            .multiply(new BigDecimal(1000)).intValue();
+    }
+
+    static int parseInteger(String value) {
+        return new BigDecimal(value).intValue();
+    }
+
+    static int nullSafeIntGet(String value) {
+        return (value == null) ? 0 : Integer.parseInt(value);
+    }
+}

--- a/common/src/main/java/io/crate/interval/NumericalIntervalParser.java
+++ b/common/src/main/java/io/crate/interval/NumericalIntervalParser.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+
+import static io.crate.interval.IntervalParser.parseInteger;
+import static io.crate.interval.IntervalParser.parseMilliSeconds;
+
+
+final class NumericalIntervalParser {
+
+    private NumericalIntervalParser() {
+    }
+
+    static Period apply(String value) {
+        return apply(value, null, null);
+    }
+
+    static Period apply(String value,
+                        @Nullable IntervalParser.Precision start,
+                        @Nullable IntervalParser.Precision end) {
+        try {
+            return roundToPrecision(parseInteger(value), parseMilliSeconds(value), start, end);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid interval format " + value);
+        }
+    }
+
+    private static Period roundToPrecision(int value,
+                                           int millis,
+                                           @Nullable IntervalParser.Precision start,
+                                           @Nullable IntervalParser.Precision end) {
+        if (start == null && end == null) {
+            return buildSecondsWithMillisPeriod(value, millis);
+        }
+        if (start == IntervalParser.Precision.YEAR) {
+            if (end == null) {
+                return Period.years(value);
+            }
+            if (end == IntervalParser.Precision.MONTH) {
+                return Period.months(value);
+            }
+        }
+        if (start == IntervalParser.Precision.MONTH && end == null) {
+            return Period.months(value);
+        }
+        if (start == IntervalParser.Precision.DAY) {
+            if (end == null) {
+                return Period.days(value);
+            }
+            if (end == IntervalParser.Precision.HOUR) {
+                return Period.hours(value);
+            }
+            if (end == IntervalParser.Precision.MINUTE) {
+                return Period.minutes(value);
+            }
+            if (end == IntervalParser.Precision.SECOND) {
+                return buildSecondsWithMillisPeriod(value, millis);
+            }
+        }
+        if (start == IntervalParser.Precision.HOUR) {
+            if (end == null) {
+                return Period.hours(value);
+            }
+            if (end == IntervalParser.Precision.MINUTE) {
+                return Period.minutes(value);
+            }
+            if (end == IntervalParser.Precision.SECOND) {
+                return buildSecondsWithMillisPeriod(value, millis);
+            }
+        }
+        if (start == IntervalParser.Precision.MINUTE) {
+            if (end == null) {
+                return Period.minutes(value);
+            }
+            if (end == IntervalParser.Precision.SECOND) {
+                return Period.seconds(value);
+            }
+        }
+        if (start == IntervalParser.Precision.SECOND && end == null) {
+            return buildSecondsWithMillisPeriod(value, millis);
+        }
+        throw new IllegalArgumentException("Invalid start and end combination");
+    }
+
+    private static Period buildSecondsWithMillisPeriod(int seconds, int millis) {
+        Period period = Period.seconds(seconds);
+        if (millis != 0) {
+            period = period.withMillis(millis);
+        }
+        return period;
+    }
+}

--- a/common/src/main/java/io/crate/interval/PGIntervalParser.java
+++ b/common/src/main/java/io/crate/interval/PGIntervalParser.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+import java.util.StringTokenizer;
+
+import static io.crate.interval.IntervalParser.nullSafeIntGet;
+import static io.crate.interval.IntervalParser.parseInteger;
+import static io.crate.interval.IntervalParser.parseMilliSeconds;
+import static io.crate.interval.IntervalParser.roundToPrecision;
+
+final class PGIntervalParser {
+
+    static Period apply(String value,
+                        @Nullable IntervalParser.Precision start,
+                        @Nullable IntervalParser.Precision end) {
+        return roundToPrecision(apply(value), start, end);
+    }
+
+    static Period apply(String value) {
+        final boolean ISOFormat = !value.startsWith("@");
+
+        // Just a simple '0'
+        if (!ISOFormat && value.length() == 3 && value.charAt(2) == '0') {
+            return new Period();
+        }
+
+        int years = 0;
+        int months = 0;
+        int days = 0;
+        int hours = 0;
+        int minutes = 0;
+        int seconds = 0;
+        int milliSeconds = 0;
+
+        try {
+            String valueToken = null;
+
+            value = value.replace('+', ' ').replace('@', ' ');
+            final StringTokenizer st = new StringTokenizer(value);
+            for (int i = 1; st.hasMoreTokens(); i++) {
+                String token = st.nextToken();
+
+                if ((i & 1) == 1) {
+                    int endHours = token.indexOf(':');
+                    if (endHours == -1) {
+                        valueToken = token;
+                        continue;
+                    }
+                    // This handles hours, minutes, seconds and microseconds for
+                    // ISO intervals
+                    int offset = (token.charAt(0) == '-') ? 1 : 0;
+
+                    hours = nullSafeIntGet(token.substring(offset + 0, endHours));
+                    minutes = nullSafeIntGet(token.substring(endHours + 1, endHours + 3));
+
+                    int endMinutes = token.indexOf(':', endHours + 1);
+                    seconds = parseInteger(token.substring(endMinutes + 1));
+                    milliSeconds = parseMilliSeconds(token.substring(endMinutes + 1));
+
+                    if (offset == 1) {
+                        hours = -hours;
+                        minutes = -minutes;
+                        seconds = -seconds;
+                        milliSeconds = -milliSeconds;
+                    }
+
+                    valueToken = null;
+                } else {
+                    // This handles years, months, days for both, ISO and
+                    // Non-ISO intervals. Hours, minutes, seconds and microseconds
+                    // are handled for Non-ISO intervals here.
+                    if (token.startsWith("year")) {
+                        years = nullSafeIntGet(valueToken);
+                    } else if (token.startsWith("mon")) {
+                        months = nullSafeIntGet(valueToken);
+                    } else if (token.startsWith("day")) {
+                        days = nullSafeIntGet(valueToken);
+                    } else if (token.startsWith("week")) {
+                        days = nullSafeIntGet(valueToken) * 7;
+                    } else if (token.startsWith("hour")) {
+                        hours = nullSafeIntGet(valueToken);
+                    } else if (token.startsWith("min")) {
+                        minutes = nullSafeIntGet(valueToken);
+                    } else if (token.startsWith("sec")) {
+                        seconds = parseInteger(valueToken);
+                        milliSeconds = parseMilliSeconds(valueToken);
+                    }
+                }
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Conversion of interval failed", e);
+
+        }
+        Period period = new Period(years, months, 0, days, hours, minutes, seconds, milliSeconds);
+
+        if (!ISOFormat && value.endsWith("ago")) {
+            // Inverse the leading sign
+            period = period.negated();
+        }
+        return period;
+    }
+
+
+}

--- a/common/src/main/java/io/crate/interval/SQLStandardIntervalParser.java
+++ b/common/src/main/java/io/crate/interval/SQLStandardIntervalParser.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+
+import static io.crate.interval.IntervalParser.nullSafeIntGet;
+import static io.crate.interval.IntervalParser.roundToPrecision;
+
+final class SQLStandardIntervalParser {
+
+    private enum ParserState {
+        NOTHING_PARSED,
+        HMS_PARSED,
+        DAY_PARSED,
+        YEAR_MONTH_PARSED
+    }
+
+    static Period apply(String value,
+                        @Nullable IntervalParser.Precision start,
+                        @Nullable IntervalParser.Precision end) {
+        return roundToPrecision(apply(value), start, end);
+    }
+
+    static Period apply(String value) {
+        String[] values = value.split(" ");
+
+        if (values.length > 3 || values.length == 0) {
+            throw new IllegalArgumentException("Invalid interval format " + value);
+        }
+
+        ParserState state = ParserState.NOTHING_PARSED;
+        boolean negative = false;
+        int years = 0;
+        int months = 0;
+        int days = 0;
+        int hours = 0;
+        int minutes = 0;
+        int seconds = 0;
+
+        try {
+            String part;
+            // Parse from backwards
+            for (int i = values.length; i > 0; i--) {
+                part = values[i - 1];
+                if (part.startsWith("-")) {
+                    negative = true;
+                    part = part.substring(1);
+                }
+                if (part.startsWith("+")) {
+                    part = part.substring(1);
+                }
+                if (part.contains(":")) {
+                    // H:M:S: Using a single value defines seconds only
+                    // Using two values defines hours and minutes.
+                    String[] hms = part.split(":");
+                    if (hms.length == 3) {
+                        hours = nullSafeIntGet(hms[0]);
+                        minutes = nullSafeIntGet(hms[1]);
+                        seconds = nullSafeIntGet(hms[2]);
+                    } else if (hms.length == 2) {
+                        hours = nullSafeIntGet(hms[0]);
+                        minutes = nullSafeIntGet(hms[1]);
+                    } else if (hms.length == 1) {
+                        seconds = nullSafeIntGet(hms[0]);
+                    }
+                    if (negative) {
+                        hours = -hours;
+                        minutes = -minutes;
+                        seconds = -seconds;
+                        negative = false;
+                    }
+                    state = ParserState.HMS_PARSED;
+                } else if (part.contains("-")) {
+                    if (state == ParserState.YEAR_MONTH_PARSED) {
+                        throw new IllegalArgumentException("Invalid interval format " + value);
+                    }
+                    //YEAR-MONTH
+                    String[] ym = part.split("-");
+                    if (ym.length == 2) {
+                        years = nullSafeIntGet(ym[0]);
+                        months = nullSafeIntGet(ym[1]);
+                    } else {
+                        throw new IllegalArgumentException("Invalid interval format " + value);
+                    }
+                    if (negative) {
+                        years = -years;
+                        months = -months;
+                        negative = false;
+                    }
+                    state = ParserState.YEAR_MONTH_PARSED;
+                } else {
+                    // Try to parse as day or second
+                    if (state == ParserState.HMS_PARSED) {
+                        days = nullSafeIntGet(part);
+                        if (negative) {
+                            days = -days;
+                            negative = false;
+                        }
+                        state = ParserState.DAY_PARSED;
+                    } else if (state == ParserState.NOTHING_PARSED) {
+                        seconds = nullSafeIntGet(part);
+                        if (negative) {
+                            seconds = -seconds;
+                            negative = false;
+                        }
+                        state = ParserState.HMS_PARSED;
+                    }
+
+                }
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid interval fornat " + value);
+        }
+        return new Period(years, months, 0, days, hours, minutes, seconds, 0);
+    }
+}

--- a/common/src/main/java/io/crate/types/DataType.java
+++ b/common/src/main/java/io/crate/types/DataType.java
@@ -53,6 +53,7 @@ public abstract class DataType<T> implements Comparable, Streamable {
         BooleanType,
         ShortType,
         IntegerType,
+        IntervalType,
         LongType,
         FloatType,
         DoubleType,

--- a/common/src/main/java/io/crate/types/DataTypeXContentExtension.java
+++ b/common/src/main/java/io/crate/types/DataTypeXContentExtension.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderExtension;
+import org.joda.time.Period;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
+import org.locationtech.spatial4j.shape.jts.JtsPoint;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class DataTypeXContentExtension implements XContentBuilderExtension {
+
+    @Override
+    public Map<Class<?>, XContentBuilder.Writer> getXContentWriters() {
+        return Map.ofEntries(
+            Map.entry(PointImpl.class, (b, v) -> {
+                Point point = (Point) v;
+                b.startArray();
+                b.value(point.getX());
+                b.value(point.getY());
+                b.endArray();
+            }),
+            Map.entry(JtsPoint.class, (b, v) -> {
+                Point point = (Point) v;
+                b.startArray();
+                b.value(point.getX());
+                b.value(point.getY());
+                b.endArray();
+            }),
+            Map.entry(Period.class, (b, v) -> {
+                Period period = (Period) v;
+                b.value(IntervalType.PERIOD_FORMATTER.print(period));
+            })
+        );
+    }
+
+    @Override
+    public Map<Class<?>, XContentBuilder.HumanReadableTransformer> getXContentHumanReadableTransformers() {
+        return Map.of();
+    }
+
+    @Override
+    public Map<Class<?>, Function<Object, Object>> getDateTransformers() {
+        return Map.of();
+    }
+}

--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -81,6 +81,8 @@ public final class DataTypes {
     public static final ArrayType<Integer> INTEGER_ARRAY = new ArrayType<>(INTEGER);
     public static final ArrayType<Short> SHORT_ARRAY = new ArrayType<>(SHORT);
 
+    public static final IntervalType INTERVAL = IntervalType.INSTANCE;
+
     public static final List<DataType> PRIMITIVE_TYPES = List.of(
         BYTE,
         BOOLEAN,
@@ -90,9 +92,14 @@ public final class DataTypes {
         FLOAT,
         SHORT,
         INTEGER,
+        INTERVAL,
         LONG,
         TIMESTAMPZ,
         TIMESTAMP
+    );
+
+    public static final Set<DataType> STORAGE_UNSUPPORTED = Set.of(
+        INTERVAL
     );
 
     public static final List<DataType> NUMERIC_PRIMITIVE_TYPES = List.of(
@@ -129,7 +136,8 @@ public final class DataTypes {
             entry(UncheckedObjectType.ID, UncheckedObjectType::new),
             entry(GeoPointType.ID, () -> GEO_POINT),
             entry(GeoShapeType.ID, () -> GEO_SHAPE),
-            entry(ArrayType.ID, ArrayType::new))
+            entry(ArrayType.ID, ArrayType::new),
+            entry(IntervalType.ID, () -> INTERVAL))
     );
 
     private static final Set<DataType> NUMBER_CONVERSIONS = Stream.concat(
@@ -324,7 +332,8 @@ public final class DataTypes {
         // `timestamp` as an alias for the `timestamp with time zone` data type
         // to warn users about the data type semantic change and give a time
         // to adjust to the change.
-        entry("timestamp", TIMESTAMPZ));
+        entry("timestamp", TIMESTAMPZ),
+        entry("interval", INTERVAL));
 
     public static DataType ofName(String name) {
         DataType dataType = TYPES_BY_NAME_OR_ALIAS.get(name);
@@ -350,7 +359,8 @@ public final class DataTypes {
         entry("geo_point", DataTypes.GEO_POINT),
         entry("geo_shape", DataTypes.GEO_SHAPE),
         entry("object", ObjectType.untyped()),
-        entry("nested", ObjectType.untyped())
+        entry("nested", ObjectType.untyped()),
+        entry("interval", DataTypes.INTERVAL)
     );
 
     private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
@@ -367,7 +377,8 @@ public final class DataTypes {
         entry(LONG.id(), "long"),
         entry(ObjectType.ID, "object"),
         entry(GEO_SHAPE.id(), "geo_shape"),
-        entry(GEO_POINT.id(), "geo_point")
+        entry(GEO_POINT.id(), "geo_point"),
+        entry(INTERVAL.id(), "interval")
     );
 
     @Nullable

--- a/common/src/main/java/io/crate/types/IntervalType.java
+++ b/common/src/main/java/io/crate/types/IntervalType.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import io.crate.Streamer;
+import io.crate.interval.IntervalParser;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.joda.time.Period;
+import org.joda.time.format.PeriodFormatter;
+import org.joda.time.format.PeriodFormatterBuilder;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Locale;
+
+public class IntervalType extends DataType<Period> implements FixedWidthType, Streamer<Period> {
+
+    public static final int ID = 17;
+    public static final IntervalType INSTANCE = new IntervalType();
+    public static final PeriodFormatter PERIOD_FORMATTER = new PeriodFormatterBuilder()
+        .appendYears()
+        .appendSuffix(" year", " years")
+        .appendSeparator(" ")
+        .appendMonths()
+        .appendSuffix(" mon", " mons")
+        .appendSeparator(" ")
+        .appendWeeks()
+        .appendSuffix(" weeks")
+        .appendSeparator(" ")
+        .appendDays()
+        .printZeroAlways()
+        .minimumPrintedDigits(2)
+        .appendSuffix(" day", " days")
+        .appendSeparator(" ")
+        .appendHours()
+        .minimumPrintedDigits(2)
+        .printZeroAlways()
+        .appendSeparator(":")
+        .appendMinutes()
+        .minimumPrintedDigits(2)
+        .printZeroAlways()
+        .appendSeparator(":")
+        .appendSecondsWithOptionalMillis()
+        .toFormatter();
+
+    @Override
+    public int id() {
+        return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.IntervalType;
+    }
+
+    @Override
+    public String getName() {
+        return "interval";
+    }
+
+    @Override
+    public Streamer<Period> streamer() {
+        return this;
+    }
+
+    @Override
+    public Period value(Object value) throws IllegalArgumentException, ClassCastException {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof Period) {
+            return (Period) value;
+        }
+
+        if (value instanceof String) {
+            return IntervalParser.apply((String) value);
+        }
+
+        throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Cannot convert %s to interval", value));
+    }
+
+    public int compareValueTo(Period p1, Period p2) {
+        return nullSafeCompareValueTo(p1.toStandardDuration(), p2.toStandardDuration(), Comparator.naturalOrder());
+
+    }
+
+    @Override
+    public Period readValueFrom(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            return new Period(
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt(),
+                in.readVInt()
+            );
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void writeValueTo(StreamOutput out, Period p) throws IOException {
+        if (p == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(p.getYears());
+            out.writeVInt(p.getMonths());
+            out.writeVInt(p.getWeeks());
+            out.writeVInt(p.getDays());
+            out.writeVInt(p.getHours());
+            out.writeVInt(p.getMinutes());
+            out.writeVInt(p.getSeconds());
+            out.writeVInt(p.getMillis());
+        }
+    }
+
+    @Override
+    public int fixedSize() {
+        return 32;
+    }
+
+}

--- a/common/src/main/resources/META-INF/services/org.elasticsearch.common.xcontent.XContentBuilderExtension
+++ b/common/src/main/resources/META-INF/services/org.elasticsearch.common.xcontent.XContentBuilderExtension
@@ -1,0 +1,1 @@
+io.crate.types.DataTypeXContentExtension

--- a/common/src/test/java/io/crate/interval/PGIntervalParserTest.java
+++ b/common/src/test/java/io/crate/interval/PGIntervalParserTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.joda.time.Period;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+
+public class PGIntervalParserTest extends CrateUnitTest {
+
+    @Test
+    public void test_psql_format_from_string() {
+        Period period = PGIntervalParser.apply("@ 1 year 1 mon 1 day 1 hour 1 minute 1 secs");
+        assertThat(period,
+            is(new Period().withYears(1).withMonths(1).withDays(1).withHours(1).withMinutes(1).withSeconds(1)));
+    }
+
+    @Test
+    public void test_psql_verbose_format_from_string_with_ago() {
+        Period period = PGIntervalParser.apply("@ 1 year 1 mon 1 day 1 hour 1 minute 1 secs ago");
+        assertThat(period,
+            is(new Period().withYears(-1).withMonths(-1).withDays(-1).withHours(-1).withMinutes(-1).withSeconds(-1)));
+    }
+
+    @Test
+    public void test_psql_verbose_format_from_string_with_negative_values() {
+        Period period = PGIntervalParser.apply("@ 1 year -23 hours -3 mins -3.30 secs");
+        assertThat(period,
+            is(new Period().withYears(1).withHours(-23).withMinutes(-3).withSeconds(-3).withMillis(-300)));
+    }
+
+    @Test
+    public void test_psql_verbose_format_from_string_with_negative_values_and_ago() {
+        Period period = PGIntervalParser.apply("@ 1 year -23 hours -3 mins -3.30 secs ago");
+        assertThat(period,
+            is(new Period().withYears(-1).withHours(23).withMinutes(3).withSeconds(3).withMillis(300)));
+    }
+
+    @Test
+    public void test_psql_compact_format_from_string() {
+        Period period = PGIntervalParser.apply("6 years 5 mons 4 days 03:02:01");
+        assertThat(period,
+            is(new Period().withYears(6).withMonths(5).withDays(4).withHours(3).withMinutes(2).withSeconds(1)));
+    }
+    @Test
+    public void test_weeks() {
+        Period period = PGIntervalParser.apply("1 week");
+        assertThat(period, is(new Period().withDays(7)));
+    }
+}

--- a/common/src/test/java/io/crate/interval/SqlStandardParserTest.java
+++ b/common/src/test/java/io/crate/interval/SqlStandardParserTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.interval;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.joda.time.Period;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+
+public class SqlStandardParserTest extends CrateUnitTest {
+
+    @Test
+    public void parse_year_month_day_hours_minutes() {
+        Period result = SQLStandardIntervalParser.apply("120-1 1 15:30");
+        assertThat(result, is(new Period().withYears(120).withMonths(1).withDays(1).withHours(15).withMinutes(30)));
+    }
+
+    @Test
+    public void negative_parse_year_month_negative_day_negative_hours_minutes() {
+        Period result = SQLStandardIntervalParser.apply("-120-1 -1 -15:30");
+        assertThat(result, is(new Period().withYears(-120).withMonths(-1).withDays(-1).withHours(-15).withMinutes(-30)));
+    }
+
+    @Test
+    public void parse_year_month_day() {
+        Period result = SQLStandardIntervalParser.apply("120-1 1");
+        assertThat(result, is(new Period().withYears(120).withMonths(1).withSeconds(1)));
+    }
+
+    @Test
+    public void parse_negative_year_month_negative_day() {
+        Period result = SQLStandardIntervalParser.apply("-120-1 -1");
+        assertThat(result, is(new Period().withYears(-120).withMonths(-1).withSeconds(-1)));
+    }
+
+    @Test
+    public void parse_year_month() {
+        Period result = SQLStandardIntervalParser.apply("120-1");
+        assertThat(result, is(new Period().withYears(120).withMonths(1)));
+    }
+
+    @Test
+    public void parse_negative_year_month() {
+        Period result = SQLStandardIntervalParser.apply("-120-1");
+        assertThat(result, is(new Period().withYears(-120).withMonths(-1)));
+    }
+
+    @Test
+    public void parse_year_month_hours_minutes() {
+        Period result = SQLStandardIntervalParser.apply("120-1 15:30");
+        assertThat(result, is(new Period().withYears(120).withMonths(1).withHours(15).withMinutes(30)));
+    }
+
+    @Test
+    public void parse_hours_minutes() {
+        Period result = SQLStandardIntervalParser.apply("15:30");
+        assertThat(result, is(new Period().withHours(15).withMinutes(30)));
+    }
+
+    @Test
+    public void parse_negative_hours_minutes() {
+        Period result = SQLStandardIntervalParser.apply("-15:30");
+        assertThat(result, is(new Period().withHours(-15).withMinutes(-30)));
+    }
+
+    @Test
+    public void parse_hours_minutes_seconds() {
+        Period result = SQLStandardIntervalParser.apply("15:30:10");
+        assertThat(result, is(new Period().withHours(15).withMinutes(30).withSeconds(10)));
+    }
+
+    @Test
+    public void parse_days_hours_minutes_seconds() {
+        Period result = SQLStandardIntervalParser.apply("1 15:30:10");
+        assertThat(result, is(new Period().withDays(1).withHours(15).withMinutes(30).withSeconds(10)));
+    }
+
+    @Test
+    public void parse_negative_days_negative_hours_minutes_seconds() {
+        Period result = SQLStandardIntervalParser.apply("-1 -15:30:10");
+        assertThat(result, is(new Period().withDays(-1).withHours(-15).withMinutes(-30).withSeconds(-10)));
+    }
+
+    @Test
+    public void parse_days_seconds() {
+        Period result = SQLStandardIntervalParser.apply("1 1");
+        assertThat(result, is(new Period().withDays(1).withSeconds(1)));
+    }
+
+    @Test
+    public void parse_negtive_days_negative_seconds() {
+        Period result = SQLStandardIntervalParser.apply("-1 -1");
+        assertThat(result, is(new Period().withDays(-1).withSeconds(-1)));
+    }
+}

--- a/common/src/test/java/io/crate/types/IntervalTypeTest.java
+++ b/common/src/test/java/io/crate/types/IntervalTypeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.hamcrest.Matchers;
+import org.joda.time.Period;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IntervalTypeTest {
+
+    @Test
+    public void test_interval_value_streaming_round_trip() throws Exception {
+        var out = new BytesStreamOutput();
+        var period = new Period(1, 2, 3, 4, 5, 6, 7, 8);
+        IntervalType.INSTANCE.writeValueTo(out, period);
+
+        var in = out.bytes().streamInput();
+        var periodFromStream = IntervalType.INSTANCE.readValueFrom(in);
+
+        assertThat(periodFromStream, is(period));
+    }
+
+    @Test
+    public void test_stream_null_period() throws Exception {
+        var out = new BytesStreamOutput();
+        IntervalType.INSTANCE.writeValueTo(out, null);
+        var in = out.bytes().streamInput();
+        assertThat(IntervalType.INSTANCE.readValueFrom(in), Matchers.nullValue());
+    }
+}

--- a/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
@@ -34,9 +34,6 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.joda.time.tz.CachedDateTimeZone;
 import org.joda.time.tz.FixedDateTimeZone;
-import org.locationtech.spatial4j.shape.Point;
-import org.locationtech.spatial4j.shape.impl.PointImpl;
-import org.locationtech.spatial4j.shape.jts.JtsPoint;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -96,20 +93,6 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
         writers.put(Year.class, (b, v) -> b.value(v.toString()));
         writers.put(Duration.class, (b, v) -> b.value(v.toString()));
         writers.put(Period.class, (b, v) -> b.value(v.toString()));
-        writers.put(PointImpl.class, (b, v) -> {
-            Point point = (Point) v;
-            b.startArray();
-            b.value(point.getX());
-            b.value(point.getY());
-            b.endArray();
-        });
-        writers.put(JtsPoint.class, (b, v) -> {
-            Point point = (Point) v;
-            b.startArray();
-            b.value(point.getX());
-            b.value(point.getY());
-            b.endArray();
-        });
 
         writers.put(BytesReference.class, (b, v) -> {
             if (v == null) {

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -272,6 +272,7 @@ parameterOrLiteral
 
 parameterOrSimpleLiteral
     : nullLiteral
+    | intervalLiteral
     | escapedCharsStringLiteral
     | stringLiteral
     | numericLiteral
@@ -403,6 +404,14 @@ stringLiteralOrIdentifierOrQname
 numericLiteral
     : decimalLiteral
     | integerLiteral
+    ;
+
+intervalLiteral
+    : INTERVAL sign=(PLUS | MINUS)? stringLiteral from=intervalField (TO to=intervalField)?
+    ;
+
+intervalField
+    : YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     ;
 
 booleanLiteral
@@ -640,7 +649,7 @@ nonReserved
     : ALIAS | ANALYZE | ANALYZER | BERNOULLI | BLOB | CATALOGS | CHAR_FILTERS | CLUSTERED
     | COLUMNS | COPY | CURRENT |  DAY | DEALLOCATE | DISTRIBUTED | DUPLICATE | DYNAMIC | EXPLAIN
     | EXTENDS | FOLLOWING | FORMAT | FULLTEXT | FUNCTIONS | GEO_POINT | GEO_SHAPE | GLOBAL
-    | GRAPHVIZ | HOUR | IGNORED | KEY | KILL | LICENSE | LOGICAL | LOCAL | MATERIALIZED | MINUTE
+    | GRAPHVIZ | HOUR | IGNORED | INTERVAL | KEY | KILL | LICENSE | LOGICAL | LOCAL | MATERIALIZED | MINUTE
     | MONTH | OFF | ONLY | OVER | OPTIMIZE | PARTITION | PARTITIONED | PARTITIONS | PLAIN
     | PRECEDING | RANGE | REFRESH | ROW | ROWS | SCHEMAS | SECOND | SESSION
     | SHARDS | SHOW | STORAGE | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME | ZONE | WITHOUT
@@ -717,6 +726,7 @@ THEN: 'THEN';
 ELSE: 'ELSE';
 END: 'END';
 IF: 'IF';
+INTERVAL: 'INTERVAL';
 JOIN: 'JOIN';
 CROSS: 'CROSS';
 OUTER: 'OUTER';

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -50,6 +50,7 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
 import io.crate.sql.tree.LikePredicate;
@@ -138,6 +139,11 @@ public final class ExpressionFormatter {
         protected String visitExpression(Expression node, @Nullable List<Expression> parameters) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
                 "not yet implemented: %s.visit%s", getClass().getName(), node.getClass().getSimpleName()));
+        }
+
+        @Override
+        public String visitIntervalLiteral(IntervalLiteral node, List<Expression> context) {
+            return IntervalLiteral.format(node);
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -57,6 +57,7 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.IndexColumnConstraint;
 import io.crate.sql.tree.IndexDefinition;
+import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.Join;
 import io.crate.sql.tree.JoinCriteria;
 import io.crate.sql.tree.JoinOn;
@@ -811,6 +812,12 @@ public final class SqlFormatter {
             builder.append(node.names().stream()
                 .map(Formatter::formatQualifiedName)
                 .collect(COMMA_JOINER));
+            return null;
+        }
+
+        @Override
+        public Void visitIntervalLiteral(IntervalLiteral node, Integer indent) {
+            builder.append(IntervalLiteral.format(node));
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -105,6 +105,7 @@ import io.crate.sql.tree.Insert;
 import io.crate.sql.tree.InsertFromSubquery;
 import io.crate.sql.tree.InsertFromValues;
 import io.crate.sql.tree.Intersect;
+import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
 import io.crate.sql.tree.Join;
@@ -221,6 +222,63 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitBegin(SqlBaseParser.BeginContext context) {
         return new BeginStatement();
+    }
+
+    @Override
+    public Node visitIntervalLiteral(SqlBaseParser.IntervalLiteralContext context) {
+        IntervalLiteral.IntervalField startField = getIntervalFieldType((Token) context.from.getChild(0).getPayload());
+        IntervalLiteral.IntervalField endField = null;
+        if (context.to != null) {
+            Token token = (Token) context.to.getChild(0).getPayload();
+            endField = getIntervalFieldType(token);
+        }
+
+        if (endField != null) {
+            if (startField.compareTo(endField) > 0) {
+                throw new IllegalArgumentException("Startfield must be less significant than Endfield");
+            }
+        }
+
+        IntervalLiteral.Sign sign = IntervalLiteral.Sign.PLUS;
+        if (context.sign != null) {
+            sign = getIntervalSign(context.sign);
+        }
+
+        return new IntervalLiteral(
+            ((StringLiteral) visit(context.stringLiteral())).getValue(),
+            sign,
+            startField,
+            endField);
+    }
+
+    private static IntervalLiteral.Sign getIntervalSign(Token token) {
+        switch (token.getType()) {
+            case SqlBaseLexer.MINUS:
+                return IntervalLiteral.Sign.MINUS;
+            case SqlBaseLexer.PLUS:
+                return IntervalLiteral.Sign.PLUS;
+            default:
+                throw new IllegalArgumentException("Unsupported sign: " + token.getText());
+        }
+    }
+
+    private static IntervalLiteral.IntervalField getIntervalFieldType(Token token) {
+        switch (token.getType()) {
+            case SqlBaseLexer.YEAR:
+                return IntervalLiteral.IntervalField.YEAR;
+            case SqlBaseLexer.MONTH:
+                return IntervalLiteral.IntervalField.MONTH;
+            case SqlBaseLexer.DAY:
+                return IntervalLiteral.IntervalField.DAY;
+            case SqlBaseLexer.HOUR:
+                return IntervalLiteral.IntervalField.HOUR;
+            case SqlBaseLexer.MINUTE:
+                return IntervalLiteral.IntervalField.MINUTE;
+            case SqlBaseLexer.SECOND:
+                return IntervalLiteral.IntervalField.SECOND;
+            default:
+                throw new IllegalArgumentException("Unsupported interval field: " + token.getText());
+        }
     }
 
     @Override
@@ -1891,8 +1949,10 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     private static void validateFunctionName(QualifiedName functionName) {
         if (functionName.getParts().size() > 2) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "The function name is not correct! " +
-                "name [%s] does not conform the [[schema_name .] function_name] format.", functionName));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                             "The function name is not correct! " +
+                                                             "name [%s] does not conform the [[schema_name .] function_name] format.",
+                                                             functionName));
         }
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -496,6 +496,10 @@ public abstract class AstVisitor<R, C> {
         return visitInsert(node, context);
     }
 
+    public R visitIntervalLiteral(IntervalLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
     public R visitInsertFromSubquery(InsertFromSubquery node, C context) {
         return visitInsert(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/IntervalLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IntervalLiteral.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * INTERVAL sign=(PLUS | MINUS)? stringLiteral from=intervalField (TO to=intervalField)?
+ */
+public class IntervalLiteral extends Literal {
+
+    public enum Sign {
+        PLUS,
+        MINUS
+    }
+
+    public enum IntervalField {
+        YEAR,
+        MONTH,
+        DAY,
+        HOUR,
+        MINUTE,
+        SECOND
+    }
+
+    private final String value;
+    private final Sign sign;
+    private final IntervalField startField;
+    @Nullable
+    private final IntervalField endField;
+
+    public IntervalLiteral(String value, Sign sign, IntervalField startField, @Nullable IntervalField endField) {
+        this.value = value;
+        this.sign = sign;
+        this.startField = startField;
+        this.endField = endField;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Sign getSign() {
+        return sign;
+    }
+
+    public IntervalField getStartField() {
+        return startField;
+    }
+    
+    @Nullable
+    public IntervalField getEndField() {
+        return endField;
+    }
+
+    public static String format(IntervalLiteral i) {
+        StringBuilder builder = new StringBuilder("INTERVAL ");
+        if (i.getSign() == IntervalLiteral.Sign.MINUS) {
+            builder.append("- ");
+        }
+        builder.append("'");
+        builder.append(i.getValue());
+        builder.append("' ")
+            .append(i.getStartField().name());
+        IntervalLiteral.IntervalField endField = i.getEndField();
+        if (endField != null) {
+            builder.append(" TO " + endField.name());
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, sign, startField, endField);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        IntervalLiteral other = (IntervalLiteral) obj;
+        return Objects.equals(this.value, other.value) &&
+               Objects.equals(this.sign, other.sign) &&
+               Objects.equals(this.startField, other.startField) &&
+               Objects.equals(this.endField, other.endField);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitIntervalLiteral(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql;
+
+
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.IntervalLiteral;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+public class IntervalLiteralTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testYear() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' YEAR");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.YEAR));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testMonth() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' MONTH");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.MONTH));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testDay() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' DAY");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.DAY));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testHour() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' HOUR");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.HOUR));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testMinute() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' MINUTE");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.MINUTE));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testSecond() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL +'1' SECOND");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.SECOND));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testNegative() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL -'1' HOUR");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.MINUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.HOUR));
+        assertThat(interval.getEndField(), is(nullValue()));
+    }
+
+    @Test
+    public void testTo() {
+        IntervalLiteral interval = (IntervalLiteral) SqlParser.createExpression("INTERVAL '1' HOUR TO SECOND");
+        assertThat(interval.getValue(), is("1"));
+        assertThat(interval.getSign(), is(IntervalLiteral.Sign.PLUS));
+        assertThat(interval.getStartField(), is(IntervalLiteral.IntervalField.HOUR));
+        assertThat(interval.getEndField(), is(IntervalLiteral.IntervalField.SECOND));
+    }
+
+    @Test
+    public void testSecondToHour() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Startfield must be less significant than Endfield");
+        SqlParser.createExpression("INTERVAL '1' SECOND TO HOUR");
+    }
+
+    @Test
+    public void testSecondToYear() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Startfield must be less significant than Endfield");
+        SqlParser.createExpression("INTERVAL '1' SECOND TO YEAR");
+    }
+
+    @Test
+    public void testDayToYear() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Startfield must be less significant than Endfield");
+        SqlParser.createExpression("INTERVAL '1' DAY TO YEAR");
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -856,6 +856,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testIntervalLiteral() {
+        printStatement("select interval '1' HOUR");
+    }
+
+    @Test
     public void testEscapedStringLiteralBuilder() {
         printStatement("select E'aValue'");
         printStatement("select E'\\141Value'");

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -37,9 +37,9 @@ import io.crate.types.DataTypes;
 import io.crate.types.GeoShapeType;
 import io.crate.types.ObjectType;
 import io.crate.types.StringType;
+import io.crate.types.TimestampType;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import io.crate.types.TimestampType;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -208,6 +208,10 @@ public class AnalyzedColumnDefinition {
         if (indexType != null && UNSUPPORTED_INDEX_TYPE_IDS.contains(dataType.id())) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "INDEX constraint cannot be used on columns of type \"%s\"", dataType));
+        }
+
+        if (DataTypes.STORAGE_UNSUPPORTED.contains(dataType)) {
+            throw new IllegalArgumentException("Cannot use the type `" + dataType.getName() + "` for column: " + name);
         }
         if (hasPrimaryKeyConstraint()) {
             ensureTypeCanBeUsedAsKey();

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -100,6 +100,7 @@ import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
 import io.crate.sql.tree.LikePredicate;
@@ -127,8 +128,10 @@ import io.crate.sql.tree.WindowFrame;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.interval.IntervalParser;
 import io.crate.types.ObjectType;
 import io.crate.types.UndefinedType;
+import org.joda.time.Period;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -145,7 +148,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.crate.common.collections.Lists2.mapTail;
-
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.DAY;
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.HOUR;
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.MINUTE;
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.MONTH;
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.SECOND;
+import static io.crate.sql.tree.IntervalLiteral.IntervalField.YEAR;
 
 /**
  * <p>This Analyzer can be used to convert Expression from the SQL AST into symbols.</p>
@@ -923,6 +931,31 @@ public class ExpressionAnalyzer {
                 MapFunction.NAME,
                 arguments,
                 context);
+        }
+
+        private final Map<IntervalLiteral.IntervalField, IntervalParser.Precision> INTERVAL_FIELDS =
+            Map.of(
+                YEAR, IntervalParser.Precision.YEAR,
+                MONTH, IntervalParser.Precision.MONTH,
+                DAY, IntervalParser.Precision.DAY,
+                HOUR, IntervalParser.Precision.HOUR,
+                MINUTE, IntervalParser.Precision.MINUTE,
+                SECOND, IntervalParser.Precision.SECOND
+            );
+
+        @Override
+        public Symbol visitIntervalLiteral(IntervalLiteral node, ExpressionAnalysisContext context) {
+            String value = node.getValue();
+
+            IntervalParser.Precision start = INTERVAL_FIELDS.get(node.getStartField());
+            IntervalParser.Precision end = node.getEndField() == null ? null : INTERVAL_FIELDS.get(node.getEndField());
+
+            Period period = IntervalParser.apply(value, start, end);
+
+            if (node.getSign() == IntervalLiteral.Sign.MINUS) {
+                period = period.negated();
+            }
+            return Literal.newInterval(period);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -44,6 +44,7 @@ import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
+import io.crate.types.IntervalType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
@@ -248,6 +249,8 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
             case StringType.ID:
             case IpType.ID:
                 return null;
+            case IntervalType.ID:
+                return IntervalType.ID;
             default:
                 throw new UnsupportedOperationException("Unsupported data type: " + dataType);
         }

--- a/sql/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Literal.java
@@ -32,6 +32,7 @@ import io.crate.types.ObjectType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.joda.time.Period;
 import org.locationtech.spatial4j.shape.Point;
 
 import java.io.IOException;
@@ -253,6 +254,10 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
 
     public static Literal<Float> of(Float value) {
         return new Literal<>(DataTypes.FLOAT, value);
+    }
+
+    public static Literal<Period> newInterval(Period value) {
+        return new Literal<>(DataTypes.INTERVAL, value);
     }
 
     public static Literal<Point> newGeoPoint(Object point) {

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import io.netty.buffer.ByteBuf;
+import org.joda.time.Period;
+import org.joda.time.ReadablePeriod;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+
+public class IntervalType extends PGType {
+
+    private static final int OID = 1186;
+    private static final int TYPE_LEN = 16;
+    private static final int TYPE_MOD = -1;
+    public static final IntervalType INSTANCE = new IntervalType();
+
+    private IntervalType() {
+        super(OID, TYPE_LEN, TYPE_MOD, "interval");
+    }
+
+    @Override
+    public int typArray() {
+        return PGArray.INTERVAL_ARRAY.oid();
+    }
+
+    @Override
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+        Period period = (Period) value;
+        buffer.writeInt(TYPE_LEN);
+        // from PostgreSQL code:
+        // pq_sendint64(&buf, interval->time);
+        // pq_sendint32(&buf, interval->day);
+        // pq_sendint32(&buf, interval->month);
+        buffer.writeLong(
+            (period.getHours() * 60 * 60 * 1000_000L)
+            + (period.getMinutes() * 60 * 1000_000L)
+            + (period.getSeconds() * 1000_000L)
+            + (period.getMillis() * 1000)
+        );
+        buffer.writeInt((period.getWeeks() * 7) + period.getDays());
+        buffer.writeInt((period.getYears() * 12) + period.getMonths());
+        return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+        assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because interval is 16. Actual length: " +
+                                         valueLength;
+        long micros = buffer.readLong();
+        int days = buffer.readInt();
+        int months = buffer.readInt();
+
+        long microsInAnHour = 60 * 60 * 1000_000L;
+        int hours = Math.toIntExact(micros / microsInAnHour);
+        long microsWithoutHours = micros % microsInAnHour;
+
+        long microsInAMinute = 60 * 1000_000L;
+        int minutes = Math.toIntExact(microsWithoutHours / microsInAMinute);
+        long microsWithoutMinutes = microsWithoutHours % microsInAMinute;
+
+        int seconds = Math.toIntExact(microsWithoutMinutes / 1000_000);
+        int millis = Math.toIntExact((microsWithoutMinutes % 1000_000) / 1000);
+        return new Period(
+            months / 12,
+            months % 12,
+            days / 7,
+            days % 7,
+            hours,
+            minutes,
+            seconds,
+            millis
+        );
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(@Nonnull Object value) {
+        StringBuffer sb = new StringBuffer();
+        io.crate.types.IntervalType.PERIOD_FORMATTER.printTo(sb, (ReadablePeriod) value);
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    Object decodeUTF8Text(byte[] bytes) {
+        return io.crate.types.IntervalType.PERIOD_FORMATTER.parsePeriod(new String(bytes, StandardCharsets.UTF_8));
+    }
+}

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -45,6 +45,7 @@ class PGArray extends PGType {
     static final PGArray VARCHAR_ARRAY = new PGArray(1015, VarCharType.INSTANCE);
     static final PGArray JSON_ARRAY = new PGArray(199, JsonType.INSTANCE);
     static final PGArray POINT_ARRAY = new PGArray(1017, PointType.INSTANCE);
+    static final PGArray INTERVAL_ARRAY = new PGArray(1187, IntervalType.INSTANCE);
 
     private static final byte[] NULL_BYTES = new byte[]{'N', 'U', 'L', 'L'};
 

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -53,6 +53,7 @@ public class PGTypes {
         .put(DataTypes.UNDEFINED, VarCharType.INSTANCE)
         .put(DataTypes.GEO_SHAPE, JsonType.INSTANCE)
         .put(DataTypes.GEO_POINT, PointType.INSTANCE)
+        .put(DataTypes.INTERVAL,IntervalType.INSTANCE)
         .put(new ArrayType<>(DataTypes.BYTE), PGArray.CHAR_ARRAY)
         .put(new ArrayType<>(DataTypes.SHORT), PGArray.INT2_ARRAY)
         .put(new ArrayType<>(DataTypes.INTEGER), PGArray.INT4_ARRAY)
@@ -66,6 +67,7 @@ public class PGTypes {
         .put(new ArrayType<>(DataTypes.IP), PGArray.VARCHAR_ARRAY)
         .put(new ArrayType<>(DataTypes.GEO_POINT), PGArray.POINT_ARRAY)
         .put(new ArrayType<>(DataTypes.GEO_SHAPE), PGArray.JSON_ARRAY)
+        .put(new ArrayType<>(DataTypes.INTERVAL), PGArray.INTERVAL_ARRAY)
         .put(new ArrayType<>(ObjectType.untyped()), JsonType.INSTANCE)
         .build();
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1244,4 +1244,11 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             e.analyze("alter table users reset (\"routing.allocation.exclude.foo\")");
         assertThat(analysis.tableParameter().settings().get(INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "foo"), nullValue());
     }
+
+    @Test
+    public void testCreateTableWithIntervalFails() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Cannot use the type `interval` for column: i");
+        e.analyze("create table test (i interval)");
+    }
 }

--- a/sql/src/test/java/io/crate/analyze/expressions/IntervalAnalysisTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/IntervalAnalysisTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.expressions;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.joda.time.Period;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class IntervalAnalysisTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (ts timestamp without time zone)")
+            .build();
+    }
+
+    @Test
+    public void test_psql_compact_format_from_string_with_start() {
+        var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' YEAR");
+        assertThat(symbol, isLiteral(
+            new Period().withYears(6)));
+    }
+
+    @Test
+    public void test_psql_compact_format_from_string_with_start_end() {
+        var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' YEAR TO MONTH");
+        assertThat(symbol, isLiteral(
+            new Period().withYears(6).withMonths(5)));
+    }
+
+    @Test
+    public void test_psql_compact_format_from_string_with_start_end1() {
+        var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' DAY TO HOUR");
+        assertThat(symbol, isLiteral(
+            new Period().withYears(6).withMonths(5).withDays(4).withHours(3)));
+    }
+
+    @Test
+    public void test_interval() throws Exception {
+        var symbol = e.asSymbol("INTERVAL '1' MONTH");
+        assertThat(symbol, isLiteral(new Period().withMonths(1)));
+    }
+
+    @Test
+    public void test_negative_interval() throws Exception {
+        var symbol = e.asSymbol("INTERVAL '-1' MONTH");
+        assertThat(symbol, isLiteral(new Period().withMonths(-1)));
+    }
+
+    @Test
+    public void test_negative_negative_interval() throws Exception {
+        var symbol = e.asSymbol("INTERVAL -'-1' MONTH");
+        assertThat(symbol, isLiteral(new Period().withMonths(1)));
+    }
+
+    @Test
+    public void test_interval_conversion() throws Exception {
+        var symbol =  e.asSymbol("INTERVAL '1' HOUR to SECOND");
+        assertThat(symbol, isLiteral(new Period().withSeconds(1)));
+
+        symbol =  e.asSymbol( "INTERVAL '100' DAY TO SECOND");
+        assertThat(symbol, isLiteral(new Period().withMinutes(1).withSeconds(40)));
+    }
+
+    @Test
+    public void test_seconds_millis() throws Exception {
+        var symbol =  e.asSymbol("INTERVAL '1'");
+        assertThat(symbol, isLiteral(new Period().withSeconds(1)));
+
+        symbol =  e.asSymbol("INTERVAL '1.1'");
+        assertThat(symbol, isLiteral(new Period().withSeconds(1).withMillis(100)));
+
+        symbol =  e.asSymbol("INTERVAL '60.1'");
+        assertThat(symbol, isLiteral(new Period().withMinutes(1).withMillis(100)));
+    }
+
+
+    @Test
+    public void testIntervalInvalidStartEnd() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Startfield must be less significant than Endfield");
+        e.asSymbol("INTERVAL '1' MONTH TO YEAR");
+    }
+}

--- a/sql/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -26,6 +26,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.BooleanType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.joda.time.Period;
 import org.junit.Test;
 import org.locationtech.spatial4j.shape.Point;
 
@@ -46,6 +47,8 @@ public class LiteralTest extends CrateUnitTest {
                 value = true;
             } else if (type.id() == DataTypes.IP.id()) {
                 value = type.value("123.34.243.23");
+            } else if (type.id() == DataTypes.INTERVAL.id()) {
+                value = type.value(new Period().withSeconds(100));
             } else {
                 value = type.value("0");
             }

--- a/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -108,4 +108,11 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         String bodyAsString = EntityUtils.toString(resp.getEntity());
         assertThat(bodyAsString, containsString("ArithmeticFunctions.java"));
     }
+
+    @Test
+    public void test_interval_is_represented_as_text_via_http() throws Exception{
+        var resp = post("{\"stmt\": \"select '5 days'::interval as x\"}");
+        String bodyAsString = EntityUtils.toString(resp.getEntity());
+        assertThat(bodyAsString, containsString("5 days"));
+    }
 }

--- a/sql/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/sql/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -27,6 +27,7 @@ import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.Version;
 import org.junit.After;
@@ -273,6 +274,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testArrayLengthWithAllSupportedTypes() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_TYPES_EXCEPT_ARRAYS) {
+            // This is temporary as long as interval is not fully implemented
+            if(DataTypes.STORAGE_UNSUPPORTED.contains(type)) {
+                continue;
+            }
             Supplier dataGenerator = DataTypeTesting.getDataGenerator(type);
             Object val1 = dataGenerator.get();
             Object val2 = dataGenerator.get();

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -71,6 +71,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testWhereRefEqNullWithDifferentTypes() throws Exception {
         for (DataType type : DataTypes.PRIMITIVE_TYPES) {
+            if (DataTypes.STORAGE_UNSUPPORTED.contains(type)) {
+                continue;
+            }
             // ensure the test is operating on a fresh, empty cluster state (no existing tables)
             resetClusterService();
 

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -23,7 +23,6 @@
 package io.crate.protocols.postgres.types;
 
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.DataTypeTesting;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -34,6 +33,7 @@ import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.joda.time.Period;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -127,6 +127,25 @@ public class PGTypesTest extends CrateUnitTest {
             PGType pgType = PGTypes.get(entry.type);
             assertEntryOfPgType(entry, pgType);
         }
+    }
+
+
+    @Test
+    public void test_period_binary_round_trip_streaming() {
+        Entry entry = new Entry(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
+        assertThat(
+            writeAndReadBinary(entry, IntervalType.INSTANCE),
+            is(entry.value)
+        );
+    }
+
+    @Test
+    public void test_period_text_round_trip_streaming() {
+        Entry entry = new Entry(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
+        assertThat(
+            writeAndReadAsText(entry, IntervalType.INSTANCE),
+            is(entry.value)
+        );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/DataTypeTesting.java
+++ b/sql/src/test/java/io/crate/testing/DataTypeTesting.java
@@ -25,6 +25,7 @@ package io.crate.testing;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.BiasedNumbers;
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -37,12 +38,14 @@ import io.crate.types.FloatType;
 import io.crate.types.GeoPointType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
+import io.crate.types.IntervalType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
 import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
+import org.joda.time.Period;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
@@ -59,6 +62,7 @@ public class DataTypeTesting {
         .addAll(DataTypes.PRIMITIVE_TYPES)
         .add(DataTypes.GEO_POINT)
         .add(DataTypes.GEO_SHAPE)
+        .add(DataTypes.INTERVAL)
         .add(ObjectType.untyped())
         .build();
 
@@ -128,6 +132,11 @@ public class DataTypeTesting {
                     map.put("x", innerValueGenerator.get());
                     return (T) map;
                 };
+            case IntervalType.ID:
+                return () -> {
+                    return (T) new Period().withSeconds(RandomNumbers.randomIntBetween(random, 0, Integer.MAX_VALUE));
+                };
+
         }
 
         throw new AssertionError("No data generator for type " + type.getName());


### PR DESCRIPTION
Add Interval literal to antlr grammar and adapt the parser to support
it internally. Add IntervalType to the crate and postgres types and
provide custom parsers to support the various interval formats.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
