### PR TITLE
Fix regression in reroute logic when a node passes disk watermarks.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -160,6 +160,10 @@ Changes
 Fixes
 =====
 
+- Fixed regression that prevented shards from reallocation when a node passes
+  over :ref:`cluster.routing.allocation.disk.watermark.high
+  <cluster.routing.allocation.disk.watermark.high>`.
+
 - Removed a case where a ``NullPointerException`` was logged if a HTTP client
   disconnected before a pending response could be sent to the client.
 

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -373,10 +373,10 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
         }
     }
 
-    static void fillDiskUsagePerNode(Logger logger,
-                                     List<NodeStats> nodeStatsArray,
-                                     ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvaiableUsages,
-                                     ImmutableOpenMap.Builder<String, DiskUsage> newMostAvaiableUsages) {
+    private static void fillDiskUsagePerNode(Logger logger,
+                                             List<NodeStats> nodeStatsArray,
+                                             ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvaiableUsages,
+                                             ImmutableOpenMap.Builder<String, DiskUsage> newMostAvaiableUsages) {
         boolean traceEnabled = logger.isTraceEnabled();
         for (NodeStats nodeStats : nodeStatsArray) {
             if (nodeStats.getFs() == null) {
@@ -396,30 +396,45 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
                 }
                 String nodeId = nodeStats.getNode().getId();
                 String nodeName = nodeStats.getNode().getName();
-                var leastAvailableTotals = leastAvailablePath.getTotal();
-                var mostAvailableTotals = mostAvailablePath.getTotal();
                 if (traceEnabled) {
-                    logger.trace("node: [{}], most available: total disk: {}, available disk: {} / least available: total disk: {}, available disk: {}",
-                            nodeId, mostAvailableTotals, leastAvailablePath.getAvailable(),
-                                 leastAvailableTotals, leastAvailablePath.getAvailable());
+                    logger.trace(
+                        "node: [{}], most available: total disk: {}, available disk: {} / least available: total disk: {}, available disk: {}",
+                        nodeId,
+                        mostAvailablePath.getTotal(),
+                        leastAvailablePath.getAvailable(),
+                        leastAvailablePath.getTotal(),
+                        leastAvailablePath.getAvailable());
                 }
-                var leastAvailableTotalBytes = leastAvailableTotals.getBytes();
-                var mostAvailableTotalBytes = mostAvailableTotals.getBytes();
-                if (leastAvailableTotalBytes < 0) {
+                if (leastAvailablePath.getTotal().getBytes() < 0) {
                     if (traceEnabled) {
-                        logger.trace("node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
-                                nodeId, leastAvailableTotalBytes);
+                        logger.trace(
+                            "node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
+                            nodeId, leastAvailablePath.getTotal().getBytes());
                     }
                 } else {
-                    newLeastAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, leastAvailablePath.getPath(), leastAvailableTotalBytes, leastAvailableTotalBytes));
+                    newLeastAvaiableUsages.put(
+                        nodeId, new DiskUsage(
+                            nodeId,
+                            nodeName,
+                            leastAvailablePath.getPath(),
+                            leastAvailablePath.getTotal().getBytes(),
+                            leastAvailablePath.getAvailable().getBytes()));
                 }
-                if (mostAvailableTotalBytes < 0) {
+                if (mostAvailablePath.getTotal().getBytes() < 0) {
                     if (traceEnabled) {
-                        logger.trace("node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
-                                nodeId, mostAvailableTotalBytes);
+                        logger.trace(
+                            "node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
+                            nodeId, mostAvailablePath.getTotal().getBytes());
                     }
                 } else {
-                    newMostAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, mostAvailablePath.getPath(), mostAvailableTotalBytes, mostAvailableTotalBytes));
+                    newMostAvaiableUsages.put(
+                        nodeId,
+                        new DiskUsage(
+                            nodeId,
+                            nodeName,
+                            mostAvailablePath.getPath(),
+                            mostAvailablePath.getTotal().getBytes(),
+                            mostAvailablePath.getAvailable().getBytes()));
                 }
             }
         }

