### PR TITLE
Do not add hidden settings to table default settings.

### DIFF
--- a/blackbox/docs/general/ddl/show-create-table.rst
+++ b/blackbox/docs/general/ddl/show-create-table.rst
@@ -41,7 +41,6 @@ already existing user-created doc tables in the cluster::
     |    "blocks.write" = false,                          |
     |    codec = 'default',                               |
     |    column_policy = 'strict',                        |
-    |    "global_checkpoint_sync.interval" = 30000,       |
     |    "mapping.total_fields.limit" = 1000,             |
     |    max_ngram_diff = 1,                              |
     |    max_shingle_diff = 3,                            |

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -146,7 +146,7 @@ public class GenericPropertiesConverter {
         for (Map.Entry<String, Setting<?>> entry : supportedSettings.entrySet()) {
             SettingHolder settingHolder = new SettingHolder(entry.getValue());
             // We'd set the "wrong" default for settings that base their default on other settings
-            if (TableParameters.SETTINGS_WITH_COMPUTED_DEFAULT.contains(settingHolder.setting)) {
+            if (TableParameters.SETTINGS_NOT_INCLUDED_IN_DEFAULT.contains(settingHolder.setting)) {
                 continue;
             }
             settingHolder.applyDefault(builder);

--- a/sql/src/main/java/io/crate/analyze/TableParameters.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameters.java
@@ -104,10 +104,11 @@ public class TableParameters {
         );
 
     /**
-     * Settings which have a default value that depends on other settings
+     * Settings which are not included in table default settings
      */
-    static final Set<Setting> SETTINGS_WITH_COMPUTED_DEFAULT = Set.of(
-        IndexMetaData.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING
+    static final Set<Setting> SETTINGS_NOT_INCLUDED_IN_DEFAULT = Set.of(
+        IndexMetaData.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,
+        IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING
     );
 
     private static final Map<String, Setting<?>> SUPPORTED_SETTINGS_DEFAULT

--- a/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -93,7 +93,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -140,7 +139,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -189,7 +187,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -238,7 +235,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -312,7 +308,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -357,7 +352,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +
@@ -401,7 +395,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"blocks.write\" = false,\n" +
                      "   codec = 'default',\n" +
                      "   column_policy = 'strict',\n" +
-                     "   \"global_checkpoint_sync.interval\" = 30000,\n" +
                      "   \"mapping.total_fields.limit\" = 1000,\n" +
                      "   max_ngram_diff = 1,\n" +
                      "   max_shingle_diff = 3,\n" +


### PR DESCRIPTION
Hidden settings should not be set by default on table creations.
This would also break backward compatibility while creating tables
in a cluster with older node versions (rollback upgrade).

Follow up of https://github.com/crate/crate/pull/9085/commits/a5c724548f5480da052c23d05e68ab5bdeebd85b.
