### PR TITLE
Remove assertion about nodes in a request in AsyncAction

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -152,8 +152,6 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             this.task = task;
             this.request = request;
             this.listener = listener;
-            assert request.concreteNodes() != null : "concreteNodes on NodesRequest must not be null";
-            assert request.concreteNodes().length > 0 : "concreteNodes on NodesRequest must not be empty";
             this.responses = new AtomicReferenceArray<>(request.concreteNodes().length);
         }
 


### PR DESCRIPTION
NodeRequests with no nodes will result now in a noop.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
