### PR TITLE
Remove eager Collect → Get optimization

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -117,11 +117,6 @@ public class Collect implements LogicalPlan {
         if (where.hasQuery() && !(relation instanceof DocTableRelation)) {
             NoPredicateVisitor.ensureNoMatchPredicate(where.query());
         }
-        if (where.hasVersions()) {
-            throw VersioninigValidationException.versionInvalidUsage();
-        } else if (where.hasSeqNoAndPrimaryTerm()) {
-            throw VersioninigValidationException.seqNoAndPrimaryTermUsage();
-        }
         this.relation = relation;
         this.where = where;
         this.tableInfo = relation.tableInfo();
@@ -232,6 +227,11 @@ public class Collect implements LogicalPlan {
             relation,
             plannerContext.functions(),
             plannerContext.transactionContext());
+        if (where.hasVersions()) {
+            throw VersioninigValidationException.versionInvalidUsage();
+        } else if (where.hasSeqNoAndPrimaryTerm()) {
+            throw VersioninigValidationException.seqNoAndPrimaryTermUsage();
+        }
         SubQueryAndParamBinder binder = new SubQueryAndParamBinder(params, subQueryResults);
         List<Symbol> boundOutputs = Lists2.map(outputs, binder);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We have a rule that does the optimization, so the eager optimization can
be removed

With https://github.com/crate/crate/pull/9104 being merged and this branch having the fetch-rewrite removed, we can already remove the eager optimization here.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)