### PR TITLE
Remove usage of Optional in all `kill job` classes.

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -616,10 +616,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitKill(SqlBaseParser.KillContext context) {
-        if (context.ALL() != null) {
-            return new KillStatement();
-        }
-        return new KillStatement((Expression) visit(context.jobId));
+        var jobId = visitIfPresent(context.jobId, Expression.class);
+        return new KillStatement(jobId.orElse(null));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/KillStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/KillStatement.java
@@ -21,43 +21,43 @@
 
 package io.crate.sql.tree;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
+import java.util.Objects;
 
 public class KillStatement extends Statement {
 
-    private final Optional<Expression> jobId;
+    @Nullable
+    private final Expression jobId;
 
-
-    public KillStatement() {
-        this.jobId = Optional.empty();
+    public KillStatement(@Nullable Expression jobId) {
+        this.jobId = jobId;
     }
 
-    public KillStatement(Expression jobId) {
-        this.jobId = Optional.of(jobId);
-    }
-
-    public Optional<Expression> jobId() {
+    @Nullable
+    public Expression jobId() {
         return jobId;
     }
 
     @Override
-    public int hashCode() {
-        return jobId.hashCode();
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KillStatement that = (KillStatement) o;
+        return Objects.equals(jobId, that.jobId);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        KillStatement that = (KillStatement) obj;
-
-        return jobId.equals(that.jobId);
+    public int hashCode() {
+        return Objects.hash(jobId);
     }
 
     @Override
     public String toString() {
-        return jobId.isPresent() ? "KILL '" + jobId.get() + "'" : "KILL ALL";
+        return jobId != null ? "KILL '" + jobId + "'" : "KILL ALL";
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -81,6 +81,7 @@ import static com.google.common.base.Strings.repeat;
 import static io.crate.sql.parser.TreeAssertions.assertFormattedSql;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -347,13 +348,13 @@ public class TestStatementBuilder {
     @Test
     public void testKillJob() {
         KillStatement stmt = (KillStatement) SqlParser.createStatement("KILL $1");
-        assertThat(stmt.jobId().isPresent(), is(true));
+        assertThat(stmt.jobId(), is(notNullValue()));
     }
 
     @Test
     public void testKillAll() {
         Statement stmt = SqlParser.createStatement("KILL ALL");
-        assertTrue(stmt.equals(new KillStatement()));
+        assertThat(stmt, is(new KillStatement(null)));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/KillAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/KillAnalyzedStatement.java
@@ -21,23 +21,20 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Optional;
-
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class KillAnalyzedStatement implements AnalyzedStatement {
 
-    private final Optional<UUID> jobId;
+    @Nullable
+    private final UUID jobId;
 
-    public KillAnalyzedStatement() {
-        jobId = Optional.absent();
+    KillAnalyzedStatement(@Nullable UUID jobId) {
+        this.jobId = jobId;
     }
 
-    public KillAnalyzedStatement(UUID jobId) {
-        this.jobId = Optional.of(jobId);
-    }
-
-    public Optional<UUID> jobId() {
+    @Nullable
+    public UUID jobId() {
         return jobId;
     }
 

--- a/sql/src/main/java/io/crate/analyze/KillAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/KillAnalyzer.java
@@ -31,18 +31,21 @@ public class KillAnalyzer {
     private KillAnalyzer() {
     }
 
-
     public static KillAnalyzedStatement analyze(KillStatement killStatement, ParameterContext parameterContext) {
-        if (killStatement.jobId().isPresent()) {
-            UUID jobId;
+        var jobIdExpression = killStatement.jobId();
+
+        UUID jobId;
+        if (jobIdExpression != null) {
             try {
                 jobId = UUID.fromString(ExpressionToStringVisitor
-                    .convert(killStatement.jobId().get(), parameterContext.parameters()));
+                    .convert(jobIdExpression, parameterContext.parameters()));
             } catch (Exception e) {
                 throw new IllegalArgumentException("Can not parse job ID", e);
             }
-            return new KillAnalyzedStatement(jobId);
+        } else {
+            jobId = null;
         }
-        return new KillAnalyzedStatement();
+
+        return new KillAnalyzedStatement(jobId);
     }
 }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -332,9 +332,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitKillAnalyzedStatement(KillAnalyzedStatement analysis, PlannerContext context) {
-        return analysis.jobId().isPresent() ?
-            new KillPlan(analysis.jobId().get()) :
-            new KillPlan();
+        return new KillPlan(analysis.jobId());
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/KillAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/KillAnalyzerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class KillAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -43,25 +44,25 @@ public class KillAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnalyzeKillAll() throws Exception {
         KillAnalyzedStatement stmt = e.analyze("kill all");
-        assertThat(stmt.jobId().isPresent(), is(false));
+        assertThat(stmt.jobId(), is(nullValue()));
     }
 
     @Test
     public void testAnalyzeKillJobWithParameter() throws Exception {
         UUID jobId = UUID.randomUUID();
         KillAnalyzedStatement stmt = e.analyze("kill $2", new Object[]{2, jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
         stmt = e.analyze("kill $1", new Object[]{jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
         stmt = e.analyze("kill ?", new Object[]{jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
     }
 
     @Test
     public void testAnalyzeKillJobWithLiteral() throws Exception {
         UUID jobId = UUID.randomUUID();
         KillAnalyzedStatement stmt = e.analyze(String.format(Locale.ENGLISH, "kill '%s'", jobId.toString()));
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -67,13 +68,13 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testKillPlanAll() throws Exception {
         KillPlan killPlan = e.plan("kill all");
         assertThat(killPlan, instanceOf(KillPlan.class));
-        assertThat(killPlan.jobToKill().isPresent(), is(false));
+        assertThat(killPlan.jobId(), is(nullValue()));
     }
 
     @Test
     public void testKillPlanJobs() throws Exception {
         KillPlan killJobsPlan = e.plan("kill '6a3d6fb6-1401-4333-933d-b38c9322fca7'");
-        assertThat(killJobsPlan.jobToKill().get().toString(), is("6a3d6fb6-1401-4333-933d-b38c9322fca7"));
+        assertThat(killJobsPlan.jobId().toString(), is("6a3d6fb6-1401-4333-933d-b38c9322fca7"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/node/management/KillPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/management/KillPlanTest.java
@@ -63,7 +63,7 @@ public class KillPlanTest extends CrateDummyClusterServiceUnitTest {
                 return super.nodeOperation(request);
             }
         };
-        KillPlan killPlan = new KillPlan();
+        KillPlan killPlan = new KillPlan(null);
         killPlan.execute(killAllNodeAction, mock(TransportKillJobsNodeAction.class), new TestingRowConsumer());;
         assertThat(broadcastCalls.get(), is(1));
         assertThat(nodeOperationCalls.get(), is(0));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The optional used as a null check in all kill job related
statements. Therefore, it is fine to replace optional with null.
It would prevent the allocation of 3 Optional objects per one kill statement.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
