### PR TITLE
Expose the total_shards_per_node cluster.routing.allocation setting

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -150,6 +150,7 @@ applied cluster settings.
     | settings['cluster']['routing']['allocation']['require']['_id']                    | text             |
     | settings['cluster']['routing']['allocation']['require']['_ip']                    | text             |
     | settings['cluster']['routing']['allocation']['require']['_name']                  | text             |
+    | settings['cluster']['routing']['allocation']['total_shards_per_node']             | integer          |
     | settings['cluster']['routing']['rebalance']                                       | object           |
     | settings['cluster']['routing']['rebalance']['enable']                             | text             |
     | settings['discovery']                                                             | object           |

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ Breaking Changes
 Changes
 =======
 
+- Added the :ref:`cluster.routing.allocation.total_shards_per_node
+  <cluster.routing.allocation.total_shards_per_node>` setting.
+
 - Added :ref:`TIMEZONE <scalar-timezone>` scalar function.
 
 - Added support for the filter clause in

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -804,6 +804,20 @@ nodes every 30 seconds. This can also be changed by setting the
    false will disable the allocation decider, but the node checks will still be
    active and warn users about running low on disk space.
 
+
+.. _cluster.routing.allocation.total_shards_per_node:
+
+**cluster.routing.allocation.total_shards_per_node**
+   | *Default*: ``-1``
+   | *Runtime*: ``yes``
+
+   Limits the number of shards that can be allocated per node. ``-1`` means
+   unlimited.
+   Setting this to for example ``1000`` will prevent CrateDB from assigning
+   more than 1000 shards per node. A node with 1000 shards would be excluded
+   from allocation decisions and CrateDB would attempt to allocate shards to
+   other nodes, or leave shards unassigned if no suitable node can be found.
+
 Recovery
 --------
 

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -587,7 +587,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(664, response.rowCount());
+        assertEquals(665, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So that in a future version we're able to change the default to prevent
users from allocating too many shards per node.

Exposing it prior with the ``-1`` default allows users to set it
explicitly to a higher value if our future default would be too low for
them.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)