### PR TITLE
Assert cluster state size in intergration test layer.

### DIFF
--- a/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -754,7 +754,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
             byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterClusterState);
             // remove local node reference
             masterClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
-            Map<String, Object> masterStateMap = convertToMap(masterClusterState);
             int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
             String masterId = masterClusterState.nodes().getMasterNodeId();
             for (Client client : cluster().getClients()) {
@@ -762,14 +761,14 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
                 // remove local node reference
                 localClusterState = ClusterState.Builder.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
-                final Map<String, Object> localStateMap = convertToMap(localClusterState);
                 final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
                 // Check that the non-master node has the same version of the cluster state as the master and
                 // that the master node matches the master (otherwise there is no requirement for the cluster state to match)
                 if (masterClusterState.version() == localClusterState.version()
                         && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
                     try {
-                        assertEquals("cluster state UUID does not match", masterClusterState.stateUUID(), localClusterState.stateUUID());
+                        assertThat("cluster state UUID does not match", masterClusterState.stateUUID(), is(localClusterState.stateUUID()));
+                        assertThat("cluster state size does not match", masterClusterStateSize, is(localClusterStateSize));
                         // remove non-core customs and compare the cluster states
                         assertNull(
                                 "cluster state JSON serialization does not match (after removing some customs)",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Assert cluster state size `ESIntegTestCase.ensureClusterStateConsistency`
to ensure cluster state consistency.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
