### PR TITLE
Register subscript for objects only once instead of per return type

### DIFF
--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -41,7 +41,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Map.entry;
@@ -418,9 +417,5 @@ public final class DataTypes {
 
     public static DataType fromId(Integer id) {
         return TYPE_REGISTRY.get(id).get();
-    }
-
-    public static List<DataType> allRegisteredTypes() {
-        return TYPE_REGISTRY.values().stream().map(Supplier::get).collect(Collectors.toList());
     }
 }

--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -87,18 +86,16 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         return innerTypes.getOrDefault(key, UndefinedType.INSTANCE);
     }
 
-    @Nullable
-    public DataType resolveInnerType(List<String> path) {
+    public DataType<?> resolveInnerType(List<String> path) {
         if (path.isEmpty()) {
-            return null;
+            return DataTypes.UNDEFINED;
         }
-
-        DataType innerType = null;
+        DataType innerType = DataTypes.UNDEFINED;
         ObjectType currentObject = this;
         for (int i = 0; i < path.size(); i++) {
             innerType = currentObject.innerTypes().get(path.get(i));
             if (innerType == null) {
-                return null;
+                return DataTypes.UNDEFINED;
             }
             if (innerType.id() == ID) {
                 currentObject = (ObjectType) innerType;

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -699,35 +699,14 @@ public class ExpressionAnalyzer {
         private Symbol createSubscript(Symbol name, Symbol index, ExpressionAnalysisContext context) {
             String function = name.valueType().id() == ObjectType.ID
                 // we don't know the the concrete object element (return) type
-                ? SubscriptObjectFunction.getNameForReturnType(UndefinedType.INSTANCE)
+                ? SubscriptObjectFunction.NAME
                 : SubscriptFunction.NAME;
             return allocateFunction(function, ImmutableList.of(name, index), context);
         }
 
         private Symbol createSubscript(Symbol symbol, List<String> parts, ExpressionAnalysisContext context) {
-            DataType symbolType = symbol.valueType();
             List<Symbol> arguments = mapTail(symbol, parts, Literal::of);
-            List<DataType> argumentTypes = Symbols.typeView(arguments);
-
-            if (symbolType.id() != ObjectType.ID) {
-                return allocateFunction(
-                    SubscriptObjectFunction.getNameForReturnType(UndefinedType.INSTANCE),
-                    arguments,
-                    context);
-            }
-
-            DataType innerType = ((ObjectType) symbolType).resolveInnerType(parts);
-            if (innerType == null) {
-                innerType = UndefinedType.INSTANCE;
-            }
-            // If the innerType is a object type, we must allocate the function with that concrete type to keep the
-            // allocated inner types as this return type is used on nested calls to resolve further inner types.
-            SubscriptObjectFunction funcImpl = SubscriptObjectFunction.ofReturnType(innerType, argumentTypes);
-            Function func = new Function(funcImpl.info(), arguments);
-            if (Symbols.allLiterals(func)) {
-                return funcImpl.normalizeSymbol(func, coordinatorTxnCtx);
-            }
-            return func;
+            return allocateFunction(SubscriptObjectFunction.NAME, arguments, context);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -22,6 +22,7 @@
 package io.crate.execution.dsl.projection.builder;
 
 import com.google.common.base.MoreObjects;
+import io.crate.expression.scalar.SubscriptObjectFunction;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.FetchReference;
@@ -49,7 +50,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 
 import static io.crate.common.collections.Lists2.mapTail;
-import static io.crate.expression.scalar.SubscriptObjectFunction.getNameForReturnType;
 import static io.crate.expression.symbol.Symbols.lookupValueByColumn;
 
 /**
@@ -243,9 +243,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         List<DataType> argumentTypes = Symbols.typeView(arguments);
 
         return new Function(
-            new FunctionInfo(
-                new FunctionIdent(getNameForReturnType(returnType), argumentTypes),
-                returnType),
+            new FunctionInfo(new FunctionIdent(SubscriptObjectFunction.NAME, argumentTypes), returnType),
             arguments
         );
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So far we encoded the return type for subscripts on objects
(`obj['x']['y']`) into the method name.

We did this to preserve the type information which we can determine
based on the object type and by the given path (`[x, y]`).

We did this because of how our `Function` is constructed (by using the
FunctionResolver, which doesn't allow us to keep onto this return type
information).

This commit now follows a different approach: We first create the
`Function` with `undefined` as return-type and then utilize
`normalizeSymbol` to try to get the concrete type from the given
arguments and `ObjectType` information.

The main motivation for this change is to get rid of
`allRegisteredTypes` from `DataType`, which makes a migration from
`Streamable` to `Writeable` more difficult.



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)