### PR TITLE
Remove two-step nodeId resolving in BaseNodesRequest

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -31,10 +31,7 @@ import java.io.IOException;
  */
 public abstract class BaseNodeResponse extends TransportResponse {
 
-    private DiscoveryNode node;
-
-    protected BaseNodeResponse() {
-    }
+    private final DiscoveryNode node;
 
     protected BaseNodeResponse(DiscoveryNode node) {
         assert node != null;

--- a/es/es-server/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/es/es-server/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -27,12 +27,12 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndicesService;
 
-import java.util.Arrays;
 import java.util.function.Function;
 
 public class Gateway {
@@ -54,9 +54,9 @@ public class Gateway {
     }
 
     public void performStateRecovery(final GatewayStateRecoveredListener listener) throws GatewayException {
-        final String[] nodesIds = clusterService.state().nodes().getMasterNodes().keys().toArray(String.class);
-        logger.trace("performing state recovery from {}", Arrays.toString(nodesIds));
-        final TransportNodesListGatewayMetaState.NodesGatewayMetaState nodesState = listGatewayMetaState.list(nodesIds, null).actionGet();
+        DiscoveryNode[] discoveryNodes = clusterService.state().nodes().getMasterNodes().values().toArray(DiscoveryNode.class);
+        logger.trace("performing state recovery from {}", discoveryNodes);
+        final TransportNodesListGatewayMetaState.NodesGatewayMetaState nodesState = listGatewayMetaState.list(discoveryNodes, null).actionGet();
 
         final int requiredAllocation = 1;
 

--- a/es/es-server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/es/es-server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -63,9 +63,9 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
         this.metaState = metaState;
     }
 
-    public ActionFuture<NodesGatewayMetaState> list(String[] nodesIds, @Nullable TimeValue timeout) {
+    public ActionFuture<NodesGatewayMetaState> list(DiscoveryNode[] discoveryNodes, @Nullable TimeValue timeout) {
         PlainActionFuture<NodesGatewayMetaState> future = PlainActionFuture.newFuture();
-        execute(new Request(nodesIds).timeout(timeout), future);
+        execute(new Request(discoveryNodes).timeout(timeout), future);
         return future;
     }
 
@@ -91,8 +91,8 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
     public static class Request extends BaseNodesRequest<Request> {
 
-        public Request(String... nodesIds) {
-            super(nodesIds);
+        public Request(DiscoveryNode... nodes) {
+            super(nodes);
         }
 
         public Request(StreamInput in) throws IOException {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The only call-site has the concrete DiscoveryNodes already available.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)