### PR TITLE
Support assignments to nested column where the parent is null

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,10 @@ Breaking Changes
 Changes
 =======
 
+- Support implicit object creation in update statements. E.g. ``UPDATE t SET
+  obj['x'] = 10`` will now implicitly set ``obj`` to ``{obj: {x: 10}}`` on rows
+  where ``obj`` was previously ``null``.
+
 - Added :ref:`LPAD <scalar-lpad>` and :ref:`RPAD <scalar-rpad>` scalar functions.
 
 - Added the :ref:`table_parameter.codec` parameter to :ref:`ref-create-table`

--- a/common/src/main/java/io/crate/common/collections/Maps.java
+++ b/common/src/main/java/io/crate/common/collections/Maps.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
@@ -100,9 +99,8 @@ public final class Maps {
             if (source.containsKey(key)) {
                 Map<String, Object> contents = (Map<String, Object>) source.get(key);
                 if (contents == null) {
-                    throw new IllegalArgumentException(String.format(Locale.ENGLISH,
-                        "Object %s is null, cannot write %s = %s into it", key, String.join(".", path), value));
-
+                    contents = new HashMap<>();
+                    source.put(key, contents);
                 }
                 String nextKey = path.get(0);
                 mergeInto(contents, nextKey, path.subList(1, path.size()), value);

--- a/common/src/test/java/io/crate/common/collections/MapsTest.java
+++ b/common/src/test/java/io/crate/common/collections/MapsTest.java
@@ -60,8 +60,8 @@ public class MapsTest extends CrateUnitTest {
         HashMap<String, Object> m = new HashMap<>();
         m.put("o", null);
 
-        expectedException.expectMessage("Object o is null, cannot write x = 10 into it");
         Maps.mergeInto(m, "o", Collections.singletonList("x"), 10);
+        assertThat(m, is(Map.of("o", Map.of("x", 10))));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class MapsTest extends CrateUnitTest {
         HashMap<String, Object> m = new HashMap<>();
         m.put("o", null);
 
-        expectedException.expectMessage("Object o is null, cannot write x.y = 10 into it");
         Maps.mergeInto(m, "o", Arrays.asList("x", "y"), 10);
+        assertThat(m, is(Map.of("o", Map.of("x", Map.of("y", 10)))));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1305,17 +1305,6 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testInsertIntoUpdateOnNullObjectColumnWithSubscript() throws Exception {
-        execute("create table t (id integer primary key, i integer, o object)");
-        ensureYellow();
-        execute("insert into t (id, i, o) values(1, 1, null)");
-        execute("refresh table t");
-
-        expectedException.expectMessage("Object o is null, cannot write x = 5 into it");
-        execute("insert into t (id, i, o) values (1, 1, null) ON CONFLICT (id) DO UPDATE set o['x'] = 5");
-    }
-
-    @Test
     public void testInsertFromQueryWithGeneratedPrimaryKey() throws Exception {
         execute("create table t (x int, y int, z as x + y primary key)");
         ensureYellow();
@@ -1427,7 +1416,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
                 " id int," +
                 " owner text default 'crate'" +
                 ") with (number_of_replicas=0)");
-        
+
         execute("insert into t (id) values (?)",
                 new Object[]{1});
         execute("insert into t (id) select 2");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/8832


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)