### PR TITLE
Always fail engine if delete operation fails.

### DIFF
--- a/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2927,27 +2927,6 @@ public class InternalEngineTests extends EngineTestCase {
                 assertNotNull(indexResult.getTranslogLocation());
                 engine.index(indexForDoc(doc2));
 
-                // test failure while deleting
-                // all these simulated exceptions are not fatal to the IW so we treat them as document failures
-                final Engine.DeleteResult deleteResult;
-                if (randomBoolean()) {
-                    throwingIndexWriter.get().setThrowFailure(() -> new IOException("simulated"));
-                    deleteResult = engine.delete(new Engine.Delete(
-                        "default", "1", newUid(doc1), UNASSIGNED_SEQ_NO,
-                        primaryTerm.get(), Versions.MATCH_ANY, VersionType.INTERNAL,
-                        Engine.Operation.Origin.PRIMARY, System.nanoTime(), UNASSIGNED_SEQ_NO, 0));
-                    assertThat(deleteResult.getFailure(), instanceOf(IOException.class));
-                } else {
-                    throwingIndexWriter.get().setThrowFailure(() -> new IllegalArgumentException("simulated max token length"));
-                    deleteResult = engine.delete(new Engine.Delete(
-                        "default", "1",  newUid(doc1), UNASSIGNED_SEQ_NO,
-                        primaryTerm.get(), Versions.MATCH_ANY, VersionType.INTERNAL,
-                        Engine.Operation.Origin.PRIMARY, System.nanoTime(), UNASSIGNED_SEQ_NO, 0));
-                    assertThat(deleteResult.getFailure(), instanceOf(IllegalArgumentException.class));
-                }
-                assertThat(deleteResult.getVersion(), equalTo(2L));
-                assertThat(deleteResult.getSeqNo(), equalTo(3L));
-
                 // test non document level failure is thrown
                 if (randomBoolean()) {
                     // simulate close by corruption
@@ -2983,6 +2962,44 @@ public class InternalEngineTests extends EngineTestCase {
                 } catch (Exception e) {
                     assertThat(e, instanceOf(AlreadyClosedException.class));
                 }
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteWithFatalError() throws Exception {
+        final IllegalStateException tragicException = new IllegalStateException("fail to store tombstone");
+        try (Store store = createStore()) {
+            EngineConfig.TombstoneDocSupplier tombstoneDocSupplier = new EngineConfig.TombstoneDocSupplier() {
+                @Override
+                public ParsedDocument newDeleteTombstoneDoc(String id) {
+                    ParsedDocument parsedDocument = tombstoneDocSupplier().newDeleteTombstoneDoc(id);
+                    parsedDocument.rootDoc().add(new StoredField("foo", "bar") {
+                        // this is a hack to add a failure during store document which triggers a tragic event
+                        // and in turn fails the engine
+                        @Override
+                        public BytesRef binaryValue() {
+                            throw tragicException;
+                        }
+                    });
+                    return parsedDocument;
+                }
+
+                @Override
+                public ParsedDocument newNoopTombstoneDoc(String reason) {
+                    return tombstoneDocSupplier().newNoopTombstoneDoc(reason);
+                }
+            };
+            try (InternalEngine engine = createEngine(config(this.engine.config(), store, tombstoneDocSupplier))) {
+                final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+                engine.index(indexForDoc(doc));
+                expectThrows(IllegalStateException.class, () -> engine.delete(
+                    new Engine.Delete(
+                        "test", "1", newUid(doc), UNASSIGNED_SEQ_NO,
+                        primaryTerm.get(), Versions.MATCH_ANY, VersionType.INTERNAL,
+                        Engine.Operation.Origin.PRIMARY, System.nanoTime(), UNASSIGNED_SEQ_NO, 0)));
+                assertTrue(engine.isClosed.get());
+                assertSame(tragicException, engine.failedEngine.get());
             }
         }
     }

--- a/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -565,12 +565,61 @@ public abstract class EngineTestCase extends ESTestCase {
             globalCheckpointSupplier = new ReplicationTracker(shardId, allocationId.getId(), indexSettings, SequenceNumbers.NO_OPS_PERFORMED, update -> {
             });
         }
-        EngineConfig config = new EngineConfig(shardId, allocationId.getId(), threadPool, indexSettings, null, store,
-            mergePolicy, iwc.getAnalyzer(), new CodecService(null, logger), listener,
-            IndexSearcher.getDefaultQueryCache(), IndexSearcher.getDefaultQueryCachingPolicy(), translogConfig,
-            TimeValue.timeValueMinutes(5), extRefreshListenerList, intRefreshListenerList, new NoneCircuitBreakerService(),
-            globalCheckpointSupplier, primaryTerm::get, tombstoneDocSupplier());
-        return config;
+
+        return new EngineConfig(
+            shardId,
+            allocationId.getId(),
+            threadPool,
+            indexSettings,
+            null,
+            store,
+            mergePolicy,
+            iwc.getAnalyzer(),
+            new CodecService(null, logger),
+            listener,
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            translogConfig,
+            TimeValue.timeValueMinutes(5),
+            extRefreshListenerList,
+            intRefreshListenerList,
+            new NoneCircuitBreakerService(),
+            globalCheckpointSupplier,
+            primaryTerm::get,
+            tombstoneDocSupplier());
+    }
+
+    protected EngineConfig config(EngineConfig config,
+                                  Store store,
+                                  EngineConfig.TombstoneDocSupplier tombstoneDocSupplier) {
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(config.getIndexSettings().getSettings())
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .build()
+        );
+        return new EngineConfig(
+            config.getShardId(),
+            config.getAllocationId(),
+            config.getThreadPool(),
+            indexSettings,
+            config.getWarmer(),
+            store,
+            config.getMergePolicy(),
+            config.getAnalyzer(),
+            new CodecService(null, logger),
+            config.getEventListener(),
+            config.getQueryCache(),
+            config.getQueryCachingPolicy(),
+            config.getTranslogConfig(),
+            config.getFlushMergesAfter(),
+            config.getExternalRefreshListener(),
+            config.getInternalRefreshListener(),
+            config.getCircuitBreakerService(),
+            config.getGlobalCheckpointSupplier(),
+            config.getPrimaryTermSupplier(),
+            tombstoneDocSupplier);
     }
 
     protected static final BytesReference B_1 = new BytesArray(new byte[]{1});


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of https://github.com/elastic/elasticsearch/pull/40117

With this change, we will always fail the engine
if we fail to apply a delete operation to Lucene.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
