### PR TITLE
Make alter table operation atomic

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,8 @@ Breaking Changes
 Changes
 =======
 
+- Improved resiliency of ``ALTER TABLE`` operation.
+
 - Extended :ref:`CONCAT <scalar_concat>` to do implicit casts, so that calls
   like ``SELECT 't' || 5`` are supported.
 

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -551,7 +551,7 @@ public class MetaDataCreateIndexService {
         }
     }
 
-    List<String> getIndexSettingsValidationErrors(final Settings settings, final boolean forbidPrivateIndexSettings) {
+    public List<String> getIndexSettingsValidationErrors(final Settings settings, final boolean forbidPrivateIndexSettings) {
         String customPath = IndexMetaData.INDEX_DATA_PATH_SETTING.get(settings);
         List<String> validationErrors = new ArrayList<>();
         if (Strings.isEmpty(customPath) == false && env.sharedDataFile() == null) {

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -65,7 +65,7 @@ public class MetaDataMappingService {
     private final IndicesService indicesService;
 
     final RefreshTaskExecutor refreshExecutor = new RefreshTaskExecutor();
-    final PutMappingExecutor putMappingExecutor = new PutMappingExecutor();
+    public final PutMappingExecutor putMappingExecutor = new PutMappingExecutor();
 
 
     @Inject
@@ -208,7 +208,7 @@ public class MetaDataMappingService {
         );
     }
 
-    class PutMappingExecutor implements ClusterStateTaskExecutor<PutMappingClusterStateUpdateRequest> {
+    public class PutMappingExecutor implements ClusterStateTaskExecutor<PutMappingClusterStateUpdateRequest> {
         @Override
         public ClusterTasksResult<PutMappingClusterStateUpdateRequest> execute(ClusterState currentState,
                                                                                List<PutMappingClusterStateUpdateRequest> tasks) throws Exception {
@@ -238,7 +238,7 @@ public class MetaDataMappingService {
             }
         }
 
-        private ClusterState applyRequest(ClusterState currentState, PutMappingClusterStateUpdateRequest request,
+        public ClusterState applyRequest(ClusterState currentState, PutMappingClusterStateUpdateRequest request,
                                           Map<Index, MapperService> indexMapperServices) throws IOException {
             String mappingType = request.type();
             CompressedXContent mappingUpdateSource = new CompressedXContent(request.source());

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -239,7 +239,7 @@ public class MetaDataUpdateSettingsService {
     /**
      * Updates the cluster block only iff the setting exists in the given settings
      */
-    private static void maybeUpdateClusterBlock(String[] actualIndices, ClusterBlocks.Builder blocks, ClusterBlock block, Setting<Boolean> setting, Settings openSettings) {
+    public static void maybeUpdateClusterBlock(String[] actualIndices, ClusterBlocks.Builder blocks, ClusterBlock block, Setting<Boolean> setting, Settings openSettings) {
         if (setting.exists(openSettings)) {
             final boolean updateBlock = setting.get(openSettings);
             for (String index : actualIndices) {

--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -26,6 +26,7 @@ import io.crate.cluster.decommission.TransportDecommissionNodeAction;
 import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.index.TransportSwapAndDropIndexNameAction;
+import io.crate.execution.ddl.tables.TransportAlterTableAction;
 import io.crate.execution.ddl.tables.TransportCreateTableAction;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.tables.TransportOpenCloseTableOrPartitionAction;
@@ -76,5 +77,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportCreateViewAction.class).asEagerSingleton();
         bind(TransportDropViewAction.class).asEagerSingleton();
         bind(TransportSwapRelationsAction.class).asEagerSingleton();
+        bind(TransportAlterTableAction.class).asEagerSingleton();
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.metadata.RelationName;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
+import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
+
+public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
+
+    private final RelationName tableIdent;
+    @Nullable
+    private final String partitionIndexName;
+    private final boolean isPartitioned;
+    private final boolean excludePartitions;
+    private final Settings settings;
+    @Nullable
+    private final String mappingDelta;
+
+    public AlterTableRequest(RelationName tableIdent,
+                             @Nullable String partitionIndexName,
+                             boolean isPartitioned,
+                             boolean excludePartitions,
+                             Settings settings,
+                             Map<String, Object> mappingDelta) throws IOException {
+        this.tableIdent = tableIdent;
+        this.partitionIndexName = partitionIndexName;
+        this.isPartitioned = isPartitioned;
+        this.excludePartitions = excludePartitions;
+        this.settings = settings;
+        this.mappingDelta = mapToJson(mappingDelta);
+    }
+
+    public AlterTableRequest(StreamInput in) throws IOException {
+        super(in);
+        tableIdent = new RelationName(in);
+        partitionIndexName = in.readOptionalString();
+        isPartitioned = in.readBoolean();
+        excludePartitions = in.readBoolean();
+        settings = readSettingsFromStream(in);
+        mappingDelta = in.readOptionalString();
+    }
+
+    public RelationName tableIdent() {
+        return tableIdent;
+    }
+
+    @Nullable
+    public String partitionIndexName() {
+        return partitionIndexName;
+    }
+
+    public boolean isPartitioned() {
+        return isPartitioned;
+    }
+
+    public boolean excludePartitions() {
+        return excludePartitions;
+    }
+
+    public Settings settings() {
+        return settings;
+    }
+
+    @Nullable
+    private static String mapToJson(Map<String, Object> mapping) throws IOException {
+        if (mapping.isEmpty()) {
+            return null;
+        }
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        builder.map(mapping);
+        return XContentHelper.convertToJson(BytesReference.bytes(builder), false, false, XContentType.JSON);
+    }
+
+    @Nullable
+    public String mappingDelta() {
+        return mappingDelta;
+    }
+
+    public Map<String, Object> mappingDeltaAsMap() {
+        if (mappingDelta == null) {
+            return Collections.emptyMap();
+        }
+        return XContentHelper.convertToMap(JsonXContent.jsonXContent, mappingDelta, false);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        tableIdent.writeTo(out);
+        out.writeOptionalString(partitionIndexName);
+        out.writeBoolean(isPartitioned);
+        out.writeBoolean(excludePartitions);
+        writeSettingsToStream(settings, out);
+        out.writeOptionalString(mappingDelta);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.cluster.AlterTableClusterStateExecutor;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
+import org.elasticsearch.cluster.metadata.MetaDataMappingService;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterTableRequest, AcknowledgedResponse> {
+
+    private static final String ACTION_NAME = "internal:crate:sql/table/alter";
+
+    private final AlterTableClusterStateExecutor executor;
+
+    @Inject
+    public TransportAlterTableAction(TransportService transportService,
+                                     ClusterService clusterService,
+                                     ThreadPool threadPool,
+                                     IndexNameExpressionResolver indexNameExpressionResolver,
+                                     MetaDataMappingService metaDataMappingService,
+                                     IndicesService indicesService,
+                                     AllocationService allocationService,
+                                     IndexScopedSettings indexScopedSettings,
+                                     MetaDataCreateIndexService metaDataCreateIndexService) {
+        super(ACTION_NAME,
+              transportService,
+              clusterService,
+              threadPool,
+              indexNameExpressionResolver,
+              AlterTableRequest::new,
+              AcknowledgedResponse::new,
+              AcknowledgedResponse::new,
+              "alter-table");
+        executor = new AlterTableClusterStateExecutor(metaDataMappingService,
+                                                      indicesService,
+                                                      allocationService,
+                                                      indexScopedSettings,
+                                                      indexNameExpressionResolver,
+                                                      metaDataCreateIndexService);
+    }
+
+    @Override
+    public ClusterStateTaskExecutor<AlterTableRequest> clusterStateTaskExecutor(AlterTableRequest request) {
+        return executor;
+    }
+
+    @Override
+    public ClusterBlockException checkBlock(AlterTableRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+}

--- a/sql/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.cluster;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.Constants;
+import io.crate.analyze.TableParameters;
+import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.execution.ddl.tables.AlterTableRequest;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
+import org.elasticsearch.cluster.metadata.MetaDataMappingService;
+import org.elasticsearch.cluster.metadata.MetaDataUpdateSettingsService;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.InvalidIndexTemplateException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
+import static org.elasticsearch.index.IndexSettings.same;
+import static org.elasticsearch.cluster.metadata.MetaDataUpdateSettingsService.maybeUpdateClusterBlock;
+
+public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<AlterTableRequest> {
+
+    private static final IndicesOptions FIND_OPEN_AND_CLOSED_INDICES_INGORE_UNAVAILABLE_AND_NON_EXISTING = IndicesOptions.fromOptions(
+        true, true, true, true);
+
+    private final MetaDataMappingService metaDataMappingService;
+    private final IndicesService indicesService;
+    private final AllocationService allocationService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final IndexScopedSettings indexScopedSettings;
+    private final MetaDataCreateIndexService metaDataCreateIndexService;
+
+    public AlterTableClusterStateExecutor(MetaDataMappingService metaDataMappingService,
+                                          IndicesService indicesService,
+                                          AllocationService allocationService,
+                                          IndexScopedSettings indexScopedSettings,
+                                          IndexNameExpressionResolver indexNameExpressionResolver,
+                                          MetaDataCreateIndexService metaDataCreateIndexService) {
+        this.metaDataMappingService = metaDataMappingService;
+        this.indicesService = indicesService;
+        this.indexScopedSettings = indexScopedSettings;
+        this.allocationService = allocationService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.metaDataCreateIndexService = metaDataCreateIndexService;
+    }
+
+    @Override
+    protected ClusterState execute(ClusterState currentState, AlterTableRequest request) throws Exception {
+        if (request.isPartitioned()) {
+            if (request.partitionIndexName() != null) {
+                Index[] concreteIndices = resolveIndices(currentState, request.partitionIndexName());
+                currentState = updateMapping(currentState, request, concreteIndices);
+                currentState = updateSettings(currentState, request.settings(), concreteIndices);
+            } else {
+                // template gets all changes unfiltered
+                currentState = updateTemplate(
+                    currentState,
+                    request.tableIdent(),
+                    request.settings(),
+                    request.mappingDeltaAsMap(),
+                    (name, settings) -> validateSettings(name,
+                                                         settings,
+                                                         indexScopedSettings,
+                                                         metaDataCreateIndexService),
+                    indexScopedSettings);
+
+                if (!request.excludePartitions()) {
+                    Index[] concreteIndices = resolveIndices(currentState, request.tableIdent().indexNameOrAlias());
+
+                    // These settings only apply for already existing partitions
+                    List<String> supportedSettings = TableParameters.PARTITIONED_TABLE_PARAMETER_INFO_FOR_TEMPLATE_UPDATE
+                        .supportedSettings()
+                        .values()
+                        .stream()
+                        .map(Setting::getKey)
+                        .collect(Collectors.toList());
+
+                    // auto_expand_replicas must be explicitly added as it is hidden under NumberOfReplicasSetting
+                    supportedSettings.add(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
+
+                    currentState = updateSettings(currentState, filterSettings(request.settings(), supportedSettings), concreteIndices);
+                    currentState = updateMapping(currentState, request, concreteIndices);
+                }
+            }
+        } else {
+            Index[] concreteIndices = resolveIndices(currentState, request.tableIdent().indexNameOrAlias());
+            currentState = updateMapping(currentState, request, concreteIndices);
+            currentState = updateSettings(currentState, request.settings(), concreteIndices);
+        }
+
+        return currentState;
+    }
+
+
+    private ClusterState updateMapping(ClusterState currentState, AlterTableRequest request, Index[] concreteIndices) throws Exception {
+        if (request.mappingDelta() == null) {
+            return currentState;
+        }
+        Map<Index, MapperService> indexMapperServices = new HashMap<>();
+        for (Index index : concreteIndices) {
+            final IndexMetaData indexMetaData = currentState.metaData().getIndexSafe(index);
+            if (indexMapperServices.containsKey(indexMetaData.getIndex()) == false) {
+                MapperService mapperService = indicesService.createIndexMapperService(indexMetaData);
+                indexMapperServices.put(index, mapperService);
+                // add mappings for all types, we need them for cross-type validation
+                mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY, false);
+            }
+        }
+
+        PutMappingClusterStateUpdateRequest updateRequest = new PutMappingClusterStateUpdateRequest()
+            .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
+            .indices(concreteIndices).type(Constants.DEFAULT_MAPPING_TYPE)
+            .source(request.mappingDelta());
+
+        return metaDataMappingService.putMappingExecutor.applyRequest(currentState, updateRequest, indexMapperServices);
+    }
+
+    /**
+     * The logic is taken over from {@link MetaDataUpdateSettingsService#updateSettings(UpdateSettingsClusterStateUpdateRequest, ActionListener)}
+     */
+    private ClusterState updateSettings(final ClusterState currentState, final Settings settings, Index[] concreteIndices) {
+
+        final Settings normalizedSettings = Settings.builder()
+            .put(markArchivedSettings(settings))
+            .normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX)
+            .build();
+
+        Settings.Builder settingsForClosedIndices = Settings.builder();
+        Settings.Builder settingsForOpenIndices = Settings.builder();
+        final Set<String> skippedSettings = new HashSet<>();
+
+        for (String key : normalizedSettings.keySet()) {
+            Setting setting = indexScopedSettings.get(key);
+            boolean isWildcard = setting == null && Regex.isSimpleMatchPattern(key);
+            assert setting != null // we already validated the normalized settings
+                   || (isWildcard && normalizedSettings.hasValue(key) == false)
+                : "unknown setting: " + key + " isWildcard: " + isWildcard + " hasValue: " +
+                  normalizedSettings.hasValue(key);
+            settingsForClosedIndices.copy(key, normalizedSettings);
+            if (isWildcard || setting.isDynamic()) {
+                settingsForOpenIndices.copy(key, normalizedSettings);
+            } else {
+                skippedSettings.add(key);
+            }
+        }
+        final Settings closedSettings = settingsForClosedIndices.build();
+        final Settings openSettings = settingsForOpenIndices.build();
+
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
+        final MetaData.Builder metaDataBuilder = MetaData.builder(currentState.metaData());
+        // allow to change any settings to a close index, and only allow dynamic settings to be changed
+        // on an open index
+        Set<Index> openIndices = new HashSet<>();
+        Set<Index> closeIndices = new HashSet<>();
+        final String[] actualIndices = new String[concreteIndices.length];
+        for (int i = 0; i < concreteIndices.length; i++) {
+            Index index = concreteIndices[i];
+            actualIndices[i] = index.getName();
+            final IndexMetaData metaData = currentState.metaData().getIndexSafe(index);
+            if (metaData.getState() == IndexMetaData.State.OPEN) {
+                openIndices.add(index);
+            } else {
+                closeIndices.add(index);
+            }
+        }
+
+        if (!skippedSettings.isEmpty() && !openIndices.isEmpty()) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
+                                                             "Can't update non dynamic settings [%s] for open indices %s",
+                                                             skippedSettings,
+                                                             openIndices));
+        }
+
+        int updatedNumberOfReplicas = openSettings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, -1);
+
+        if (updatedNumberOfReplicas != -1) {
+            // we do *not* update the in sync allocation ids as they will be removed upon the first index
+            // operation which make these copies stale
+            // TODO: update the list once the data is deleted by the node?
+            routingTableBuilder.updateNumberOfReplicas(updatedNumberOfReplicas, actualIndices);
+            metaDataBuilder.updateNumberOfReplicas(updatedNumberOfReplicas, actualIndices);
+        }
+
+        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+        maybeUpdateClusterBlock(actualIndices,
+                                blocks,
+                                IndexMetaData.INDEX_READ_ONLY_BLOCK,
+                                IndexMetaData.INDEX_READ_ONLY_SETTING,
+                                openSettings);
+        maybeUpdateClusterBlock(actualIndices,
+                                blocks,
+                                IndexMetaData.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK,
+                                IndexMetaData.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
+                                openSettings);
+        maybeUpdateClusterBlock(actualIndices,
+                                blocks,
+                                IndexMetaData.INDEX_METADATA_BLOCK,
+                                IndexMetaData.INDEX_BLOCKS_METADATA_SETTING,
+                                openSettings);
+        maybeUpdateClusterBlock(actualIndices,
+                                blocks,
+                                IndexMetaData.INDEX_WRITE_BLOCK,
+                                IndexMetaData.INDEX_BLOCKS_WRITE_SETTING,
+                                openSettings);
+        maybeUpdateClusterBlock(actualIndices,
+                                blocks,
+                                IndexMetaData.INDEX_READ_BLOCK,
+                                IndexMetaData.INDEX_BLOCKS_READ_SETTING,
+                                openSettings);
+
+        if (!openIndices.isEmpty()) {
+            for (Index index : openIndices) {
+                IndexMetaData indexMetaData = metaDataBuilder.getSafe(index);
+                Settings.Builder updates = Settings.builder();
+                Settings.Builder indexSettings = Settings.builder().put(indexMetaData.getSettings());
+                if (indexScopedSettings.updateDynamicSettings(openSettings, indexSettings, updates, index.getName())) {
+                    Settings finalSettings = indexSettings.build();
+                    indexScopedSettings.validate(finalSettings.filter(k -> indexScopedSettings.isPrivateSetting(k) ==
+                                                                           false), true);
+                    metaDataBuilder.put(IndexMetaData.builder(indexMetaData).settings(finalSettings));
+                }
+            }
+        }
+
+        if (!closeIndices.isEmpty()) {
+            for (Index index : closeIndices) {
+                IndexMetaData indexMetaData = metaDataBuilder.getSafe(index);
+                Settings.Builder updates = Settings.builder();
+                Settings.Builder indexSettings = Settings.builder().put(indexMetaData.getSettings());
+                if (indexScopedSettings.updateSettings(closedSettings, indexSettings, updates, index.getName())) {
+                    Settings finalSettings = indexSettings.build();
+                    indexScopedSettings.validate(finalSettings.filter(k -> indexScopedSettings.isPrivateSetting(k) ==
+                                                                           false), true);
+                    metaDataBuilder.put(IndexMetaData.builder(indexMetaData).settings(finalSettings));
+                }
+            }
+        }
+
+        // increment settings versions
+        for (final String index : actualIndices) {
+            if (same(currentState.metaData().index(index).getSettings(), metaDataBuilder.get(index).getSettings()) ==
+                false) {
+                final IndexMetaData.Builder builder = IndexMetaData.builder(metaDataBuilder.get(index));
+                builder.settingsVersion(1 + builder.settingsVersion());
+                metaDataBuilder.put(builder);
+            }
+        }
+
+        ClusterState updatedState = ClusterState.builder(currentState).metaData(metaDataBuilder).routingTable(
+            routingTableBuilder.build()).blocks(blocks).build();
+
+        // now, reroute in case things change that require it (like number of replicas)
+        updatedState = allocationService.reroute(updatedState, "settings update");
+        try {
+            for (Index index : openIndices) {
+                final IndexMetaData currentMetaData = currentState.getMetaData().getIndexSafe(index);
+                final IndexMetaData updatedMetaData = updatedState.metaData().getIndexSafe(index);
+                indicesService.verifyIndexMetadata(currentMetaData, updatedMetaData);
+            }
+            for (Index index : closeIndices) {
+                final IndexMetaData currentMetaData = currentState.getMetaData().getIndexSafe(index);
+                final IndexMetaData updatedMetaData = updatedState.metaData().getIndexSafe(index);
+                // Verifies that the current index settings can be updated with the updated dynamic settings.
+                indicesService.verifyIndexMetadata(currentMetaData, updatedMetaData);
+                // Now check that we can create the index with the updated settings (dynamic and non-dynamic).
+                // This step is mandatory since we allow to update non-dynamic settings on closed indices.
+                indicesService.verifyIndexMetadata(updatedMetaData, updatedMetaData);
+            }
+        } catch (IOException ex) {
+            throw ExceptionsHelper.convertToElastic(ex);
+        }
+        return updatedState;
+    }
+
+    static ClusterState updateTemplate(ClusterState currentState,
+                                       RelationName relationName,
+                                       Settings newSetting,
+                                       Map<String, Object> newMapping,
+                                       BiConsumer<String, Settings> settingsValidator,
+                                       IndexScopedSettings indexScopedSettings) throws IOException {
+
+        String templateName = PartitionName.templateName(relationName.schema(), relationName.name());
+
+        IndexTemplateMetaData indexTemplateMetaData = currentState.metaData().templates().get(templateName);
+
+        final Settings settings = Settings.builder()
+            .put(indexTemplateMetaData.settings())
+            .put(newSetting)
+            .normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX)
+            // Private settings must not be (over-)written as they are generated, remove them.
+            .build().filter(k -> indexScopedSettings.isPrivateSetting(k) == false);
+
+        settingsValidator.accept(templateName, settings);
+
+        final IndexTemplateMetaData.Builder templateBuilder = IndexTemplateMetaData.builder(templateName)
+            .order(indexTemplateMetaData.order())
+            .patterns(indexTemplateMetaData.getPatterns())
+            .settings(settings)
+            .putMapping(Constants.DEFAULT_MAPPING_TYPE, mergeTemplateMapping(indexTemplateMetaData, newMapping));
+
+        for (ObjectObjectCursor<String, AliasMetaData> container : indexTemplateMetaData.aliases()) {
+            templateBuilder.putAlias(container.value);
+        }
+
+        final MetaData.Builder metaData = MetaData.builder(currentState.metaData()).put(templateBuilder.build());
+        return ClusterState.builder(currentState).metaData(metaData).build();
+    }
+
+    private static String mergeTemplateMapping(IndexTemplateMetaData templateMetaData, Map<String, Object> newMapping) {
+        Map<String, Object> merged = AlterTableOperation.mergeTemplateMapping(templateMetaData, newMapping);
+        try {
+            return Strings.toString(XContentFactory.contentBuilder(XContentType.JSON).map(MapBuilder.<String, Object>newMapBuilder().put(
+                Constants.DEFAULT_MAPPING_TYPE,
+                merged).map()));
+        } catch (IOException e) {
+            throw new ElasticsearchException("failed to serialize mapping");
+        }
+    }
+
+    private static void validateSettings(String name,
+                                         Settings settings,
+                                         IndexScopedSettings indexScopedSettings,
+                                         MetaDataCreateIndexService metaDataCreateIndexService) {
+        List<String> validationErrors = new ArrayList<>();
+        try {
+            indexScopedSettings.validate(settings, true); // templates must be consistent with regards to dependencies
+        } catch (IllegalArgumentException iae) {
+            validationErrors.add(iae.getMessage());
+            for (Throwable t : iae.getSuppressed()) {
+                validationErrors.add(t.getMessage());
+            }
+        }
+        List<String> indexSettingsValidation = metaDataCreateIndexService.getIndexSettingsValidationErrors(settings, true);
+        validationErrors.addAll(indexSettingsValidation);
+        if (!validationErrors.isEmpty()) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationErrors(validationErrors);
+            throw new InvalidIndexTemplateException(name, validationException.getMessage());
+        }
+    }
+
+    private Settings filterSettings(Settings settings, List<String> settingsFilter) {
+        Settings.Builder settingsBuilder = Settings.builder();
+        for (String settingName : settingsFilter) {
+            String setting = settings.get(settingName);
+            if (setting != null) {
+                settingsBuilder.put(settingName, setting);
+            }
+        }
+        return settingsBuilder.build();
+    }
+
+    private Index[] resolveIndices(ClusterState currentState, String indexExpressions) {
+        return indexNameExpressionResolver.concreteIndices(currentState, FIND_OPEN_AND_CLOSED_INDICES_INGORE_UNAVAILABLE_AND_NON_EXISTING, indexExpressions);
+    }
+
+    /**
+     * Mark possible archived settings to be removed, they are not allowed to be written.
+     * (Private settings are already filtered out later at the meta data update service.)
+     */
+    @VisibleForTesting
+    static Settings markArchivedSettings(Settings settings) {
+        return Settings.builder()
+            .put(settings)
+            .putNull(ARCHIVED_SETTINGS_PREFIX + "*")
+            .build();
+    }
+}

--- a/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -82,33 +82,6 @@ public class AlterTableOperationTest extends CrateUnitTest {
     }
 
     @Test
-    public void testPrivateSettingsAreRemovedOnPrepareIndexTemplateRequest() {
-        IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, Collections.emptySet());
-
-        Settings settings = Settings.builder()
-            .put(SETTING_CREATION_DATE, false)      // private, must be filtered out
-            .put(SETTING_NUMBER_OF_SHARDS, 4)
-            .build();
-        IndexTemplateMetaData indexTemplateMetaData = IndexTemplateMetaData.builder("t1")
-            .patterns(Collections.singletonList("*"))
-            .settings(settings)
-            .build();
-
-        PutIndexTemplateRequest request = AlterTableOperation.preparePutIndexTemplateRequest(indexScopedSettings, indexTemplateMetaData,
-            Collections.emptyMap(), Collections.emptyMap(), Settings.EMPTY, new RelationName(Schemas.DOC_SCHEMA_NAME, "t1"), "t1.*");
-
-        assertThat(request.settings().keySet(), contains(SETTING_NUMBER_OF_SHARDS));
-    }
-
-    @Test
-    public void testMarkArchivedSettings() {
-        Settings.Builder builder = Settings.builder()
-            .put(SETTING_NUMBER_OF_SHARDS, 4);
-        Settings preparedSettings = AlterTableOperation.markArchivedSettings(builder.build());
-        assertThat(preparedSettings.keySet(), containsInAnyOrder(SETTING_NUMBER_OF_SHARDS, ARCHIVED_SETTINGS_PREFIX + "*"));
-    }
-
-    @Test
     public void testValidateReadOnlyForResizeOperation() {
         Settings settings = Settings.builder()
             .put(baseIndexSettings())

--- a/sql/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
+++ b/sql/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.cluster;
+
+import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class AlterTableClusterStateExecutorTest {
+
+    @Test
+    public void testPrivateSettingsAreRemovedOnUpdateTemplate() throws IOException {
+        IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, Collections.emptySet());
+
+        RelationName relationName = new RelationName(Schemas.DOC_SCHEMA_NAME, "t1");
+        String templateName = PartitionName.templateName(relationName.schema(), relationName.name());
+
+        Settings settings = Settings.builder()
+            .put(SETTING_CREATION_DATE, false)      // private, must be filtered out
+            .put(SETTING_NUMBER_OF_SHARDS, 4)
+            .build();
+        IndexTemplateMetaData indexTemplateMetaData = IndexTemplateMetaData.builder(templateName)
+            .patterns(Collections.singletonList("*"))
+            .settings(settings)
+            .build();
+
+        ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metaData(MetaData.builder().put(indexTemplateMetaData))
+            .build();
+
+        ClusterState result =
+            AlterTableClusterStateExecutor.updateTemplate(initialState,
+                                                          relationName,
+                                                          settings,
+                                                          Collections.emptyMap(),
+                                                          (x, y) -> { },
+                                                          indexScopedSettings);
+
+        IndexTemplateMetaData template = result.getMetaData().getTemplates().get(templateName);
+        assertThat(template.settings().keySet(), contains(SETTING_NUMBER_OF_SHARDS));
+    }
+
+    @Test
+    public void testMarkArchivedSettings() {
+        Settings.Builder builder = Settings.builder()
+            .put(SETTING_NUMBER_OF_SHARDS, 4);
+        Settings preparedSettings = AlterTableClusterStateExecutor.markArchivedSettings(builder.build());
+        assertThat(preparedSettings.keySet(), containsInAnyOrder(SETTING_NUMBER_OF_SHARDS, ARCHIVED_SETTINGS_PREFIX + "*"));
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
