### PR TITLE
recovery process improvements  (making some parts async)

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -157,4 +157,48 @@ public interface ActionListener<Response> {
             }
         };
     }
+
+    /**
+     * Wraps a given listener and returns a new listener which executes the provided {@code runAfter}
+     * callback when the listener is notified via either {@code #onResponse} or {@code #onFailure}.
+     */
+    static <Response> ActionListener<Response> runAfter(ActionListener<Response> delegate, Runnable runAfter) {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(Response response) {
+                try {
+                    delegate.onResponse(response);
+                } finally {
+                    runAfter.run();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    delegate.onFailure(e);
+                } finally {
+                    runAfter.run();
+                }
+            }
+        };
+    }
+
+    /**
+     * Wraps a given listener and returns a new listener which makes sure {@link #onResponse(Object)}
+     * and {@link #onFailure(Exception)} of the provided listener will be called at most once.
+     */
+    static <Response> ActionListener<Response> notifyOnce(ActionListener<Response> delegate) {
+        return new NotifyOnceListener<>() {
+            @Override
+            protected void innerOnResponse(Response response) {
+                delegate.onResponse(response);
+            }
+
+            @Override
+            protected void innerOnFailure(Exception e) {
+                delegate.onFailure(e);
+            }
+        };
+    }
 }

--- a/es/es-server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.CheckedSupplier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -200,5 +201,18 @@ public interface ActionListener<Response> {
                 delegate.onFailure(e);
             }
         };
+    }
+
+    /**
+     * Completes the given listener with the result from the provided supplier accordingly.
+     * This method is mainly used to complete a listener with a block of synchronous code.
+     */
+    static <Response> void completeWith(ActionListener<Response> listener,
+                                        CheckedSupplier<Response, ? extends Exception> supplier) {
+        try {
+            listener.onResponse(supplier.get());
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 }

--- a/es/es-server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -37,10 +37,19 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
 
     private final ActionListener<? super Response> listener;
     private final Writeable.Reader<Response> reader;
+    private final String executor;
 
-    public ActionListenerResponseHandler(ActionListener<? super Response> listener, Writeable.Reader<Response> reader) {
+    public ActionListenerResponseHandler(ActionListener<? super Response> listener,
+                                         Writeable.Reader<Response> reader,
+                                         String executor) {
         this.listener = Objects.requireNonNull(listener);
         this.reader = Objects.requireNonNull(reader);
+        this.executor = Objects.requireNonNull(executor);
+    }
+
+    public ActionListenerResponseHandler(ActionListener<? super Response> listener,
+                                         Writeable.Reader<Response> reader) {
+        this(listener, reader, ThreadPool.Names.SAME);
     }
 
     @Override
@@ -60,6 +69,6 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
 
     @Override
     public String executor() {
-        return ThreadPool.Names.SAME;
+        return executor;
     }
 }

--- a/es/es-server/src/main/java/org/elasticsearch/action/StepListener.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/StepListener.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * A {@link StepListener} provides a simple way to write a flow consisting of
+ * multiple asynchronous steps without having nested callbacks. For example:
+ *
+ * <pre>{@code
+ *  void asyncFlowMethod(... ActionListener<R> flowListener) {
+ *    StepListener<R1> step1 = new StepListener<>();
+ *    asyncStep1(..., step1);
+
+ *    StepListener<R2> step2 = new StepListener<>();
+ *    step1.whenComplete(r1 -> {
+ *      asyncStep2(r1, ..., step2);
+ *    }, flowListener::onFailure);
+ *
+ *    step2.whenComplete(r2 -> {
+ *      R1 r1 = step1.result();
+ *      R r = combine(r1, r2);
+ *     flowListener.onResponse(r);
+ *    }, flowListener::onFailure);
+ *  }
+ * }</pre>
+ */
+
+public final class StepListener<Response> implements ActionListener<Response> {
+    private final ListenableFuture<Response> delegate;
+
+    public StepListener() {
+        this.delegate = new ListenableFuture<>();
+    }
+
+    @Override
+    public void onResponse(Response response) {
+        delegate.onResponse(response);
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        delegate.onFailure(e);
+    }
+
+    /**
+     * Registers the given actions which are called when this step is completed. If this step is completed successfully,
+     * the {@code onResponse} is called with the result; otherwise the {@code onFailure} is called with the failure.
+     *
+     * @param onResponse is called when this step is completed successfully
+     * @param onFailure  is called when this step is completed with a failure
+     */
+    public void whenComplete(CheckedConsumer<Response, Exception> onResponse, Consumer<Exception> onFailure) {
+        delegate.addListener(ActionListener.wrap(onResponse, onFailure), EsExecutors.newDirectExecutorService(), null);
+    }
+
+    /**
+     * Gets the result of this step. This method will throw {@link IllegalStateException} if this step is not completed yet.
+     */
+    public Response result() {
+        if (delegate.isDone() == false) {
+            throw new IllegalStateException("step is not completed yet");
+        }
+        return FutureUtils.get(delegate, 0L, TimeUnit.NANOSECONDS); // this future is done already - use a non-blocking method.
+    }
+}

--- a/es/es-server/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.util;
 
+import org.apache.lucene.util.SetOnce;
 import org.apache.lucene.util.ThreadInterruptedException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
@@ -35,36 +36,40 @@ import java.util.Set;
  * Cancellation policy: This class does not support external interruption via <code>Thread#interrupt()</code>. Always use #cancel() instead.
  */
 public class CancellableThreads {
+
     private final Set<Thread> threads = new HashSet<>();
     // needs to be volatile as it is also read outside of synchronized blocks.
     private volatile boolean cancelled = false;
+    private final SetOnce<OnCancel> onCancel = new SetOnce<>();
     private String reason;
 
     public synchronized boolean isCancelled() {
         return cancelled;
     }
 
-
-    /** call this will throw an exception if operation was cancelled. Override {@link #onCancel(String, Exception)} for custom failure logic */
-    public synchronized void checkForCancel() {
-        if (isCancelled()) {
-            onCancel(reason, null);
-        }
+    public void checkForCancel() {
+        checkForCancel(null);
     }
 
-    /**
-     * called if {@link #checkForCancel()} was invoked after the operation was cancelled.
-     * the default implementation always throws an {@link ExecutionCancelledException}, suppressing
-     * any other exception that occurred before cancellation
-     *  @param reason              reason for failure supplied by the caller of {@link #cancel}
-     * @param suppressedException any error that was encountered during the execution before the operation was cancelled.
-     */
-    protected void onCancel(String reason, @Nullable Exception suppressedException) {
-        RuntimeException e = new ExecutionCancelledException("operation was cancelled reason [" + reason + "]");
-        if (suppressedException != null) {
-            e.addSuppressed(suppressedException);
+    private void checkForCancel(Exception beforeCancelException) {
+        if (isCancelled()) {
+            final String reason;
+            final OnCancel onCancel;
+            synchronized (this) {
+                reason = this.reason;
+                onCancel = this.onCancel.get();
+            }
+            if (onCancel != null) {
+                onCancel.onCancel(reason, beforeCancelException);
+            }
+            // fallback to the default exception
+            final RuntimeException cancelExp =
+                new ExecutionCancelledException("operation was cancelled reason [" + reason + "]");
+            if (beforeCancelException != null) {
+                cancelExp.addSuppressed(beforeCancelException);
+            }
+            throw cancelExp;
         }
-        throw e;
     }
 
     private synchronized boolean add() {
@@ -76,8 +81,9 @@ public class CancellableThreads {
     }
 
     /**
-     * run the Interruptable, capturing the executing thread. Concurrent calls to {@link #cancel(String)} will interrupt this thread
-     * causing the call to prematurely return.
+     * run the Interruptable, capturing the executing thread. Concurrent calls
+     * to {@link #cancel(String)} will interrupt this thread causing the call
+     * to prematurely return.
      *
      * @param interruptable code to run
      */
@@ -124,17 +130,14 @@ public class CancellableThreads {
             // clear the flag interrupted flag as we are checking for failure..
             Thread.interrupted();
         }
-        synchronized (this) {
-            if (isCancelled()) {
-                onCancel(reason, ioException != null ? ioException : runtimeException);
-            } else if (ioException != null) {
-                // if we're not canceling, we throw the original exception
-                throw ioException;
-            }
-            if (runtimeException != null) {
-                // if we're not canceling, we throw the original exception
-                throw runtimeException;
-            }
+        checkForCancel(ioException != null ? ioException : runtimeException);
+        if (ioException != null) {
+            // if we're not canceling, we throw the original exception
+            throw ioException;
+        }
+        if (runtimeException != null) {
+            // if we're not canceling, we throw the original exception
+            throw runtimeException;
         }
         if (cancelledByExternalInterrupt) {
             // restore interrupt flag to at least adhere to expected behavior
@@ -143,7 +146,6 @@ public class CancellableThreads {
         }
 
     }
-
 
     private synchronized void remove() {
         threads.remove(Thread.currentThread());
@@ -183,5 +185,27 @@ public class CancellableThreads {
         public ExecutionCancelledException(StreamInput in) throws IOException {
             super(in);
         }
+    }
+
+    /**
+     * Registers a callback that will be invoked when some running operations are cancelled or {@link #checkForCancel()} is called.
+     */
+    public synchronized void setOnCancel(OnCancel onCancel) {
+        this.onCancel.set(onCancel);
+    }
+
+    @FunctionalInterface
+    public interface OnCancel {
+        /**
+         * Called when some running operations are cancelled or {@link #checkForCancel()} is explicitly called.
+         * If this method throws an exception, cancelling tasks will fail with that exception; otherwise they
+         * will fail with the default exception {@link ExecutionCancelledException}.
+         *
+         * @param reason                the reason of the cancellation
+         * @param beforeCancelException any error that was encountered during the execution before the operations were cancelled.
+         * @see #checkForCancel()
+         * @see #setOnCancel(OnCancel)
+         */
+        void onCancel(String reason, @Nullable Exception beforeCancelException);
     }
 }

--- a/es/es-server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2651,7 +2651,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * which is at least the value of the max_seq_no_of_updates marker on the primary after that operation was executed on the primary.
      *
      * @see #acquireReplicaOperationPermit(long, long, long, ActionListener, String, Object)
-     * @see org.elasticsearch.indices.recovery.RecoveryTarget#indexTranslogOperations(List, int, long, long)
+     * @see org.elasticsearch.indices.recovery.RecoveryTarget#indexTranslogOperations(List, int, long, long, ActionListener)
      */
     public void advanceMaxSeqNoOfUpdatesOrDeletes(long seqNo) {
         assert seqNo != UNASSIGNED_SEQ_NO

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -22,6 +22,8 @@ package org.elasticsearch.indices.recovery;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
@@ -84,7 +86,7 @@ public class PeerRecoverySourceService implements IndexEventListener {
         }
     }
 
-    private RecoveryResponse recover(final StartRecoveryRequest request) throws IOException {
+    private void recover(StartRecoveryRequest request, ActionListener<RecoveryResponse> listener) throws IOException {
         final IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
         final IndexShard shard = indexService.getShard(request.shardId().id());
 
@@ -94,25 +96,30 @@ public class PeerRecoverySourceService implements IndexEventListener {
             throw new DelayRecoveryException("source shard [" + routingEntry + "] is not an active primary");
         }
 
-        if (request.isPrimaryRelocation() && (routingEntry.relocating() == false || routingEntry.relocatingNodeId().equals(request.targetNode().getId()) == false)) {
-            logger.debug("delaying recovery of {} as source shard is not marked yet as relocating to {}", request.shardId(), request.targetNode());
+        if (request.isPrimaryRelocation()
+            && (
+                routingEntry.relocating() == false
+                || routingEntry.relocatingNodeId().equals(request.targetNode().getId()) == false)) {
+            logger.debug(
+                "delaying recovery of {} as source shard is not marked yet as relocating to {}",
+                request.shardId(), request.targetNode());
             throw new DelayRecoveryException("source shard is not marked yet as relocating to [" + request.targetNode() + "]");
         }
 
         RecoverySourceHandler handler = ongoingRecoveries.addNewRecovery(request, shard);
-        logger.trace("[{}][{}] starting recovery to {}", request.shardId().getIndex().getName(), request.shardId().id(), request.targetNode());
-        try {
-            return handler.recoverToTarget();
-        } finally {
-            ongoingRecoveries.remove(shard, handler);
-        }
+        logger.trace(
+            "[{}][{}] starting recovery to {}",
+            request.shardId().getIndex().getName(), request.shardId().id(), request.targetNode());
+        handler.recoverToTarget(ActionListener.runAfter(listener, () -> ongoingRecoveries.remove(shard, handler)));
     }
 
     class StartRecoveryTransportRequestHandler implements TransportRequestHandler<StartRecoveryRequest> {
+
         @Override
-        public void messageReceived(final StartRecoveryRequest request, final TransportChannel channel, Task task) throws Exception {
-            RecoveryResponse response = recover(request);
-            channel.sendResponse(response);
+        public void messageReceived(final StartRecoveryRequest request,
+                                    final TransportChannel channel,
+                                    Task task) throws Exception {
+            recover(request, new HandledTransportAction.ChannelActionListener<>(channel, Actions.START_RECOVERY, request));
         }
     }
 

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -542,52 +542,60 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     class TranslogOperationsRequestHandler implements TransportRequestHandler<RecoveryTranslogOperationsRequest> {
 
         @Override
-        public void messageReceived(final RecoveryTranslogOperationsRequest request, final TransportChannel channel, Task task) throws IOException {
+        public void messageReceived(final RecoveryTranslogOperationsRequest request, final TransportChannel channel,
+                                    Task task) throws IOException {
             try (RecoveryRef recoveryRef =
-                         onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
-                final ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger, threadPool.getThreadContext());
+                     onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
+                final ClusterStateObserver observer =
+                    new ClusterStateObserver(clusterService, null, logger, threadPool.getThreadContext());
                 final RecoveryTarget recoveryTarget = recoveryRef.target();
-                try {
-                    recoveryTarget.indexTranslogOperations(request.operations(), request.totalTranslogOps(),
-                        request.maxSeenAutoIdTimestampOnPrimary(), request.maxSeqNoOfUpdatesOrDeletesOnPrimary());
-                    channel.sendResponse(new RecoveryTranslogOperationsResponse(recoveryTarget.indexShard().getLocalCheckpoint()));
-                } catch (MapperException exception) {
-                    // in very rare cases a translog replay from primary is processed before a mapping update on this node
-                    // which causes local mapping changes since the mapping (clusterstate) might not have arrived on this node.
+                final ActionListener<RecoveryTranslogOperationsResponse> listener =
+                    new HandledTransportAction.ChannelActionListener<>(channel, Actions.TRANSLOG_OPS, request);
+                final Consumer<Exception> retryOnMappingException = exception -> {
+                    // in very rare cases a translog replay from primary is processed before
+                    // a mapping update on this node which causes local mapping changes since
+                    // the mapping (clusterstate) might not have arrived on this node.
                     logger.debug("delaying recovery due to missing mapping changes", exception);
-                    // we do not need to use a timeout here since the entire recovery mechanism has an inactivity protection (it will be
-                    // canceled)
+                    // we do not need to use a timeout here since the entire recovery mechanism has an
+                    // inactivity protection (it will be canceled)
                     observer.waitForNextChange(new ClusterStateObserver.Listener() {
                         @Override
                         public void onNewClusterState(ClusterState state) {
                             try {
                                 messageReceived(request, channel, task);
                             } catch (Exception e) {
-                                onFailure(e);
-                            }
-                        }
-
-                        void onFailure(Exception e) {
-                            try {
-                                channel.sendResponse(e);
-                            } catch (IOException e1) {
-                                logger.warn("failed to send error back to recovery source", e1);
+                                listener.onFailure(e);
                             }
                         }
 
                         @Override
                         public void onClusterServiceClose() {
-                            onFailure(new ElasticsearchException("cluster service was closed while waiting for mapping updates"));
+                            listener.onFailure(new ElasticsearchException(
+                                "cluster service was closed while waiting for mapping updates"));
                         }
 
                         @Override
                         public void onTimeout(TimeValue timeout) {
                             // note that we do not use a timeout (see comment above)
-                            onFailure(new ElasticsearchTimeoutException("timed out waiting for mapping updates (timeout [" + timeout +
-                                    "])"));
+                            listener.onFailure(new ElasticsearchTimeoutException(
+                                "timed out waiting for mapping updates (timeout [" + timeout + "])"));
                         }
                     });
-                }
+                };
+                recoveryTarget.indexTranslogOperations(
+                    request.operations(),
+                    request.totalTranslogOps(),
+                    request.maxSeenAutoIdTimestampOnPrimary(), request.maxSeqNoOfUpdatesOrDeletesOnPrimary(),
+                    ActionListener.wrap(
+                        checkpoint -> listener.onResponse(new RecoveryTranslogOperationsResponse(checkpoint)),
+                        e -> {
+                            if (e instanceof MapperException) {
+                                retryOnMappingException.accept(e);
+                            } else {
+                                listener.onFailure(e);
+                            }
+                        })
+                );
             }
         }
     }

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -489,11 +489,17 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
         @Override
         public void messageReceived(RecoveryPrepareForTranslogOperationsRequest request, TransportChannel channel, Task task) throws Exception {
-            try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
-            )) {
-                recoveryRef.target().prepareForTranslogOperations(request.isFileBasedRecovery(), request.totalTranslogOps());
+            try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
+                final ActionListener<TransportResponse> listener =
+                    new HandledTransportAction.ChannelActionListener<>(channel, Actions.PREPARE_TRANSLOG, request);
+                recoveryRef.target().prepareForTranslogOperations(
+                    request.isFileBasedRecovery(),
+                    request.totalTranslogOps(),
+                    ActionListener.wrap(
+                        nullVal -> listener.onResponse(TransportResponse.Empty.INSTANCE),
+                        listener::onFailure)
+                );
             }
-            channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
     }
 

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -61,17 +61,18 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
-import org.elasticsearch.transport.FutureTransportResponseHandler;
 import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 
@@ -145,16 +146,25 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     public void startRecovery(final IndexShard indexShard, final DiscoveryNode sourceNode, final RecoveryListener listener) {
         // create a new recovery status, and process...
         final long recoveryId = onGoingRecoveries.startRecovery(indexShard, sourceNode, listener, recoverySettings.activityTimeout());
+        // we fork off quickly here and go async but this is called from the cluster state applier
+        // thread too and that can cause assertions to trip if we executed it on the same thread
+        // hence we fork off to the generic threadpool.
         threadPool.generic().execute(new RecoveryRunner(recoveryId));
     }
 
-    protected void retryRecovery(final long recoveryId, final Throwable reason, TimeValue retryAfter, TimeValue activityTimeout) {
+    private void retryRecovery(final long recoveryId,
+                               final Throwable reason,
+                               TimeValue retryAfter,
+                               TimeValue activityTimeout) {
         logger.trace(() -> new ParameterizedMessage(
                 "will retry recovery with id [{}] in [{}]", recoveryId, retryAfter), reason);
         retryRecovery(recoveryId, retryAfter, activityTimeout);
     }
 
-    protected void retryRecovery(final long recoveryId, final String reason, TimeValue retryAfter, TimeValue activityTimeout) {
+    private void retryRecovery(final long recoveryId,
+                               final String reason,
+                               TimeValue retryAfter,
+                               TimeValue activityTimeout) {
         logger.trace("will retry recovery with id [{}] in [{}] (reason [{}])", recoveryId, retryAfter, reason);
         retryRecovery(recoveryId, retryAfter, activityTimeout);
     }
@@ -168,17 +178,16 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
     private void doRecovery(final long recoveryId) {
         final StartRecoveryRequest request;
-        final CancellableThreads cancellableThreads;
         final RecoveryState.Timer timer;
-
+        CancellableThreads cancellableThreads;
         try (RecoveryRef recoveryRef = onGoingRecoveries.getRecovery(recoveryId)) {
             if (recoveryRef == null) {
                 logger.trace("not running recovery with id [{}] - can not find it (probably finished)", recoveryId);
                 return;
             }
             final RecoveryTarget recoveryTarget = recoveryRef.target();
-            cancellableThreads = recoveryTarget.cancellableThreads();
             timer = recoveryTarget.state().getTimer();
+            cancellableThreads = recoveryTarget.cancellableThreads();
             try {
                 assert recoveryTarget.sourceNode() != null : "can not do a recovery without a source node";
                 request = getStartRecoveryRequest(recoveryTarget);
@@ -188,59 +197,24 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 // this will be logged as warning later on...
                 logger.trace("unexpected error while preparing shard for peer recovery, failing recovery", e);
                 onGoingRecoveries.failRecovery(recoveryId,
-                    new RecoveryFailedException(recoveryTarget.state(), "failed to prepare shard for recovery", e), true);
+                                               new RecoveryFailedException(recoveryTarget.state(),
+                                                                           "failed to prepare shard for recovery",
+                                                                           e), true);
                 return;
             }
         }
-
-        try {
-            logger.trace("{} starting recovery from {}", request.shardId(), request.sourceNode());
-            final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
-            cancellableThreads.execute(() -> responseHolder.set(
-                    transportService.submitRequest(request.sourceNode(), PeerRecoverySourceService.Actions.START_RECOVERY, request,
-                            new FutureTransportResponseHandler<RecoveryResponse>() {
-                                @Override
-                                public RecoveryResponse read(StreamInput in) throws IOException {
-                                    return new RecoveryResponse(in);
-                                }
-                            }).txGet()));
-            final RecoveryResponse recoveryResponse = responseHolder.get();
-            final TimeValue recoveryTime = new TimeValue(timer.time());
-            // do this through ongoing recoveries to remove it from the collection
-            onGoingRecoveries.markRecoveryAsDone(recoveryId);
-            if (logger.isTraceEnabled()) {
-                StringBuilder sb = new StringBuilder();
-                sb.append('[').append(request.shardId().getIndex().getName()).append(']').append('[').append(request.shardId().id())
-                        .append("] ");
-                sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
-                sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with " +
-                        "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
-                        .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append
-                        (timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
-                        .append("\n");
-                sb.append("         : reusing_files   [").append(recoveryResponse.phase1ExistingFileNames.size()).append("] with " +
-                        "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize)).append("]\n");
-                sb.append("   phase2: start took [").append(timeValueMillis(recoveryResponse.startTime)).append("]\n");
-                sb.append("         : recovered [").append(recoveryResponse.phase2Operations).append("]").append(" transaction log " +
-                        "operations")
-                        .append(", took [").append(timeValueMillis(recoveryResponse.phase2Time)).append("]")
-                        .append("\n");
-                logger.trace("{}", sb);
-            } else {
-                logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), request.sourceNode(), recoveryTime);
-            }
-        } catch (CancellableThreads.ExecutionCancelledException e) {
-            logger.trace("recovery cancelled", e);
-        } catch (Exception e) {
+        Consumer<Exception> handleException = e -> {
             if (logger.isTraceEnabled()) {
                 logger.trace(() -> new ParameterizedMessage(
-                        "[{}][{}] Got exception on recovery", request.shardId().getIndex().getName(), request.shardId().id()), e);
+                    "[{}][{}] Got exception on recovery", request.shardId().getIndex().getName(),
+                    request.shardId().id()), e);
             }
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
                 // this can also come from the source wrapped in a RemoteTransportException
                 onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request,
-                    "source has canceled the recovery", cause), false);
+                                                                                       "source has canceled the recovery",
+                                                                                       cause), false);
                 return;
             }
             if (cause instanceof RecoveryEngineException) {
@@ -268,24 +242,135 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             }
 
             if (cause instanceof DelayRecoveryException) {
-                retryRecovery(recoveryId, cause, recoverySettings.retryDelayStateSync(), recoverySettings.activityTimeout());
+                retryRecovery(recoveryId, cause, recoverySettings.retryDelayStateSync(),
+                              recoverySettings.activityTimeout());
                 return;
             }
 
             if (cause instanceof ConnectTransportException) {
                 logger.debug("delaying recovery of {} for [{}] due to networking error [{}]", request.shardId(),
-                    recoverySettings.retryDelayNetwork(), cause.getMessage());
-                retryRecovery(recoveryId, cause.getMessage(), recoverySettings.retryDelayNetwork(), recoverySettings.activityTimeout());
+                             recoverySettings.retryDelayNetwork(), cause.getMessage());
+                retryRecovery(recoveryId, cause.getMessage(), recoverySettings.retryDelayNetwork(),
+                              recoverySettings.activityTimeout());
                 return;
             }
 
             if (cause instanceof AlreadyClosedException) {
                 onGoingRecoveries.failRecovery(recoveryId,
-                    new RecoveryFailedException(request, "source shard is closed", cause), false);
+                                               new RecoveryFailedException(request, "source shard is closed", cause),
+                                               false);
                 return;
             }
 
             onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, e), true);
