### PR TITLE
Fix a race condition resulting in an error on sys.shards queries

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -104,4 +104,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a race condition which could result in a ``AlreadyClosedException``
+  when querying the ``sys.shards`` table.

--- a/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -361,7 +361,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testShardSizeExpressionWhenIndexShardHasBeenClosed() {
         IndexShard mock = mockIndexShard();
-        when(mock.storeStats()).thenReturn(null);
+        when(mock.storeStats()).thenThrow(new AlreadyClosedException("shard already closed"));
 
         ShardReferenceResolver resolver = new ShardReferenceResolver(schemas, new ShardRowContext(mock, clusterService));
         Reference refInfo = refInfo("sys.shards.size", DataTypes.LONG, RowGranularity.SHARD);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`ShardCollectorProviderTest.testQuerySysShardsWhileDropTable` failed:

    org.apache.lucene.store.AlreadyClosedException: store is already closed
            at __randomizedtesting.SeedInfo.seed([13EBE2975358553C:2213A773335A3E0E]:0)
            at org.elasticsearch.index.store.Store.ensureOpen(Store.java:227)
            at org.elasticsearch.index.store.Store.stats(Store.java:361)
            at org.elasticsearch.index.shard.IndexShard.storeStats(IndexShard.java:902)
            at io.crate.expression.reference.sys.shard.ShardRowContext.lambda$new$0(ShardRowContext.java:59)
            at com.google.common.base.Suppliers$ExpiringMemoizingSupplier.get(Suppliers.java:243)
            at io.crate.expression.reference.sys.shard.ShardRowContext.size(ShardRowContext.java:116)
            at io.crate.execution.engine.collect.NestableCollectExpression$FuncExpression.setNextRow(NestableCollectExpression.java:74)
            at io.crate.execution.engine.collect.ValueAndInputRow.apply(ValueAndInputRow.java:61)
            at io.crate.execution.engine.collect.ValueAndInputRow.apply(ValueAndInputRow.java:41)
            at com.google.common.collect.Iterators$6.transform(Iterators.java:783)
            at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
            at com.google.common.collect.Iterators$5.computeNext(Iterators.java:636)
            at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141)
            at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:136)
            at io.crate.data.InMemoryBatchIterator.moveNext(InMemoryBatchIterator.java:82)
            at io.crate.data.CloseAssertingBatchIterator.moveNext(CloseAssertingBatchIterator.java:55)
            at io.crate.data.MappedForwardingBatchIterator.moveNext(MappedForwardingBatchIterator.java:42)
            at io.crate.execution.engine.distribution.DistributingConsumer.consumeIt(DistributingConsumer.java:109)
            at io.crate.execution.engine.distribution.DistributingConsumer.accept(DistributingConsumer.java:100)
            at io.crate.data.ListenableRowConsumer.accept(ListenableRowConsumer.java:40)
            at io.crate.execution.engine.collect.CollectTask.lambda$innerStart$0(CollectTask.java:142)
            at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:624)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at java.lang.Thread.run(Thread.java:835)



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
