### PR TITLE
Fix documentation header level of `pg_typeof` section

### DIFF
--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -2341,7 +2341,7 @@ Example::
 .. _pg_typeof:
 
 ``pg_typeof``
-=============
+-------------
 
 The function ``pg_typeof`` returns the text representation of the value's data
 type passed to it.


### PR DESCRIPTION
Level is wrong and documentation section is broken, see https://crate.io/docs/crate/reference/en/latest/general/builtins/index.html.