+        };
+
+        try {
+            logger.trace("{} starting recovery from {}", request.shardId(), request.sourceNode());
+            cancellableThreads.executeIO(
+                () ->
+                    // we still execute under cancelableThreads here to ensure we interrupt any blocking call to the network if any
+                    // on the underlying transport. It's unclear if we need this here at all after moving to async execution but
+                    // the issues that a missing call to this could cause are sneaky and hard to debug. If we don't need it on this
+                    // call we can potentially remove it altogether which we should do it in a major release only with enough
+                    // time to test. This shoudl be done for 7.0 if possible
+                    transportService.submitRequest(
+                        request.sourceNode(),
+                        PeerRecoverySourceService.Actions.START_RECOVERY,
+                        request,
+                        new TransportResponseHandler<RecoveryResponse>() {
+                            @Override
+                            public void handleResponse(
+                                RecoveryResponse recoveryResponse) {
+                                final TimeValue recoveryTime = new TimeValue(
+                                    timer.time());
+                                // do this through ongoing recoveries to remove it from the collection
+                                onGoingRecoveries.markRecoveryAsDone(
+                                    recoveryId);
+                                if (logger.isTraceEnabled()) {
+                                    StringBuilder sb = new StringBuilder();
+                                    sb.append('[').append(request.shardId().getIndex().getName()).append(
+                                        ']')
+                                        .append('[').append(request.shardId().id()).append(
+                                        "] ");
+                                    sb.append(
+                                        "recovery completed from ").append(
+                                        request.sourceNode()).append(
+                                        ", took[").append(
+                                        recoveryTime)
+                                        .append("]\n");
+                                    sb.append(
+                                        "   phase1: recovered_files [").append(
+                                        recoveryResponse.phase1FileNames.size()).append(
+                                        "]")
+                                        .append(
+                                            " with total_size of [").append(
+                                        new ByteSizeValue(
+                                            recoveryResponse.phase1TotalSize)).append(
+                                        "]")
+                                        .append(", took [").append(
+                                        timeValueMillis(
+                                            recoveryResponse.phase1Time)).append(
+                                        "], throttling_wait [")
+                                        .append(timeValueMillis(
+                                            recoveryResponse.phase1ThrottlingWaitTime)).append(
+                                        ']').append("\n");
+                                    sb.append(
+                                        "         : reusing_files   [").append(
+                                        recoveryResponse.phase1ExistingFileNames.size())
+                                        .append(
+                                            "] with total_size of [").append(
+                                        new ByteSizeValue(
+                                            recoveryResponse.phase1ExistingTotalSize))
+                                        .append("]\n");
+                                    sb.append(
+                                        "   phase2: start took [").append(
+                                        timeValueMillis(
+                                            recoveryResponse.startTime)).append(
+                                        "]\n");
+                                    sb.append(
+                                        "         : recovered [").append(
+                                        recoveryResponse.phase2Operations).append(
+                                        "]")
+                                        .append(
+                                            " transaction log operations")
+                                        .append(", took [").append(
+                                        timeValueMillis(
+                                            recoveryResponse.phase2Time)).append(
+                                        "]")
+                                        .append("\n");
+                                    logger.trace("{}", sb);
+                                } else {
+                                    logger.debug(
+                                        "{} recovery done from [{}], took [{}]",
+                                        request.shardId(),
+                                        request.sourceNode(),
+                                        recoveryTime);
+                                }
+                            }
+
+                            @Override
+                            public void handleException(
+                                TransportException e) {
+                                handleException.accept(e);
+                            }
+
+                            @Override
+                            public String executor() {
+                                // we do some heavy work like refreshes in the response so fork off to the generic threadpool
+                                return ThreadPool.Names.GENERIC;
+                            }
+
+                            @Override
+                            public RecoveryResponse read(StreamInput in) throws IOException {
+                                return new RecoveryResponse(in);
+                            }
+                        })
+            );
+        } catch (CancellableThreads.ExecutionCancelledException e) {
+            logger.trace("recovery cancelled", e);
+        } catch (Exception e) {
+            handleException.accept(e);
         }
     }
 