--- a/es/es-testing/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -18,19 +18,30 @@
  */
 package org.elasticsearch.cluster;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Consumer;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 
 /**
  * Fake ClusterInfoService class that allows updating the nodes stats disk
@@ -38,13 +49,66 @@ import java.util.function.Consumer;
  */
 public class MockInternalClusterInfoService extends InternalClusterInfoService {
 
-    /** This is a marker plugin used to trigger MockNode to use this mock info service. */
+    /**
+     * This is a marker plugin used to trigger MockNode to use this mock info service.
+     */
     public static class TestPlugin extends Plugin {}
 
+    private final ClusterName clusterName;
+    private volatile NodeStats[] stats = new NodeStats[3];
 
-    public MockInternalClusterInfoService(Settings settings, ClusterService clusterService, ThreadPool threadPool, NodeClient client,
+    /**
+     * Create a fake NodeStats for the given node and usage
+     */
+    private static NodeStats makeStats(String nodeName, DiskUsage usage) {
+        FsInfo.Path[] paths = new FsInfo.Path[1];
+        FsInfo.Path path = new FsInfo.Path("/dev/null", null,
+                                           usage.getTotalBytes(), usage.getFreeBytes(), usage.getFreeBytes());
+        paths[0] = path;
+        FsInfo fsInfo = new FsInfo(System.currentTimeMillis(), null, paths);
+        return new NodeStats(
+            new DiscoveryNode(
+                nodeName,
+                ESTestCase.buildNewFakeTransportAddress(),
+                emptyMap(),
+                emptySet(),
+                Version.CURRENT),
+            System.currentTimeMillis(),
+            fsInfo);
+    }
+
+    public MockInternalClusterInfoService(Settings settings,
+                                          ClusterService clusterService,
+                                          ThreadPool threadPool,
+                                          NodeClient client,
                                           Consumer<ClusterInfo> listener) {
         super(settings, clusterService, threadPool, client, listener);
+        this.clusterName = ClusterName.CLUSTER_NAME_SETTING.get(settings);
+        stats[0] = makeStats("node_t1", new DiskUsage("node_t1", "n1", "/dev/null", 100, 100));
+        stats[1] = makeStats("node_t2", new DiskUsage("node_t2", "n2", "/dev/null", 100, 100));
+        stats[2] = makeStats("node_t3", new DiskUsage("node_t3", "n3", "/dev/null", 100, 100));
+    }
+
+    public void setN1Usage(String nodeName, DiskUsage newUsage) {
+        stats[0] = makeStats(nodeName, newUsage);
+    }
+
+    public void setN2Usage(String nodeName, DiskUsage newUsage) {
+        stats[1] = makeStats(nodeName, newUsage);
+    }
+
+    public void setN3Usage(String nodeName, DiskUsage newUsage) {
+        stats[2] = makeStats(nodeName, newUsage);
+    }
+
+    @Override
+    public CountDownLatch updateNodeStats(final ActionListener<NodesStatsResponse> listener) {
+        NodesStatsResponse response = new NodesStatsResponse(
+            clusterName,
+            Arrays.asList(stats),
+            Collections.emptyList());
+        listener.onResponse(response);
+        return new CountDownLatch(0);
     }
 
     @Override
@@ -57,15 +121,16 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
     public ClusterInfo getClusterInfo() {
         ClusterInfo clusterInfo = super.getClusterInfo();
         return new DevNullClusterInfo(clusterInfo.getNodeLeastAvailableDiskUsages(),
-                clusterInfo.getNodeMostAvailableDiskUsages(), clusterInfo.shardSizes);
+                                      clusterInfo.getNodeMostAvailableDiskUsages(), clusterInfo.shardSizes);
     }
 
     /**
      * ClusterInfo that always points to DevNull.
      */
     public static class DevNullClusterInfo extends ClusterInfo {
-        public DevNullClusterInfo(ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage, ImmutableOpenMap<String, Long> shardSizes) {
+        DevNullClusterInfo(ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
+                           ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage,
+                           ImmutableOpenMap<String, Long> shardSizes) {
             super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null);
         }
 

--- a/sql/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.MockInternalClusterInfoService;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class DiskUsagesITest extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        // Use the mock internal cluster info service, which has fake-able disk usages
+        plugins.add(MockInternalClusterInfoService.TestPlugin.class);
+        return plugins;
+    }
+
+    public void testRerouteOccursOnDiskPassingHighWatermark() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            // ensure that each node has a single data path
+            internalCluster().startNode(
+                Settings.builder()
+                    .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
+                    .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "1ms"));
+        }
+
+        List<String> nodeIds = StreamSupport.stream(clusterState().getRoutingNodes().spliterator(), false)
+            .map(RoutingNode::nodeId)
+            .collect(toList());
+
+        // Start with all nodes at 50% usage
+        var clusterInfoService = (MockInternalClusterInfoService)
+            internalCluster().getInstance(ClusterInfoService.class, internalCluster().getMasterName());
+        clusterInfoService.setUpdateFrequency(TimeValue.timeValueMillis(200));
+        clusterInfoService.onMaster();
+        clusterInfoService.setN1Usage(nodeIds.get(0), new DiskUsage(nodeIds.get(0), "n1", "/dev/null", 100, 50));
+        clusterInfoService.setN2Usage(nodeIds.get(1), new DiskUsage(nodeIds.get(1), "n2", "/dev/null", 100, 50));
+        clusterInfoService.setN3Usage(nodeIds.get(2), new DiskUsage(nodeIds.get(2), "n3", "/dev/null", 100, 50));
+
+        execute("SET GLOBAL TRANSIENT" +
+                "   cluster.routing.allocation.disk.watermark.low='80%'," +
+                "   cluster.routing.allocation.disk.watermark.high='90%'," +
+                "   cluster.routing.allocation.disk.watermark.flood_stage='100%'");
+
+        // Create a table with 10 shards so we can check allocation for it
+        execute("CREATE TABLE t (id INT PRIMARY KEY) " +
+                "CLUSTERED INTO 10 SHARDS " +
+                "WITH (number_of_replicas = 0)");
+        ensureGreen();
+
+        assertBusy(() -> {
+            HashMap<String, Integer> shardCountByNodeId = getShardCountByNodeId();
+            assertThat("node0 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(0)), greaterThanOrEqualTo(3));
+            assertThat("node1 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(1)), greaterThanOrEqualTo(3));
+            assertThat("node2 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(2)), greaterThanOrEqualTo(3));
+        });
+
+        // move node3 above high watermark
+        clusterInfoService.setN1Usage(nodeIds.get(0), new DiskUsage(nodeIds.get(0), "n1", "_na_", 100, 50));
+        clusterInfoService.setN2Usage(nodeIds.get(1), new DiskUsage(nodeIds.get(1), "n2", "_na_", 100, 50));
+        clusterInfoService.setN3Usage(nodeIds.get(2), new DiskUsage(nodeIds.get(2), "n3", "_na_", 100, 0));
+
+        assertBusy(() -> {
+            HashMap<String, Integer> shardCountByNodeId = getShardCountByNodeId();
+            assertThat("node0 has 5 shards", shardCountByNodeId.get(nodeIds.get(0)), equalTo(5));
+            assertThat("node1 has 5 shards", shardCountByNodeId.get(nodeIds.get(1)), equalTo(5));
+            assertThat("node2 has 0 shards", shardCountByNodeId.get(nodeIds.get(2)), equalTo(0));
+        });
+
+        // move all nodes below watermark again
+        clusterInfoService.setN1Usage(nodeIds.get(0), new DiskUsage(nodeIds.get(0), "n1", "_na_", 100, 50));
+        clusterInfoService.setN2Usage(nodeIds.get(1), new DiskUsage(nodeIds.get(1), "n2", "_na_", 100, 50));
+        clusterInfoService.setN3Usage(nodeIds.get(2), new DiskUsage(nodeIds.get(2), "n3", "_na_", 100, 50));
+
+        assertBusy(() -> {
+            HashMap<String, Integer> shardCountByNodeId = getShardCountByNodeId();
+            assertThat("node0 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(0)), greaterThanOrEqualTo(3));
+            assertThat("node1 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(1)), greaterThanOrEqualTo(3));
+            assertThat("node2 has at least 3 shards", shardCountByNodeId.get(nodeIds.get(2)), greaterThanOrEqualTo(3));
+        });
+    }
+
+    static private ClusterState clusterState() {
+        return client().admin().cluster().prepareState().get().getState();
+    }
+
+    private HashMap<String, Integer> getShardCountByNodeId() {
+        HashMap<String, Integer> shardCountByNodeId = new HashMap<>();
+        var clusterState = clusterState();
+        for (final RoutingNode node : clusterState.getRoutingNodes()) {
+            shardCountByNodeId.put(
+                node.nodeId(),
+                clusterState.getRoutingNodes().node(node.nodeId()).numberOfOwningShards());
+        }
+        return shardCountByNodeId;
+    }
+}


### PR DESCRIPTION
#  Summary of the changes / Why this improves CrateDB

`DiskUsage` takes disk path total bytes instead of
available bytes as the last argument.

relates to #9153 
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
