### PR TITLE
Add arithmetic operations +,- between timestamp, timestampz and intervals

### DIFF
--- a/common/src/main/java/io/crate/interval/IntervalParser.java
+++ b/common/src/main/java/io/crate/interval/IntervalParser.java
@@ -156,10 +156,6 @@ public final class IntervalParser {
             .multiply(new BigDecimal(1000)).intValue();
     }
 
-    static int parseInteger(String value) {
-        return new BigDecimal(value).intValue();
-    }
-
     static int nullSafeIntGet(String value) {
         return (value == null) ? 0 : Integer.parseInt(value);
     }

--- a/common/src/main/java/io/crate/interval/NumericalIntervalParser.java
+++ b/common/src/main/java/io/crate/interval/NumericalIntervalParser.java
@@ -26,9 +26,10 @@ import org.joda.time.Period;
 
 import javax.annotation.Nullable;
 
-import static io.crate.interval.IntervalParser.parseInteger;
-import static io.crate.interval.IntervalParser.parseMilliSeconds;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import static io.crate.interval.IntervalParser.parseMilliSeconds;
 
 final class NumericalIntervalParser {
 
@@ -104,6 +105,16 @@ final class NumericalIntervalParser {
             return buildSecondsWithMillisPeriod(value, millis);
         }
         throw new IllegalArgumentException("Invalid start and end combination");
+    }
+
+    private static int parseInteger(String value) {
+        BigInteger result = new BigDecimal(value).toBigInteger();
+        if (result.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0 ||
+            result.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0
+        ) {
+            throw new ArithmeticException("Interval field value out of range " + value);
+        }
+        return result.intValue();
     }
 
     private static Period buildSecondsWithMillisPeriod(int seconds, int millis) {

--- a/common/src/main/java/io/crate/interval/PGIntervalParser.java
+++ b/common/src/main/java/io/crate/interval/PGIntervalParser.java
@@ -25,10 +25,10 @@ package io.crate.interval;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.util.StringTokenizer;
 
 import static io.crate.interval.IntervalParser.nullSafeIntGet;
-import static io.crate.interval.IntervalParser.parseInteger;
 import static io.crate.interval.IntervalParser.parseMilliSeconds;
 import static io.crate.interval.IntervalParser.roundToPrecision;
 
@@ -124,5 +124,7 @@ final class PGIntervalParser {
         return period;
     }
 
-
+    private static int parseInteger(String value) {
+        return new BigDecimal(value).intValue();
+    }
 }

--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -24,7 +24,6 @@ package io.crate.types;
 import io.crate.Streamer;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -23,7 +23,10 @@
 package io.crate.expression.scalar.arithmetic;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.common.collections.Lists2;
+import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.FuncArg;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.BaseFunctionResolver;
@@ -31,6 +34,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ByteType;
@@ -39,19 +43,27 @@ import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
+import io.crate.types.IntervalType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
+import org.elasticsearch.common.util.set.Sets;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 
 public class ArithmeticFunctions {
 
     private static final Param ARITHMETIC_TYPE = Param.of(
-        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP);
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP, DataTypes.INTERVAL, DataTypes.UNDEFINED);
 
     public static class Names {
         public static final String ADD = "add";
@@ -131,7 +143,6 @@ public class ArithmeticFunctions {
         }
     }
 
