### PR TITLE
Switch JDK_11 and JDK_12 in Jenkinsfile to use latest available

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ pipeline {
     timeout(time: 30, unit: 'MINUTES') 
   }
   environment {
-    CI_RUN = "true"
-    JDK_11 = 'openjdk@1.11.0-2'
-    JDK_12 = 'openjdk@1.12.0-2'
+    CI_RUN = 'true'
+    JDK_11 = 'openjdk@1.11.0'
+    JDK_12 = 'openjdk@1.12.0'
     ADOPT_JDK_12 = 'adopt@1.12.33-0'
   }
   stages {


### PR DESCRIPTION
## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)