### PR TITLE
Exclude `node.store.allow_mmap` from table/partition defaults.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/TableParameters.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameters.java
@@ -110,7 +110,8 @@ public class TableParameters {
      */
     static final Set<Setting> SETTINGS_NOT_INCLUDED_IN_DEFAULT = Set.of(
         IndexMetaData.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,
-        IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING
+        IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING,
+        IndexModule.NODE_STORE_ALLOW_MMAP
     );
 
     private static final Map<String, Setting<?>> SUPPORTED_SETTINGS_DEFAULT


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/pull/9125

Fixes the `node.store.allow_mmap` bwc setting issue 4.0 -> 4.1
 
## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
