### PR TITLE
Rename collectPhaseId → fetchPhaseId in FetchProjection

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
@@ -45,7 +45,7 @@ public class FetchProjection extends Projection {
     private static final int HEAP_IN_MB = (int) (JvmInfo.jvmInfo().getConfiguredMaxHeapSize() / (1024 * 1024));
     private static final int MAX_FETCH_SIZE = maxFetchSize(HEAP_IN_MB);
 
-    private final int collectPhaseId;
+    private final int fetchPhaseId;
     private final int fetchSize;
     private final Map<RelationName, FetchSource> fetchSources;
     private final List<Symbol> outputSymbols;
@@ -53,7 +53,7 @@ public class FetchProjection extends Projection {
     private final TreeMap<Integer, String> readerIndices;
     private final Map<String, RelationName> indicesToIdents;
 
-    public FetchProjection(int collectPhaseId,
+    public FetchProjection(int fetchPhaseId,
                            int suppliedFetchSize,
                            Map<RelationName, FetchSource> fetchSources,
                            List<Symbol> outputSymbols,
@@ -63,7 +63,7 @@ public class FetchProjection extends Projection {
         assert outputSymbols.stream().noneMatch(s ->
             SymbolVisitors.any(x -> x instanceof Field || x instanceof SelectSymbol, s))
             : "Cannot operate on Field or SelectSymbol symbols: " + outputSymbols;
-        this.collectPhaseId = collectPhaseId;
+        this.fetchPhaseId = fetchPhaseId;
         this.fetchSources = fetchSources;
         this.outputSymbols = outputSymbols;
         this.nodeReaders = nodeReaders;
@@ -100,8 +100,8 @@ public class FetchProjection extends Projection {
         return Math.min(suppliedFetchSize, maxSize);
     }
 
-    public int collectPhaseId() {
-        return collectPhaseId;
+    public int fetchPhaseId() {
+        return fetchPhaseId;
     }
 
     public int getFetchSize() {
@@ -148,12 +148,12 @@ public class FetchProjection extends Projection {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         FetchProjection that = (FetchProjection) o;
-        return collectPhaseId == that.collectPhaseId;
+        return fetchPhaseId == that.fetchPhaseId;
     }
 
     @Override
     public int hashCode() {
-        return collectPhaseId;
+        return fetchPhaseId;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
@@ -40,18 +40,18 @@ public class TransportFetchOperation implements FetchOperation {
     private final TransportFetchNodeAction transportFetchNodeAction;
     private final Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers;
     private final UUID jobId;
-    private final int executionPhaseId;
+    private final int fetchPhaseId;
     private final RamAccountingContext ramAccountingContext;
 
     public TransportFetchOperation(TransportFetchNodeAction transportFetchNodeAction,
                                    Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers,
                                    UUID jobId,
-                                   int executionPhaseId,
+                                   int fetchPhaseId,
                                    RamAccountingContext ramAccountingContext) {
         this.transportFetchNodeAction = transportFetchNodeAction;
         this.nodeIdToReaderIdToStreamers = nodeIdToReaderIdToStreamers;
         this.jobId = jobId;
-        this.executionPhaseId = executionPhaseId;
+        this.fetchPhaseId = fetchPhaseId;
         this.ramAccountingContext = ramAccountingContext;
     }
 
@@ -63,7 +63,7 @@ public class TransportFetchOperation implements FetchOperation {
         transportFetchNodeAction.execute(
             nodeId,
             nodeIdToReaderIdToStreamers.get(nodeId),
-            new NodeFetchRequest(jobId, executionPhaseId, closeContext, toFetch),
+            new NodeFetchRequest(jobId, fetchPhaseId, closeContext, toFetch),
             ramAccountingContext,
             listener);
         return listener;

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -558,7 +558,7 @@ public class ProjectionToProjectorVisitor
                 transportActionProvider.transportFetchNodeAction(),
                 projectorContext.nodeIdsToStreamers(),
                 context.jobId,
-                projection.collectPhaseId(),
+                projection.fetchPhaseId(),
                 context.ramAccountingContext
             ),
             functions,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The name changed: `fetchPhaseId → collectPhaseId → executionPhaseId →
fetchPhaseId` through several layers. The correct name is
`fetchPhaseId`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)