### PR TITLE
Support building of multiple ReaderAllocations

### DIFF
--- a/sql/src/main/java/io/crate/planner/RoutingBuilder.java
+++ b/sql/src/main/java/io/crate/planner/RoutingBuilder.java
@@ -47,8 +47,6 @@ final class RoutingBuilder {
     private final ClusterState clusterState;
     private final RoutingProvider routingProvider;
 
-    private ReaderAllocations readerAllocations;
-
     RoutingBuilder(ClusterState clusterState, RoutingProvider routingProvider) {
         this.clusterState = clusterState;
         this.routingProvider = routingProvider;
@@ -70,10 +68,6 @@ final class RoutingBuilder {
     }
 
     ReaderAllocations buildReaderAllocations() {
-        if (readerAllocations != null) {
-            return readerAllocations;
-        }
-
         Multimap<RelationName, String> indicesByTable = HashMultimap.create();
         IndexBaseBuilder indexBaseBuilder = new IndexBaseBuilder();
         Map<String, Map<Integer, String>> shardNodes = new HashMap<>();
@@ -94,8 +88,8 @@ final class RoutingBuilder {
                 }
             }
         }
-        readerAllocations = new ReaderAllocations(indexBaseBuilder.build(), shardNodes, indicesByTable);
-        return readerAllocations;
+        routingListByTable.clear();
+        return new ReaderAllocations(indexBaseBuilder.build(), shardNodes, indicesByTable);
     }
 
     private static void allocateRoutingNodes(Map<String, Map<Integer, String>> shardNodes,

--- a/sql/src/test/java/io/crate/planner/RoutingBuilderTest.java
+++ b/sql/src/test/java/io/crate/planner/RoutingBuilderTest.java
@@ -46,6 +46,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
 
@@ -109,8 +111,7 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(readerAllocations.bases().get(relationName.indexNameOrAlias()), is(0));
 
-        // allocations must stay same on multiple calls
         ReaderAllocations readerAllocations2 = routingBuilder.buildReaderAllocations();
-        assertThat(readerAllocations, is(readerAllocations2));
+        assertThat(readerAllocations, not(sameInstance(readerAllocations2)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Once we introduce a rule to do the fetch-optimization, this rule can
work independently on sub-trees, so we end up with scenarios where we've
multiple fetch phases in the same query. For example in the following
query:

    SELECT
      *
    FROM
      (SELECT * FROM t1 LIMIT 10) tt1,
      (SELECT * FROM t2 LIMIT 10) tt2

We can have a `QueryThenFetch` for both t1 and t2 before we join the
result.

This would currently not work because `buildReaderAllocations` caches
its result, and the reader allocations required for the fetch phase for
t1 doesn't match the reader allocations required for t2.

So this commit removes the caching in `buildReaderAllocations` and
instead adds an implicit reset, so that the `RoutingBuilder` can be used
to create a new `ReaderAllocations` configuration from scratch, which
will support the above mentioned scenario.



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)