### PR TITLE
Add typeof function

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,8 @@ Breaking Changes
 Changes
 =======
 
+- Added the :ref:`PG_TYPEOF <pg_typeof>` system function.
+
 - Support implicit object creation in update statements. E.g. ``UPDATE t SET
   obj['x'] = 10`` will now implicitly set ``obj`` to ``{obj: {x: 10}}`` on rows
   where ``obj`` was previously ``null``.

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -2338,6 +2338,32 @@ Example::
     +--------------------+
     SELECT 1 row in set (... sec)
 
+.. _pg_typeof:
+
+``pg_typeof``
+=============
+
+The function ``pg_typeof`` returns the text representation of the value's data
+type passed to it.
+
+Returns: ``text``
+
+Synopsis::
+
+   pg_typeof(expression)
+
+Example:
+
+::
+
+    cr> select pg_typeof([1, 2, 3]) as typeof;
+    +--------------+
+    | typeof       |
+    +--------------+
+    | bigint_array |
+    +--------------+
+    SELECT 1 row in set (... sec)
+
 Special functions
 =================
 

--- a/blackbox/docs/general/ddl/data-types.rst
+++ b/blackbox/docs/general/ddl/data-types.rst
@@ -992,6 +992,11 @@ See the table below for a full list of aliases:
 | timestamptz | timestamp with time zone |
 +-------------+--------------------------+
 
+.. NOTE::
+
+   The :ref:`PG_TYPEOF <pg_typeof>` system function can be used to resolve the
+   data type of any expression.
+
 .. _pattern letters and symbols:
     https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html
 .. _WKT: http://en.wikipedia.org/wiki/Well-known_text

--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -79,6 +79,7 @@ public final class DataTypes {
     public static final ArrayType<String> STRING_ARRAY = new ArrayType<>(STRING);
     public static final ArrayType<Integer> INTEGER_ARRAY = new ArrayType<>(INTEGER);
     public static final ArrayType<Short> SHORT_ARRAY = new ArrayType<>(SHORT);
+    public static final ArrayType<Long> BIGINT_ARRAY = new ArrayType<>(LONG);
 
     public static final List<DataType> PRIMITIVE_TYPES = List.of(
         BYTE,

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -62,6 +62,7 @@ import io.crate.expression.scalar.string.TrimFunctions;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
+import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.scalar.timestamp.TimezoneFunction;
 import io.crate.metadata.FunctionIdent;
@@ -168,6 +169,7 @@ public class ScalarFunctionModule extends AbstractModule {
 
         PgBackendPidFunction.register(this);
         PgGetUserByIdFunction.register(this);
+        PgTypeofFunction.register(this);
         register(new CurrentDatabaseFunction());
 
         // bind all registered functions and resolver

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.BaseFunctionResolver;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.params.FuncParams;
+import io.crate.metadata.functions.params.Param;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+public final class PgTypeofFunction extends Scalar<String, Object> {
+
+    private static final FunctionName FQNAME = new FunctionName(PgCatalogSchemaInfo.NAME, "pg_typeof");
+    private static final FuncParams FUNCTION_PARAMS = FuncParams.builder(Param.ANY).build();
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(FQNAME, new BaseFunctionResolver(FUNCTION_PARAMS) {
+            @Override
+            public FunctionImplementation getForTypes(List<DataType> signatureTypes) throws IllegalArgumentException {
+                return new PgTypeofFunction(new FunctionInfo(new FunctionIdent(FQNAME, signatureTypes),
+                                                             DataTypes.STRING));
+            }
+        });
+    }
+
+    private final FunctionInfo info;
+    private final String type;
+
+    private PgTypeofFunction(FunctionInfo info) {
+        this.info = info;
+        type = this.info.ident().argumentTypes().get(0).getName();
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return info;
+    }
+
+    @SafeVarargs
+    @Override
+    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        assert args.length == 1 : "typeof expects exactly 1 argument, got: " + args.length;
+        return type;
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -86,6 +86,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             "  tags array(text)," +
             "  age int," +
             "  a int," +
+            "  ip ip," +
+            "  c char," +
             "  x bigint," +
             "  shape geo_shape," +
             "  timestamp_tz timestamp with time zone," +
@@ -95,6 +97,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             "  time_format text," +
             "  long_array array(bigint)," +
             "  int_array array(int)," +
+            "  short_array array(short)," +
+            "  double_array array(double precision)," +
             "  regex_pattern text," +
             "  geoshape geo_shape," +
             "  geopoint geo_point," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

During the development of the timezone scalar function it would have 
helped me to have a typeof function to reveal the type of the values I
was playing with. I have created this draft to get feedback as to whether
I am on the right track. I coded this function while exploring the code
base.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