-
     static final class ArithmeticFunctionResolver extends BaseFunctionResolver {
 
         private final String name;
@@ -160,40 +171,84 @@ public class ArithmeticFunctions {
             this.features = features;
         }
 
+        @Nullable
+        @Override
+        public List<DataType> getSignature(List<? extends FuncArg> dataTypes) {
+            if (dataTypes.size() == 2) {
+                DataType fst = dataTypes.get(0).valueType();
+                DataType snd = dataTypes.get(1).valueType();
+
+                if ((isInterval(fst) && isTimestamp(snd)) ||
+                    (isTimestamp(fst) && isInterval(snd))) {
+                    return Lists2.map(dataTypes, FuncArg::valueType);
+                }
+            }
+            return super.getSignature(dataTypes);
+        }
+
         @Override
         public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            assert dataTypes.size() == 2 && dataTypes.get(0).equals(dataTypes.get(1))
-                : "Arithmetic operator must receive two arguments with a matching type";
+            assert dataTypes.size() == 2 : "Arithmetic operator must receive two arguments";
 
-            DataType dataType = dataTypes.get(0);
-            final BinaryScalar<?> scalar;
-            switch (dataType.id()) {
-                case DoubleType.ID:
-                    scalar = new BinaryScalar<>(doubleFunction, name, DataTypes.DOUBLE, features);
-                    break;
+            DataType fst = dataTypes.get(0);
+            DataType snd = dataTypes.get(1);
 
-                case FloatType.ID:
-                    scalar = new BinaryScalar<>(floatFunction, name, DataTypes.FLOAT, features);
-                    break;
+            if (fst.equals(snd)) {
+                final Scalar<?, ?> scalar;
+                switch (fst.id()) {
+                    case DoubleType.ID:
+                        scalar = new BinaryScalar<>(doubleFunction, name, DataTypes.DOUBLE, features);
+                        break;
 
-                case ByteType.ID:
-                case ShortType.ID:
-                case IntegerType.ID:
-                    scalar = new BinaryScalar<>(integerFunction, name, DataTypes.INTEGER, features);
-                    break;
+                    case FloatType.ID:
+                        scalar = new BinaryScalar<>(floatFunction, name, DataTypes.FLOAT, features);
+                        break;
 
-                case LongType.ID:
-                case TimestampType.ID_WITH_TZ:
-                case TimestampType.ID_WITHOUT_TZ:
-                    scalar = new BinaryScalar<>(longFunction, name, DataTypes.LONG, features);
-                    break;
+                    case ByteType.ID:
+                    case ShortType.ID:
+                    case IntegerType.ID:
+                        scalar = new BinaryScalar<>(integerFunction, name, DataTypes.INTEGER, features);
+                        break;
 
-                default:
-                    throw new UnsupportedOperationException(
-                        operator + " is not supported on expressions of type " + dataType.getName());
+                    case IntervalType.ID:
+                        scalar = new IntervalArithmeticScalar(operator, name);
+                        break;
+
+                    case LongType.ID:
+                    case TimestampType.ID_WITH_TZ:
+                    case TimestampType.ID_WITHOUT_TZ:
+                        scalar = new BinaryScalar<>(longFunction, name, DataTypes.LONG, features);
+                        break;
+
+                    default:
+                        throw new UnsupportedOperationException(
+                            operator + " is not supported on expressions of type " + fst.getName());
+                }
+                return Scalar.withOperator(scalar, operator);
             }
-            return Scalar.withOperator(scalar, operator);
+
+            if (isInterval(fst) && isTimestamp(snd)) {
+                return new IntervalTimestampScalar(operator, name, fst, snd, snd);
+            }
+            if (isTimestamp(fst) && isInterval(snd)) {
+                return new IntervalTimestampScalar(operator, name, fst, snd, fst);
+            }
+
+            throw new UnsupportedOperationException(
+                String.format(Locale.ENGLISH, "Arithmetic operation are not supported for type %s %s", fst, snd));
         }
+
+        private static boolean isInterval(DataType d) {
+            return d.id() == IntervalType.ID;
+        }
+
+        private static boolean isTimestamp(DataType d) {
+            return TIMESTAMP_IDS.contains(d.id());
+        }
+
+        static final Set<Integer> TIMESTAMP_IDS = Sets.newHashSet(DataTypes.TIMESTAMP.id(),
+                                                                          DataTypes.TIMESTAMPZ.id());
+
     }
 
     public static Function of(String name, Symbol first, Symbol second, Set<FunctionInfo.Feature> features) {
@@ -207,5 +262,95 @@ public class ArithmeticFunctions {
             ),
             ImmutableList.of(first, second)
         );
