### PR TITLE
Handle delete document level failures.

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -88,6 +88,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -1403,9 +1404,21 @@ public class InternalEngine extends Engine {
             }
             return new DeleteResult(
                 plan.versionOfDeletion, getPrimaryTerm(), plan.seqNoOfDeletion, plan.currentlyDeleted == false);
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
+            /*
+             * Document level failures when deleting are unexpected, we likely
+             * hit something fatal such as the Lucene index being corrupt, or
+             * the Lucene document limit. We have already issued a sequence number
+             * here so this is fatal, fail the engine.
+             */
             if (ex instanceof AlreadyClosedException == false && indexWriter.getTragicException() == null) {
-                throw new AssertionError("delete operation should never fail at document level", ex);
+                final String reason = String.format(
+                    Locale.ROOT,
+                    "delete id[%s] origin [%s] seq#[%d] failed at the document level",
+                    delete.id(),
+                    delete.origin(),
+                    delete.seqNo());
+                failEngine(reason, ex);
             }
             throw ex;
         }

--- a/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -137,18 +137,6 @@ public abstract class EngineTestCase extends ESTestCase {
     // A default primary term is used by engine instances created in this test.
     protected final PrimaryTermSupplier primaryTerm = new PrimaryTermSupplier(0L);
 
-
-    protected static void assertVisibleCount(Engine engine, int numDocs, boolean refresh) throws IOException {
-        if (refresh) {
-            engine.refresh("test");
-        }
-        try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
-            final TotalHitCountCollector collector = new TotalHitCountCollector();
-            searcher.searcher().search(new MatchAllDocsQuery(), collector);
-            assertThat(collector.getTotalHits(), equalTo(numDocs));
-        }
-    }
-
     protected Settings indexSettings() {
         // TODO randomize more settings
         return Settings.builder()


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of https://github.com/elastic/elasticsearch/pull/46100

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
