### PR TITLE
Add optional parameter 'file_name_filter' to gradle task :blackbox:itest

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -38,6 +38,15 @@ from crate.crash.printer import PrintWrapper, ColorPrinter
 from crate.client import connect
 
 
+ITEST_FILE_NAME_FILTER = os.environ.get('ITEST_FILE_NAME_FILTER')
+if ITEST_FILE_NAME_FILTER:
+    print("Applying file name filter: {}".format(ITEST_FILE_NAME_FILTER))
+
+
+def is_target_file_name(item):
+    return not ITEST_FILE_NAME_FILTER or (item and ITEST_FILE_NAME_FILTER in item)
+
+
 CRATE_CE = True if os.environ.get('CRATE_CE') == "1" else False
 
 CRATE_SETTINGS = {
@@ -407,7 +416,7 @@ doctest_file = partial(os.path.join, 'docs')
 
 
 def doctest_files(*items):
-    return (doctest_file(item) for item in items)
+    return (doctest_file(item) for item in items if is_target_file_name(item))
 
 
 def get_abspath(name):
@@ -505,6 +514,9 @@ def load_tests(loader, suite, ignore):
 
     for fn in doctest_files('general/dql/union.rst',):
         tests.append(docsuite(fn, setUp=setUpPhotosAndCountries))
+
+    if not tests:
+        raise ValueError("ITEST_FILE_NAME_FILTER, no matches for: {}".format(ITEST_FILE_NAME_FILTER))
 
     # randomize order of tests to make sure they don't depend on each other
     random.shuffle(tests)

--- a/devs/docs/tests.rst
+++ b/devs/docs/tests.rst
@@ -9,6 +9,9 @@ Run tests in a single module using multiple forks::
 Run the doc-tests::
 
     $ ./gradlew itest
+      (export ITEST_FILE_NAME_FILTER=<file-name>
+       if you want to only run the test of a particular file.
+       Clear the env var to test all files.)
 
 Filter tests::
 


### PR DESCRIPTION
Task itest of module blackbox can be invoked with -Pfile_name_filter=<file-name>.
Only RST files whose name contains <file-name> are accounted for when running the
doctests. For example:

    gradle :blackbox:itest -Pfile_name_filter=sharding

results in only the doctests within file 'blackbox/docs/general/ddl/sharding.rst'
being run.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
