### PR TITLE
Use cause to determine if node with primary is closing.

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -202,8 +202,11 @@ public class ReplicationOperation<
     }
 
     private void onNoLongerPrimary(Exception failure) {
-        final boolean nodeIsClosing = failure instanceof NodeClosedException ||
-            (failure instanceof TransportException && "TransportService is closed stopped can't send request".equals(failure.getMessage()));
+        final Throwable cause = ExceptionsHelper.unwrapCause(failure);
+        final boolean nodeIsClosing =
+            cause instanceof NodeClosedException ||
+            (cause instanceof TransportException && "TransportService is closed stopped can't send request".equals(cause.getMessage()));
+
         final String message;
         if (nodeIsClosing) {
             message = String.format(Locale.ROOT,

--- a/es/es-server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.SendRequestTransportException;
 import org.elasticsearch.transport.TransportException;
 import org.junit.Test;
 
@@ -207,7 +208,9 @@ public class ReplicationOperationTests extends ESTestCase {
         if (randomBoolean()) {
             shardActionFailure = new NodeClosedException(new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT));
         } else if (randomBoolean()) {
-            shardActionFailure = new TransportException("TransportService is closed stopped can't send request");
+            shardActionFailure = new SendRequestTransportException(
+                new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT), "internal:cluster/shard/failure",
+                new TransportException("TransportService is closed stopped can't send request"));
         } else {
             shardActionFailure = new ShardStateAction.NoLongerPrimaryShardException(failedReplica.shardId(), "the king is dead");
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of https://github.com/elastic/elasticsearch/pull/39723

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
