### PR TITLE
Account for the count(*) aggregate filter in optimizer.

### DIFF
--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -59,6 +59,14 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     @Override
     public Count apply(HashAggregate aggregate, Captures captures) {
         Collect collect = captures.get(collectCapture);
-        return new Count(Lists2.getOnlyElement(aggregate.aggregates()), collect.relation(), collect.where());
+        var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
+        if (countAggregate.filter() != null) {
+            return new Count(
+                countAggregate,
+                collect.relation(),
+                collect.where().add(countAggregate.filter()));
+        } else {
+            return new Count(countAggregate, collect.relation(), collect.where());
+        }
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -126,9 +126,11 @@ public class AggregateExpressionIntegrationTest extends SQLTransportIntegrationT
 
     @Test
     public void test_filter_in_count_star_aggregate_function() {
-        execute("SELECT" +
-                "   COUNT(*) FILTER (WHERE x > 2) " +
-                "FROM UNNEST([1, 3, 4, 2, 5, 4]) as t(x)");
-        assertThat(printedTable(response.rows()), is("4\n"));
+        execute("CREATE TABLE t (x int)");
+        execute("INSERT INTO t VALUES (1), (3), (2), (4)");
+        execute("REFRESH TABLE t");
+
+        execute("SELECT COUNT(*) FILTER (WHERE x > 2) FROM t");
+        assertThat(printedTable(response.rows()), is("2\n"));
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -170,6 +170,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_select_count_star_is_optimized_if_there_is_a_single_agg_in_select_list() {
+        LogicalPlan plan = plan("SELECT COUNT(*), COUNT(x) FROM t1 WHERE x > 10");
+        assertThat(plan, isPlan("Aggregate[count(*), count(x)]\n" +
+                                "Collect[doc.t1 | [x] | (x > 10)]\n"));
+    }
+
+    @Test
     public void testSelectCountStarIsOptimizedOnNestedSubqueries() throws Exception {
         LogicalPlan plan = plan("select * from t1 where x > (select 1 from t1 where x > (select count(*) from t2 limit 1)::integer)");
         // instead of a Collect plan, this must result in a CountPlan through optimization

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -438,4 +438,21 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "Collect[doc.t1 | [x] | (x = 10)]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }
+
+    @Test
+    public void test_count_start_aggregate_filter_is_pushed_down() {
+        var plan = plan("SELECT COUNT(*) FILTER (WHERE x > 1) FROM t1");
+        var expectedPlan = "Count[doc.t1 | (x > 1)]\n";
+        assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
+    }
+
+    @Test
+    public void test_count_start_aggregate_filter_is_merged_with_where_clause_query() {
+        var plan = plan(
+            "SELECT COUNT(*) FILTER (WHERE x > 1) " +
+            "FROM t1 " +
+            "WHERE x > 10");
+        var expectedPlan = "Count[doc.t1 | ((x > 10) AND (x > 1))]\n";
+        assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `MergeAggregateAndCollectToCount` rule merges the aggregate
and collect to the count operator if there is only a single
collect star aggregate. The rule was neglecting the aggregate filter
while building the new count operator. This change adds the filter
to the count operator or merges it with an existing where clause
query.

It is hard to split it this commit into a fix and predicate push down. 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
