### PR TITLE
Reduce global checkpoint sync interval in disruption tests

### DIFF
--- a/blackbox/docs/general/ddl/show-create-table.rst
+++ b/blackbox/docs/general/ddl/show-create-table.rst
@@ -41,6 +41,7 @@ already existing user-created doc tables in the cluster::
     |    "blocks.write" = false,                          |
     |    codec = 'default',                               |
     |    column_policy = 'strict',                        |
+    |    "global_checkpoint_sync.interval" = 30000,       |
     |    "mapping.total_fields.limit" = 1000,             |
     |    max_ngram_diff = 1,                              |
     |    max_shingle_diff = 3,                            |

--- a/es/es-server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDe
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.MergeSchedulerConfig;
@@ -115,6 +116,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         EngineConfig.INDEX_CODEC_SETTING,
         EngineConfig.INDEX_OPTIMIZE_AUTO_GENERATED_IDS,
         IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS,
+        IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING,
         Setting.groupSetting("index.analysis.", Property.IndexScope));
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -330,7 +330,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             logger.trace("{} preparing for file-based recovery from [{}]", recoveryTarget.shardId(), recoveryTarget.sourceNode());
         } else {
             logger.trace(
-                "{} preparing for sequence-number-based recovery starting at local checkpoint [{}] from [{}]",
+                "{} preparing for sequence-number-based recovery starting at sequence number [{}] from [{}]",
                 recoveryTarget.shardId(),
                 startingSeqNo,
                 recoveryTarget.sourceNode());

--- a/sql/src/main/java/io/crate/analyze/TableParameters.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameters.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.mapper.MapperService;
@@ -96,7 +97,10 @@ public class TableParameters {
             IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING,
             IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING,
             IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING,
-            EngineConfig.INDEX_CODEC_SETTING
+            EngineConfig.INDEX_CODEC_SETTING,
+
+            // this setting is needed for tests and is not documented. see ClusterDisruptionIT for usages.
+            IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING
         );
 
     /**

--- a/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -93,6 +93,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -139,6 +140,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -187,6 +189,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -235,6 +238,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -308,6 +312,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -352,6 +357,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -395,6 +401,7 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
+                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +

--- a/sql/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
+++ b/sql/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
@@ -97,7 +97,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
 
         logger.info("creating table t clustered into {} shards with {} replicas", numberOfShards, replicas);
         execute("create table t (id int primary key, x string) clustered into " + numberOfShards + " shards " +
-                "with (number_of_replicas = " + replicas + ", \"write.wait_for_active_shards\" = 1)");
+                "with (number_of_replicas = " + replicas + ", \"write.wait_for_active_shards\" = 1, \"global_checkpoint_sync.interval\"='1s')");
         ensureGreen();
 
         ServiceDisruptionScheme disruptionScheme = addRandomDisruptionScheme();


### PR DESCRIPTION
This should remove flakiness of the cluster disruption integration tests.
See https://github.com/elastic/elasticsearch/pull/38931 and
https://github.com/elastic/elasticsearch/commit/d49d9b53d6e0ac8acda61913489fa55e5118f0c5
