### PR TITLE
Remove duplicate window function processing in WindowAgg operator

### DIFF
--- a/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
@@ -50,8 +50,9 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
         for (Symbol arg : symbol.arguments()) {
             process(arg, context);
         }
-        if (symbol.filter() != null) {
-            process(symbol.filter(), context);
+        Symbol filter = symbol.filter();
+        if (filter != null) {
+            process(filter, context);
         }
         WindowDefinition windowDefinition = symbol.windowDefinition();
         OrderBy orderBy = windowDefinition.orderBy();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`extractColumns(windowFunctions)` already extracts all used columns from
the window function including the window definition, there is no need to
further extract columns from the individual parts manually.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)