### PR TITLE
Lift anonymous JoinOperations RowConsumer to top level class

### DIFF
--- a/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+
+public final class CapturingRowConsumer implements RowConsumer {
+
+    private final CompletableFuture<BatchIterator<Row>> batchIterator;
+    private final boolean requiresScroll;
+
+    public CapturingRowConsumer(boolean requiresScroll) {
+        this.requiresScroll = requiresScroll;
+        this.batchIterator = new CompletableFuture<>();
+    }
+
+    @Override
+    public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
+        if (failure == null) {
+            batchIterator.complete(iterator);
+        } else {
+            batchIterator.completeExceptionally(failure);
+        }
+    }
+
+    @Override
+    public boolean requiresScroll() {
+        return requiresScroll;
+    }
+
+    public CompletableFuture<BatchIterator<Row>> capturedBatchIterator() {
+        return batchIterator;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
@@ -25,9 +25,6 @@ package io.crate.execution.engine.join;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import io.crate.analyze.relations.JoinPair;
-import io.crate.data.BatchIterator;
-import io.crate.data.Row;
-import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.Projection;
@@ -50,7 +47,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 public final class JoinOperations {
 
@@ -90,24 +86,6 @@ public final class JoinOperations {
             DistributionInfo.DEFAULT_SAME_NODE,
             resultDescription.orderBy()
         );
-    }
-
-    static RowConsumer getBatchConsumer(CompletableFuture<BatchIterator<Row>> future, boolean requiresRepeat) {
-        return new RowConsumer() {
-            @Override
-            public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
-                if (failure == null) {
-                    future.complete(iterator);
-                } else {
-                    future.completeExceptionally(failure);
-                }
-            }
-
-            @Override
-            public boolean requiresScroll() {
-                return requiresRepeat;
-            }
-        };
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Having a name for the RowConsumer should clarify the semantics a bit.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)