### PR TITLE
Inline SymbolVisitor.process

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/ParameterTypeExtractor.java
+++ b/sql/src/main/java/io/crate/action/sql/ParameterTypeExtractor.java
@@ -47,7 +47,7 @@ class ParameterTypeExtractor extends DefaultTraversalSymbolVisitor<Void, Void> i
 
     @Override
     public void accept(Symbol symbol) {
-        process(symbol, null);
+        symbol.accept(this, null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -115,7 +115,7 @@ public final class GeneratedColumnExpander {
                 return symbol;
             } else {
                 Context ctx = new Context(referencedSingleReferences);
-                return process(symbol, ctx);
+                return symbol.accept(this, ctx);
             }
         }
 

--- a/sql/src/main/java/io/crate/analyze/NegateLiterals.java
+++ b/sql/src/main/java/io/crate/analyze/NegateLiterals.java
@@ -41,7 +41,7 @@ public final class NegateLiterals extends SymbolVisitor<Void, Symbol> {
     }
 
     public static Symbol negate(Symbol symbol) {
-        return INSTANCE.process(symbol, null);
+        return symbol.accept(INSTANCE, null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
+++ b/sql/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
@@ -62,7 +62,7 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
     }
 
     public static Symbol rewrite(Symbol symbol) {
-        return INSTANCE.process(symbol, null);
+        return symbol.accept(INSTANCE, null);
     }
 
     @Override
@@ -72,10 +72,10 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
         if (functionName.equals(NotPredicate.NAME)) {
             Symbol argument = symbol.arguments().get(0);
             if (argument instanceof Reference) {
-                return process(argument, context);
+                return argument.accept(this, context);
             } else if (argument instanceof Function) {
                 if (!Operators.LOGICAL_OPERATORS.contains(((Function) argument).info().ident().name())) {
-                    return process(argument, context);
+                    return argument.accept(this, context);
                 }
             }
         }
@@ -84,7 +84,7 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
         boolean allLiterals = true;
         boolean isNull = false;
         for (Symbol arg : symbol.arguments()) {
-            Symbol processedArg = process(arg, context);
+            Symbol processedArg = arg.accept(this, context);
             newArgs.add(processedArg);
             if (!processedArg.symbolType().isValueSymbol()) {
                 allLiterals = false;

--- a/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -61,7 +61,7 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
                                   Row params,
                                   SubQueryResults subQueryValues) {
         SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, functions, subQueryValues);
-        return symbolEval.process(symbol, params).value();
+        return symbol.accept(symbolEval, params).value();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -34,7 +34,7 @@ public class GroupBySymbolValidator {
     private static final InnerValidator INNER_VALIDATOR = new InnerValidator();
 
     public static void validate(Symbol symbol) throws IllegalArgumentException, UnsupportedOperationException {
-        INNER_VALIDATOR.process(symbol, "Cannot GROUP BY '%s': invalid data type '%s'");
+        symbol.accept(INNER_VALIDATOR, "Cannot GROUP BY '%s': invalid data type '%s'");
     }
 
     private static class InnerValidator extends SymbolVisitor<String, Void> {
@@ -44,7 +44,7 @@ public class GroupBySymbolValidator {
             switch (function.info().type()) {
                 case SCALAR:
                     for (Symbol argument : function.arguments()) {
-                        process(argument, errorMsgTemplate);
+                        argument.accept(this, errorMsgTemplate);
                     }
                     break;
                 case AGGREGATE:

--- a/sql/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
@@ -38,7 +38,7 @@ public class HavingSymbolValidator {
     private static final InnerValidator INNER_VALIDATOR = new InnerValidator();
 
     public static void validate(Symbol symbol, @Nullable List<Symbol> groupBySymbols) throws IllegalArgumentException {
-        INNER_VALIDATOR.process(symbol, new HavingContext(groupBySymbols));
+        symbol.accept(INNER_VALIDATOR, new HavingContext(groupBySymbols));
     }
 
     static class HavingContext {
@@ -84,7 +84,7 @@ public class HavingSymbolValidator {
             }
 
             for (Symbol argument : function.arguments()) {
-                process(argument, context);
+                argument.accept(this, context);
             }
             if (type == FunctionInfo.Type.AGGREGATE) {
                 context.insideAggregation = false;

--- a/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -35,7 +35,7 @@ public class SelectSymbolValidator {
 
     public static void validate(Collection<Symbol> symbols) {
         for (Symbol symbol : symbols) {
-            INNER_VALIDATOR.process(symbol, null);
+            symbol.accept(INNER_VALIDATOR, null);
         }
     }
 
@@ -53,7 +53,7 @@ public class SelectSymbolValidator {
                         "FunctionInfo.Type %s not handled", symbol.info().type()));
             }
             for (Symbol arg : symbol.arguments()) {
-                process(arg, context);
+                arg.accept(this, context);
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -41,7 +41,7 @@ public class SemanticSortValidator {
     private static final InnerValidator INNER_VALIDATOR = new InnerValidator();
 
     public static void validate(Symbol symbol) throws UnsupportedOperationException {
-        INNER_VALIDATOR.process(symbol, new SortContext("ORDER BY"));
+        symbol.accept(INNER_VALIDATOR, new SortContext("ORDER BY"));
     }
 
     /**
@@ -52,7 +52,7 @@ public class SemanticSortValidator {
      * @throws UnsupportedOperationException
      */
     public static void validate(Symbol symbol, String operation) throws UnsupportedOperationException {
-        INNER_VALIDATOR.process(symbol, new SortContext(operation));
+        symbol.accept(INNER_VALIDATOR, new SortContext(operation));
     }
 
     static class SortContext {
@@ -81,7 +81,7 @@ public class SemanticSortValidator {
             try {
                 context.inFunction = true;
                 for (Symbol arg : symbol.arguments()) {
-                    process(arg, context);
+                    arg.accept(this, context);
                 }
             } finally {
                 context.inFunction = false;

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -111,7 +111,7 @@ public class EqualityExtractor {
                                               @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
             new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
-        Symbol proxiedTree = ProxyInjectingVisitor.INSTANCE.process(symbol, context);
+        Symbol proxiedTree = symbol.accept(ProxyInjectingVisitor.INSTANCE, context);
 
         // bail out if we have any unknown part in the tree
         if (context.exact && context.seenUnknown) {
@@ -427,7 +427,7 @@ public class EqualityExtractor {
                 ArrayList<Symbol> newArgs = new ArrayList<>(arguments.size());
                 for (Symbol arg : arguments) {
                     context.proxyBelow = proxyBelowPre;
-                    newArgs.add(process(arg, context));
+                    newArgs.add(arg.accept(this, context));
                     proxyBelowPost = context.proxyBelow || proxyBelowPost;
                 }
                 context.proxyBelow = proxyBelowPost;

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -52,7 +52,7 @@ public final class WhereClauseValidator {
     }
 
     public static void validate(Symbol query) {
-        VISITOR.process(query, new Visitor.Context());
+        query.accept(VISITOR, new Visitor.Context());
     }
 
     private static class Visitor extends SymbolVisitor<Visitor.Context, Symbol> {
@@ -108,7 +108,7 @@ public final class WhereClauseValidator {
 
         private Function continueTraversal(Function symbol, Context context) {
             for (Symbol argument : symbol.arguments()) {
-                process(argument, context);
+                argument.accept(this, context);
             }
             return symbol;
         }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -124,7 +124,7 @@ final class UpdateSourceGen {
         Doc updatedDoc = result.withUpdatedSource(updatedSource);
         for (int i = 0; i < updateColumns.size(); i++) {
             Reference ref = updateColumns.get(i);
-            Object value = eval.process(updateAssignments[i], values).value();
+            Object value = updateAssignments[i].accept(eval, values).value();
             ColumnIdent column = ref.column();
             Maps.mergeInto(updatedSource, column.name(), column.path(), value);
         }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -75,7 +75,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
     private void process(Collection<Symbol> symbols, Context context) {
         for (Symbol symbol : symbols) {
             context.foundAggregateOrTableFunction = false;
-            process(symbol, context);
+            symbol.accept(this, context);
             if (context.foundAggregateOrTableFunction == false) {
                 context.standalone.add(symbol);
             }
@@ -91,7 +91,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
         }
         HavingClause having = relation.having();
         if (having != null && having.hasQuery()) {
-            INSTANCE.process(having.query(), context);
+            having.query().accept(INSTANCE, context);
         }
         LinkedHashSet<Symbol> toCollect = new LinkedHashSet<>();
         for (Function tableFunction : context.tableFunctions) {

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchBatchAccumulator.java
@@ -74,7 +74,7 @@ public class FetchBatchAccumulator implements BatchAccumulator<Row, Iterator<? e
 
         List<Input<?>> inputs = new ArrayList<>(outputSymbols.size());
         for (Symbol symbol : outputSymbols) {
-            inputs.add(rowInputSymbolVisitor.process(symbol, collectRowContext));
+            inputs.add(symbol.accept(rowInputSymbolVisitor, collectRowContext));
         }
         outputRow = new InputRow(inputs);
     }

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -123,7 +123,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
 
 
     private SortField generateSortField(Symbol symbol, SortSymbolContext sortSymbolContext) {
-        return process(symbol, sortSymbolContext);
+        return symbol.accept(this, sortSymbolContext);
     }
 
 

--- a/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -60,7 +60,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
             Input[] argumentInputs = new Input[arguments.size()];
             int i = 0;
             for (Symbol argument : function.arguments()) {
-                argumentInputs[i++] = process(argument, context);
+                argumentInputs[i++] = argument.accept(this, context);
             }
             return new FunctionExpression<>(txnCtx, scalarImpl, argumentInputs);
         } else {

--- a/sql/src/main/java/io/crate/expression/InputFactory.java
+++ b/sql/src/main/java/io/crate/expression/InputFactory.java
@@ -156,7 +156,7 @@ public class InputFactory {
          * </p>
          */
         public Input<?> add(Symbol symbol) {
-            return visitor.process(symbol, null);
+            return symbol.accept(visitor, null);
         }
 
         public List<AggregationContext> aggregations() {
@@ -203,10 +203,10 @@ public class InputFactory {
         public Input<?> visitAggregation(Aggregation symbol, Void context) {
             FunctionImplementation impl = functions.getQualified(symbol.functionIdent());
             //noinspection unchecked
-            Input<Boolean> filter = (Input<Boolean>) process(symbol.filter(), context);
+            Input<Boolean> filter = (Input<Boolean>) symbol.filter().accept(this, context);
             AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl, filter);
             for (Symbol aggInput : symbol.inputs()) {
-                aggregationContext.addInput(process(aggInput, context));
+                aggregationContext.addInput(aggInput.accept(this, context));
             }
             aggregationContexts.add(aggregationContext);
 

--- a/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -110,7 +110,7 @@ public class EvaluatingNormalizer {
 
                 List<Symbol> columnBoostMapArgs = new ArrayList<>(fieldBoostMap.size() * 2);
                 for (Map.Entry<Field, Symbol> entry : fieldBoostMap.entrySet()) {
-                    Symbol resolved = process(entry.getKey(), null);
+                    Symbol resolved = ((Symbol) entry.getKey()).accept(this, null);
                     if (resolved instanceof Reference) {
                         columnBoostMapArgs.add(Literal.of(((Reference) resolved).column().fqn()));
                         columnBoostMapArgs.add(entry.getValue());
@@ -127,7 +127,7 @@ public class EvaluatingNormalizer {
                         Literal.of(matchPredicate.matchType()),
                         matchPredicate.options()
                     ));
-                return process(function, context);
+                return ((Symbol) function).accept(this, context);
             }
             return matchPredicate;
         }
@@ -167,7 +167,7 @@ public class EvaluatingNormalizer {
                 normalizedFunction.info(),
                 normalizedFunction.arguments(),
                 normalizedFunction.filter(),
-                function.windowDefinition().map(s -> process(s, context))
+                function.windowDefinition().map(s -> s.accept(this, context))
             );
         }
     }
@@ -176,6 +176,6 @@ public class EvaluatingNormalizer {
         if (symbol == null) {
             return null;
         }
-        return visitor.process(symbol, txnCtx);
+        return symbol.accept(visitor, txnCtx);
     }
 }

--- a/sql/src/main/java/io/crate/expression/eval/NullEliminator.java
+++ b/sql/src/main/java/io/crate/expression/eval/NullEliminator.java
@@ -66,7 +66,7 @@ public final class NullEliminator {
      */
     public static Symbol eliminateNullsIfPossible(Symbol symbol,
                                                   java.util.function.Function<Symbol, Symbol> postProcessor) {
-        return VISITOR.process(symbol, new Context(postProcessor));
+        return symbol.accept(VISITOR, new Context(postProcessor));
     }
 
     private static class Context {

--- a/sql/src/main/java/io/crate/expression/symbol/Aggregations.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Aggregations.java
@@ -36,14 +36,14 @@ public final class Aggregations {
      * @return true if the symbol is an aggregation or function which contains an aggregation or a scalar.
      */
     public static boolean containsAggregationOrscalar(Symbol s) {
-        return AGGREGATION_OR_SCALAR_SEARCHER.process(s, null);
+        return s.accept(AGGREGATION_OR_SCALAR_SEARCHER, null);
     }
 
     /**
      * @return true if the symbol is found in the group by, if the symbol is a scalar function all column arguments must be found in the group by.
      */
     public static boolean matchGroupBySymbol(Symbol s, List<Symbol> groupBy) {
-        return GROUP_BY_MATCHER.process(s, groupBy);
+        return s.accept(GROUP_BY_MATCHER, groupBy);
     }
 
     private static class AggregationOrScalarSearcher extends SymbolVisitor<Void, Boolean> {
@@ -91,7 +91,7 @@ public final class Aggregations {
             boolean isSymbolContained = true;
             if (symbol.info().type() == FunctionInfo.Type.SCALAR) {
                 for (int i = 0; i < symbol.arguments().size(); i++) {
-                    isSymbolContained = isSymbolContained && this.process(symbol.arguments().get(i), context);
+                    isSymbolContained = isSymbolContained && symbol.arguments().get(i).accept(this, context);
                 }
             }
             return isSymbolContained;

--- a/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
@@ -36,11 +36,11 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
     @Override
     public R visitFunction(Function symbol, C context) {
         for (Symbol arg : symbol.arguments()) {
-            process(arg, context);
+            arg.accept(this, context);
         }
         var filter = symbol.filter();
         if (filter != null) {
-            process(filter, context);
+            filter.accept(this, context);
         }
         return null;
     }
@@ -48,33 +48,33 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
     @Override
     public R visitWindowFunction(WindowFunction symbol, C context) {
         for (Symbol arg : symbol.arguments()) {
-            process(arg, context);
+            arg.accept(this, context);
         }
         Symbol filter = symbol.filter();
         if (filter != null) {
-            process(filter, context);
+            filter.accept(this, context);
         }
         WindowDefinition windowDefinition = symbol.windowDefinition();
         OrderBy orderBy = windowDefinition.orderBy();
         if (orderBy != null) {
             for (Symbol orderBySymbol : orderBy.orderBySymbols()) {
-                process(orderBySymbol, context);
+                orderBySymbol.accept(this, context);
             }
         }
         for (Symbol partition : windowDefinition.partitions()) {
-            process(partition, context);
+            partition.accept(this, context);
         }
 
         Symbol frameStartValueSymbol = windowDefinition.windowFrameDefinition().start().value();
         if (frameStartValueSymbol != null) {
-            process(frameStartValueSymbol, context);
+            frameStartValueSymbol.accept(this, context);
         }
 
         FrameBoundDefinition end = windowDefinition.windowFrameDefinition().end();
         if (end != null) {
             Symbol frameEndValueSymbol = end.value();
             if (frameEndValueSymbol != null) {
-                process(frameEndValueSymbol, context);
+                frameEndValueSymbol.accept(this, context);
             }
         }
 
@@ -83,15 +83,15 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
 
     @Override
     public R visitFetchReference(FetchReference fetchReference, C context) {
-        process(fetchReference.fetchId(), context);
-        process(fetchReference.ref(), context);
+        ((Symbol) fetchReference.fetchId()).accept(this, context);
+        ((Symbol) fetchReference.ref()).accept(this, context);
         return null;
     }
 
     @Override
     public R visitMatchPredicate(MatchPredicate matchPredicate, C context) {
         for (Field field : matchPredicate.identBoostMap().keySet()) {
-            process(field, context);
+            ((Symbol) field).accept(this, context);
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/expression/symbol/FieldReplacer.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FieldReplacer.java
@@ -37,7 +37,7 @@ public final class FieldReplacer extends FunctionCopyVisitor<Function<? super Fi
         if (tree == null) {
             return null;
         }
-        return REPLACER.process(tree, replaceFunc);
+        return tree.accept(REPLACER, replaceFunc);
     }
 
     public static Function<? super Symbol, ? extends Symbol> bind(Function<? super Field, ? extends Symbol> replaceFunc) {

--- a/sql/src/main/java/io/crate/expression/symbol/FieldsVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FieldsVisitor.java
@@ -35,6 +35,6 @@ public final class FieldsVisitor extends DefaultTraversalSymbolVisitor<Consumer<
     }
 
     public static void visitFields(Symbol symbolTree, Consumer<? super Field> consumer) {
-        FIELDS_VISITOR.process(symbolTree, consumer);
+        symbolTree.accept(FIELDS_VISITOR, consumer);
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -67,7 +67,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         boolean changed = false;
         for (Symbol arg : args) {
             Symbol newArg = requireNonNull(
-                process(arg, context),
+                arg.accept(this, context),
                 "function arguments must never be NULL"
             );
             changed |= arg != newArg;
@@ -84,10 +84,10 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
     private Function twoArgs(Function func, C context) {
         assert func.arguments().size() == 2 : "size of arguments must be two";
         Symbol arg1 = func.arguments().get(0);
-        Symbol newArg1 = requireNonNull(process(arg1, context), "function arguments must never be NULL");
+        Symbol newArg1 = requireNonNull(arg1.accept(this, context), "function arguments must never be NULL");
 
         Symbol arg2 = func.arguments().get(1);
-        Symbol newArg2 = requireNonNull(process(arg2, context), "function arguments must never be NULL");
+        Symbol newArg2 = requireNonNull(arg2.accept(this, context), "function arguments must never be NULL");
 
         Symbol filter = func.filter();
         Symbol newFilter = processNullable(filter, context);
@@ -106,7 +106,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
             return func;
         }
 
-        Symbol newFilter = process(filter, context);
+        Symbol newFilter = filter.accept(this, context);
         if (filter == newFilter) {
             return func;
         }
@@ -116,7 +116,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
     private Function oneArg(Function func, C context) {
         assert func.arguments().size() == 1 : "size of arguments must be one";
         Symbol arg = func.arguments().get(0);
-        Symbol newArg = requireNonNull(process(arg, context), "function arguments must never be NULL");
+        Symbol newArg = requireNonNull(arg.accept(this, context), "function arguments must never be NULL");
 
         Symbol filter = func.filter();
         Symbol newFilter = processNullable(filter, context);
@@ -147,7 +147,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
             processedFunction.info(),
             processedFunction.arguments(),
             processNullable(windowFunction.filter(), context),
-            windowFunction.windowDefinition().map(s -> process(s, context))
+            windowFunction.windowDefinition().map(s -> s.accept(this, context))
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/symbol/MappingSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/MappingSymbolVisitor.java
@@ -39,13 +39,12 @@ public class MappingSymbolVisitor extends FunctionCopyVisitor<Map<? extends Symb
         super();
     }
 
-    @Override
     public Symbol process(Symbol symbol, Map<? extends Symbol, ? extends Symbol> context) {
         Symbol mapped = context.get(symbol);
         if (mapped != null) {
             return mapped;
         }
-        return super.process(symbol, context);
+        return symbol.accept(this, context);
     }
 
 }

--- a/sql/src/main/java/io/crate/expression/symbol/RefReplacer.java
+++ b/sql/src/main/java/io/crate/expression/symbol/RefReplacer.java
@@ -40,7 +40,7 @@ public final class RefReplacer extends FunctionCopyVisitor<Function<? super Refe
      * Applies {@code mapper} on all {@link Reference} instances within {@code tree}
      */
     public static Symbol replaceRefs(Symbol tree, Function<? super Reference, ? extends Symbol> mapper) {
-        return REPLACER.process(tree, mapper);
+        return tree.accept(REPLACER, mapper);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/symbol/RefVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/RefVisitor.java
@@ -34,7 +34,7 @@ public final class RefVisitor extends DefaultTraversalSymbolVisitor<Consumer<? s
     }
 
     public static void visitRefs(Symbol tree, Consumer<? super Reference> consumer) {
-        VISITOR.process(tree, consumer);
+        tree.accept(VISITOR, consumer);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
@@ -23,14 +23,8 @@ package io.crate.expression.symbol;
 
 import io.crate.metadata.Reference;
 
-import javax.annotation.Nullable;
-
 
 public class SymbolVisitor<C, R> {
-
-    public R process(Symbol symbol, @Nullable C context) {
-        return symbol.accept(this, context);
-    }
 
     protected R visitSymbol(Symbol symbol, C context) {
         return null;

--- a/sql/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -29,7 +29,7 @@ public class SymbolVisitors {
     private static final AnyPredicateVisitor ANY_VISITOR = new AnyPredicateVisitor();
 
     public static boolean any(Predicate<? super Symbol> symbolPredicate, Symbol symbol) {
-        return ANY_VISITOR.process(symbol, symbolPredicate);
+        return symbol.accept(ANY_VISITOR, symbolPredicate);
     }
 
     private static class AnyPredicateVisitor extends SymbolVisitor<Predicate<? super Symbol>, Boolean> {

--- a/sql/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -79,7 +79,7 @@ public class Symbols {
         if (symbol == null) {
             return false;
         }
-        return HAS_COLUMN_VISITOR.process(symbol, path);
+        return symbol.accept(HAS_COLUMN_VISITOR, path);
     }
 
     /**
@@ -96,7 +96,7 @@ public class Symbols {
 
     public static boolean allLiterals(Symbol symbol) {
         assert symbol != null : "symbol must not be null";
-        return ALL_LITERALS_MATCHER.process(symbol, null);
+        return symbol.accept(ALL_LITERALS_MATCHER, null);
     }
 
     public static void toStream(Collection<? extends Symbol> symbols, StreamOutput out) throws IOException {
@@ -157,7 +157,7 @@ public class Symbols {
         @Override
         public Boolean visitFunction(Function symbol, ColumnIdent column) {
             for (Symbol arg : symbol.arguments()) {
-                if (process(arg, column)) {
+                if (arg.accept(this, column)) {
                     return true;
                 }
             }
@@ -166,10 +166,10 @@ public class Symbols {
 
         @Override
         public Boolean visitFetchReference(FetchReference fetchReference, ColumnIdent column) {
-            if (process(fetchReference.fetchId(), column)) {
+            if (((Symbol) fetchReference.fetchId()).accept(this, column)) {
                 return true;
             }
-            return process(fetchReference.ref(), column);
+            return ((Symbol) fetchReference.ref()).accept(this, column);
         }
 
         @Override
@@ -190,7 +190,7 @@ public class Symbols {
 
         @Override
         public Boolean visitFunction(Function function, Void context) {
-            return function.arguments().stream().allMatch(arg -> process(arg, null));
+            return function.arguments().stream().allMatch(arg -> arg.accept(this, null));
         }
 
         @Override

--- a/sql/src/main/java/io/crate/expression/symbol/format/MatchPrinter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/MatchPrinter.java
@@ -73,7 +73,7 @@ class MatchPrinter {
                                      SymbolPrinter.SymbolPrintVisitor symbolPrintVisitor,
                                      SymbolPrinterContext context) {
         // second argument (keyword)
-        symbolPrintVisitor.process(keyword, context);
+        keyword.accept(symbolPrintVisitor, context);
     }
 
     private static void printMethod(Symbol method, StringBuilder sb) {

--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
@@ -101,7 +101,7 @@ public final class SymbolPrinter {
      */
     private String print(Symbol symbol, Style style) {
         SymbolPrinterContext context = style.createNewContext();
-        symbolPrintVisitor.process(symbol, context);
+        symbol.accept(symbolPrintVisitor, context);
         return context.formatted();
     }
 
@@ -184,7 +184,7 @@ public final class SymbolPrinter {
             List<Symbol> args = function.arguments();
             assert args.size() == 2 : "function's number of arguments must be 2";
             context.builder.append(PAREN_OPEN); // wrap operator in parens to ensure precedence
-            process(args.get(0), context);
+            args.get(0).accept(this, context);
 
             // print operator
             String operatorName = anyOperatorName(function.info().ident().name());
@@ -194,7 +194,7 @@ public final class SymbolPrinter {
                 .append(WS);
 
             context.builder.append(ANY).append(PAREN_OPEN);
-            process(args.get(1), context);
+            args.get(1).accept(this, context);
             context.builder.append(PAREN_CLOSE)
                 .append(PAREN_CLOSE);
         }
@@ -216,15 +216,15 @@ public final class SymbolPrinter {
                 Reference firstArgument = (Reference) arguments.get(0);
                 context.builder.append(firstArgument.column().name());
                 context.builder.append("[");
-                process(arguments.get(1), context);
+                arguments.get(1).accept(this, context);
                 context.builder.append("]");
                 context.builder.append("['");
                 context.builder.append(firstArgument.column().path().get(0));
                 context.builder.append("']");
             } else {
-                process(arguments.get(0), context);
+                arguments.get(0).accept(this, context);
                 context.builder.append("[");
-                process(arguments.get(1), context);
+                arguments.get(1).accept(this, context);
                 context.builder.append("]");
             }
         }
@@ -265,9 +265,9 @@ public final class SymbolPrinter {
         @Override
         public Void visitFetchReference(FetchReference fetchReference, SymbolPrinterContext context) {
             context.builder.append("FETCH(");
-            process(fetchReference.fetchId(), context);
+            ((Symbol) fetchReference.fetchId()).accept(this, context);
             context.builder.append(", ");
-            process(fetchReference.ref(), context);
+            ((Symbol) fetchReference.ref()).accept(this, context);
             context.builder.append(")");
             return null;
         }
@@ -313,7 +313,7 @@ public final class SymbolPrinter {
         private void printFunctionFilterIfPresent(@Nullable Symbol filter, SymbolPrinterContext context) {
             if (filter != null) {
                 context.builder.append(" : ");
-                process(filter, context);
+                filter.accept(this, context);
             }
         }
 

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -64,7 +64,7 @@ public class SubqueryPlanner {
 
         @Override
         public void accept(Symbol symbol) {
-            process(symbol, null);
+            symbol.accept(this, null);
         }
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
+++ b/sql/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
@@ -68,7 +68,7 @@ public class OrderByPositionVisitor extends SymbolVisitor<OrderByPositionVisitor
                                                List<? extends Symbol> outputSymbols) {
         Context context = new Context(outputSymbols);
         for (Symbol orderBySymbol : orderBySymbols) {
-            INSTANCE.process(orderBySymbol, context);
+            orderBySymbol.accept(INSTANCE, context);
         }
         if (context.orderByPositions.size() == orderBySymbols.size()) {
             return context.orderByPositions();

--- a/sql/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
+++ b/sql/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
@@ -48,7 +48,7 @@ public class OrderByWithAggregationValidator {
     public static void validate(Symbol symbol,
                                 Collection<? extends Symbol> outputSymbols,
                                 boolean isDistinct) throws UnsupportedOperationException {
-        INNER_VALIDATOR.process(symbol, new ValidatorContext(outputSymbols, isDistinct));
+        symbol.accept(INNER_VALIDATOR, new ValidatorContext(outputSymbols, isDistinct));
     }
 
     private static class ValidatorContext {
@@ -72,7 +72,7 @@ public class OrderByWithAggregationValidator {
             }
             if (symbol.info().type() == FunctionInfo.Type.SCALAR) {
                 for (Symbol arg : symbol.arguments()) {
-                    process(arg, context);
+                    arg.accept(this, context);
                 }
             } else {
                 throw new UnsupportedOperationException(

--- a/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
@@ -80,7 +80,7 @@ public class GroupByConsumer {
 
     public static void validateGroupBySymbols(List<Symbol> groupBySymbols) {
         for (Symbol symbol : groupBySymbols) {
-            GROUP_BY_VALIDATOR.process(symbol, null);
+            symbol.accept(GROUP_BY_VALIDATOR, null);
         }
     }
 
@@ -97,7 +97,7 @@ public class GroupByConsumer {
 
         @Override
         public Void visitField(Field field, Void context) {
-            return process(field.pointer(), context);
+            return field.pointer().accept(this, context);
         }
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -417,7 +417,7 @@ public class Collect implements LogicalPlan {
         }
 
         static void ensureNoMatchPredicate(Symbol symbolTree) {
-            NO_PREDICATE_VISITOR.process(symbolTree, null);
+            symbolTree.accept(NO_PREDICATE_VISITOR, null);
         }
 
         @Override
@@ -426,7 +426,7 @@ public class Collect implements LogicalPlan {
                 throw new UnsupportedFeatureException("Cannot use match predicate on system tables");
             }
             for (Symbol argument : symbol.arguments()) {
-                process(argument, context);
+                argument.accept(this, context);
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/sql/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -60,7 +60,7 @@ public class EquiJoinDetector {
     private static boolean isEquiJoin(Symbol joinCondition) {
         assert joinCondition != null : "join condition must not be null on inner joins";
         Context context = new Context();
-        VISITOR.process(joinCondition, context);
+        joinCondition.accept(VISITOR, context);
         return context.isHashJoinPossible;
     }
 
@@ -78,14 +78,14 @@ public class EquiJoinDetector {
             switch (functionName) {
                 case AndOperator.NAME:
                     for (Symbol arg : function.arguments()) {
-                        process(arg, context);
+                        arg.accept(this, context);
                     }
                     break;
                 case EqOperator.NAME:
                     context.isHashJoinPossible = true;
                     context.insideEqOperator = true;
                     for (Symbol arg : function.arguments()) {
-                        process(arg, context);
+                        arg.accept(this, context);
                         if (context.usedRelationsInsideEqOperatorArgument.isEmpty() ||
                             context.usedRelationsInsideEqOperatorArgument.size() > 1) {
                             context.isHashJoinPossible = false;
@@ -96,7 +96,7 @@ public class EquiJoinDetector {
                 default:
                     if (context.insideEqOperator) {
                         for (Symbol arg : function.arguments()) {
-                            process(arg, context);
+                            arg.accept(this, context);
                         }
                     } else {
                         context.isHashJoinPossible = false;

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -160,7 +160,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
             OutputValidatorContext ctx = new OutputValidatorContext();
             for (Symbol output : outputs) {
                 ctx.insideAggregation = false;
-                INSTANCE.process(output, ctx);
+                output.accept(INSTANCE, ctx);
             }
         }
 
@@ -169,7 +169,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
             context.insideAggregation =
                 context.insideAggregation || symbol.info().type().equals(FunctionInfo.Type.AGGREGATE);
             for (Symbol argument : symbol.arguments()) {
-                process(argument, context);
+                argument.accept(this, context);
             }
             context.insideAggregation = false;
             return null;

--- a/sql/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
@@ -69,7 +69,7 @@ public final class HashJoinConditionSymbolsExtractor {
      */
     public static Map<AnalyzedRelation, List<Symbol>> extract(Symbol symbol) {
         Context ctx = new Context();
-        SYMBOL_EXTRACTOR.process(symbol, ctx);
+        symbol.accept(SYMBOL_EXTRACTOR, ctx);
         return ctx.symbolsPerRelation;
     }
 
@@ -90,7 +90,7 @@ public final class HashJoinConditionSymbolsExtractor {
                     context.insideEqOperator = true;
                     int duplicatePos = 0;
                     for (Symbol arg : function.arguments()) {
-                        AnalyzedRelation relation = RELATION_EXTRACTOR.process(arg, null);
+                        AnalyzedRelation relation = arg.accept(RELATION_EXTRACTOR, null);
                         List<Symbol> symbols = context.symbolsPerRelation.computeIfAbsent(relation, k -> new ArrayList<>());
                         if (symbols.contains(arg)) {
                             // duplicate detected, use the current size as the position of the other relation symbol we
@@ -127,7 +127,7 @@ public final class HashJoinConditionSymbolsExtractor {
         @Override
         public AnalyzedRelation visitFunction(Function symbol, Void context) {
             for (Symbol arg : symbol.arguments()) {
-                AnalyzedRelation relation = process(arg, context);
+                AnalyzedRelation relation = arg.accept(this, context);
                 if (relation != null) {
                     return relation;
                 }

--- a/sql/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/sql/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -66,7 +66,7 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
 
     @Override
     public Symbol apply(Symbol symbol) {
-        return process(symbol, null);
+        return symbol.accept(this, null);
     }
 
     private static Symbol convert(ParameterSymbol parameterSymbol, Row params) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`process` only forwarded a call. The extra indirection makes debugging a
bit more troublesome, so this removes it.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)