### PR TITLE
Revert "Make RowConsumer listenable by default"

### DIFF
--- a/blackbox/bin/test-docs
+++ b/blackbox/bin/test-docs
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/../.venv/bin/python -m unittest -v --failfast test_docs
+$DIR/../.venv/bin/python -X faulthandler -m unittest -v --failfast test_docs

--- a/dex/src/main/java/io/crate/data/RowConsumer.java
+++ b/dex/src/main/java/io/crate/data/RowConsumer.java
@@ -23,7 +23,6 @@
 package io.crate.data;
 
 import javax.annotation.Nullable;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 /**
@@ -59,8 +58,6 @@ public interface RowConsumer extends BiConsumer<BatchIterator<Row>, Throwable> {
      */
     @Override
     void accept(BatchIterator<Row> iterator, @Nullable Throwable failure);
-
-    CompletableFuture<?> completionFuture();
 
     /**
      * @return true if the consumer wants to scroll backwards by using {@link BatchIterator#moveToStart}

--- a/dex/src/test/java/io/crate/data/CollectingRowConsumerTest.java
+++ b/dex/src/test/java/io/crate/data/CollectingRowConsumerTest.java
@@ -44,18 +44,18 @@ public class CollectingRowConsumerTest {
             .mapToObj(i -> new Object[]{i})
             .collect(Collectors.toList());
 
-        BatchSimulatingIterator<Row> batchSimulatingIterator =
-            new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 10),
+        BatchSimulatingIterator batchSimulatingIterator =
+            new BatchSimulatingIterator(TestingBatchIterators.range(0, 10),
                 2,
                 5,
                 null);
 
         CollectingRowConsumer<?, List<Object[]>> batchConsumer =
-            new CollectingRowConsumer<>(Collectors.mapping(Row::materialize, Collectors.toList()));
+            new CollectingRowConsumer(Collectors.mapping(Row::materialize, Collectors.toList()));
 
         batchConsumer.accept(batchSimulatingIterator, null);
 
-        CompletableFuture<List<Object[]>> result = batchConsumer.completionFuture();
+        CompletableFuture<List<Object[]>> result = batchConsumer.resultFuture();
         List<Object[]> consumedRows = result.get(10, TimeUnit.SECONDS);
 
         assertThat(consumedRows.size(), is(10));

--- a/dex/src/test/java/io/crate/data/ListenableRowConsumerTest.java
+++ b/dex/src/test/java/io/crate/data/ListenableRowConsumerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import io.crate.testing.TestingRowConsumer;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public class ListenableRowConsumerTest {
+
+    @Test
+    public void testErrorCaseHandling() throws Exception {
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        ListenableRowConsumer listenableBatchConsumer = new ListenableRowConsumer(consumer);
+
+        listenableBatchConsumer.accept(null, new IllegalStateException("dummy"));
+
+        // both the delegate consumer must receive the error and also the listenableBatchConsumers future must trigger
+        try {
+            consumer.getResult();
+            fail("should have raised an exception");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+
+        try {
+            listenableBatchConsumer.completionFuture().get(10, TimeUnit.SECONDS);
+            fail("should have raised an exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+    }
+}

--- a/dex/src/test/java/io/crate/testing/TestingRowConsumer.java
+++ b/dex/src/test/java/io/crate/testing/TestingRowConsumer.java
@@ -32,7 +32,6 @@ import io.crate.data.RowConsumer;
 import io.crate.exceptions.Exceptions;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -55,14 +54,9 @@ public final class TestingRowConsumer implements RowConsumer {
         consumer.accept(it, failure);
     }
 
-    @Override
-    public CompletableFuture<?> completionFuture() {
-        return consumer.completionFuture();
-    }
-
     public List<Object[]> getResult() throws Exception {
         try {
-            return consumer.completionFuture().get(10, TimeUnit.SECONDS);
+            return consumer.resultFuture().get(10, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause != null) {

--- a/sql/src/main/java/io/crate/execution/MultiPhaseExecutor.java
+++ b/sql/src/main/java/io/crate/execution/MultiPhaseExecutor.java
@@ -56,7 +56,7 @@ public final class MultiPhaseExecutor {
             depPlan.execute(
                 executor, PlannerContext.forSubPlan(plannerContext), rowConsumer, params, SubQueryResults.EMPTY);
 
-            dependencyFutures.add(rowConsumer.completionFuture().thenAccept(val -> {
+            dependencyFutures.add(rowConsumer.resultFuture().thenAccept(val -> {
                 synchronized (valueBySubQuery) {
                     valueBySubQuery.put(selectSymbol, val);
                 }

--- a/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -29,14 +29,13 @@ import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.support.ThreadPools;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -73,11 +72,6 @@ class InterceptingRowConsumer implements RowConsumer {
             this.iterator = iterator;
             tryForwardResult(failure);
         }
-    }
-
-    @Override
-    public CompletableFuture<?> completionFuture() {
-        return consumer.completionFuture();
     }
 
     private void tryForwardResult(Throwable throwable) {

--- a/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/sql/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -170,7 +170,7 @@ public final class JobLauncher {
             CollectingRowConsumer<?, Long> consumer = new CollectingRowConsumer<>(
                 Collectors.collectingAndThen(Collectors.summingLong(r -> ((long) r.get(0))), sum -> sum));
             handlerConsumers.add(consumer);
-            results.add(consumer.completionFuture());
+            results.add(consumer.resultFuture());
             handlerPhases.add(nodeOperationTree.leaf());
         }
         try {

--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -26,14 +26,15 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
+import io.crate.data.ListenableRowConsumer;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.jobs.AbstractTask;
 import io.crate.execution.jobs.SharedShardContexts;
-import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.RowGranularity;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -46,12 +47,12 @@ public class CollectTask extends AbstractTask {
     private final TransactionContext txnCtx;
     private final MapSideDataCollectOperation collectOperation;
     private final RamAccountingContext queryPhaseRamAccountingContext;
+    private final ListenableRowConsumer consumer;
     private final SharedShardContexts sharedShardContexts;
 
     private final IntObjectHashMap<Engine.Searcher> searchers = new IntObjectHashMap<>();
     private final Object subContextLock = new Object();
     private final String threadPoolName;
-    private final RowConsumer consumer;
 
     private BatchIterator<Row> batchIterator = null;
     private long totalBytes = -1;
@@ -68,7 +69,7 @@ public class CollectTask extends AbstractTask {
         this.collectOperation = collectOperation;
         this.queryPhaseRamAccountingContext = queryPhaseRamAccountingContext;
         this.sharedShardContexts = sharedShardContexts;
-        this.consumer = consumer;
+        this.consumer = new ListenableRowConsumer(consumer);
         this.consumer.completionFuture().whenComplete(closeOrKill(this));
         this.threadPoolName = threadPoolName(collectPhase);
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -118,7 +118,7 @@ public class RemoteCollectorFactory {
             shardStateAwareRemoteCollector::kill,
             () -> {
                 shardStateAwareRemoteCollector.doCollect();
-                return consumer.completionFuture().thenApply(results -> results.stream().map(Buckets.arrayToSharedRow())::iterator);
+                return consumer.resultFuture().thenApply(results -> results.stream().map(Buckets.arrayToSharedRow())::iterator);
             },
             true
         );

--- a/sql/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -62,7 +61,6 @@ public class DistributingConsumer implements RowConsumer {
     private final StreamBucket[] buckets;
     private final List<Downstream> downstreams;
     private final boolean traceEnabled;
-    private final CompletableFuture<Void> completionFuture;
 
     @VisibleForTesting
     final MultiBucketBuilder multiBucketBuilder;
@@ -90,7 +88,6 @@ public class DistributingConsumer implements RowConsumer {
         this.distributedResultAction = distributedResultAction;
         this.pageSize = pageSize;
         this.buckets = new StreamBucket[downstreamNodeIds.size()];
-        this.completionFuture = new CompletableFuture<>();
         downstreams = new ArrayList<>(downstreamNodeIds.size());
         for (String downstreamNodeId : downstreamNodeIds) {
             downstreams.add(new Downstream(downstreamNodeId));
@@ -104,11 +101,6 @@ public class DistributingConsumer implements RowConsumer {
         } else {
             forwardFailure(null, failure);
         }
-    }
-
-    @Override
-    public CompletableFuture<?> completionFuture() {
-        return completionFuture;
     }
 
     private void consumeIt(BatchIterator<Row> it) {
@@ -177,7 +169,6 @@ public class DistributingConsumer implements RowConsumer {
         if (numActiveRequests.decrementAndGet() == 0) {
             if (it != null) {
                 it.close();
-                completionFuture.complete(null);
             }
         }
     }
@@ -244,7 +235,6 @@ public class DistributingConsumer implements RowConsumer {
                 // The NodeDisconnectJobMonitorService takes care of node disconnects, so we don't have to manage
                 // that scenario.
                 it.close();
-                completionFuture.complete(null);
             }
         }
     }

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -25,6 +25,7 @@ package io.crate.execution.engine.join;
 import io.crate.breaker.RowAccounting;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.BatchIterator;
+import io.crate.data.ListenableBatchIterator;
 import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -45,7 +46,7 @@ public class HashJoinOperation implements CompletionListenable {
 
     private final CompletableFuture<BatchIterator<Row>> leftBatchIterator = new CompletableFuture<>();
     private final CompletableFuture<BatchIterator<Row>> rightBatchIterator = new CompletableFuture<>();
-    private final RowConsumer resultConsumer;
+    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
 
     public HashJoinOperation(int numLeftCols,
                              int numRightCols,
@@ -60,13 +61,12 @@ public class HashJoinOperation implements CompletionListenable {
                              long estimatedRowSizeForLeft,
                              long numberOfRowsForLeft) {
 
-        this.resultConsumer = nlResultConsumer;
         CompletableFuture.allOf(leftBatchIterator, rightBatchIterator)
             .whenComplete((result, failure) -> {
                 if (failure == null) {
                     BatchIterator<Row> joinIterator;
                     try {
-                        joinIterator = createHashJoinIterator(
+                        joinIterator = new ListenableBatchIterator<>(createHashJoinIterator(
                             leftBatchIterator.join(),
                             numLeftCols,
                             rightBatchIterator.join(),
@@ -76,7 +76,7 @@ public class HashJoinOperation implements CompletionListenable {
                             getHashBuilderFromSymbols(txnCtx, inputFactory, joinRightInputs),
                             rowAccounting,
                             new RamBlockSizeCalculator(Paging.PAGE_SIZE, circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
-                        );
+                        ), completionFuture);
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {
                         nlResultConsumer.accept(null, e);
@@ -89,7 +89,7 @@ public class HashJoinOperation implements CompletionListenable {
 
     @Override
     public CompletableFuture<?> completionFuture() {
-        return resultConsumer.completionFuture();
+        return completionFuture;
     }
 
     public RowConsumer leftConsumer() {

--- a/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
@@ -104,11 +104,6 @@ public final class JoinOperations {
             }
 
             @Override
-            public CompletableFuture<?> completionFuture() {
-                return future;
-            }
-
-            @Override
             public boolean requiresScroll() {
                 return requiresRepeat;
             }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Consumer implementation which applies projections onto the BatchIterator received on accept,
@@ -112,11 +111,6 @@ public class ProjectingRowConsumer implements RowConsumer {
         } else {
             consumer.accept(iterator, failure);
         }
-    }
-
-    @Override
-    public CompletableFuture<?> completionFuture() {
-        return consumer.completionFuture();
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateAwareRemoteCollectorTest.java
@@ -128,7 +128,7 @@ public class ShardStateAwareRemoteCollectorTest extends CrateDummyClusterService
         setNewClusterStateFor(createStartedShardRouting("n2"));
         shardAwareRemoteCollector.doCollect();
 
-        consumer.completionFuture().get(10, TimeUnit.SECONDS);
+        consumer.resultFuture().get(10, TimeUnit.SECONDS);
         verify(remoteCrateCollector, times(1)).doCollect();
     }
 
@@ -136,7 +136,7 @@ public class ShardStateAwareRemoteCollectorTest extends CrateDummyClusterService
     public void testIsLocalCollectorIfRemoteNodeEqualsLocalNodeAndShardStarted() throws Exception {
         setNewClusterStateFor(createStartedShardRouting("n1"));
         shardAwareRemoteCollector.doCollect();
-        consumer.completionFuture().get(10, TimeUnit.SECONDS);
+        consumer.resultFuture().get(10, TimeUnit.SECONDS);
 
         // either being exhausted or closed is fine, just make sure the localBatchIterator was used.
         try {
@@ -153,7 +153,7 @@ public class ShardStateAwareRemoteCollectorTest extends CrateDummyClusterService
         shardAwareRemoteCollector.doCollect();
         setNewClusterStateFor(createStartedShardRouting("n2"));
 
-        consumer.completionFuture().get(10, TimeUnit.SECONDS);
+        consumer.resultFuture().get(10, TimeUnit.SECONDS);
         verify(remoteCrateCollector, times(1)).doCollect();
     }
 

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -42,10 +42,10 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
@@ -69,7 +69,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.data.SentinelRow.SENTINEL;
@@ -128,11 +127,6 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
 
         @Override
         public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
-        }
-
-        @Override
-        public CompletableFuture<?> completionFuture() {
-            return CompletableFuture.completedFuture(null);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -25,7 +25,6 @@ package io.crate.planner;
 import com.google.common.collect.ImmutableList;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
-import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.node.management.ExplainPlan;
 import io.crate.planner.operators.ExplainLogicalPlan;
@@ -39,11 +38,9 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -142,25 +139,17 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
         PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
         CountDownLatch counter = new CountDownLatch(1);
 
-        AtomicReference<BatchIterator<Row>> itRef = new AtomicReference<>();
-        AtomicReference<Throwable> failureRef = new AtomicReference<>();
+        AtomicReference<BatchIterator<Row>> iterator = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        plan.execute(null, plannerContext, new RowConsumer() {
-            @Override
-            public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
-                itRef.set(iterator);
-                failureRef.set(failure);
-                counter.countDown();
-            }
-
-            @Override
-            public CompletableFuture<?> completionFuture() {
-                return null;
-            }
+        plan.execute(null, plannerContext, (i, f) -> {
+            iterator.set(i);
+            failure.set(f);
+            counter.countDown();
         }, Row.EMPTY, SubQueryResults.EMPTY);
 
-        assertNull(itRef.get());
-        assertNotNull(failureRef.get());
-        assertThat(failureRef.get().getMessage(), containsString("EXPLAIN ANALYZE does not support profiling multi-phase plans, such as queries with scalar subselects."));
+        assertNull(iterator.get());
+        assertNotNull(failure.get());
+        assertThat(failure.get().getMessage(), containsString("EXPLAIN ANALYZE does not support profiling multi-phase plans, such as queries with scalar subselects."));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit 119497448d4e5ceabba4b97ced13e588f8a5360f.

Looks like it made some tests flaky


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)