@@ -476,7 +561,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                             }
                         }
 
-                        protected void onFailure(Exception e) {
+                        void onFailure(Exception e) {
                             try {
                                 channel.sendResponse(e);
                             } catch (IOException e1) {
@@ -503,14 +588,18 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
     private void waitForClusterState(long clusterStateVersion) {
         final ClusterState clusterState = clusterService.state();
-        ClusterStateObserver observer = new ClusterStateObserver(clusterState, clusterService, TimeValue.timeValueMinutes(5), logger,
+        ClusterStateObserver observer = new ClusterStateObserver(
+            clusterState,
+            clusterService,
+            TimeValue.timeValueMinutes(5),
+            logger,
             threadPool.getThreadContext());
         if (clusterState.getVersion() >= clusterStateVersion) {
-            logger.trace("node has cluster state with version higher than {} (current: {})", clusterStateVersion,
-                clusterState.getVersion());
-            return;
+            logger.trace("node has cluster state with version higher than {} (current: {})",
+                         clusterStateVersion, clusterState.getVersion());
         } else {
-            logger.trace("waiting for cluster state version {} (current: {})", clusterStateVersion, clusterState.getVersion());
+            logger.trace("waiting for cluster state version {} (current: {})",
+                         clusterStateVersion, clusterState.getVersion());
             final PlainActionFuture<Long> future = new PlainActionFuture<>();
             observer.waitForNextChange(new ClusterStateObserver.Listener() {
 
@@ -621,10 +710,12 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         public void onFailure(Exception e) {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecovery(recoveryId)) {
                 if (recoveryRef != null) {
-                    logger.error(() -> new ParameterizedMessage("unexpected error during recovery [{}], failing shard", recoveryId), e);
-                    onGoingRecoveries.failRecovery(recoveryId,
-                            new RecoveryFailedException(recoveryRef.target().state(), "unexpected error", e),
-                            true // be safe
+                    logger.error(() -> new ParameterizedMessage(
+                        "unexpected error during recovery [{}], failing shard", recoveryId), e);
+                    onGoingRecoveries.failRecovery(
+                        recoveryId,
+                        new RecoveryFailedException(recoveryRef.target().state(), "unexpected error", e),
+                        true // be safe
                     );
                 } else {
                     logger.debug(() -> new ParameterizedMessage(
@@ -638,5 +729,4 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             doRecovery(recoveryId);
         }
     }
-
 }

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -501,11 +501,17 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
         @Override
         public void messageReceived(RecoveryFinalizeRecoveryRequest request, TransportChannel channel, Task task) throws Exception {
-            try (RecoveryRef recoveryRef =
-                     onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
-                recoveryRef.target().finalizeRecovery(request.globalCheckpoint());
+            try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
+                final ActionListener<TransportResponse> listener =
+                    new HandledTransportAction.ChannelActionListener<>(channel, Actions.FINALIZE, request);
+                recoveryRef.target().finalizeRecovery(
+                    request.globalCheckpoint(),
+                    ActionListener.wrap(
+                        nullVal -> listener.onResponse(TransportResponse.Empty.INSTANCE),
+                        listener::onFailure
+                    )
+                );
             }
-            channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
     }
 

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-final class RecoveryResponse extends TransportResponse {
+public final class RecoveryResponse extends TransportResponse {
 
     final List<String> phase1FileNames;
     final List<Long> phase1FileSizes;

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -33,9 +33,9 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.Tuple;
@@ -71,7 +71,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -555,18 +555,6 @@ public class RecoverySourceHandler {
                 long maxSeenAutoIdTimestamp,
                 long maxSeqNoOfUpdatesOrDeletes,
                 ActionListener<SendSnapshotResult> listener) throws IOException {
-        ActionListener.completeWith(listener, () -> sendSnapshotBlockingly(
-            startingSeqNo,
-            requiredSeqNoRangeStart,
-            endingSeqNo,
-            snapshot,
-            maxSeenAutoIdTimestamp,
-            maxSeqNoOfUpdatesOrDeletes));
-    }
-
-    private SendSnapshotResult sendSnapshotBlockingly(long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo,
-                                                      Translog.Snapshot snapshot, long maxSeenAutoIdTimestamp,
-                                                      long maxSeqNoOfUpdatesOrDeletes) throws IOException {
         assert requiredSeqNoRangeStart <= endingSeqNo + 1:
             "requiredSeqNoRangeStart " + requiredSeqNoRangeStart + " is larger than endingSeqNo " + endingSeqNo;
         assert startingSeqNo <= requiredSeqNoRangeStart :
@@ -574,88 +562,96 @@ public class RecoverySourceHandler {
         if (shard.state() == IndexShardState.CLOSED) {
             throw new IndexShardClosedException(request.shardId());
         }
-
-        final StopWatch stopWatch = new StopWatch().start();
-
         logger.trace("recovery [phase2]: sending transaction log operations (seq# from [" +  startingSeqNo  + "], " +
-            "required [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "]");
+                     "required [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "]");
 
-        int ops = 0;
-        long size = 0;
-        int skippedOps = 0;
-        int totalSentOps = 0;
-        final AtomicLong targetLocalCheckpoint = new AtomicLong(SequenceNumbers.UNASSIGNED_SEQ_NO);
-        final List<Translog.Operation> operations = new ArrayList<>();
+        final AtomicInteger skippedOps = new AtomicInteger();
+        final AtomicInteger totalSentOps = new AtomicInteger();
         final LocalCheckpointTracker requiredOpsTracker = new LocalCheckpointTracker(endingSeqNo, requiredSeqNoRangeStart - 1);
+        final AtomicInteger lastBatchCount = new AtomicInteger(); // used to estimate the count of the subsequent batch.
+        final CheckedSupplier<List<Translog.Operation>, IOException> readNextBatch = () -> {
+            // We need to synchronized Snapshot#next() because it's called by different threads through sendBatch.
+            // Even though those calls are not concurrent, Snapshot#next() uses non-synchronized state and is not multi-thread-compatible.
+            synchronized (snapshot) {
+                final List<Translog.Operation> ops = lastBatchCount.get() > 0 ? new ArrayList<>(lastBatchCount.get()) : new ArrayList<>();
+                long batchSizeInBytes = 0L;
+                Translog.Operation operation;
+                while ((operation = snapshot.next()) != null) {
+                    if (shard.state() == IndexShardState.CLOSED) {
+                        throw new IndexShardClosedException(request.shardId());
+                    }
+                    cancellableThreads.checkForCancel();
+                    final long seqNo = operation.seqNo();
+                    if (seqNo < startingSeqNo || seqNo > endingSeqNo) {
+                        skippedOps.incrementAndGet();
+                        continue;
+                    }
+                    ops.add(operation);
+                    batchSizeInBytes += operation.estimateSize();
+                    totalSentOps.incrementAndGet();
+                    requiredOpsTracker.markSeqNoAsCompleted(seqNo);
 
-        final int expectedTotalOps = snapshot.totalOperations();
-        if (expectedTotalOps == 0) {
-            logger.trace("no translog operations to send");
-        }
-
-        final CancellableThreads.IOInterruptable sendBatch = () -> {
-            // TODO: Make this non-blocking
-            final PlainActionFuture<Long> future = new PlainActionFuture<>();
-            recoveryTarget.indexTranslogOperations(
-                operations,
-                expectedTotalOps,
-                maxSeenAutoIdTimestamp,
-                maxSeqNoOfUpdatesOrDeletes,
-                future
-            );
-            targetLocalCheckpoint.set(future.actionGet());
+                    // check if this request is past bytes threshold, and if so, send it off
+                    if (batchSizeInBytes >= chunkSizeInBytes) {
+                        break;
+                    }
+                }
+                lastBatchCount.set(ops.size());
+                return ops;
+            }
         };
 
-        // send operations in batches
-        Translog.Operation operation;
-        while ((operation = snapshot.next()) != null) {
-            if (shard.state() == IndexShardState.CLOSED) {
-                throw new IndexShardClosedException(request.shardId());
-            }
-            cancellableThreads.checkForCancel();
+        final StopWatch stopWatch = new StopWatch().start();
+        final ActionListener<Long> batchedListener = ActionListener.wrap(
+            targetLocalCheckpoint -> {
+                assert snapshot.totalOperations() == snapshot.skippedOperations() + skippedOps.get() + totalSentOps.get()
+                    : String.format(Locale.ROOT, "expected total [%d], overridden [%d], skipped [%d], total sent [%d]",
+                                    snapshot.totalOperations(), snapshot.skippedOperations(), skippedOps.get(), totalSentOps.get());
+                if (requiredOpsTracker.getCheckpoint() < endingSeqNo) {
+                    throw new IllegalStateException("translog replay failed to cover required sequence numbers" +
+                                                    " (required range [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "). first missing op is ["
+                                                    + (requiredOpsTracker.getCheckpoint() + 1) + "]");
+                }
+                stopWatch.stop();
+                final TimeValue tookTime = stopWatch.totalTime();
+                logger.trace("recovery [phase2]: took [{}]", tookTime);
+                listener.onResponse(new SendSnapshotResult(targetLocalCheckpoint, totalSentOps.get(), tookTime));
+            },
+            listener::onFailure
+        );
 
-            final long seqNo = operation.seqNo();
-            if (seqNo < startingSeqNo || seqNo > endingSeqNo) {
-                skippedOps++;
-                continue;
-            }
-            operations.add(operation);
-            ops++;
-            size += operation.estimateSize();
-            totalSentOps++;
-            requiredOpsTracker.markSeqNoAsCompleted(seqNo);
+        sendBatch(readNextBatch, true, SequenceNumbers.UNASSIGNED_SEQ_NO, snapshot.totalOperations(),
+                  maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes, batchedListener);
+    }
 
-            // check if this request is past bytes threshold, and if so, send it off
-            if (size >= chunkSizeInBytes) {
-                cancellableThreads.executeIO(sendBatch);
-                logger.trace("sent batch of [{}][{}] (total: [{}]) translog operations", ops, new ByteSizeValue(size), expectedTotalOps);
-                ops = 0;
-                size = 0;
-                operations.clear();
-            }
+    private void sendBatch(CheckedSupplier<List<Translog.Operation>, IOException> nextBatch,
+                           boolean firstBatch,
+                           long targetLocalCheckpoint,
+                           int totalTranslogOps,
+                           long maxSeenAutoIdTimestamp,
+                           long maxSeqNoOfUpdatesOrDeletes,
+                           ActionListener<Long> listener) throws IOException {
+        final List<Translog.Operation> operations = nextBatch.get();
+        // send the leftover operations or if no operations were sent, request
+        // the target to respond with its local checkpoint
+        if (operations.isEmpty() == false || firstBatch) {
+            cancellableThreads.execute(() -> recoveryTarget.indexTranslogOperations(
+                operations, totalTranslogOps, maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes,
+                ActionListener.wrap(newCheckpoint ->
+                        sendBatch(
+                            nextBatch,
+                            false,
+                            SequenceNumbers.max(targetLocalCheckpoint, newCheckpoint),
+                            totalTranslogOps,
+                            maxSeenAutoIdTimestamp,
+                            maxSeqNoOfUpdatesOrDeletes,
+                            listener),
+                    listener::onFailure
+                ))
+            );
+        } else {
+            listener.onResponse(targetLocalCheckpoint);
         }
-
-        if (!operations.isEmpty() || totalSentOps == 0) {
-            // send the leftover operations or if no operations were sent, request the target to respond with its local checkpoint
-            cancellableThreads.executeIO(sendBatch);
-        }
-
-        assert expectedTotalOps == snapshot.skippedOperations() + skippedOps + totalSentOps
-            : String.format(Locale.ROOT, "expected total [%d], overridden [%d], skipped [%d], total sent [%d]",
-            expectedTotalOps, snapshot.skippedOperations(), skippedOps, totalSentOps);
-
-        if (requiredOpsTracker.getCheckpoint() < endingSeqNo) {
-            throw new IllegalStateException("translog replay failed to cover required sequence numbers" +
-                " (required range [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "). first missing op is ["
-                + (requiredOpsTracker.getCheckpoint() + 1) + "]");
-        }
-
-        logger.trace("sent final batch of [{}][{}] (total: [{}]) translog operations", ops, new ByteSizeValue(size), expectedTotalOps);
-
-        stopWatch.stop();
-        final TimeValue tookTime = stopWatch.totalTime();
-        logger.trace("recovery [phase2]: took [{}]", tookTime);
-        return new SendSnapshotResult(targetLocalCheckpoint.get(), totalSentOps, tookTime);
     }
 
     /*

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -32,6 +32,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.StepListener;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.StopWatch;
@@ -71,6 +72,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
@@ -143,6 +145,9 @@ public class RecoverySourceHandler {
                 IOUtils.closeWhileHandlingException(releaseResources, () -> wrappedListener.onFailure(e));
                 throw e;
             });
+            final Consumer<Exception> onFailure = e ->
+                IOUtils.closeWhileHandlingException(releaseResources, () -> wrappedListener.onFailure(e));
+
             runUnderPrimaryPermit(
                 () -> {
                     final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
@@ -255,16 +260,29 @@ public class RecoverySourceHandler {
                 throw new RecoveryEngineException(shard.shardId(), 2, "phase2 failed", e);
             }
 
-            finalizeRecovery(sendSnapshotResult.targetLocalCheckpoint);
-            final long phase1ThrottlingWaitTime = 0L; // TODO: return the actual throttle time
-            assert resources.isEmpty() : "not every resource is released [" + resources + "]";
-            IOUtils.close(resources);
-            wrappedListener.onResponse(
-                new RecoveryResponse(sendFileResult.phase1FileNames, sendFileResult.phase1FileSizes,
-                                     sendFileResult.phase1ExistingFileNames, sendFileResult.phase1ExistingFileSizes, sendFileResult.totalSize,
-                                     sendFileResult.existingTotalSize, sendFileResult.took.millis(), phase1ThrottlingWaitTime, prepareEngineTime.millis(),
-                                     sendSnapshotResult.totalOperations, sendSnapshotResult.tookTime.millis())
-            );
+            final StepListener<Void> finalizeStep = new StepListener<>();
+            finalizeRecovery(sendSnapshotResult.targetLocalCheckpoint, finalizeStep);
+            finalizeStep.whenComplete(r -> {
+                assert resources.isEmpty() : "not every resource is released [" + resources + "]";
+                final long phase1ThrottlingWaitTime = 0L; // TODO: return the actual throttle time
+                final RecoveryResponse response = new RecoveryResponse(
+                    sendFileResult.phase1FileNames,
+                    sendFileResult.phase1FileSizes,
+                    sendFileResult.phase1ExistingFileNames,
+                    sendFileResult.phase1ExistingFileSizes,
+                    sendFileResult.totalSize,
+                    sendFileResult.existingTotalSize,
+                    sendFileResult.took.millis(),
+                    phase1ThrottlingWaitTime,
+                    prepareEngineTime.millis(),
+                    sendSnapshotResult.totalOperations,
+                    sendSnapshotResult.tookTime.millis());
+                try {
+                    wrappedListener.onResponse(response);
+                } finally {
+                    IOUtils.close(resources);
+                }
+            }, onFailure);
         } catch (Exception e) {
             IOUtils.closeWhileHandlingException(releaseResources, () -> wrappedListener.onFailure(e));
         }
@@ -620,7 +638,7 @@ public class RecoverySourceHandler {
     /*
      * finalizes the recovery process
      */
-    private void finalizeRecovery(final long targetLocalCheckpoint) throws IOException {
+    void finalizeRecovery(final long targetLocalCheckpoint, final ActionListener<Void> listener) throws IOException {
         if (shard.state() == IndexShardState.CLOSED) {
             throw new IndexShardClosedException(request.shardId());
         }
@@ -636,21 +654,26 @@ public class RecoverySourceHandler {
         runUnderPrimaryPermit(() -> shard.markAllocationIdAsInSync(request.targetAllocationId(), targetLocalCheckpoint),
                               shardId + " marking " + request.targetAllocationId() + " as in sync", shard, cancellableThreads, logger);
         final long globalCheckpoint = shard.getGlobalCheckpoint();
-        cancellableThreads.executeIO(() -> recoveryTarget.finalizeRecovery(globalCheckpoint));
-        runUnderPrimaryPermit(() -> shard.updateGlobalCheckpointForShard(request.targetAllocationId(), globalCheckpoint),
-                              shardId + " updating " + request.targetAllocationId() + "'s global checkpoint", shard, cancellableThreads, logger);
+        final StepListener<Void> finalizeListener = new StepListener<>();
+        cancellableThreads.executeIO(() -> recoveryTarget.finalizeRecovery(globalCheckpoint, finalizeListener));
+        finalizeListener.whenComplete(r -> {
+            runUnderPrimaryPermit(() -> shard.updateGlobalCheckpointForShard(request.targetAllocationId(), globalCheckpoint),
+                                  shardId + " updating " + request.targetAllocationId() + "'s global checkpoint", shard, cancellableThreads, logger);
 
-        if (request.isPrimaryRelocation()) {
-            logger.trace("performing relocation hand-off");
-            // this acquires all IndexShard operation permits and will thus delay new recoveries until it is done
-            cancellableThreads.execute(() -> shard.relocated(recoveryTarget::handoffPrimaryContext));
-            /*
-             * if the recovery process fails after disabling primary mode on the source shard, both relocation source and
-             * target are failed (see {@link IndexShard#updateRoutingEntry}).
-             */
-        }
-        stopWatch.stop();
-        logger.trace("finalizing recovery took [{}]", stopWatch.totalTime());
+            if (request.isPrimaryRelocation()) {
+                logger.trace("performing relocation hand-off");
+                // TODO: make relocated async
+                // this acquires all IndexShard operation permits and will thus delay new recoveries until it is done
+                cancellableThreads.execute(() -> shard.relocated(recoveryTarget::handoffPrimaryContext));
+                /*
+                 * if the recovery process fails after disabling primary mode on the source shard, both relocation source and
+                 * target are failed (see {@link IndexShard#updateRoutingEntry}).
+                 */
+            }
+            stopWatch.stop();
+            logger.trace("finalizing recovery took [{}]", stopWatch.totalTime());
+            listener.onResponse(null);
+        }, listener::onFailure);
     }
 
     static final class SendSnapshotResult {

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -34,7 +34,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.Tuple;
@@ -69,6 +68,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -98,22 +98,7 @@ public class RecoverySourceHandler {
     private final int chunkSizeInBytes;
     private final RecoveryTargetHandler recoveryTarget;
     private final int maxConcurrentFileChunks;
-
-    protected final CancellableThreads cancellableThreads = new CancellableThreads() {
-        @Override
-        protected void onCancel(String reason, @Nullable Exception suppressedException) {
-            RuntimeException e;
-            if (shard.state() == IndexShardState.CLOSED) { // check if the shard got closed on us
-                e = new IndexShardClosedException(shard.shardId(), "shard is closed and recovery was canceled reason [" + reason + "]");
-            } else {
-                e = new ExecutionCancelledException("recovery was canceled reason [" + reason + "]");
-            }
-            if (suppressedException != null) {
-                e.addSuppressed(suppressedException);
-            }
-            throw e;
-        }
-    };
+    protected final CancellableThreads cancellableThreads = new CancellableThreads();
 
     public RecoverySourceHandler(final IndexShard shard,
                                  RecoveryTargetHandler recoveryTarget,
@@ -139,23 +124,49 @@ public class RecoverySourceHandler {
     /**
      * performs the recovery from the local engine to the target
      */
-    public RecoveryResponse recoverToTarget() throws IOException {
-        runUnderPrimaryPermit(() -> {
-            final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
-            ShardRouting targetShardRouting = routingTable.getByAllocationId(request.targetAllocationId());
-            if (targetShardRouting == null) {
-                logger.debug("delaying recovery of {} as it is not listed as assigned to target node {}", request.shardId(),
-                    request.targetNode());
-                throw new DelayRecoveryException("source node does not have the shard listed in its state as allocated on the node");
-            }
-            assert targetShardRouting.initializing() : "expected recovery target to be initializing but was " + targetShardRouting;
-        }, shardId + " validating recovery target ["+ request.targetAllocationId() + "] registered ", shard, cancellableThreads, logger);
 
-        try (Closeable ignored = shard.acquireRetentionLockForPeerRecovery()) {
+    public void recoverToTarget(ActionListener<RecoveryResponse> listener) {
+        final List<Closeable> resources = new CopyOnWriteArrayList<>();
+        final Closeable releaseResources = () -> IOUtils.close(resources);
+        final ActionListener<RecoveryResponse> wrappedListener = ActionListener.notifyOnce(listener);
+        try {
+            cancellableThreads.setOnCancel((reason, beforeCancelEx) -> {
+                final RuntimeException e;
+                if (shard.state() == IndexShardState.CLOSED) { // check if the shard got closed on us
+                    e = new IndexShardClosedException(shard.shardId(), "shard is closed and recovery was canceled reason [" + reason + "]");
+                } else {
+                    e = new CancellableThreads.ExecutionCancelledException("recovery was canceled reason [" + reason + "]");
+                }
+                if (beforeCancelEx != null) {
+                    e.addSuppressed(beforeCancelEx);
+                }
+                IOUtils.closeWhileHandlingException(releaseResources, () -> wrappedListener.onFailure(e));
+                throw e;
+            });
+            runUnderPrimaryPermit(
+                () -> {
+                    final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
+                    ShardRouting targetShardRouting = routingTable.getByAllocationId(request.targetAllocationId());
+                    if (targetShardRouting == null) {
+                        logger.debug(
+                            "delaying recovery of {} as it is not listed as assigned to target node {}",
+                            request.shardId(), request.targetNode());
+                        throw new DelayRecoveryException(
+                            "source node does not have the shard listed in its state as allocated on the node");
+                    }
+                    assert targetShardRouting.initializing() :
+                        "expected recovery target to be initializing but was " + targetShardRouting;
+                },
+                shardId + " validating recovery target [" + request.targetAllocationId() + "] registered ",
+                shard,
+                cancellableThreads,
+                logger);
+            final Closeable retentionLock = shard.acquireRetentionLockForPeerRecovery();
+            resources.add(retentionLock);
             final long startingSeqNo;
             final long requiredSeqNoRangeStart;
             final boolean isSequenceNumberBasedRecovery = request.startingSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO &&
-                isTargetSameHistory() && shard.hasCompleteHistoryOperations("peer-recovery", request.startingSeqNo());
+                                                          isTargetSameHistory() && shard.hasCompleteHistoryOperations("peer-recovery", request.startingSeqNo());
             final SendFileResult sendFileResult;
             if (isSequenceNumberBasedRecovery) {
                 logger.trace("performing sequence numbers based recovery. starting at [{}]", request.startingSeqNo());
@@ -231,8 +242,9 @@ public class RecoverySourceHandler {
                     shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo));
             }
             final SendSnapshotResult sendSnapshotResult;
-            final long targetLocalCheckpoint;
             try (Translog.Snapshot snapshot = shard.getHistoryOperations("peer-recovery", startingSeqNo)) {
+                // we can release the retention lock here because the snapshot itself will retain the required operations.
+                IOUtils.close(retentionLock, () -> resources.remove(retentionLock));
                 // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
                 // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
                 final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
@@ -245,10 +257,16 @@ public class RecoverySourceHandler {
 
             finalizeRecovery(sendSnapshotResult.targetLocalCheckpoint);
             final long phase1ThrottlingWaitTime = 0L; // TODO: return the actual throttle time
-            return new RecoveryResponse(sendFileResult.phase1FileNames, sendFileResult.phase1FileSizes,
-                                        sendFileResult.phase1ExistingFileNames, sendFileResult.phase1ExistingFileSizes, sendFileResult.totalSize,
-                                        sendFileResult.existingTotalSize, sendFileResult.took.millis(), phase1ThrottlingWaitTime, prepareEngineTime.millis(),
-                                        sendSnapshotResult.totalOperations, sendSnapshotResult.tookTime.millis());
+            assert resources.isEmpty() : "not every resource is released [" + resources + "]";
+            IOUtils.close(resources);
+            wrappedListener.onResponse(
+                new RecoveryResponse(sendFileResult.phase1FileNames, sendFileResult.phase1FileSizes,
+                                     sendFileResult.phase1ExistingFileNames, sendFileResult.phase1ExistingFileSizes, sendFileResult.totalSize,
+                                     sendFileResult.existingTotalSize, sendFileResult.took.millis(), phase1ThrottlingWaitTime, prepareEngineTime.millis(),
+                                     sendSnapshotResult.totalOperations, sendSnapshotResult.tookTime.millis())
+            );
+        } catch (Exception e) {
+            IOUtils.closeWhileHandlingException(releaseResources, () -> wrappedListener.onFailure(e));
         }
     }
 
@@ -289,7 +307,7 @@ public class RecoverySourceHandler {
                                       IndexShard primary, CancellableThreads cancellableThreads, Logger logger) {
         cancellableThreads.execute(() -> {
             CompletableFuture<Releasable> permit = new CompletableFuture<>();
-            final ActionListener<Releasable> onAcquired = new ActionListener<Releasable>() {
+            final ActionListener<Releasable> onAcquired = new ActionListener<>() {
                 @Override
                 public void onResponse(Releasable releasable) {
                     if (permit.complete(releasable) == false) {
@@ -602,7 +620,7 @@ public class RecoverySourceHandler {
     /*
      * finalizes the recovery process
      */
-    public void finalizeRecovery(final long targetLocalCheckpoint) throws IOException {
+    private void finalizeRecovery(final long targetLocalCheckpoint) throws IOException {
         if (shard.state() == IndexShardState.CLOSED) {
             throw new IndexShardClosedException(request.shardId());
         }

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -210,57 +210,72 @@ public class RecoverySourceHandler {
             assert requiredSeqNoRangeStart >= startingSeqNo : "requiredSeqNoRangeStart [" + requiredSeqNoRangeStart + "] is lower than ["
                 + startingSeqNo + "]";
 
-            final TimeValue prepareEngineTime;
-            try {
-                // For a sequence based recovery, the target can keep its local translog
-                prepareEngineTime = prepareTargetForTranslog(
-                    isSequenceNumberBasedRecovery == false,
-                    shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo));
-            } catch (final Exception e) {
-                throw new RecoveryEngineException(shard.shardId(), 1, "prepare target for translog failed", e);
-            }
 
-            /*
-             * add shard to replication group (shard will receive replication requests from this point on) now that engine is open.
-             * This means that any document indexed into the primary after this will be replicated to this replica as well
-             * make sure to do this before sampling the max sequence number in the next step, to ensure that we send
-             * all documents up to maxSeqNo in phase2.
-             */
-            runUnderPrimaryPermit(() -> shard.initiateTracking(request.targetAllocationId()),
-                shardId + " initiating tracking of " + request.targetAllocationId(), shard, cancellableThreads, logger);
-
-            final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
-            /*
-             * We need to wait for all operations up to the current max to complete, otherwise we can not guarantee that all
-             * operations in the required range will be available for replaying from the translog of the source.
-             */
-            cancellableThreads.execute(() -> shard.waitForOpsToComplete(endingSeqNo));
-
-            // CRATE_PATCH
-            try {
-                blobRecoveryHook();
-            } catch (Exception e) {
-                throw new RecoveryEngineException(shard.shardId(), 1, "blobRecoveryHook failed", e);
-            }
-            if (logger.isTraceEnabled()) {
-                logger.trace("all operations up to [{}] completed, which will be used as an ending sequence number", endingSeqNo);
-                logger.trace("snapshot translog for recovery; current size is [{}]",
-                    shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo));
-            }
-            final Translog.Snapshot phase2Snapshot = shard.getHistoryOperations("peer-recovery", startingSeqNo);
-            resources.add(phase2Snapshot);
-            // we can release the retention lock here because the snapshot itself will retain the required operations.
-            IOUtils.close(retentionLock);
-            // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
-            // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
-            final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
-            final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
+            final StepListener<TimeValue> prepareEngineStep = new StepListener<>();
+            // For a sequence based recovery, the target can keep its local translog
+            prepareTargetForTranslog(
+                isSequenceNumberBasedRecovery == false,
+                shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo),
+                prepareEngineStep);
             final StepListener<SendSnapshotResult> sendSnapshotStep = new StepListener<>();
-            phase2(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, phase2Snapshot, maxSeenAutoIdTimestamp,
-                   maxSeqNoOfUpdatesOrDeletes, sendSnapshotStep);
-            sendSnapshotStep.whenComplete(
-                r -> IOUtils.close(phase2Snapshot),
-                e -> onFailure.accept(new RecoveryEngineException(shard.shardId(), 2, "phase2 failed", e)));
+            prepareEngineStep.whenComplete(prepareEngineTime -> {
+                /*
+                 * add shard to replication group (shard will receive replication requests from this point on)
+                 * now that engine is open. This means that any document indexed into the primary after
+                 * this will be replicated to this replica as well make sure to do this before sampling
+                 * the max sequence number in the next step, to ensure that we send all documents up to
+                 * maxSeqNo in phase2.
+                 */
+                runUnderPrimaryPermit(
+                    () -> shard.initiateTracking(request.targetAllocationId()),
+                    shardId + " initiating tracking of " + request.targetAllocationId(),
+                    shard,
+                    cancellableThreads,
+                    logger);
+
+                final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
+                /*
+                 * We need to wait for all operations up to the current max to complete, otherwise we can not guarantee that all
+                 * operations in the required range will be available for replaying from the translog of the source.
+                 */
+                cancellableThreads.execute(() -> shard.waitForOpsToComplete(endingSeqNo));
+
+                // CRATE_PATCH
+                try {
+                    blobRecoveryHook();
+                } catch (Exception e) {
+                    throw new RecoveryEngineException(shard.shardId(), 1, "blobRecoveryHook failed", e);
+                }
+                if (logger.isTraceEnabled()) {
+                    logger.trace("all operations up to [{}] completed, which will be used as an ending sequence number", endingSeqNo);
+                    logger.trace("snapshot translog for recovery; current size is [{}]",
+                                 shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo));
+                }
+
+                final Translog.Snapshot phase2Snapshot = shard.getHistoryOperations("peer-recovery", startingSeqNo);
+                resources.add(phase2Snapshot);
+                // we can release the retention lock here because the snapshot itself will retain the required operations.
+                retentionLock.close();
+                // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
+                // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
+                final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
+                final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
+                phase2(
+                    startingSeqNo,
+                    requiredSeqNoRangeStart,
+                    endingSeqNo,
+                    phase2Snapshot,
+                    maxSeenAutoIdTimestamp,
+                    maxSeqNoOfUpdatesOrDeletes,
+                    sendSnapshotStep);
+                sendSnapshotStep.whenComplete(
+                    r -> IOUtils.close(phase2Snapshot),
+                    e -> {
+                        IOUtils.closeWhileHandlingException(phase2Snapshot);
+                        onFailure.accept(new RecoveryEngineException(shard.shardId(), 2, "phase2 failed", e));
+                    });
+
+            }, onFailure);
 
             final StepListener<Void> finalizeStep = new StepListener<>();
             sendSnapshotStep.whenComplete(r -> finalizeRecovery(r.targetLocalCheckpoint, finalizeStep), onFailure);
@@ -277,7 +292,7 @@ public class RecoverySourceHandler {
                     sendFileResult.existingTotalSize,
                     sendFileResult.took.millis(),
                     phase1ThrottlingWaitTime,
-                    prepareEngineTime.millis(),
+                    prepareEngineStep.result().millis(),
                     sendSnapshotResult.totalOperations,
                     sendSnapshotResult.tookTime.millis());
                 try {
@@ -520,16 +535,27 @@ public class RecoverySourceHandler {
         }
     }
 
-    TimeValue prepareTargetForTranslog(final boolean fileBasedRecovery, final int totalTranslogOps) throws IOException {
+    void prepareTargetForTranslog(boolean fileBasedRecovery,
+                                  int totalTranslogOps,
+                                  ActionListener<TimeValue> listener) {
         StopWatch stopWatch = new StopWatch().start();
-        logger.trace("recovery [phase1]: prepare remote engine for translog");
+        final ActionListener<Void> wrappedListener = ActionListener.wrap(
+            nullVal -> {
+                stopWatch.stop();
+                final TimeValue tookTime = stopWatch.totalTime();
+                logger.trace("recovery [phase1]: remote engine start took [{}]", tookTime);
+                listener.onResponse(tookTime);
+            },
+            e -> listener.onFailure(new RecoveryEngineException(shard.shardId(), 1, "prepare target for translog failed", e)));
         // Send a request preparing the new shard's translog to receive operations. This ensures the shard engine is started and disables
         // garbage collection (not the JVM's GC!) of tombstone deletes.
-        cancellableThreads.executeIO(() -> recoveryTarget.prepareForTranslogOperations(fileBasedRecovery, totalTranslogOps));
-        stopWatch.stop();
-        final TimeValue tookTime = stopWatch.totalTime();
-        logger.trace("recovery [phase1]: remote engine start took [{}]", tookTime);
-        return tookTime;
+        logger.trace("recovery [phase1]: prepare remote engine for translog");
+        cancellableThreads.execute(
+            () -> recoveryTarget.prepareForTranslogOperations(
+                fileBasedRecovery,
+                totalTranslogOps,
+                wrappedListener)
+        );
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -420,25 +420,10 @@ public class RecoverySourceHandler {
                             recoverySourceMetadata.asMap().size() + " files", name);
                 }
             }
-            // Generate a "diff" of all the identical, different, and missing
-            // segment files on the target node, using the existing files on
-            // the source node
-            String recoverySourceSyncId = recoverySourceMetadata.getSyncId();
-            String recoveryTargetSyncId = request.metadataSnapshot().getSyncId();
-            final boolean recoverWithSyncId = recoverySourceSyncId != null &&
-                    recoverySourceSyncId.equals(recoveryTargetSyncId);
-            if (recoverWithSyncId) {
-                final long numDocsTarget = request.metadataSnapshot().getNumDocs();
-                final long numDocsSource = recoverySourceMetadata.getNumDocs();
-                if (numDocsTarget != numDocsSource) {
-                    throw new IllegalStateException("try to recover " + request.shardId() + " from primary shard with sync id but number " +
-                            "of docs differ: " + numDocsSource + " (" + request.sourceNode().getName() + ", primary) vs " + numDocsTarget
-                            + "(" + request.targetNode().getName() + ")");
-                }
-                // we shortcut recovery here because we have nothing to copy. but we must still start the engine on the target.
-                // so we don't return here
-                logger.trace("skipping [phase1]- identical sync id [{}] found on both source and target", recoverySourceSyncId);
-            } else {
+            if (canSkipPhase1(recoverySourceMetadata, request.metadataSnapshot()) == false) {
+                // Generate a "diff" of all the identical, different, and missing
+                // segment files on the target node, using the existing files on
+                // the source node
                 final Store.RecoveryDiff diff = recoverySourceMetadata.recoveryDiff(request.metadataSnapshot());
                 for (StoreFileMetaData md : diff.identical) {
                     phase1ExistingFileNames.add(md.name());
@@ -521,8 +506,10 @@ public class RecoverySourceHandler {
                         throw targetException;
                     }
                 }
+            } else {
+                logger.trace("skipping [phase1]- identical sync id [{}] found on both source and target",
+                             recoverySourceMetadata.getSyncId());
             }
-
             final TimeValue took = stopWatch.totalTime();
             logger.trace("recovery [phase1]: took [{}]", took);
             return new SendFileResult(phase1FileNames, phase1FileSizes, totalSize, phase1ExistingFileNames,
@@ -533,6 +520,28 @@ public class RecoverySourceHandler {
         } finally {
             store.decRef();
         }
+    }
+
+    boolean canSkipPhase1(Store.MetadataSnapshot source, Store.MetadataSnapshot target) {
+        if (source.getSyncId() == null || source.getSyncId().equals(target.getSyncId()) == false) {
+            return false;
+        }
+        if (source.getNumDocs() != target.getNumDocs()) {
+            throw new IllegalStateException(
+                "try to recover " + request.shardId() + " from primary shard with sync id but number " +
+                "of docs differ: " + source.getNumDocs() + " (" + request.sourceNode().getName() + ", primary) vs " + target.getNumDocs()
+                + "(" + request.targetNode().getName() + ")");
+        }
+        SequenceNumbers.CommitInfo sourceSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(source.getCommitUserData().entrySet());
+        SequenceNumbers.CommitInfo targetSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(target.getCommitUserData().entrySet());
+        if (sourceSeqNos.localCheckpoint != targetSeqNos.localCheckpoint || targetSeqNos.maxSeqNo != sourceSeqNos.maxSeqNo) {
+            final String message =
+                "try to recover " + request.shardId() + " with sync id but " +
+                "seq_no stats are mismatched: [" + source.getCommitUserData() + "] vs [" + target.getCommitUserData() + "]";
+            assert false : message;
+            throw new IllegalStateException(message);
+        }
+        return true;
     }
 
     void prepareTargetForTranslog(boolean fileBasedRecovery,

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -33,6 +33,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.StopWatch;
@@ -246,25 +247,27 @@ public class RecoverySourceHandler {
                 logger.trace("snapshot translog for recovery; current size is [{}]",
                     shard.estimateNumberOfHistoryOperations("peer-recovery", startingSeqNo));
             }
-            final SendSnapshotResult sendSnapshotResult;
-            try (Translog.Snapshot snapshot = shard.getHistoryOperations("peer-recovery", startingSeqNo)) {
-                // we can release the retention lock here because the snapshot itself will retain the required operations.
-                IOUtils.close(retentionLock, () -> resources.remove(retentionLock));
-                // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
-                // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
-                final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
-                final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
-                sendSnapshotResult = phase2(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, snapshot,
-                    maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes);
-            } catch (Exception e) {
-                throw new RecoveryEngineException(shard.shardId(), 2, "phase2 failed", e);
-            }
+            final Translog.Snapshot phase2Snapshot = shard.getHistoryOperations("peer-recovery", startingSeqNo);
+            resources.add(phase2Snapshot);
+            // we can release the retention lock here because the snapshot itself will retain the required operations.
+            IOUtils.close(retentionLock);
+            // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
+            // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
+            final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
+            final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
+            final StepListener<SendSnapshotResult> sendSnapshotStep = new StepListener<>();
+            phase2(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, phase2Snapshot, maxSeenAutoIdTimestamp,
+                   maxSeqNoOfUpdatesOrDeletes, sendSnapshotStep);
+            sendSnapshotStep.whenComplete(
+                r -> IOUtils.close(phase2Snapshot),
+                e -> onFailure.accept(new RecoveryEngineException(shard.shardId(), 2, "phase2 failed", e)));
 
             final StepListener<Void> finalizeStep = new StepListener<>();
-            finalizeRecovery(sendSnapshotResult.targetLocalCheckpoint, finalizeStep);
+            sendSnapshotStep.whenComplete(r -> finalizeRecovery(r.targetLocalCheckpoint, finalizeStep), onFailure);
+
             finalizeStep.whenComplete(r -> {
-                assert resources.isEmpty() : "not every resource is released [" + resources + "]";
                 final long phase1ThrottlingWaitTime = 0L; // TODO: return the actual throttle time
+                final SendSnapshotResult sendSnapshotResult = sendSnapshotStep.result();
                 final RecoveryResponse response = new RecoveryResponse(
                     sendFileResult.phase1FileNames,
                     sendFileResult.phase1FileSizes,
@@ -543,14 +546,27 @@ public class RecoverySourceHandler {
      * @param snapshot                   a snapshot of the translog
      * @param maxSeenAutoIdTimestamp     the max auto_id_timestamp of append-only requests on the primary
      * @param maxSeqNoOfUpdatesOrDeletes the max seq_no of updates or deletes on the primary after these operations were executed on it.
-     * @return the send snapshot result
+     * @param listener                   a listener which will be notified with the local checkpoint on the target.
      */
-    SendSnapshotResult phase2(long startingSeqNo,
-                              long requiredSeqNoRangeStart,
-                              long endingSeqNo,
-                              Translog.Snapshot snapshot,
-                              long maxSeenAutoIdTimestamp,
-                              long maxSeqNoOfUpdatesOrDeletes) throws IOException {
+    void phase2(long startingSeqNo,
+                long requiredSeqNoRangeStart,
+                long endingSeqNo,
+                Translog.Snapshot snapshot,
+                long maxSeenAutoIdTimestamp,
+                long maxSeqNoOfUpdatesOrDeletes,
+                ActionListener<SendSnapshotResult> listener) throws IOException {
+        ActionListener.completeWith(listener, () -> sendSnapshotBlockingly(
+            startingSeqNo,
+            requiredSeqNoRangeStart,
+            endingSeqNo,
+            snapshot,
+            maxSeenAutoIdTimestamp,
+            maxSeqNoOfUpdatesOrDeletes));
+    }
+
+    private SendSnapshotResult sendSnapshotBlockingly(long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo,
+                                                      Translog.Snapshot snapshot, long maxSeenAutoIdTimestamp,
+                                                      long maxSeqNoOfUpdatesOrDeletes) throws IOException {
         assert requiredSeqNoRangeStart <= endingSeqNo + 1:
             "requiredSeqNoRangeStart " + requiredSeqNoRangeStart + " is larger than endingSeqNo " + endingSeqNo;
         assert startingSeqNo <= requiredSeqNoRangeStart :
@@ -578,9 +594,16 @@ public class RecoverySourceHandler {
         }
 
         final CancellableThreads.IOInterruptable sendBatch = () -> {
-            final long targetCheckpoint = recoveryTarget.indexTranslogOperations(
-                operations, expectedTotalOps, maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes);
-            targetLocalCheckpoint.set(targetCheckpoint);
+            // TODO: Make this non-blocking
+            final PlainActionFuture<Long> future = new PlainActionFuture<>();
+            recoveryTarget.indexTranslogOperations(
+                operations,
+                expectedTotalOps,
+                maxSeenAutoIdTimestamp,
+                maxSeqNoOfUpdatesOrDeletes,
+                future
+            );
+            targetLocalCheckpoint.set(future.actionGet());
         };
 
         // send operations in batches

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -362,12 +362,18 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
         }
     }
 
-    /*** Implementation of {@link RecoveryTargetHandler } */
-
+    /*
+     *  Implementation of {@link RecoveryTargetHandler}
+     */
     @Override
-    public void prepareForTranslogOperations(boolean fileBasedRecovery, int totalTranslogOps) throws IOException {
-        state().getTranslog().totalOperations(totalTranslogOps);
-        indexShard().openEngineAndSkipTranslogRecovery();
+    public void prepareForTranslogOperations(boolean fileBasedRecovery,
+                                             int totalTranslogOps,
+                                             ActionListener<Void> listener) {
+        ActionListener.completeWith(listener, () -> {
+            state().getTranslog().totalOperations(totalTranslogOps);
+            indexShard().openEngineAndSkipTranslogRecovery();
+            return null;
+        });
     }
 
     @Override

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -393,41 +393,47 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     }
 
     @Override
-    public long indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long maxSeenAutoIdTimestampOnPrimary,
-                                        long maxSeqNoOfDeletesOrUpdatesOnPrimary) throws IOException {
-        final RecoveryState.Translog translog = state().getTranslog();
-        translog.totalOperations(totalTranslogOps);
-        assert indexShard().recoveryState() == state();
-        if (indexShard().state() != IndexShardState.RECOVERING) {
-            throw new IndexShardNotRecoveringException(shardId, indexShard().state());
-        }
-        /*
-         * The maxSeenAutoIdTimestampOnPrimary received from the primary is at least the highest auto_id_timestamp from any operation
-         * will be replayed. Bootstrapping this timestamp here will disable the optimization for original append-only requests
-         * (source of these operations) replicated via replication. Without this step, we may have duplicate documents if we
-         * replay these operations first (without timestamp), then optimize append-only requests (with timestamp).
-         */
-        indexShard().updateMaxUnsafeAutoIdTimestamp(maxSeenAutoIdTimestampOnPrimary);
-        /*
-         * Bootstrap the max_seq_no_of_updates from the primary to make sure that the max_seq_no_of_updates on this replica when
-         * replaying any of these operations will be at least the max_seq_no_of_updates on the primary when that operation was executed on.
-         */
-        indexShard().advanceMaxSeqNoOfUpdatesOrDeletes(maxSeqNoOfDeletesOrUpdatesOnPrimary);
-        for (Translog.Operation operation : operations) {
-            Engine.Result result = indexShard().applyTranslogOperation(operation, Engine.Operation.Origin.PEER_RECOVERY);
-            if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
-                throw new MapperException("mapping updates are not allowed [" + operation + "]");
+    public void indexTranslogOperations(List<Translog.Operation> operations,
+                                        int totalTranslogOps,
+                                        long maxSeenAutoIdTimestampOnPrimary,
+                                        long maxSeqNoOfDeletesOrUpdatesOnPrimary,
+                                        ActionListener<Long> listener) {
+        ActionListener.completeWith(listener, () -> {
+            final RecoveryState.Translog translog = state().getTranslog();
+            translog.totalOperations(totalTranslogOps);
+            assert indexShard().recoveryState() == state();
+            if (indexShard().state() != IndexShardState.RECOVERING) {
+                throw new IndexShardNotRecoveringException(shardId, indexShard().state());
             }
-            assert result.getFailure() == null: "unexpected failure while replicating translog entry: " + result.getFailure();
-            ExceptionsHelper.reThrowIfNotNull(result.getFailure());
-        }
-        // update stats only after all operations completed (to ensure that mapping updates don't mess with stats)
-        translog.incrementRecoveredOperations(operations.size());
-        indexShard().sync();
-        // roll over / flush / trim if needed
-        indexShard().afterWriteOperation();
-        return indexShard().getLocalCheckpoint();
+            /*
+             * The maxSeenAutoIdTimestampOnPrimary received from the primary is at least the highest auto_id_timestamp from any operation
+             * will be replayed. Bootstrapping this timestamp here will disable the optimization for original append-only requests
+             * (source of these operations) replicated via replication. Without this step, we may have duplicate documents if we
+             * replay these operations first (without timestamp), then optimize append-only requests (with timestamp).
+             */
+            indexShard().updateMaxUnsafeAutoIdTimestamp(maxSeenAutoIdTimestampOnPrimary);
+            /*
+             * Bootstrap the max_seq_no_of_updates from the primary to make sure that the max_seq_no_of_updates on this replica when
+             * replaying any of these operations will be at least the max_seq_no_of_updates on the primary when that op was executed on.
+             */
+            indexShard().advanceMaxSeqNoOfUpdatesOrDeletes(maxSeqNoOfDeletesOrUpdatesOnPrimary);
+            for (Translog.Operation operation : operations) {
+                Engine.Result result = indexShard().applyTranslogOperation(operation, Engine.Operation.Origin.PEER_RECOVERY);
+                if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
+                    throw new MapperException("mapping updates are not allowed [" + operation + "]");
+                }
+                assert result.getFailure() == null : "unexpected failure while replicating translog entry: " + result.getFailure();
+                ExceptionsHelper.reThrowIfNotNull(result.getFailure());
+            }
+            // update stats only after all operations completed (to ensure that mapping updates don't mess with stats)
+            translog.incrementRecoveredOperations(operations.size());
+            indexShard().sync();
+            // roll over / flush / trim if needed
+            indexShard().afterWriteOperation();
+            return indexShard().getLocalCheckpoint();
+        });
     }
+
 
     @Override
     public void receiveFileInfo(List<String> phase1FileNames,

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -371,12 +371,15 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     }
 
     @Override
-    public void finalizeRecovery(final long globalCheckpoint) throws IOException {
-        final IndexShard indexShard = indexShard();
-        indexShard.updateGlobalCheckpointOnReplica(globalCheckpoint, "finalizing recovery");
-        // Persist the global checkpoint.
-        indexShard.sync();
-        indexShard.finalizeRecovery();
+    public void finalizeRecovery(final long globalCheckpoint, ActionListener<Void> listener) {
+        ActionListener.completeWith(listener, () -> {
+            final IndexShard indexShard = indexShard();
+            indexShard.updateGlobalCheckpointOnReplica(globalCheckpoint, "finalizing recovery");
+            // Persist the global checkpoint.
+            indexShard.sync();
+            indexShard.finalizeRecovery();
+            return null;
+        });
     }
 
     @Override

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -37,7 +37,9 @@ public interface RecoveryTargetHandler {
      * @param fileBasedRecovery whether or not this call is part of an file based recovery
      * @param totalTranslogOps  total translog operations expected to be sent
      */
-    void prepareForTranslogOperations(boolean fileBasedRecovery, int totalTranslogOps) throws IOException;
+    void prepareForTranslogOperations(boolean fileBasedRecovery,
+                                      int totalTranslogOps,
+                                      ActionListener<Void> listener);
 
     /**
      * The finalize request refreshes the engine now that new segments are available, enables garbage collection of tombstone files, and

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -69,10 +69,12 @@ public interface RecoveryTargetHandler {
      * @param maxSeqNoOfUpdatesOrDeletesOnPrimary the max seq_no of update operations (index operations overwrite Lucene) or delete ops on
      *                                            the primary shard when capturing these operations. This value is at least as high as the
      *                                            max_seq_no_of_updates on the primary was when any of these ops were processed on it.
+     * @param listener                            a listener which will be notified with the local checkpoint on the target
+     *                                            after these operations are successfully indexed on the target.
      * @return the local checkpoint on the target shard
      */
-    long indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps,
-                                 long maxSeenAutoIdTimestampOnPrimary, long maxSeqNoOfUpdatesOrDeletesOnPrimary) throws IOException;
+    void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long maxSeenAutoIdTimestampOnPrimary,
+                                 long maxSeqNoOfUpdatesOrDeletesOnPrimary, ActionListener<Long> listener);
 
     /**
      * Notifies the target of the files it is going to receive

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -44,8 +44,9 @@ public interface RecoveryTargetHandler {
      * updates the global checkpoint.
      *
      * @param globalCheckpoint the global checkpoint on the recovery source
+     * @param listener         the listener which will be notified when this method is completed
      */
-    void finalizeRecovery(long globalCheckpoint) throws IOException;
+    void finalizeRecovery(long globalCheckpoint, ActionListener<Void> listener);
 
     /**
      * Blockingly waits for cluster state with at least clusterStateVersion to be available

--- a/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
 import org.elasticsearch.transport.TransportFuture;
 import org.elasticsearch.transport.TransportRequestOptions;
@@ -87,11 +88,17 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     }
 
     @Override
-    public void finalizeRecovery(final long globalCheckpoint) {
-        transportService.submitRequest(targetNode, PeerRecoveryTargetService.Actions.FINALIZE,
+    public void finalizeRecovery(final long globalCheckpoint, final ActionListener<Void> listener) {
+        transportService.submitRequest(
+            targetNode,
+            PeerRecoveryTargetService.Actions.FINALIZE,
             new RecoveryFinalizeRecoveryRequest(recoveryId, shardId, globalCheckpoint),
             TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionLongTimeout()).build(),
-            EmptyTransportResponseHandler.INSTANCE_SAME).txGet();
+            new ActionListenerResponseHandler<>(
+                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure),
+                in -> TransportResponse.Empty.INSTANCE, ThreadPool.Names.GENERIC
+            )
+        );
     }
 
     @Override

--- a/es/es-server/src/test/java/org/elasticsearch/action/StepListenerTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/action/StepListenerTests.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StepListenerTests extends ESTestCase {
+    private ThreadPool threadPool;
+
+    @Before
+    public void setUpThreadPool() {
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void tearDownThreadPool() {
+        terminate(threadPool);
+    }
+
+    public void testSimpleSteps() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Consumer<Exception> onFailure = e -> {
+            latch.countDown();
+            fail("test a happy path");
+        };
+
+        StepListener<String> step1 = new StepListener<>(); //[a]sync provide a string
+        executeAction(() -> step1.onResponse("hello"));
+        StepListener<Integer> step2 = new StepListener<>(); //[a]sync calculate the length of the string
+        step1.whenComplete(str -> executeAction(() -> step2.onResponse(str.length())), onFailure);
+        step2.whenComplete(length -> executeAction(latch::countDown), onFailure);
+        latch.await();
+        assertThat(step1.result(), equalTo("hello"));
+        assertThat(step2.result(), equalTo(5));
+    }
+
+    public void testAbortOnFailure() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        int failedStep = randomBoolean() ? 1 : 2;
+        AtomicInteger failureNotified = new AtomicInteger();
+        Consumer<Exception> onFailure = e -> {
+            failureNotified.getAndIncrement();
+            latch.countDown();
+            assertThat(e.getMessage(), equalTo("failed at step " + failedStep));
+        };
+
+        StepListener<String> step1 = new StepListener<>(); //[a]sync provide a string
+        if (failedStep == 1) {
+            executeAction(() -> step1.onFailure(new RuntimeException("failed at step 1")));
+        } else {
+            executeAction(() -> step1.onResponse("hello"));
+        }
+
+        StepListener<Integer> step2 = new StepListener<>(); //[a]sync calculate the length of the string
+        step1.whenComplete(str -> {
+            if (failedStep == 2) {
+                executeAction(() -> step2.onFailure(new RuntimeException("failed at step 2")));
+            } else {
+                executeAction(() -> step2.onResponse(str.length()));
+            }
+        }, onFailure);
+
+        step2.whenComplete(length -> latch.countDown(), onFailure);
+        latch.await();
+        assertThat(failureNotified.get(), equalTo(1));
+
+        if (failedStep == 1) {
+            assertThat(expectThrows(RuntimeException.class, step1::result).getMessage(),
+                       equalTo("failed at step 1"));
+            assertThat(expectThrows(RuntimeException.class, step2::result).getMessage(),
+                       equalTo("step is not completed yet"));
+        } else {
+            assertThat(step1.result(), equalTo("hello"));
+            assertThat(expectThrows(RuntimeException.class, step2::result).getMessage(),
+                       equalTo("failed at step 2"));
+        }
+    }
+
+    private void executeAction(Runnable runnable) {
+        if (randomBoolean()) {
+            threadPool.generic().execute(runnable);
+        } else {
+            runnable.run();
+        }
+    }
+}

--- a/es/es-testing/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -66,6 +67,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
+import org.elasticsearch.indices.recovery.RecoveryResponse;
 import org.elasticsearch.indices.recovery.RecoverySourceHandler;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
@@ -657,7 +659,9 @@ public abstract class IndexShardTestCase extends ESTestCase {
             inSyncIds,
             routingTable
         );
-        recovery.recoverToTarget();
+        PlainActionFuture<RecoveryResponse> future = new PlainActionFuture<>();
+        recovery.recoverToTarget(future);
+        future.actionGet();
         recoveryTarget.markAsDone();
     }
 

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -732,7 +732,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
 
         @Override
-        public void finalizeRecovery(long globalCheckpoint) {
+        public void finalizeRecovery(long globalCheckpoint, ActionListener<Void> listener) {
         }
 
         @Override

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -87,6 +87,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -707,6 +708,47 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         // we have to use assert busy as we may be interrupted while acquiring the permit, if so we want to check
         // that the permit is released.
         assertBusy(() -> assertTrue(freed.get()));
+    }
+
+    @Test
+    public void testVerifySeqNoStatsWhenRecoverWithSyncId() throws Exception {
+        IndexShard shard = mock(IndexShard.class);
+        when(shard.state()).thenReturn(IndexShardState.STARTED);
+        RecoverySourceHandler handler = new RecoverySourceHandler(
+            shard, new TestRecoveryTargetHandler(), getStartRecoveryRequest(), between(1, 16), between(1, 4));
+
+        String syncId = UUIDs.randomBase64UUID();
+        int numDocs = between(0, 1000);
+        long localCheckpoint = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
+        long maxSeqNo = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
+        assertTrue(handler.canSkipPhase1(
+            newMetadataSnapshot(syncId, Long.toString(localCheckpoint), Long.toString(maxSeqNo), numDocs),
+            newMetadataSnapshot(syncId, Long.toString(localCheckpoint), Long.toString(maxSeqNo), numDocs)));
+
+        AssertionError error = expectThrows(AssertionError.class, () -> {
+            long localCheckpointOnTarget = randomValueOtherThan(
+                localCheckpoint,
+                () -> randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE));
+            long maxSeqNoOnTarget = randomValueOtherThan(
+                maxSeqNo,
+                () -> randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE));
+            handler.canSkipPhase1(
+                newMetadataSnapshot(syncId, Long.toString(localCheckpoint), Long.toString(maxSeqNo), numDocs),
+                newMetadataSnapshot(syncId, Long.toString(localCheckpointOnTarget), Long.toString(maxSeqNoOnTarget), numDocs));
+        });
+        assertThat(error.getMessage(), containsString("try to recover [index][1] with sync id but seq_no stats are mismatched:"));
+    }
+
+    private Store.MetadataSnapshot newMetadataSnapshot(String syncId, String localCheckpoint, String maxSeqNo, int numDocs) {
+        HashMap<String, String> userData = new HashMap<>();
+        userData.put(Engine.SYNC_COMMIT_ID, syncId);
+        if (localCheckpoint != null) {
+            userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, localCheckpoint);
+        }
+        if (maxSeqNo != null) {
+            userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, maxSeqNo);
+        }
+        return new Store.MetadataSnapshot(Collections.emptyMap(), userData, numDocs);
     }
 
     private Store newStore(Path path) throws IOException {

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -75,6 +75,10 @@ import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -120,6 +124,18 @@ public class RecoverySourceHandlerTests extends ESTestCase {
     );
     private final ShardId shardId = new ShardId(INDEX_SETTINGS.getIndex(), 1);
     private final ClusterSettings service = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setUpThreadPool() {
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void tearDownThreadPool() {
+        terminate(threadPool);
+    }
 
     @Test
     public void testSendFiles() throws Throwable {
@@ -214,18 +230,17 @@ public class RecoverySourceHandlerTests extends ESTestCase {
 
     @Test
     public void testSendSnapshotSendsOps() throws IOException {
-        final RecoverySettings recoverySettings = new RecoverySettings(Settings.EMPTY, service);
-        final int fileChunkSizeInBytes = recoverySettings.getChunkSize().bytesAsInt();
+        final int fileChunkSizeInBytes = between(1, 4096);
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.state()).thenReturn(IndexShardState.STARTED);
         final List<Translog.Operation> operations = new ArrayList<>();
-        final int initialNumberOfDocs = randomIntBetween(16, 64);
+        final int initialNumberOfDocs = randomIntBetween(10, 1000);
         for (int i = 0; i < initialNumberOfDocs; i++) {
             final Engine.Index index = getIndex(Integer.toString(i));
             operations.add(new Translog.Index(index, new Engine.IndexResult(1, 1, SequenceNumbers.UNASSIGNED_SEQ_NO, true)));
         }
-        final int numberOfDocsWithValidSequenceNumbers = randomIntBetween(16, 64);
+        final int numberOfDocsWithValidSequenceNumbers = randomIntBetween(10, 1000);
         for (int i = initialNumberOfDocs; i < initialNumberOfDocs + numberOfDocsWithValidSequenceNumbers; i++) {
             final Engine.Index index = getIndex(Integer.toString(i));
             operations.add(new Translog.Index(index, new Engine.IndexResult(1, 1, i - initialNumberOfDocs, true)));
@@ -235,12 +250,17 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo - 1, numberOfDocsWithValidSequenceNumbers - 1);
 
         final List<Translog.Operation> shippedOps = new ArrayList<>();
+        final AtomicLong checkpointOnTarget = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         RecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
             @Override
-            public void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long timestamp, long msu,
+            public void indexTranslogOperations(List<Translog.Operation> operations,
+                                                int totalTranslogOps,
+                                                long timestamp,
+                                                long msu,
                                                 ActionListener<Long> listener) {
                 shippedOps.addAll(operations);
-                listener.onResponse(SequenceNumbers.NO_OPS_PERFORMED);
+                checkpointOnTarget.set(randomLongBetween(checkpointOnTarget.get(), Long.MAX_VALUE));
+                maybeExecuteAsync(() -> listener.onResponse(checkpointOnTarget.get()));
             }
         };
         RecoverySourceHandler handler = new RecoverySourceHandler(shard, recoveryTarget, request, fileChunkSizeInBytes, between(1, 10));
@@ -255,6 +275,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         for (int i = 0; i < shippedOps.size(); i++) {
             assertThat(shippedOps.get(i), equalTo(operations.get(i + (int) startingSeqNo + initialNumberOfDocs)));
         }
+        assertThat(result.targetLocalCheckpoint, equalTo(checkpointOnTarget.get()));
         if (endingSeqNo >= requiredStartingSeqNo + 1) {
             // check that missing ops blows up
             List<Translog.Operation> requiredOps = operations.subList(0, operations.size() - 1).stream() // remove last null marker
@@ -266,6 +287,41 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                                randomNonNegativeLong(), randomNonNegativeLong(), failedFuture);
                 failedFuture.actionGet();
             });
+        }
+    }
+
+    @Test
+    public void testSendSnapshotStopOnError() throws Exception {
+        final int fileChunkSizeInBytes = between(1, 10 * 1024);
+        final StartRecoveryRequest request = getStartRecoveryRequest();
+        final IndexShard shard = mock(IndexShard.class);
+        when(shard.state()).thenReturn(IndexShardState.STARTED);
+        final List<Translog.Operation> ops = new ArrayList<>();
+        for (int numOps = between(1, 256), i = 0; i < numOps; i++) {
+            final Engine.Index index = getIndex(Integer.toString(i));
+            ops.add(new Translog.Index(index, new Engine.IndexResult(1, 1, i, true)));
+        }
+        final AtomicBoolean wasFailed = new AtomicBoolean();
+        RecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
+            @Override
+            public void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long timestamp,
+                                                long msu, ActionListener<Long> listener) {
+                if (randomBoolean()) {
+                    maybeExecuteAsync(() -> listener.onResponse(SequenceNumbers.NO_OPS_PERFORMED));
+                } else {
+                    maybeExecuteAsync(() -> listener.onFailure(new RuntimeException("test - failed to index")));
+                    wasFailed.set(true);
+                }
+            }
+        };
+        RecoverySourceHandler handler = new RecoverySourceHandler(shard, recoveryTarget, request, fileChunkSizeInBytes, between(1, 10));
+        PlainActionFuture<RecoverySourceHandler.SendSnapshotResult> future = new PlainActionFuture<>();
+        final long startingSeqNo = randomLongBetween(0, ops.size() - 1L);
+        final long endingSeqNo = randomLongBetween(startingSeqNo, ops.size() - 1L);
+        handler.phase2(startingSeqNo, startingSeqNo, endingSeqNo, newTranslogSnapshot(ops, Collections.emptyList()),
+                       randomNonNegativeLong(), randomNonNegativeLong(), future);
+        if (wasFailed.get()) {
+            assertThat(expectThrows(RuntimeException.class, future::actionGet).getMessage(), equalTo("test - failed to index"));
         }
     }
 
@@ -694,6 +750,14 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             files.add(md);
         }
         return files;
+    }
+
+    private void maybeExecuteAsync(Runnable runnable) {
+        if (randomBoolean()) {
+            threadPool.generic().execute(runnable);
+        } else {
+            runnable.run();
+        }
     }
 
     class TestRecoveryTargetHandler implements RecoveryTargetHandler {

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -76,7 +76,6 @@ import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -110,7 +109,6 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RecoverySourceHandlerTests extends ESTestCase {
@@ -221,9 +219,6 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.state()).thenReturn(IndexShardState.STARTED);
-        final RecoveryTargetHandler recoveryTarget = mock(RecoveryTargetHandler.class);
-        final RecoverySourceHandler handler =
-            new RecoverySourceHandler(shard, recoveryTarget, request, fileChunkSizeInBytes, between(1, 10));
         final List<Translog.Operation> operations = new ArrayList<>();
         final int initialNumberOfDocs = randomIntBetween(16, 64);
         for (int i = 0; i < initialNumberOfDocs; i++) {
@@ -235,40 +230,26 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             final Engine.Index index = getIndex(Integer.toString(i));
             operations.add(new Translog.Index(index, new Engine.IndexResult(1, 1, i - initialNumberOfDocs, true)));
         }
-        operations.add(null);
         final long startingSeqNo = randomIntBetween(0, numberOfDocsWithValidSequenceNumbers - 1);
         final long requiredStartingSeqNo = randomIntBetween((int) startingSeqNo, numberOfDocsWithValidSequenceNumbers - 1);
         final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo - 1, numberOfDocsWithValidSequenceNumbers - 1);
-        RecoverySourceHandler.SendSnapshotResult result = handler.phase2(
-            startingSeqNo, requiredStartingSeqNo, endingSeqNo, new Translog.Snapshot() {
 
-                @Override
-                public void close() {
-
-                }
-
-                private int counter = 0;
-
-                @Override
-                public int totalOperations() {
-                    return operations.size() - 1;
-                }
-
-                @Override
-                public Translog.Operation next() throws IOException {
-                    return operations.get(counter++);
-                }
-            }, randomNonNegativeLong(), randomNonNegativeLong());
+        final List<Translog.Operation> shippedOps = new ArrayList<>();
+        RecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
+            @Override
+            public void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long timestamp, long msu,
+                                                ActionListener<Long> listener) {
+                shippedOps.addAll(operations);
+                listener.onResponse(SequenceNumbers.NO_OPS_PERFORMED);
+            }
+        };
+        RecoverySourceHandler handler = new RecoverySourceHandler(shard, recoveryTarget, request, fileChunkSizeInBytes, between(1, 10));
+        PlainActionFuture<RecoverySourceHandler.SendSnapshotResult> future = new PlainActionFuture<>();
+        handler.phase2(startingSeqNo, requiredStartingSeqNo, endingSeqNo, newTranslogSnapshot(operations, Collections.emptyList()),
+                       randomNonNegativeLong(), randomNonNegativeLong(), future);
         final int expectedOps = (int) (endingSeqNo - startingSeqNo + 1);
+        RecoverySourceHandler.SendSnapshotResult result = future.actionGet();
         assertThat(result.totalOperations, equalTo(expectedOps));
-        final ArgumentCaptor<List> shippedOpsCaptor = ArgumentCaptor.forClass(List.class);
-        verify(recoveryTarget).indexTranslogOperations(
-            shippedOpsCaptor.capture(), ArgumentCaptor.forClass(Integer.class).capture(),
-            ArgumentCaptor.forClass(Long.class).capture(), ArgumentCaptor.forClass(Long.class).capture());
-        List<Translog.Operation> shippedOps = new ArrayList<>();
-        for (List list : shippedOpsCaptor.getAllValues()) {
-            shippedOps.addAll(list);
-        }
         shippedOps.sort(Comparator.comparing(Translog.Operation::seqNo));
         assertThat(shippedOps.size(), equalTo(expectedOps));
         for (int i = 0; i < shippedOps.size(); i++) {
@@ -279,29 +260,12 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             List<Translog.Operation> requiredOps = operations.subList(0, operations.size() - 1).stream() // remove last null marker
                 .filter(o -> o.seqNo() >= requiredStartingSeqNo && o.seqNo() <= endingSeqNo).collect(Collectors.toList());
             List<Translog.Operation> opsToSkip = randomSubsetOf(randomIntBetween(1, requiredOps.size()), requiredOps);
-            expectThrows(IllegalStateException.class, () ->
-                handler.phase2(startingSeqNo, requiredStartingSeqNo, endingSeqNo, new Translog.Snapshot() {
-                        @Override
-                        public void close() {
-
-                        }
-
-                        private int counter = 0;
-
-                        @Override
-                        public int totalOperations() {
-                            return operations.size() - 1 - opsToSkip.size();
-                        }
-
-                        @Override
-                        public Translog.Operation next() {
-                            Translog.Operation op;
-                            do {
-                                op = operations.get(counter++);
-                            } while (op != null && opsToSkip.contains(op));
-                            return op;
-                        }
-                    }, randomNonNegativeLong(), randomNonNegativeLong()));
+            PlainActionFuture<RecoverySourceHandler.SendSnapshotResult> failedFuture = new PlainActionFuture<>();
+            expectThrows(IllegalStateException.class, () -> {
+                handler.phase2(startingSeqNo, requiredStartingSeqNo, endingSeqNo, newTranslogSnapshot(operations, opsToSkip),
+                               randomNonNegativeLong(), randomNonNegativeLong(), failedFuture);
+                failedFuture.actionGet();
+            });
         }
     }
 
@@ -514,17 +478,24 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             }
 
             @Override
-            SendSnapshotResult phase2(long startingSeqNo,
-                                      long requiredSeqNoRangeStart,
-                                      long endingSeqNo,
-                                      Translog.Snapshot snapshot,
-                                      long maxSeenAutoIdTimestamp,
-                                      long maxSeqNoOfUpdatesOrDeletes) throws IOException {
+            void phase2(long startingSeqNo,
+                        long requiredSeqNoRangeStart,
+                        long endingSeqNo,
+                        Translog.Snapshot snapshot,
+                        long maxSeenAutoIdTimestamp,
+                        long maxSeqNoOfUpdatesOrDeletes,
+                        ActionListener<SendSnapshotResult> listener) throws IOException {
                 phase2Called.set(true);
-                return super.phase2(
-                    startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, snapshot,
-                    maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes);
+                super.phase2(
+                    startingSeqNo,
+                    requiredSeqNoRangeStart,
+                    endingSeqNo,
+                    snapshot,
+                    maxSeenAutoIdTimestamp,
+                    maxSeqNoOfUpdatesOrDeletes,
+                    listener);
             }
+
         };
         PlainActionFuture<RecoveryResponse> future = new PlainActionFuture<>();
         expectThrows(IndexShardRelocatedException.class, () -> {
@@ -744,11 +715,11 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
 
         @Override
-        public long indexTranslogOperations(List<Translog.Operation> operations,
+        public void indexTranslogOperations(List<Translog.Operation> operations,
                                             int totalTranslogOps,
                                             long timestamp,
-                                            long msu) {
-            return 0;
+                                            long msu,
+                                            ActionListener<Long> listener) {
         }
 
         @Override
@@ -771,5 +742,41 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                                    int totalTranslogOps,
                                    ActionListener<Void> listener) {
         }
+    }
+
+    private Translog.Snapshot newTranslogSnapshot(List<Translog.Operation> operations,
+                                                  List<Translog.Operation> operationsToSkip) {
+        return new Translog.Snapshot() {
+            int index = 0;
+            int skippedCount = 0;
+
+            @Override
+            public int totalOperations() {
+                return operations.size();
+            }
+
+            @Override
+            public int skippedOperations() {
+                return skippedCount;
+            }
+
+            @Override
+            public Translog.Operation next() {
+                while (index < operations.size()) {
+                    Translog.Operation op = operations.get(index++);
+                    if (operationsToSkip.contains(op)) {
+                        skippedCount++;
+                    } else {
+                        return op;
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public void close() {
+
+            }
+        };
     }
 }

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -527,10 +527,11 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             }
 
             @Override
-            TimeValue prepareTargetForTranslog(final boolean fileBasedRecovery,
-                                               final int totalTranslogOps) throws IOException {
+            void prepareTargetForTranslog(boolean fileBasedRecovery,
+                                          int totalTranslogOps,
+                                          ActionListener<TimeValue> listener) {
                 prepareTargetForTranslogCalled.set(true);
-                return super.prepareTargetForTranslog(fileBasedRecovery, totalTranslogOps);
+                super.prepareTargetForTranslog(fileBasedRecovery, totalTranslogOps, listener);
             }
 
             @Override
@@ -763,7 +764,9 @@ public class RecoverySourceHandlerTests extends ESTestCase {
     class TestRecoveryTargetHandler implements RecoveryTargetHandler {
 
         @Override
-        public void prepareForTranslogOperations(boolean fileBasedRecovery, int totalTranslogOps) {
+        public void prepareForTranslogOperations(boolean fileBasedRecovery,
+                                                 int totalTranslogOps,
+                                                 ActionListener<Void> listener) {
         }
 
         @Override

--- a/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -37,6 +37,7 @@ import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Numbers;
@@ -525,7 +526,11 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                     maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes);
             }
         };
-        expectThrows(IndexShardRelocatedException.class, handler::recoverToTarget);
+        PlainActionFuture<RecoveryResponse> future = new PlainActionFuture<>();
+        expectThrows(IndexShardRelocatedException.class, () -> {
+            handler.recoverToTarget(future);
+            future.actionGet();
+        });
         assertFalse(phase1Called.get());
         assertFalse(prepareTargetForTranslogCalled.get());
         assertFalse(phase2Called.get());

--- a/es/es-testing/src/test/java/org/elasticsearch/common/util/CancellableThreadsTests.java
+++ b/es/es-testing/src/test/java/org/elasticsearch/common/util/CancellableThreadsTests.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.common.util.CancellableThreads.IOInterruptable;
+import org.elasticsearch.common.util.CancellableThreads.Interruptable;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.common.util.CancellableThreads.ExecutionCancelledException;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CancellableThreadsTests extends ESTestCase {
+
+    public static class CustomException extends RuntimeException {
+        CustomException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class IOCustomException extends IOException {
+        IOCustomException(String msg) {
+            super(msg);
+        }
+    }
+
+    private static class ThrowOnCancelException extends RuntimeException {
+    }
+
+    private class TestPlan {
+        public final int id;
+        final boolean busySpin;
+        final boolean exceptBeforeCancel;
+        final boolean exitBeforeCancel;
+        final boolean exceptAfterCancel;
+        final boolean presetInterrupt;
+        final boolean ioOp;
+        private final boolean ioException;
+
+        private TestPlan(int id) {
+            this.id = id;
+            this.busySpin = randomBoolean();
+            this.exceptBeforeCancel = randomBoolean();
+            this.exitBeforeCancel = randomBoolean();
+            this.exceptAfterCancel = randomBoolean();
+            this.presetInterrupt = randomBoolean();
+            this.ioOp = randomBoolean();
+            this.ioException = ioOp && randomBoolean();
+        }
+    }
+
+    static class TestRunnable implements Interruptable {
+        final TestPlan plan;
+        final CountDownLatch readyForCancel;
+
+        TestRunnable(TestPlan plan, CountDownLatch readyForCancel) {
+            this.plan = plan;
+            this.readyForCancel = readyForCancel;
+        }
+
+        @Override
+        public void run() throws InterruptedException {
+            assertFalse("interrupt thread should have been clear", Thread.currentThread().isInterrupted());
+            if (plan.exceptBeforeCancel) {
+                throw new CustomException("thread [" + plan.id + "] pre-cancel exception");
+            } else if (plan.exitBeforeCancel) {
+                return;
+            }
+            readyForCancel.countDown();
+            try {
+                if (plan.busySpin) {
+                    while (!Thread.currentThread().isInterrupted()) {
+                    }
+                } else {
+                    Thread.sleep(50000);
+                }
+            } finally {
+                if (plan.exceptAfterCancel) {
+                    throw new CustomException("thread [" + plan.id + "] post-cancel exception");
+                }
+            }
+        }
+    }
+
+    static class TestIORunnable implements IOInterruptable {
+        final TestPlan plan;
+        final CountDownLatch readyForCancel;
+
+        TestIORunnable(TestPlan plan, CountDownLatch readyForCancel) {
+            this.plan = plan;
+            this.readyForCancel = readyForCancel;
+        }
+
+        @Override
+        public void run() throws IOException, InterruptedException {
+            assertFalse("interrupt thread should have been clear", Thread.currentThread().isInterrupted());
+            if (plan.exceptBeforeCancel) {
+                throw new IOCustomException("thread [" + plan.id + "] pre-cancel exception");
+            } else if (plan.exitBeforeCancel) {
+                return;
+            }
+            readyForCancel.countDown();
+            try {
+                if (plan.busySpin) {
+                    while (!Thread.currentThread().isInterrupted()) {
+                    }
+                } else {
+                    Thread.sleep(50000);
+                }
+            } finally {
+                if (plan.exceptAfterCancel) {
+                    throw new IOCustomException("thread [" + plan.id + "] post-cancel exception");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCancellableThreads() throws InterruptedException {
+        Thread[] threads = new Thread[randomIntBetween(3, 10)];
+        final TestPlan[] plans = new TestPlan[threads.length];
+        final Exception[] exceptions = new Exception[threads.length];
+        final boolean[] interrupted = new boolean[threads.length];
+        final CancellableThreads cancellableThreads = new CancellableThreads();
+        final CountDownLatch readyForCancel = new CountDownLatch(threads.length);
+        for (int i = 0; i < threads.length; i++) {
+            final TestPlan plan = new TestPlan(i);
+            plans[i] = plan;
+            threads[i] = new Thread(() -> {
+                try {
+                    if (plan.presetInterrupt) {
+                        Thread.currentThread().interrupt();
+                    }
+                    if (plan.ioOp) {
+                        if (plan.ioException) {
+                            cancellableThreads.executeIO(new TestIORunnable(plan, readyForCancel));
+                        } else {
+                            cancellableThreads.executeIO(new TestRunnable(plan, readyForCancel));
+                        }
+                    } else {
+                        cancellableThreads.execute(new TestRunnable(plan, readyForCancel));
+                    }
+                } catch (Exception e) {
+                    exceptions[plan.id] = e;
+                }
+                if (plan.exceptBeforeCancel || plan.exitBeforeCancel) {
+                    // we have to mark we're ready now (actually done).
+                    readyForCancel.countDown();
+                }
+                interrupted[plan.id] = Thread.currentThread().isInterrupted();
+            });
+            threads[i].setDaemon(true);
+            threads[i].start();
+        }
+
+        readyForCancel.await();
+        final boolean throwInOnCancel = randomBoolean();
+        final AtomicInteger invokeTimes = new AtomicInteger();
+        cancellableThreads.setOnCancel((reason, beforeCancelException) -> {
+            invokeTimes.getAndIncrement();
+            if (throwInOnCancel) {
+                ThrowOnCancelException e = new ThrowOnCancelException();
+                if (beforeCancelException != null) {
+                    e.addSuppressed(beforeCancelException);
+                }
+                throw e;
+            }
+        });
+
+        cancellableThreads.cancel("test");
+        for (Thread thread : threads) {
+            thread.join(20000);
+            assertFalse(thread.isAlive());
+        }
+        for (int i = 0; i < threads.length; i++) {
+            TestPlan plan = plans[i];
+            final Class<?> exceptionClass = plan.ioException ? IOCustomException.class : CustomException.class;
+            if (plan.exceptBeforeCancel) {
+                assertThat(exceptions[i], Matchers.instanceOf(exceptionClass));
+            } else if (plan.exitBeforeCancel) {
+                assertNull(exceptions[i]);
+            } else {
+                // in all other cases, we expect a cancellation exception.
+                if (throwInOnCancel) {
+                    assertThat(exceptions[i], Matchers.instanceOf(ThrowOnCancelException.class));
+                } else {
+                    assertThat(exceptions[i], Matchers.instanceOf(ExecutionCancelledException.class));
+                }
+                if (plan.exceptAfterCancel) {
+                    assertThat(exceptions[i].getSuppressed(),
+                               Matchers.arrayContaining(
+                                   Matchers.instanceOf(exceptionClass)
+                               ));
+                } else {
+                    assertThat(exceptions[i].getSuppressed(), Matchers.emptyArray());
+                }
+            }
+            assertThat(interrupted[plan.id], equalTo(plan.presetInterrupt));
+        }
+        assertThat(
+            invokeTimes.longValue(),
+            equalTo(
+                Arrays.stream(plans)
+                    .filter(p -> p.exceptBeforeCancel == false && p.exitBeforeCancel == false)
+                    .count())
+        );
+        if (throwInOnCancel) {
+            expectThrows(ThrowOnCancelException.class, cancellableThreads::checkForCancel);
+        } else {
+            expectThrows(ExecutionCancelledException.class, cancellableThreads::checkForCancel);
+        }
+        assertThat(
+            invokeTimes.longValue(),
+            equalTo(
+                Arrays.stream(plans)
+                    .filter(p -> p.exceptBeforeCancel == false && p.exitBeforeCancel == false)
+                    .count() + 1)
+        );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backports of the recovery process enhancements and bug fix (https://github.com/crate/crate/commit/330629d9ff7997f406618fad853cf4cd07f3317f)

Some of the backports (https://github.com/crate/crate/commit/22ab7981a23a6c7bed71d9302dbd6711f3cd734d, https://github.com/crate/crate/commit/8e2a0d507e23048d8611601e762dc9b7010d51c9) are related to https://github.com/elastic/elasticsearch/issues/36195. The rest are preparation for the next backports related to the same issue. 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
