### PR TITLE
Use separate translog dir in testDeleteWithFatalError.

### DIFF
--- a/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2990,7 +2990,8 @@ public class InternalEngineTests extends EngineTestCase {
                     return tombstoneDocSupplier().newNoopTombstoneDoc(reason);
                 }
             };
-            try (InternalEngine engine = createEngine(config(this.engine.config(), store, tombstoneDocSupplier))) {
+            EngineConfig config = config(this.engine.config(), store, createTempDir(), tombstoneDocSupplier);
+            try (InternalEngine engine = createEngine(config)) {
                 final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
                 engine.index(indexForDoc(doc));
                 expectThrows(IllegalStateException.class, () -> engine.delete(

--- a/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -591,6 +591,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
     protected EngineConfig config(EngineConfig config,
                                   Store store,
+                                  Path translogPath,
                                   EngineConfig.TombstoneDocSupplier tombstoneDocSupplier) {
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
             "test",
@@ -599,6 +600,8 @@ public abstract class EngineTestCase extends ESTestCase {
                 .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
                 .build()
         );
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
         return new EngineConfig(
             config.getShardId(),
             config.getAllocationId(),
@@ -612,7 +615,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getEventListener(),
             config.getQueryCache(),
             config.getQueryCachingPolicy(),
-            config.getTranslogConfig(),
+            translogConfig,
             config.getFlushMergesAfter(),
             config.getExternalRefreshListener(),
             config.getInternalRefreshListener(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes flaky `testDeleteWithFatalError`.

This test currently opens a new engine but shares the
same translog directory of the previous opening engine.

See https://github.com/elastic/elasticsearch/commit/790fdb156c37294e52fefcc9a8664928d99a8aa6

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
