### PR TITLE
Fix `ssl.resource_poll_interval` setting processing and docu

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -123,4 +123,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed the :ref:`ssl.resource_poll_interval <ssl.resource_poll_interval>`
+  setting processing and documentation.

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -518,10 +518,10 @@ Layer Security (TLS).
 
 **ssl.resource_poll_interval**
   | *Runtime:* ``no``
-  | *Default:* ``5s``
+  | *Default:* ``10s``
 
   The frequency at which SSL files such as keystore and truststore are polled
-  for changes.
+  for changes. Possible effective values are ``2s``, ``10s`` or ``30s``.
 
 Cross-origin resource sharing (CORS)
 ====================================

--- a/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/FilesWatcher.java
+++ b/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/FilesWatcher.java
@@ -55,9 +55,10 @@ class FilesWatcher implements Runnable, Closeable {
 
     void addListener(Path path,
                      Consumer<WatchEvent<Path>> listener,
-                     WatchEvent.Kind<?>... watchEventKinds) throws IOException {
+                     WatchEvent.Kind<?>[] events,
+                     WatchEvent.Modifier... modifiers) throws IOException {
         Watcher watcher = new Watcher(path, listener);
-        WatchKey key = watcher.registrablePath().register(watchService, watchEventKinds);
+        WatchKey key = watcher.registrablePath().register(watchService, events, modifiers);
 
         if (watchers.containsKey(key)) {
             watchers.get(key).add(watcher);

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
@@ -105,7 +105,7 @@ public class HttpsTransportKeyStoreReloadIntegrationTest extends SQLHttpIntegrat
             .put(SslConfigSettings.SSL_HTTP_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_KEYSTORE_FILEPATH.getKey(), keyStoreFile.getAbsolutePath())
             .put(SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.getKey(), trustStoreFile.getAbsolutePath())
-            .put(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.getKey(), 1)
+            .put(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.getKey(), "2s")
             .build();
     }
 

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-
 @UseJdbc(value = 0)
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class HttpsTransportKeyStoreReloadIntegrationTest extends SQLHttpIntegrationTest {
@@ -133,7 +132,7 @@ public class HttpsTransportKeyStoreReloadIntegrationTest extends SQLHttpIntegrat
                 assertThat(result, containsString("\"rowcount\":1"));
                 assertThat(result, containsString("sslWorks"));
             } catch (Exception e) {
-                fail();
+                fail(e.getMessage());
             }
         }, 20, TimeUnit.SECONDS);
     }

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
@@ -110,7 +110,7 @@ public class SslReqHandlerIntegrationTest extends SQLTransportIntegrationTest {
                 SQLResponse response = execute("select name from sys.nodes");
                 assertEquals(1, response.rowCount());
             } catch (Exception e) {
-                fail();
+                fail(e.getMessage());
             }
         }, 20, TimeUnit.SECONDS);
     }

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
@@ -85,7 +85,7 @@ public class SslReqHandlerIntegrationTest extends SQLTransportIntegrationTest {
             .put(super.nodeSettings(nodeOrdinal))
             .put(SslConfigSettings.SSL_PSQL_ENABLED.getKey(), true)
             .put(SslConfigSettings.SSL_KEYSTORE_FILEPATH.getKey(), keyStoreFile.getAbsolutePath())
-            .put(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.getKey(), 1)
+            .put(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.getKey(), "2s")
             .build();
     }
 

--- a/ssl/build.gradle
+++ b/ssl/build.gradle
@@ -8,4 +8,8 @@ dependencies {
     implementation project(':common')
     implementation project(':es:es-server')
     implementation "io.netty:netty-handler:${versions.netty4}"
+
+    testImplementation project(':es:es-testing')
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }

--- a/ssl/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
+++ b/ssl/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
@@ -22,8 +22,11 @@
 
 package io.crate.protocols.ssl;
 
