### PR TITLE
Fix TablesNeedUpgradeSysCheck to list partitioned tables only once.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -126,5 +126,8 @@ Changes
 Fixes
 =====
 
+- Fixed the ``Tables need to be recreated`` :ref:`cluster check <sys-checks>`
+  to list partitioned tables only once instead of once per partition.
+
 - Fixed the :ref:`ssl.resource_poll_interval <ssl.resource_poll_interval>`
   setting processing and documentation.

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -30,8 +30,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 
 @Singleton
@@ -57,7 +57,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
     @Override
     public CompletableFuture<?> computeResult() {
-        ArrayList<String> fqTables = new ArrayList<>();
+        HashSet<String> fqTables = new HashSet<>();
         for (ObjectCursor<IndexMetaData> cursor : clusterService.state()
             .metaData()
             .indices()


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)