### PR TITLE
Throw correct error if window func arg is not in grouping

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -113,6 +113,9 @@ Changes
 Fixes
 =====
 
+- Improved error handling if an argument of a window function is not used as a
+  grouping symbol.
+
 - Fixed an ``OUTER JOIN`` issue resulting in an ``ArrayOutOfBoundException``
   if the gap between matching rows of the tables was growing to big numbers.
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -427,7 +427,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             Symbol output = outputSymbols.get(i);
             if (groupBy == null || !groupBy.contains(output)) {
                 SymbolType symbolType = output.symbolType();
-                if (symbolType.isValueSymbol() || symbolType.equals(SymbolType.WINDOW_FUNCTION)) {
+                if (symbolType.isValueSymbol()) {
                     // values and window functions are allowed even if not present in group by
                     continue;
                 }
@@ -437,8 +437,9 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     String offendingSymbolName = symbolPrinter.printUnqualified(output);
                     if (output instanceof Function) {
                         Function function = (Function) output;
-                        if (function.info().type() == FunctionInfo.Type.TABLE) {
-                            // table function can occur in the outputs without being present in the GROUP BY
+                        if (function.info().type() == FunctionInfo.Type.TABLE
+                            || function.symbolType() == SymbolType.WINDOW_FUNCTION) {
+                            // table or window function can occur in the outputs without being present in the GROUP BY
                             // if the arguments to it are within GROUP BY
                             ensureNonAggregatesInGroupBy(symbolPrinter, function.arguments(), groupBy);
                             return;

--- a/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
@@ -183,4 +183,13 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
         expectedException.expectMessage("Window w does not exist");
         e.analyze("SELECT AVG(x) OVER w FROM t WINDOW ww AS ()");
     }
+
+    @Test
+    public void test_window_function_symbols_not_in_grouping_raises_an_error() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("'x' must appear in the GROUP BY clause or be used in an aggregation function.");
+        e.analyze("select y, sum(x) over(partition by x) " +
+                "FROM unnest([1], [6]) as t(x, y) " +
+                "group by 1");
+    }
 }


### PR DESCRIPTION
All symbols used for a window function must be part of the grouping symbols. This case was not handled and thus resulted in non-user friendly errors while trying to resolve these symbols.
