### PR TITLE
Remove partition tie break restriction

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,11 @@ Breaking Changes
 Changes
 =======
 
+- Removed a restriction for predicates in the ``WHERE`` clause involving
+  partitioned by columns which could result in a failure response with the
+  message ``logical conjunction of the conditions in the WHERE clause which
+  involve partitioned columns led to a query that can't be executed``.
+
 - Added a dynamic bulk sizing mechanism that should prevent ``INSERT INTO ...
   FROM query`` operations to run into out of memory errors if the individual
   records of a table are very large.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Due to how an early version of our select query execution worked we
added a restriction on predicates involving partitioned by columns. We
required to be able to determine which partitions can match already on
the coordinator node.

Given how our execution pipeline has evolved, this restriction is no
longer necessary. This commit therefore removes it.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)