### PR TITLE
Move sync translog operation outside writeLock to improve performance.

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1640,6 +1640,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * required generation
      */
     public void trimUnreferencedReaders() throws IOException {
+        List<TranslogReader> toDeleteReaderList = new ArrayList<>();
         try (ReleasableLock ignored = writeLock.acquire()) {
             if (closed.get()) {
                 // we're shutdown potentially on some tragic event, don't delete anything
@@ -1660,15 +1661,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                     break;
                 }
                 iterator.remove();
+                toDeleteReaderList.add(reader);
                 IOUtils.closeWhileHandlingException(reader);
-                final Path translogPath = reader.path();
-                logger.trace("delete translog file [{}], not referenced and not current anymore", translogPath);
-                // The checkpoint is used when opening the translog to know which files should be recovered from.
-                // We now update the checkpoint to ignore the file we are going to remove.
-                // Note that there is a provision in recoverFromFiles to allow for the case where we synced the checkpoint
-                // but crashed before we could delete the file.
-                current.sync();
-                deleteReaderFiles(reader);
             }
             assert readers.isEmpty() == false || current.generation == minReferencedGen :
                 "all readers were cleaned but the minReferenceGen [" + minReferencedGen + "] is not the current writer's gen [" +
@@ -1676,6 +1670,24 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         } catch (final Exception ex) {
             closeOnTragicEvent(ex);
             throw ex;
+        }
+        // Do sync outside the writeLock to avoid blocking all writing thread.
+        if (toDeleteReaderList.isEmpty() == false) {
+            try {
+                // The checkpoint is used when opening the translog to know which files should be recovered from.
+                // We now update the checkpoint to ignore the file we are going to remove.
+                // Note that there is a provision in recoverFromFiles to allow for the case where we synced the checkpoint
+                // but crashed before we could delete the file.
+                sync();
+                for (TranslogReader reader : toDeleteReaderList) {
+                    final Path translogPath = reader.path();
+                    logger.trace("delete translog file [{}], not referenced and not current anymore", translogPath);
+                    deleteReaderFiles(reader);
+                }
+            } catch (final Exception ex) {
+                closeOnTragicEvent(ex);
+                throw ex;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of https://github.com/elastic/elasticsearch/pull/46203

In `Translog.trimUnreferencedReaders`, `current.sync()` is called
inside the writeLock. Taking it out of the writeLock can improve
the indexing performance. See https://github.com/elastic/elasticsearch/issues/46201

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