+import com.sun.nio.file.SensitivityWatchEventModifier;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -32,6 +35,8 @@ import org.elasticsearch.common.unit.TimeValue;
  * Settings for configuring Postgres SSL. Only applicable to the ssl-impl module.
  */
 public final class SslConfigSettings {
+
+    private static final Logger LOGGER = LogManager.getLogger(SslConfigSettings.class);
 
     private SslConfigSettings() {}
 
@@ -44,7 +49,7 @@ public final class SslConfigSettings {
     static final String SSL_KEYSTORE_PASSWORD_SETTING_NAME = "ssl.keystore_password";
     static final String SSL_KEYSTORE_KEY_PASSWORD_SETTING_NAME = "ssl.keystore_key_password";
 
-    private static final String SSL_RESOURCE_POLL_INTERVAL_NAME = "ssl.resource_poll_interval";
+    static final String SSL_RESOURCE_POLL_INTERVAL_NAME = "ssl.resource_poll_interval";
 
     public static final CrateSetting<Boolean> SSL_HTTP_ENABLED = CrateSetting.of(
         Setting.boolSetting(SSL_HTTP_ENABLED_SETTING_NAME, false, Setting.Property.NodeScope),
@@ -74,9 +79,10 @@ public final class SslConfigSettings {
         DataTypes.STRING);
 
     public static final CrateSetting<TimeValue> SSL_RESOURCE_POLL_INTERVAL = CrateSetting.of(
-        Setting.timeSetting(
+        new Setting<>(
             SSL_RESOURCE_POLL_INTERVAL_NAME,
-            TimeValue.timeValueSeconds(5),
+            TimeValue.timeValueSeconds(SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds()).getStringRep(),
+            new SslResourcePollIntervalParser(LOGGER),
             Setting.Property.NodeScope),
         DataTypes.STRING);
 

--- a/ssl/src/main/java/io/crate/protocols/ssl/SslResourcePollIntervalParser.java
+++ b/ssl/src/main/java/io/crate/protocols/ssl/SslResourcePollIntervalParser.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.ssl;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public final class SslResourcePollIntervalParser implements Function<String, TimeValue> {
+
+    private static final List<Long> EFFECTIVE_VALUES = List.of(2L, 10L, 30L);
+
+    private final Logger logger;
+
+    public SslResourcePollIntervalParser(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public TimeValue apply(String s) {
+        TimeValue value = TimeValue.parseTimeValue(s, SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL_NAME);
+        final long seconds = value.getSeconds();
+        long effectiveSeconds = seconds;
+        if (EFFECTIVE_VALUES.stream().anyMatch(l -> l == seconds) == false) {
+            if (seconds < SensitivityWatchEventModifier.HIGH.sensitivityValueInSeconds()) {
+                logger.warn("Value {} is smaller than the minimum effective value of {}s, will use {}s instead.",
+                            value.getStringRep(),
+                            SensitivityWatchEventModifier.HIGH.sensitivityValueInSeconds(),
+                            SensitivityWatchEventModifier.HIGH.sensitivityValueInSeconds());
+                effectiveSeconds = SensitivityWatchEventModifier.HIGH.sensitivityValueInSeconds();
+            } else if (seconds < SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds()) {
+                logger.warn("Value {} is smaller than the next effective value of {}s, will use {}s instead.",
+                            value.getStringRep(),
+                            SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds(),
+                            SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds());
+                effectiveSeconds = SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds();
+            } else if (seconds < SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds()) {
+                logger.warn("Value {} is smaller than the next effective value of {}s, will use {}s instead.",
+                            value.getStringRep(),
+                            SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds(),
+                            SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds());
+                effectiveSeconds = SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds();
+            } else if (seconds > SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds()) {
+                logger.warn("Value {} is greater than the maximum effective value of {}s, will use {}s instead.",
+                            value.getStringRep(),
+                            SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds(),
+                            SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds());
+                effectiveSeconds = SensitivityWatchEventModifier.LOW.sensitivityValueInSeconds();
+            }
+        }
+        return new TimeValue(effectiveSeconds, TimeUnit.SECONDS);
+    }
+}

--- a/ssl/src/test/java/io/crate/ssl/SslResourcePollIntervalParserTest.java
+++ b/ssl/src/test/java/io/crate/ssl/SslResourcePollIntervalParserTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.ssl;
+
+import io.crate.protocols.ssl.SslResourcePollIntervalParser;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.MockLogAppender;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SslResourcePollIntervalParserTest {
+
+    private static final Logger LOGGER = Loggers.getLogger(SslResourcePollIntervalParserTest.class);
+
+    @Test
+    public void testPollIntervalParserExpectedIsParsed() {
+        var p = new SslResourcePollIntervalParser(LOGGER);
+        assertThat(p.apply("2s"), is(TimeValue.timeValueSeconds(2)));
+        assertThat(p.apply("10s"), is(TimeValue.timeValueSeconds(10)));
+        assertThat(p.apply("30s"), is(TimeValue.timeValueSeconds(30)));
+    }
+
+    @Test
+    public void testPollIntervalParserLogsOnSmallerThanMinimum() throws Exception {
+        String expectedLogMsg = "Value 100ms is smaller than the minimum effective value of 2s, will use 2s instead.";
+        assertExpectedLogMessagesAndParsedValue("100ms",
+                                                TimeValue.timeValueSeconds(2),
+                                                expectedLogMsg);
+    }
+
+    @Test
+    public void testPollIntervalParserLogsOnSmallerThanMedium() throws Exception {
+        String expectedLogMsg = "Value 5s is smaller than the next effective value of 10s, will use 10s instead.";
+        assertExpectedLogMessagesAndParsedValue("5s",
+                                                TimeValue.timeValueSeconds(10),
+                                                expectedLogMsg);
+    }
+
+    @Test
+    public void testPollIntervalParserLogsOnSmallerThanLow() throws Exception {
+        String expectedLogMsg = "Value 13s is smaller than the next effective value of 30s, will use 30s instead.";
+        assertExpectedLogMessagesAndParsedValue("13s",
+                                                TimeValue.timeValueSeconds(30),
+                                                expectedLogMsg);
+    }
+
+    @Test
+    public void testPollIntervalParserLogsOnGreaterThanLow() throws Exception {
+        String expectedLogMsg = "Value 50s is greater than the maximum effective value of 30s, will use 30s instead.";
+        assertExpectedLogMessagesAndParsedValue("50s",
+                                                TimeValue.timeValueSeconds(30),
+                                                expectedLogMsg);
+    }
+
+
+    private <T> void assertExpectedLogMessagesAndParsedValue(String value,
+                                                             T expectedParsedValue,
+                                                             String expectedLogMessage) throws IllegalAccessException {
+        String loggerName = "org.elasticsearch.test";
+        Logger testLogger = LogManager.getLogger(loggerName);
+        MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(testLogger, appender);
+
+        var expectation = new MockLogAppender.SeenEventExpectation("warn logging",
+                                                 loggerName,
+                                                 Level.WARN,
+                                                 expectedLogMessage);
+        try {
+            appender.start();
+            appender.addExpectation(expectation);
+            var p = new SslResourcePollIntervalParser(testLogger);
+            assertThat(p.apply(value), is(expectedParsedValue));
+            appender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(testLogger, appender);
+        }
+    }
+
+}


### PR DESCRIPTION
The underlaying WatchService will poll the FS by default every 10s.
Polling the WatchService for events in a different interval won’t have
any effect until the poll interval of the WatchService itself is changed.
This poll interval can only be changed to fixed intervals, defined by 
the JDK (currently ‘2s’, ‘10s’ and ‘30s’).
This is now reflected at the setting documentation and the ssl provider
will correctly propagate it.