### PR TITLE
Extend FieldReplacer to process MatchPredicate symbols

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -115,6 +115,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.0 that broke the ``MATCH`` predicate if
+  used on aliased relations.
+
 - Improved error handling if an argument of a window function is not used as a
   grouping symbol.
 

--- a/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -160,5 +160,4 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
     protected Symbol visitSymbol(Symbol symbol, C context) {
         return symbol;
     }
-
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -870,4 +870,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         }
         assertThat(numShards, is(1));
     }
+
+    @Test
+    public void test_match_used_on_table_with_alias_is_resolved_to_a_function() {
+        Merge merge = e.plan("select name from users as u where match(u.text, 'yalla') order by 1");
+        Collect collect = (Collect) merge.subPlan();
+        assertThat(((RoutedCollectPhase) collect.collectPhase()).where(), isFunction("match"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A `match` on an aliased table wasn't re-written to a function because
it's fields couldn't be resolved.

We've a re-write in the RelationAnalyzer from `AliasedAnalyzedRelation
-> AbstractTableRelation` to `AliasedAnalyzedRelation -> QueriedTable ->
AbstractTableRelation` which uses the `FieldReplacer` to re-map the
fields. This didn't process the `MatchPredicate` so that later on its `Field`
keys couldn't be resolved to `Reference`, breaking a re-write from the
`MatchPredicate` to a `Function`.

Fixes https://github.com/crate/crate/issues/9041


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)