### PR TITLE
Fixed dynamic resize logic of our long BitSet wrapper.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -104,7 +104,10 @@ Changes
 Fixes
 =====
 
-- Fix serialization issue that might occur in distributed queries that
+- Fixed an ``OUTER JOIN`` issue resulting in an ``ArrayOutOfBoundException``
+  if the gap between matching rows of the tables was growing to big numbers.
+
+- Fixed serialization issue that might occur in distributed queries that
   contain window function calls with the partition by clause in the select
   list.
 

--- a/dex/src/test/java/io/crate/data/join/LuceneLongBitSetWrapperTest.java
+++ b/dex/src/test/java/io/crate/data/join/LuceneLongBitSetWrapperTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data.join;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class LuceneLongBitSetWrapperTest {
+
+    @Test
+    public void testCapacityIsIncreasedDynamically() {
+        LuceneLongBitSetWrapper bitSet = new LuceneLongBitSetWrapper();
+
+        // we had a regression which threw an exception if the index was greater than the step * 2.
+        long index = LuceneLongBitSetWrapper.INCREASE_BY_STEP * 3;
+        bitSet.set(index);
+
+        assertThat(bitSet.get(index), is(true));
+    }
+}


### PR DESCRIPTION
The existing logic only increased the size by multiple of 2 while an incoming index could be much larger and thus resulted in an out-of-bound exception when trying to set the index.
