### PR TITLE
Fix output symbols order in WindowAggProjection.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -104,5 +104,9 @@ Changes
 Fixes
 =====
 
+- Fix serialization issue that might occur in distributed queries that
+  contain window function calls with the partition by clause in the select
+  list.
+
 - Fixed a race condition which could result in a ``AlreadyClosedException``
   when querying the ``sys.shards`` table.

--- a/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
@@ -263,4 +263,16 @@ public class WindowFunctionsIntegrationTest extends SQLTransportIntegrationTest 
                       "4\n" +
                       "4\n"));
     }
+
+    // the query execution plan (distributed, non-distributed)
+    // depends on the test cluster setup.
+    @Test
+    public void test_select_with_standalone_ref_and_partitioned_window_on_table_relation() {
+        execute("create table t (x int, y string)");
+        execute("insert into t values (1, '1')");
+        execute("refresh table t");
+
+        execute("SELECT x, COLLECT_SET(y) OVER(PARTITION BY y) FROM t");
+        assertThat(printedTable(response.rows()), is("1| [1]\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It might happen that outputs of `WindowAggProjection`
don't match actual outputs of the `WindowBatchIterator`.
The reason why it happens is that the window function symbols
in the window aggregation projection outputs list are placed in
the beginning and the standalone input symbols are placed after
them. The materialization of row in the window batch iterator
happens in a way that the result of the window function evaluation
is placed in a prepared spare cell at the end of a row. That would
results in a mismatch between outputs of the projection and the
outputs of the batch iterator. It may lead to various exceptions,
for instance, streaming the result of window function evaluation
to a handler node might fail because of serialization exception,
such as streamers for the values are created based on the outputs
of the projection.

One scenario where it can happen is a select statement with a
standalone reference and a window function call that contains
the partition by clause in its definition ran against against
a concrete table relation.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
