### PR TITLE
Remove JVM version dependent GC setting handling

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -4,8 +4,6 @@ SETLOCAL EnableDelayedExpansion
 
 if NOT DEFINED JAVA_HOME goto err
 
-for /f tokens^=2-5^ delims^=.-_^" %%j in ('"%JAVA_HOME%\bin\java" -fullversion 2^>^&1') do set "JAVA_VERSION=%%j.%%k"
-
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set CRATE_HOME=%%~dpfI
 
@@ -59,21 +57,8 @@ if NOT DEFINED "%CRATE_DISABLE_GC_LOGGING%" (
   IF DEFINED %CRATE_GC_LOG_FILES% (SET GC_LOG_FILES=!CRATE_GC_LOG_FILES!)
 
   SET LOGGC=!GC_LOG_DIR!\gc.log
-  ECHO %JAVA_VERSION%
 
-  IF "%JAVA_VERSION%" == "9.0" (
-    SET JAVA_OPTS=!JAVA_OPTS! -Xlog:gc*,gc+age=trace,safepoint:file=\"!LOGGC!\":utctime,pid,tags:filecount=!GC_LOG_FILES!,filesize=!GC_LOG_SIZE!
-  )
-  IF "%JAVA_VERSION%" == "1.8" (
-    SET JAVA_OPTS=!JAVA_OPTS! -Xloggc:!LOGGC!
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:+PrintGCDetails
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:+PrintGCDateStamps
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:+PrintTenuringDistribution
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:+PrintGCApplicationStoppedTime
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:+UseGCLogFileRotation
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:NumberOfGCLogFiles=!GC_LOG_FILES!
-    SET JAVA_OPTS=!JAVA_OPTS! -XX:GCLogFileSize=!GC_LOG_SIZE!
-  )
+  SET JAVA_OPTS=!JAVA_OPTS! -Xlog:gc*,gc+age=trace,safepoint:file=\"!LOGGC!\":utctime,pid,tags:filecount=!GC_LOG_FILES!,filesize=!GC_LOG_SIZE!
 )
 
 REM Disables explicit GC

--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -80,26 +80,7 @@ EOF
   else
       JAVA=java
   fi
-  JAVA_VERSION=`$JAVA -version 2>&1 | awk '/version/ {gsub(/"/, "", $3); split($3, parts, ".")} END {print (parts[1] == 1 ? parts[2] : parts[1])}'`
-
-  if [ "x$JAVA_VERSION" = "x" ]; then
-    echo 'Java is missing or $JAVA_HOME is not set correctly. Install a JRE or setup $JAVA_HOME'
-    exit 1
-  fi
-
-  if [ $JAVA_VERSION -ge 9 ]; then
-    JAVA_OPTS="$JAVA_OPTS -Xlog:gc*,gc+age=trace,safepoint:file=${LOGGC}:utctime,pid,tags:filecount=${GC_LOG_FILES},filesize=${GC_LOG_SIZE}"
-  fi
-  if [ $JAVA_VERSION -le 8 ]; then
-    JAVA_OPTS="$JAVA_OPTS -Xloggc:$LOGGC"
-    JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
-    JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDateStamps"
-    JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
-    JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
-    JAVA_OPTS="$JAVA_OPTS -XX:+UseGCLogFileRotation"
-    JAVA_OPTS="$JAVA_OPTS -XX:NumberOfGCLogFiles=$GC_LOG_FILES"
-    JAVA_OPTS="$JAVA_OPTS -XX:GCLogFileSize=$GC_LOG_SIZE"
-  fi
+  JAVA_OPTS="$JAVA_OPTS -Xlog:gc*,gc+age=trace,safepoint:file=${LOGGC}:utctime,pid,tags:filecount=${GC_LOG_FILES},filesize=${GC_LOG_SIZE}"
 fi
 
 # Disables explicit GC


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We require 11+, so we no longer need to handle <= 1.8 style GC flags

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)