### PR TITLE
Add a rule to rewrite Collect to Get

### DIFF
--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -39,7 +39,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
-import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -72,7 +72,7 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext coordinatorTxnCtx) {
         return extractMatches(columns, symbol, false, coordinatorTxnCtx);
     }
 
@@ -100,15 +100,15 @@ public class EqualityExtractor {
     @Nullable
     public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns,
                                                   Symbol symbol,
-                                                  @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
-        return extractMatches(columns, symbol, true, coordinatorTxnCtx);
+                                                  @Nullable TransactionContext transactionContext) {
+        return extractMatches(columns, symbol, true, transactionContext);
     }
 
     @Nullable
     private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns,
                                               Symbol symbol,
                                               boolean exact,
-                                              @Nullable CoordinatorTxnCtx coordinatorTxnCtx) {
+                                              @Nullable TransactionContext transactionContext) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
             new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
         Symbol proxiedTree = symbol.accept(ProxyInjectingVisitor.INSTANCE, context);
@@ -131,7 +131,7 @@ public class EqualityExtractor {
                     anyNull = true;
                 }
             }
-            Symbol normalized = normalizer.normalize(proxiedTree, coordinatorTxnCtx);
+            Symbol normalized = normalizer.normalize(proxiedTree, transactionContext);
             if (normalized == Literal.BOOLEAN_TRUE) {
                 if (anyNull) {
                     return null;

--- a/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.SubQueryAndParamBinder;
@@ -143,7 +144,7 @@ public final class WhereClauseOptimizer {
     public static DetailedQuery optimize(EvaluatingNormalizer normalizer,
                                          Symbol query,
                                          DocTableInfo table,
-                                         CoordinatorTxnCtx txnCtx) {
+                                         TransactionContext txnCtx) {
         Symbol queryGenColsProcessed = GeneratedColumnExpander.maybeExpand(
             query,
             table.generatedColumns(),

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -61,7 +61,7 @@ public class Get implements LogicalPlan {
     final long estimatedSizePerRow;
     private final List<Symbol> outputs;
 
-    Get(DocTableRelation table, DocKeys docKeys, List<Symbol> outputs, TableStats tableStats) {
+    public Get(DocTableRelation table, DocKeys docKeys, List<Symbol> outputs, TableStats tableStats) {
         this.outputs = outputs;
         this.tableRelation = table;
         this.docKeys = docKeys;

--- a/sql/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -30,5 +32,5 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    LogicalPlan apply(T plan, Captures captures);
+    LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx);
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
@@ -62,7 +64,10 @@ public final class DeduplicateOrder implements Rule<Order> {
     }
 
     @Override
-    public LogicalPlan apply(Order plan, Captures captures) {
+    public LogicalPlan apply(Order plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         Order childOrder = captures.get(this.childOrder);
         return plan.replaceSources(childOrder.sources());
     }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -24,7 +24,9 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.common.collections.Lists2;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
 import io.crate.planner.operators.HashAggregate;
@@ -57,7 +59,10 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     }
 
     @Override
-    public Count apply(HashAggregate aggregate, Captures captures) {
+    public Count apply(HashAggregate aggregate,
+                       Captures captures,
+                       TableStats tableStats,
+                       TransactionContext txnCtx) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -50,7 +52,10 @@ public class MergeFilterAndCollect implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         Collect collect = captures.get(collectCapture);
         return new Collect(
             collect.preferSourceLookup(),

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -24,6 +24,8 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -65,7 +67,10 @@ public class MergeFilters implements Rule<Filter> {
     }
 
     @Override
-    public Filter apply(Filter plan, Captures captures) {
+    public Filter apply(Filter plan,
+                        Captures captures,
+                        TableStats tableStats,
+                        TransactionContext txnCtx) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathBoundary.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathBoundary.java
@@ -24,6 +24,8 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.RelationBoundary;
@@ -54,7 +56,10 @@ public class MoveFilterBeneathBoundary implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures) {
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         RelationBoundary boundary = captures.get(this.boundary);
         Filter newFilter = new Filter(
             boundary.source(),

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -23,6 +23,8 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.FetchOrEval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -55,11 +57,14 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures) {
-        FetchOrEval fetchOrEval = captures.get(fetchOrEvalCapture);
-        List<Symbol> outputsOfFetchSource = fetchOrEval.source().outputs();
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
+        FetchOrEval eval = captures.get(fetchOrEvalCapture);
+        List<Symbol> outputsOfFetchSource = eval.source().outputs();
         if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {
-            return transpose(plan, fetchOrEval);
+            return transpose(plan, eval);
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -27,6 +27,8 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.LogicalPlan;
@@ -72,7 +74,10 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
         // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
         Symbol predicate = filter.query();

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
@@ -51,7 +53,10 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         HashJoin hashJoin = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), hashJoin);
     }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
@@ -57,7 +59,10 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         NestedLoopJoin join = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), join);
     }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -75,7 +77,10 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         return transpose(filter, captures.get(orderCapture));
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -27,6 +27,8 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.ProjectSet;
@@ -60,7 +62,10 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         var projectSet = captures.get(projectSetCapture);
 
         var queryParts = AndOperator.split(filter.query());

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -24,6 +24,8 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Union;
@@ -54,7 +56,10 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         Union union = captures.get(unionCapture);
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -23,6 +23,8 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.analyze.WindowDefinition;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
@@ -53,7 +55,10 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures) {
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         if (windowDefinition.partitions().containsAll(extractColumns(plan.query()))) {

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathBoundary.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathBoundary.java
@@ -25,6 +25,8 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.RelationBoundary;
@@ -75,7 +77,10 @@ public final class MoveOrderBeneathBoundary implements Rule<Order> {
     }
 
     @Override
-    public LogicalPlan apply(Order plan, Captures captures) {
+    public LogicalPlan apply(Order plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         RelationBoundary relationBoundary = captures.get(boundary);
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(Field::pointer);
         Order newOrder = new Order(relationBoundary.source(), plan.orderBy().map(mapField));

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -27,6 +27,8 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
@@ -73,7 +75,10 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
     }
 
     @Override
-    public LogicalPlan apply(Order order, Captures captures) {
+    public LogicalPlan apply(Order order,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<AnalyzedRelation> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -23,6 +23,8 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Union;
@@ -53,7 +55,10 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
     }
 
     @Override
-    public LogicalPlan apply(Order order, Captures captures) {
+    public LogicalPlan apply(Order order,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         Union union = captures.get(unionCapture);
         List<LogicalPlan> unionSources = union.sources();
         assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -22,6 +22,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.FetchOrEval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -31,7 +33,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 /**
- * Eliminates any FetchOrEval nodes that have the same output as their source
+ * Eliminates any Eval nodes that have the same output as their source
  */
 public final class RemoveRedundantFetchOrEval implements Rule<FetchOrEval> {
 
@@ -39,7 +41,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<FetchOrEval> {
 
     public RemoveRedundantFetchOrEval() {
         this.pattern = typeOf(FetchOrEval.class)
-            .with(fetchOrEval -> fetchOrEval.outputs().equals(fetchOrEval.source().outputs()));
+            .with(fetchOrFetchOrEval -> fetchOrFetchOrEval.outputs().equals(fetchOrFetchOrEval.source().outputs()));
     }
 
     @Override
@@ -48,7 +50,10 @@ public final class RemoveRedundantFetchOrEval implements Rule<FetchOrEval> {
     }
 
     @Override
-    public LogicalPlan apply(FetchOrEval plan, Captures captures) {
+    public LogicalPlan apply(FetchOrEval plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         return plan.source();
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.where.DocKeys;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.planner.TableStats;
+import io.crate.planner.WhereClauseOptimizer;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Get;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+import java.util.Optional;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+public final class RewriteCollectToGet implements Rule<Collect> {
+
+    private final Pattern<Collect> pattern;
+    private Functions functions;
+
+    public RewriteCollectToGet(Functions functions) {
+        this.functions = functions;
+        this.pattern = typeOf(Collect.class)
+            .with(collect ->
+                      collect.relation() instanceof DocTableRelation
+                      && collect.where().hasQuery()
+                      && !Symbols.containsColumn(collect.outputs(), DocSysColumns.FETCHID)
+            );
+    }
+
+    @Override
+    public Pattern<Collect> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Collect collect,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
+        var relation = (DocTableRelation) collect.relation();
+        var normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, relation);
+        WhereClause where = collect.where();
+        var detailedQuery = WhereClauseOptimizer.optimize(
+            normalizer,
+            where.queryOrFallback(),
+            relation.tableInfo(),
+            txnCtx
+        );
+        Optional<DocKeys> docKeys = detailedQuery.docKeys();
+        //noinspection OptionalIsPresent no capturing lambda allocation
+        if (docKeys.isPresent()) {
+            return new Get(relation, docKeys.get(), collect.outputs(), tableStats);
+        } else {
+            return null;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -30,6 +30,8 @@ import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.TableStats;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -117,7 +119,10 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter filter, Captures captures) {
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx) {
         NestedLoopJoin nl = captures.get(nlCapture);
         Symbol query = filter.query();
         Map<Set<QualifiedName>, Symbol> splitQueries = QuerySplitter.split(query);

--- a/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/sql/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -25,6 +25,8 @@ package io.crate.planner.optimizer.rule;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.planner.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -67,7 +69,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
         assertThat(match.isPresent(), Matchers.is(true));
         assertThat(match.value(), Matchers.sameInstance(parentFilter));
 
-        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures());
+        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures(), new TableStats(), CoordinatorTxnCtx.systemTransactionContext());
         assertThat(mergedFilter.query(), isSQL("((doc.t2.y > 10) AND (doc.t1.x > 10))"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We currently do the `Collect → Get` optimization eagerly when we
initially build the logical plan, but that doesn't work for queries on
derived tables or views, so this commit introduces a rule to do the same
optimization.

This is currently limited to queries where the fetch-rewrite doesn't
apply (e.g ORDER BY containing all selected columns), because the fetch
rewrite breaks Get lookups and happens eagerly.

Once we change the fetch optimization to happen in a later phase, we can
also remove the eager `Get` creation and only do it via rule.

This is a subset of https://github.com/crate/crate/pull/9103 but against
master.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)