### PR TITLE
Fix column’s ordinal being NULL on tables created < 4.0.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -134,6 +134,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue resulting in ``pg_catalog.pg_attribute.attnum`` and
+  ``information_schema.columns.ordinal_position`` being ``NULL`` on tables
+  created with CrateDB < 4.0.
+
 - Fail the storage engine if indexing on a replica shard fails after it was
   successfully done on a primary shard. It prevents replica and primary shards
   from going out of sync.

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -299,6 +299,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
 
         private final Iterator<Reference> columns;
         private final RelationInfo tableInfo;
+        private int ordinal = 1;
 
         ColumnsIterator(RelationInfo tableInfo) {
             columns = stream(tableInfo.spliterator(), false)
@@ -321,7 +322,15 @@ public class InformationSchemaIterables implements ClusterStateListener {
             if (ref.column().isTopLevel() == false) {
                 return new ColumnContext(tableInfo, ref, null);
             }
-            return new ColumnContext(tableInfo, ref, ref.position());
+
+            // Tables created with CrateDB < 4.0 don't have any positional information stored inside the meta data so
+            // we must fallback to old behaviour which uses a simple increased iterating based var.
+            Integer position = ref.position();
+            if (position == null) {
+                position = ordinal;
+            }
+            ordinal++;
+            return new ColumnContext(tableInfo, ref, position);
         }
     }
 


### PR DESCRIPTION
Tables created with < 4.0 don’t story any positional information inside
their meta data, we must fallback to old behaviour in such cases.