+    }
+
+    private static final class IntervalArithmeticScalar extends Scalar<Period, Object> {
+
+        private final FunctionInfo info;
+        private final BiFunction<Period, Period, Period> operation;
+
+        IntervalArithmeticScalar(String operator, String name) {
+            this.info = new FunctionInfo(
+                new FunctionIdent(name, Arrays.asList(DataTypes.INTERVAL, DataTypes.INTERVAL)), DataTypes.INTERVAL);
+            switch (operator) {
+                case "+":
+                    operation = Period::plus;
+                    break;
+                case "-":
+                    operation = Period::minus;
+                    break;
+                default:
+                    operation = (a,b) -> {
+                        throw new IllegalArgumentException("Unsupported operator for interval " + operator);
+                    };
+            }
+        }
+
+        @Override
+        public Period evaluate(TransactionContext txnCtx, Input<Object>... args) {
+            Period fst = (Period) args[0].value();
+            Period snd = (Period) args[1].value();
+
+            if (fst == null || snd == null) {
+                return null;
+            }
+            return operation.apply(fst, snd);
+        }
+
+        @Override
+        public FunctionInfo info() {
+            return this.info;
+        }
+    }
+
+    private static final class IntervalTimestampScalar extends Scalar<Long, Object> {
+
+        private final BiFunction<DateTime, Period, DateTime> operation;
+        private final FunctionInfo info;
+        private final int periodIdx;
+        private final int timestampIdx;
+
+        IntervalTimestampScalar(String operator, String name, DataType firstType, DataType secondType, DataType returnType) {
+            this.info = new FunctionInfo(new FunctionIdent(name, Arrays.asList(firstType, secondType)), returnType);
+            if (ArithmeticFunctionResolver.isInterval(firstType)) {
+                periodIdx = 0;
+                timestampIdx = 1;
+            } else {
+                periodIdx = 1;
+                timestampIdx = 0;
+            }
+
+            switch (operator) {
+                case "+":
+                    operation = DateTime::plus;
+                    break;
+                case "-":
+                    if (ArithmeticFunctionResolver.isInterval(firstType)) {
+                        throw new IllegalArgumentException("Unsupported operator for interval " + operator);
+                    }
+                    operation = DateTime::minus;
+                    break;
+                default:
+                    operation = (a,b) -> {
+                        throw new IllegalArgumentException("Unsupported operator for interval " + operator);
+                    };
+            }
+        }
+
+        @Override
+        public Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
+            final Long timestamp = (Long) args[timestampIdx].value();
+            final Period period = (Period) args[periodIdx].value();
+
+            if (period == null || timestamp == null) {
+                return null;
+            }
+            return operation.apply(new DateTime(timestamp, DateTimeZone.UTC), period).toInstant().getMillis();
+        }
+
+        @Override
+        public FunctionInfo info() {
+            return this.info;
+        }
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.arithmetic;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.hamcrest.Matchers;
+import org.joda.time.Period;
+import org.junit.Test;
+
+public class IntervalFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_interval_to_interval() {
+        assertEvaluate("interval '1 second' + interval '1 second'", Period.seconds(2));
+        assertEvaluate("interval '1100 years' + interval '2000 years'", Period.years(3100));
+        assertEvaluate("interval '-10 years' + interval '1 years'", Period.years(-9));
+        assertEvaluate("interval '2 second' - interval '1 second'", Matchers.is(Period.seconds(1)));
+        assertEvaluate("interval '-1 second' - interval '-1 second'", Matchers.is(Period.seconds(0)));
+        assertEvaluate("interval '1 month' + interval '1 year'", Matchers.is(Period.years(1).withMonths(1)));
+    }
+
+    @Test
+    public void test_out_of_range_value() {
+        expectedException.expect(ArithmeticException.class);
+        expectedException.expectMessage("Interval field value out of range");
+        assertEvaluate("interval '9223372036854775807'", Matchers.is(Period.seconds(1)));
+    }
+
+    @Test
+    public void test_null_interval() {
+        assertEvaluate("null + interval '1 second'", Matchers.nullValue());
+        assertEvaluate("null - interval '1 second'", Matchers.nullValue());
+        assertEvaluate("null * interval '1 second'", Matchers.nullValue());
+        assertEvaluate("null / interval '1 second'", Matchers.nullValue());
+        assertEvaluate("null % interval '1 second'", Matchers.nullValue());
+        assertEvaluate("interval '1 second' + null", Matchers.nullValue());
+        assertEvaluate("interval '1 second' - null", Matchers.nullValue());
+        assertEvaluate("interval '1 second' * null", Matchers.nullValue());
+        assertEvaluate("interval '1 second' / null", Matchers.nullValue());
+        assertEvaluate("interval '1 second' % null", Matchers.nullValue());
+    }
+
+    @Test
+    public void test_timestamp_interval() {
+        assertEvaluate("interval '1 second' + '86400000'::timestamp", Matchers.is(86401000L));
+        assertEvaluate("'86401000'::timestamp - interval '1 second'", Matchers.is(86400000L));
+        assertEvaluate("'86400000'::timestamp - interval '-1 second'", Matchers.is(86401000L));
+        assertEvaluate("'86400000'::timestamp + interval '-1 second'", Matchers.is(86399000L));
+        assertEvaluate("'86400000'::timestamp - interval '1000 years'", Matchers.is(-31556822400000L));
+        assertEvaluate("'9223372036854775807'::timestamp - interval '1 second'", Matchers.is(9223372036854774807L));
+
+    }
+
+    @Test
+    public void test_unallowed_operations() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Unsupported operator for interval -");
+        assertEvaluate("interval '1 second' - '86401000'::timestamp", Matchers.is(86400000L));
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
