### PR TITLE
Support functions without arguments in FunctionCopyVisitor.

### DIFF
--- a/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -44,7 +44,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         switch (args.size()) {
             // specialized functions to avoid allocations for common cases
             case 0:
-                return func;
+                return zeroArg(func, context);
 
             case 1:
                 return oneArg(func, context);
@@ -96,6 +96,21 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
             return func;
         }
         return new Function(func.info(), List.of(newArg1, newArg2), newFilter);
+    }
+
+    private Function zeroArg(Function func, C context) {
+        assert func.arguments().size() == 0 : "size of arguments must be zero";
+
+        Symbol filter = func.filter();
+        if (filter == null) {
+            return func;
+        }
+
+        Symbol newFilter = process(filter, context);
+        if (filter == newFilter) {
+            return func;
+        }
+        return new Function(func.info(), List.of(), newFilter);
     }
 
     private Function oneArg(Function func, C context) {

--- a/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -123,4 +123,12 @@ public class AggregateExpressionIntegrationTest extends SQLTransportIntegrationT
                    is("a| [1, 4]| [3]\n" +
                       "b| [4]| [3, 5]\n"));
     }
+
+    @Test
+    public void test_filter_in_count_star_aggregate_function() {
+        execute("SELECT" +
+                "   COUNT(*) FILTER (WHERE x > 2) " +
+                "FROM UNNEST([1, 3, 4, 2, 5, 4]) as t(x)");
+        assertThat(printedTable(response.rows()), is("4\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The filter clause in aggregate expressions is not released yet, therefore, there is no changelog entry.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
