### PR TITLE
Close searchers via BatchIterator instead of via CollectTask

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
@@ -85,7 +85,8 @@ public class LuceneBatchIteratorBenchmark {
             collectorContext,
             RAM_ACCOUNTING_CONTEXT,
             columnRefs,
-            columnRefs
+            columnRefs,
+            () -> {}
         );
 
         while (it.moveNext()) {

--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -148,7 +148,8 @@ public class OrderedLuceneBatchIteratorBenchmark {
             f -> null,
             new Sort(new SortedNumericSortField(sortByColumnName, SortField.Type.INT, reverseFlags[0])),
             expressions,
-            expressions
+            expressions,
+            () -> {}
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -141,7 +141,6 @@ final class GroupByOptimizedIterator {
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
         try {
             QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
             InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
             docCtx.add(collectPhase.toCollect().stream()::iterator);

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -115,7 +115,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 queryShardContext,
                 sharedShardContext.indexService().cache()
             );
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
             InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx =
                 docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
 
@@ -127,7 +126,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 getCollectorContext(sharedShardContext.readerId(), queryShardContext::getForField),
                 collectTask.queryPhaseRamAccountingContext(),
                 docCtx.topLevelInputs(),
-                docCtx.expressions()
+                docCtx.expressions(),
+                searcher::close
             );
         } catch (Throwable t) {
             searcher.close();
@@ -172,7 +172,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 queryShardContext,
                 indexService.cache()
             );
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
             ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
             collectorContext = getCollectorContext(sharedShardContext.readerId(), queryShardContext::getForField);
         } catch (Throwable t) {
@@ -204,7 +203,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             optimizeQueryForSearchAfter,
             LuceneSortGenerator.generateLuceneSort(collectTask.txnCtx(), collectorContext, collectPhase.orderBy(), docInputFactory, fieldTypeLookup),
             ctx.topLevelInputs(),
-            ctx.expressions()
+            ctx.expressions(),
+            searcher::close
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -61,6 +61,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
 
     private final IndexSearcher indexSearcher;
     private final Query query;
+    private final Runnable releaseResources;
     private final CollectorContext collectorContext;
     private final RamAccountingContext ramAccountingContext;
     private final boolean doScores;
@@ -84,9 +85,11 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
                                CollectorContext collectorContext,
                                RamAccountingContext ramAccountingContext,
                                List<? extends Input<?>> inputs,
-                               Collection<? extends LuceneCollectorExpression<?>> expressions) {
+                               Collection<? extends LuceneCollectorExpression<?>> expressions,
+                               Runnable releaseResources) {
         this.indexSearcher = indexSearcher;
         this.query = query;
+        this.releaseResources = releaseResources;
         this.doScores = doScores || minScore != null;
         this.minScore = minScore;
         this.collectorContext = collectorContext;
@@ -178,8 +181,11 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
 
     @Override
     public void close() {
-        closed = true;
-        clearState();
+        if (!closed) {
+            closed = true;
+            clearState();
+            releaseResources.run();
+        }
     }
 
     @Override
@@ -243,5 +249,8 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     @Override
     public void kill(@Nonnull Throwable throwable) {
         killed = throwable;
+        if (!closed) {
+            releaseResources.run();
+        }
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
@@ -77,7 +77,12 @@ public final class Projectors {
             if (projection.requiredGranularity().ordinal() > projectorFactory.supportedGranularity().ordinal()) {
                 continue;
             }
-            result = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId).apply(result);
+            try {
+                result = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId).apply(result);
+            } catch (Throwable t) {
+                result.close();
+                throw t;
+            }
         }
         return result;
     }
@@ -85,7 +90,12 @@ public final class Projectors {
     public BatchIterator<Row> wrap(BatchIterator<Row> source) {
         BatchIterator<Row> result = source;
         for (Projector projector : projectors) {
-            result = projector.apply(result);
+            try {
+                result = projector.apply(result);
+            } catch (Throwable t) {
+                result.close();
+                throw t;
+            }
         }
         return result;
     }

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -78,7 +78,8 @@ public class LuceneBatchIteratorTest extends CrateUnitTest {
                 new CollectorContext(mappedFieldType -> null),
                 new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy")),
                 columnRefs,
-                columnRefs
+                columnRefs,
+                () -> {}
             )
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -394,7 +394,8 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
             f -> null,
             new Sort(SortField.FIELD_SCORE),
             columnReferences,
-            columnReferences
+            columnReferences,
+            () -> {}
         );
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -202,7 +202,8 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
             f -> null,
             new Sort(new SortedNumericSortField(columnName, SortField.Type.LONG, reverseFlags[0])),
             expressions,
-            expressions
+            expressions,
+            () -> {}
         );
     }
 }

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -170,7 +170,8 @@ public final class QueryTester implements AutoCloseable {
                 new CollectorContext(indexEnv.queryShardContext()::getForField),
                 new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy")),
                 Collections.singletonList(input),
-                ctx.expressions()
+                ctx.expressions(),
+                () -> {}
             );
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So that we don't have to maintain an additional map of searchers.
The main purpose of the `BatchIterator.close` is to release resources,
so we can utilize it for that.

It also fixes a couple of places where we didn't close previously created BatchIterators in case they fall out of scope unused due to other errors. This wasn't an issue so far because the searchers would be released via the task, but it didn't follow the contract.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)