### PR TITLE
Fix some spelling mistakes

### DIFF
--- a/common/src/main/java/io/crate/geo/GeoJSONUtils.java
+++ b/common/src/main/java/io/crate/geo/GeoJSONUtils.java
@@ -71,7 +71,7 @@ public class GeoJSONUtils {
     public static final String POLYGON = "Polygon";
     private static final String MULTI_POLYGON = "MultiPolygon";
 
-    private static final ImmutableMap<String, String> GEOSJON_TYPES = ImmutableMap.<String, String>builder()
+    private static final ImmutableMap<String, String> GEOJSON_TYPES = ImmutableMap.<String, String>builder()
         .put(GEOMETRY_COLLECTION, GEOMETRY_COLLECTION)
         .put(GEOMETRY_COLLECTION.toLowerCase(Locale.ENGLISH), GEOMETRY_COLLECTION)
         .put(POINT, POINT)
@@ -157,7 +157,7 @@ public class GeoJSONUtils {
             throw new IllegalArgumentException(invalidGeoJSON("type field missing"));
         }
 
-        type = GEOSJON_TYPES.get(type);
+        type = GEOJSON_TYPES.get(type);
         if (type == null) {
             throw new IllegalArgumentException(invalidGeoJSON("invalid type"));
         }

--- a/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
@@ -35,11 +35,11 @@ public class RerouteMoveShardAnalyzedStatement extends RerouteAnalyzedStatement 
     private final Expression toNodeIdOrName;
 
     public RerouteMoveShardAnalyzedStatement(ShardedTable tableInfo,
-                                             List<Assignment> partitionPropeties,
+                                             List<Assignment> partitionProperties,
                                              Expression shardId,
                                              Expression fromNodeIdOrName,
                                              Expression toNodeIdOrName) {
-        super(tableInfo, partitionPropeties);
+        super(tableInfo, partitionProperties);
         this.shardId = shardId;
         this.fromNodeIdOrName = fromNodeIdOrName;
         this.toNodeIdOrName = toNodeIdOrName;

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -370,7 +370,7 @@ public class EqualityExtractor {
             private List<Set<EqProxy>> comparisonSet() {
                 List<Set<EqProxy>> comps = new ArrayList<>(comparisons.size());
                 for (Comparison comparison : comparisons.values()) {
-                    // TODO: probably create a view instead of a seperate set
+                    // TODO: probably create a view instead of a separate set
                     comps.add(new HashSet<>(comparison.proxies.values()));
                 }
                 return comps;

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -133,7 +133,7 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
         this.updateSettingsAction = updateSettingsAction;
 
         // There is a window where this node removed the last shards but still receives new operations because
-        // other nodes created the routing based on an earlier cluterState.
+        // other nodes created the routing based on an earlier clusterState.
         // We delay here to give these requests a chance to finish
         this.safeExitAction = safeExitAction == null
             ? () -> executorService.schedule(this::exit, 5, TimeUnit.SECONDS)

--- a/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -115,7 +115,7 @@ class InterceptingRowConsumer implements RowConsumer {
     @Override
     public String toString() {
         return "InterceptingBatchConsumer{" +
-               "consumerInvokedAndJobInitilaized=" + consumerInvokedAndJobInitialized +
+               "consumerInvokedAndJobInitialized=" + consumerInvokedAndJobInitialized +
                ", jobId=" + jobId +
                ", consumer=" + consumer +
                ", rowReceiverDone=" + consumerAccepted +

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -85,7 +85,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
 
     /**
      * Executing aggregations as window functions might require different runtime implementations in order to still be
-     * performant. This attempts to compile a new implementation that will be optimizied for the window functions
+     * performant. This attempts to compile a new implementation that will be optimized for the window functions
      * scenario (eg. a function might use a different execution path in order to become removable cumulative)
      */
     public AggregationFunction<?, TFinal> optimizeForExecutionAsWindowFunction() {
@@ -93,7 +93,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     }
 
     /**
-     * Indicates if this aggregation permits the reemoval of state from the previous aggregate state as defined in
+     * Indicates if this aggregation permits the removal of state from the previous aggregate state as defined in
      * http://www.vldb.org/pvldb/vol8/p1058-leis.pdf
      * If a function is removable cumulative it will allow clients to remove previously aggregate values from the partial
      * state using {@link #removeFromAggregatedState(RamAccountingContext, Object, Input[])}

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -195,7 +195,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
                 if (v == null) {
                     ramAccountingContext.addBytes(
                         // values size + 32 bytes for entry, 4 bytes for increased capacity, 8 bytes for the new array
-                        // instance and 4 for the occurence count we store
+                        // instance and 4 for the occurrence count we store
                         RamAccountingContext.roundUp(innerTypeEstimator.estimateSize(value) + 48L)
                     );
                     return occurrenceIncrement;

--- a/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -141,7 +141,7 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
         PageBucketReceiver pageBucketReceiver = rxTask.getBucketReceiver(request.executionPhaseInputId());
         if (pageBucketReceiver == null) {
             return CompletableFuture.failedFuture(new IllegalStateException(String.format(Locale.ENGLISH,
-                                                                                          "Couldn't find BucketReciever for input %d", request.executionPhaseInputId())));
+                                                                                          "Couldn't find BucketReceiver for input %d", request.executionPhaseInputId())));
         }
 
         Throwable throwable = request.throwable();

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/SortedPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/SortedPagingIterator.java
@@ -37,7 +37,7 @@ public class SortedPagingIterator<TKey, TRow> implements PagingIterator<TKey, TR
     /**
      * @param comparator    determining how the items are sorted
      * @param needsRepeat if true additional internal state is kept in order to be able to repeat this iterator.
-     *                    If this is false a call to {@link #repeat()} might result in an excaption, at best the behaviour is undefined.
+     *                    If this is false a call to {@link #repeat()} might result in an exception, at best the behaviour is undefined.
      */
     public SortedPagingIterator(Comparator<TRow> comparator, boolean needsRepeat) {
         if (needsRepeat) {

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -571,7 +571,7 @@ public class ProjectionToProjectorVisitor
     @Override
     public Projector visitSysUpdateProjection(SysUpdateProjection projection, Context context) {
         Map<Reference, Symbol> assignments = projection.assignments();
-        assert !assignments.isEmpty() : "at least one assignement is required";
+        assert !assignments.isEmpty() : "at least one assignment is required";
 
         List<Input<?>> valueInputs = new ArrayList<>(assignments.size());
         List<ColumnIdent> assignmentCols = new ArrayList<>(assignments.size());

--- a/sql/src/main/java/io/crate/expression/reference/sys/SysRowUpdater.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/SysRowUpdater.java
@@ -63,7 +63,7 @@ public interface SysRowUpdater<TRow> {
     /**
      * Returns a new row writer which allows for updating multiple columns at once.
      *
-     * The returned writer takes an id object as arguemnt and uses {@link #getRow(Object)} to retrieve the row to write on.
+     * The returned writer takes an id object as argument and uses {@link #getRow(Object)} to retrieve the row to write on.
      * When called the values of the given list of inputs gets evaluated and written on the given columns by using
      * writers returned by {@link #getWriter(ColumnIdent)}.
      *

--- a/sql/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -42,7 +42,7 @@ public abstract class Symbol implements FuncArg, Writeable, ExplainLeaf {
 
     /**
      * Casts this Symbol to a new {@link DataType} by wrapping a cast function around it.
-     * Sublasses of this class may provide another cast methods.
+     * Subclasses of this class may provide another cast methods.
      * @param newDataType The resulting data type after applying the cast
      * @return An instance of {@link Function} which casts this symbol.
      */
@@ -52,7 +52,7 @@ public abstract class Symbol implements FuncArg, Writeable, ExplainLeaf {
 
     /**
      * Casts this Symbol to a new {@link DataType} by wrapping a cast function around it.
-     * Sublasses of this class may provide another cast methods.
+     * Subclasses of this class may provide another cast methods.
      * @param newDataType The resulting data type after applying the cast
      * @param tryCast If set to true, will return null the symbol cannot be casted.
      * @return An instance of {@link Function} which casts this symbol.

--- a/sql/src/main/java/io/crate/metadata/table/ConstraintInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/ConstraintInfo.java
@@ -27,7 +27,7 @@ import io.crate.metadata.RelationName;
 
 /**
  * This class is used as information store of table constraints when
- * beeing displayed.
+ * being displayed.
  */
 public class ConstraintInfo {
 

--- a/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -160,7 +160,7 @@ public final class WhereClauseOptimizer {
         EqualityExtractor eqExtractor = new EqualityExtractor(normalizer);
         List<List<Symbol>> pkValues = eqExtractor.extractExactMatches(pkCols, query, txnCtx);
 
-        int clusterdIdxWithinPK = table.primaryKey().indexOf(table.clusteredBy());
+        int clusterIdxWithinPK = table.primaryKey().indexOf(table.clusteredBy());
         final DocKeys docKeys;
         if (pkValues == null) {
             docKeys = null;
@@ -172,7 +172,7 @@ public final class WhereClauseOptimizer {
             docKeys = new DocKeys(pkValues,
                                   versionInQuery,
                                   sequenceVersioningInQuery,
-                                  clusterdIdxWithinPK,
+                                  clusterIdxWithinPK,
                                   partitionIndicesWithinPks);
         }
         List<List<Symbol>> partitionValues = null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix some spelling mistakes

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
