### PR TITLE
Implement unbound analyis support for create table statements

### DIFF
--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -27,6 +27,7 @@ import io.crate.analyze.AlterTableRenameAnalyzedStatement;
 import io.crate.analyze.AlterUserAnalyzedStatement;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedCommit;
+import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
@@ -38,7 +39,6 @@ import io.crate.analyze.CreateBlobTableAnalyzedStatement;
 import io.crate.analyze.CreateFunctionAnalyzedStatement;
 import io.crate.analyze.CreateRepositoryAnalyzedStatement;
 import io.crate.analyze.CreateSnapshotAnalyzedStatement;
-import io.crate.analyze.CreateTableAnalyzedStatement;
 import io.crate.analyze.CreateUserAnalyzedStatement;
 import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.DeallocateAnalyzedStatement;
@@ -276,11 +276,11 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        protected Void visitCreateTableStatement(CreateTableAnalyzedStatement analysis, User user) {
+        public Void visitCreateTable(AnalyzedCreateTable createTable, User user) {
             Privileges.ensureUserHasPrivilege(
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
-                analysis.tableIdent().schema(),
+                createTable.relationName().schema(),
                 user,
                 defaultSchema);
             return null;

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -546,10 +546,10 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        public String visitGenericProperties(GenericProperties node, @Nullable List<Expression> parameters) {
+        public String visitGenericProperties(GenericProperties<?> node, @Nullable List<Expression> parameters) {
             return " WITH (" +
                 node.properties().entrySet().stream()
-                    .map(prop -> prop.getKey() + "=" + prop.getValue().accept(this, null))
+                    .map(prop -> prop.getKey() + "=" + ((Expression) prop.getValue()).accept(this, null))
                     .collect(COMMA_JOINER) +
                 ")";
         }

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -634,17 +634,17 @@ public final class ExpressionFormatter {
         }
 
         @Override
-        public String visitColumnType(ColumnType node, @Nullable List<Expression> parameters) {
+        public String visitColumnType(ColumnType<?> node, @Nullable List<Expression> parameters) {
             return node.name();
         }
 
         @Override
-        public String visitCollectionColumnType(CollectionColumnType node, @Nullable List<Expression> parameters) {
+        public String visitCollectionColumnType(CollectionColumnType<?> node, @Nullable List<Expression> parameters) {
             return node.name() + "(" + node.innerType().accept(this, parameters) + ")";
         }
 
         @Override
-        public String visitObjectColumnType(ObjectColumnType node, @Nullable List<Expression> parameters) {
+        public String visitObjectColumnType(ObjectColumnType<?> node, @Nullable List<Expression> parameters) {
             return node.name();
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -566,24 +566,25 @@ public final class SqlFormatter {
         }
 
         @Override
-        public Void visitColumnDefinition(ColumnDefinition node, Integer indent) {
-            builder.append(quoteIdentifierIfNeeded(node.ident()))
+        public Void visitColumnDefinition(ColumnDefinition<?> node, Integer indent) {
+            ColumnDefinition<Expression> columnDefinition = (ColumnDefinition<Expression>) node;
+            builder.append(quoteIdentifierIfNeeded(columnDefinition.ident()))
                 .append(" ");
-            ColumnType type = node.type();
+            ColumnType type = columnDefinition.type();
             if (type != null) {
                 type.accept(this, indent);
             }
-            if (node.defaultExpression() != null) {
+            if (columnDefinition.defaultExpression() != null) {
                 builder.append(" DEFAULT ")
-                    .append(formatStandaloneExpression(node.defaultExpression(), parameters));
+                    .append(formatStandaloneExpression(columnDefinition.defaultExpression(), parameters));
             }
-            if (node.generatedExpression() != null) {
+            if (columnDefinition.generatedExpression() != null) {
                 builder.append(" GENERATED ALWAYS AS ")
-                    .append(formatStandaloneExpression(node.generatedExpression(), parameters));
+                    .append(formatStandaloneExpression(columnDefinition.generatedExpression(), parameters));
             }
 
-            if (!node.constraints().isEmpty()) {
-                for (ColumnConstraint constraint : node.constraints()) {
+            if (!columnDefinition.constraints().isEmpty()) {
+                for (ColumnConstraint constraint : columnDefinition.constraints()) {
                     builder.append(" ");
                     constraint.accept(this, indent);
                 }
@@ -599,15 +600,16 @@ public final class SqlFormatter {
 
         @Override
         public Void visitObjectColumnType(ObjectColumnType node, Integer indent) {
+            ObjectColumnType<Expression> objectColumnType = node;
             builder.append("OBJECT");
-            if (node.objectType().isPresent()) {
+            if (objectColumnType.objectType().isPresent()) {
                 builder.append('(');
-                builder.append(node.objectType().get().name());
+                builder.append(objectColumnType.objectType().get().name());
                 builder.append(')');
             }
-            if (!node.nestedColumns().isEmpty()) {
+            if (!objectColumnType.nestedColumns().isEmpty()) {
                 builder.append(" AS ");
-                appendNestedNodeList(node.nestedColumns(), indent);
+                appendNestedNodeList(objectColumnType.nestedColumns(), indent);
             }
             return null;
         }
@@ -624,7 +626,7 @@ public final class SqlFormatter {
         @Override
         public Void visitIndexColumnConstraint(IndexColumnConstraint node, Integer indent) {
             builder.append("INDEX ");
-            if (node.equals(IndexColumnConstraint.OFF)) {
+            if (node.equals(IndexColumnConstraint.off())) {
                 builder.append(node.indexMethod().toUpperCase(Locale.ENGLISH));
             } else {
                 builder.append("USING ")

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -396,7 +396,7 @@ public final class SqlFormatter {
         }
 
         @Override
-        protected Void visitTable(Table node, Integer indent) {
+        protected Void visitTable(Table<?> node, Integer indent) {
             if (node.excludePartitions()) {
                 builder.append("ONLY ");
             }

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -25,6 +25,7 @@ package io.crate.sql.parser;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
+import io.crate.common.collections.Lists2;
 import io.crate.sql.parser.antlr.v4.SqlBaseBaseVisitor;
 import io.crate.sql.parser.antlr.v4.SqlBaseLexer;
 import io.crate.sql.parser.antlr.v4.SqlBaseParser;
@@ -585,7 +586,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
                 conflictColumns = emptyList();
             }
             if (onConflictContext.NOTHING() != null) {
-                return new Insert.DuplicateKeyContext(
+                return new Insert.DuplicateKeyContext<>(
                     Insert.DuplicateKeyContext.Type.ON_CONFLICT_DO_NOTHING,
                     emptyList(),
                     conflictColumns);
@@ -593,13 +594,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
                 if (conflictColumns.isEmpty()) {
                     throw new IllegalStateException("ON CONFLICT <conflict_target> <- conflict_target missing");
                 }
-                return new Insert.DuplicateKeyContext(
+                var assignments = Lists2.map(onConflictContext.assignment(), x -> (Assignment<Expression>) visit(x));
+                return new Insert.DuplicateKeyContext<>(
                     Insert.DuplicateKeyContext.Type.ON_CONFLICT_DO_UPDATE_SET,
-                    visitCollection(onConflictContext.assignment(), Assignment.class),
+                    assignments,
                     conflictColumns);
             }
         } else {
-            return Insert.DuplicateKeyContext.NONE;
+            return Insert.DuplicateKeyContext.none();
         }
     }
 
@@ -617,9 +619,10 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitUpdate(SqlBaseParser.UpdateContext context) {
+        var assignments = Lists2.map(context.assignment(), x -> (Assignment<Expression>) visit(x));
         return new Update(
             (Relation) visit(context.aliasedRelation()),
-            visitCollection(context.assignment(), Assignment.class),
+            assignments,
             visitIfPresent(context.where(), Expression.class));
     }
 
@@ -635,24 +638,25 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     private Assignment prepareSetAssignment(SqlBaseParser.SetContext context) {
         Expression settingName = new QualifiedNameReference(getQualifiedName(context.qname()));
         if (context.DEFAULT() != null) {
-            return new Assignment(settingName, ImmutableList.of());
+            return new Assignment<>(settingName, ImmutableList.of());
         }
-        return new Assignment(settingName, visitCollection(context.setExpr(), Expression.class));
+        return new Assignment<>(settingName, visitCollection(context.setExpr(), Expression.class));
     }
 
     @Override
     public Node visitSetGlobal(SqlBaseParser.SetGlobalContext context) {
+        var assignments = Lists2.map(context.setGlobalAssignment(), x -> (Assignment<Expression>) visit(x));
         if (context.PERSISTENT() != null) {
             return new SetStatement(SetStatement.Scope.GLOBAL,
                 SetStatement.SettingType.PERSISTENT,
-                visitCollection(context.setGlobalAssignment(), Assignment.class));
+                assignments);
         }
-        return new SetStatement(SetStatement.Scope.GLOBAL, visitCollection(context.setGlobalAssignment(), Assignment.class));
+        return new SetStatement(SetStatement.Scope.GLOBAL, assignments);
     }
 
     @Override
     public Node visitSetLicense(SqlBaseParser.SetLicenseContext ctx) {
-        Assignment assignment = new Assignment(
+        Assignment<Expression> assignment = new Assignment<>(
             new StringLiteral("license"), (Expression) visit(ctx.stringLiteral()));
 
         return new SetStatement(SetStatement.Scope.LICENSE,
@@ -661,7 +665,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitSetSessionTransactionMode(SqlBaseParser.SetSessionTransactionModeContext ctx) {
-        Assignment assignment = new Assignment(
+        Assignment<Expression> assignment = new Assignment<>(
             new StringLiteral("transaction_mode"),
             visitCollection(ctx.setExpr(), Expression.class));
         return new SetStatement(SetStatement.Scope.SESSION_TRANSACTION_MODE, assignment);
@@ -863,7 +867,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     // Properties
 
     private GenericProperties extractGenericProperties(ParserRuleContext context) {
-        return visitIfPresent(context, GenericProperties.class).orElse(GenericProperties.EMPTY);
+        return visitIfPresent(context, GenericProperties.class).orElse(GenericProperties.empty());
     }
 
     @Override
@@ -873,14 +877,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitGenericProperties(SqlBaseParser.GenericPropertiesContext context) {
-        GenericProperties properties = new GenericProperties();
-        context.genericProperty().forEach(p -> properties.add((GenericProperty) visit(p)));
+        GenericProperties<Expression> properties = new GenericProperties<>();
+        context.genericProperty().forEach(p -> properties.add((GenericProperty<Expression>) visit(p)));
         return properties;
     }
 
     @Override
     public Node visitGenericProperty(SqlBaseParser.GenericPropertyContext context) {
-        return new GenericProperty(getIdentText(context.ident()), (Expression) visit(context.expr()));
+        return new GenericProperty<>(getIdentText(context.ident()), (Expression) visit(context.expr()));
     }
 
     // Amending tables
@@ -1141,7 +1145,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitTable(SqlBaseParser.TableContext context) {
         if (context.qname() != null) {
-            return new Table(getQualifiedName(context.qname()), visitCollection(context.valueExpression(), Assignment.class));
+            var assignments = Lists2.map(context.valueExpression(), x -> (Assignment<Expression>) visit(x));
+            return new Table<>(getQualifiedName(context.qname()), assignments);
         }
         FunctionCall fc = new FunctionCall(
             getQualifiedName(context.ident()), visitCollection(context.valueExpression(), Expression.class));

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
@@ -28,20 +28,20 @@ import java.util.List;
 
 public class AlterTable extends Statement {
 
-    private final Table table;
-    private final GenericProperties genericProperties;
+    private final Table<Expression> table;
+    private final GenericProperties<Expression> genericProperties;
     private final List<String> resetProperties;
 
-    public AlterTable(Table table, GenericProperties genericProperties) {
+    public AlterTable(Table<Expression> table, GenericProperties<Expression> genericProperties) {
         this.table = table;
         this.genericProperties = genericProperties;
         this.resetProperties = ImmutableList.of();
     }
 
-    public AlterTable(Table table, List<String> resetProperties) {
+    public AlterTable(Table<Expression> table, List<String> resetProperties) {
         this.table = table;
         this.resetProperties = resetProperties;
-        this.genericProperties = GenericProperties.EMPTY;
+        this.genericProperties = GenericProperties.empty();
     }
 
     @Override
@@ -49,11 +49,11 @@ public class AlterTable extends Statement {
         return visitor.visitAlterTable(this, context);
     }
 
-    public Table table() {
+    public Table<Expression> table() {
         return table;
     }
 
-    public GenericProperties genericProperties() {
+    public GenericProperties<Expression> genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableAddColumn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableAddColumn.java
@@ -23,21 +23,21 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
-public class AlterTableAddColumn extends Statement {
+public class AlterTableAddColumn<T> extends Statement {
 
-    private final Table table;
-    private final AddColumnDefinition addColumnDefinition;
+    private final Table<T> table;
+    private final AddColumnDefinition<T> addColumnDefinition;
 
-    public AlterTableAddColumn(Table table, AddColumnDefinition addColumnDefinition) {
+    public AlterTableAddColumn(Table<T> table, AddColumnDefinition<T> addColumnDefinition) {
         this.table = table;
         this.addColumnDefinition = addColumnDefinition;
     }
 
-    public TableElement tableElement() {
+    public TableElement<T> tableElement() {
         return addColumnDefinition;
     }
 
-    public Table table() {
+    public Table<T> table() {
         return table;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
@@ -26,11 +26,11 @@ import com.google.common.base.MoreObjects;
 
 public class AlterTableReroute extends Statement {
 
-    private final Table table;
+    private final Table<Expression> table;
     private final RerouteOption rerouteOption;
     private final boolean blob;
 
-    public AlterTableReroute(Table table, boolean blob, RerouteOption rerouteOption) {
+    public AlterTableReroute(Table<Expression> table, boolean blob, RerouteOption rerouteOption) {
         this.table = table;
         this.blob = blob;
         this.rerouteOption = rerouteOption;
@@ -42,7 +42,7 @@ public class AlterTableReroute extends Statement {
         return visitor.visitAlterTableReroute(this, context);
     }
 
-    public Table table() {
+    public Table<Expression> table() {
         return table;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
@@ -27,15 +27,15 @@ import com.google.common.base.Objects;
 
 public class AlterUser extends Statement {
 
-    private final GenericProperties genericProperties;
+    private final GenericProperties<Expression> genericProperties;
     private final String name;
 
-    public AlterUser(String name, GenericProperties genericProperties) {
+    public AlterUser(String name, GenericProperties<Expression> genericProperties) {
         this.genericProperties = genericProperties;
         this.name = name;
     }
 
-    public GenericProperties genericProperties() {
+    public GenericProperties<Expression> genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
@@ -24,9 +24,11 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import io.crate.common.collections.Lists2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class Assignment<T> extends Node {
 
@@ -71,6 +73,9 @@ public class Assignment<T> extends Node {
         return expressions;
     }
 
+    public <U> Assignment<U> map(Function<? super T, ? extends U> mapper) {
+        return new Assignment<>(mapper.apply(columnName), Lists2.map(expressions, mapper));
+    }
 
     @Override
     public int hashCode() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
@@ -28,10 +28,10 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 
-public class Assignment extends Node {
+public class Assignment<T> extends Node {
 
-    private final Expression columnName;
-    private final List<Expression> expressions;
+    private final T columnName;
+    private final List<T> expressions;
 
     /**
      * Constructor for SET SESSION/LOCAL statements
@@ -41,7 +41,7 @@ public class Assignment extends Node {
      *                        value can be either string literal, numeric literal, or ident
      * VALUE, VALUE, ...   -> two or more items in expressions list
      */
-    public Assignment(Expression columnName, List<Expression> expressions) {
+    public Assignment(T columnName, List<T> expressions) {
         Preconditions.checkNotNull(columnName, "columnname is null");
         Preconditions.checkNotNull(expressions, "expression is null");
         this.columnName = columnName;
@@ -52,22 +52,22 @@ public class Assignment extends Node {
      * Constructor for SET GLOBAL statements
      * only single expression is allowed on right side of assignment
      */
-    public Assignment(Expression columnName, Expression expression) {
+    public Assignment(T columnName, T expression) {
         Preconditions.checkNotNull(columnName, "columnname is null");
         Preconditions.checkNotNull(expression, "expression is null");
         this.columnName = columnName;
         this.expressions = Collections.singletonList(expression);
     }
 
-    public Expression columnName() {
+    public T columnName() {
         return columnName;
     }
 
-    public Expression expression() {
+    public T expression() {
         return expressions.isEmpty() ? null : expressions.get(0);
     }
 
-    public List<Expression> expressions() {
+    public List<T> expressions() {
         return expressions;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -212,7 +212,7 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    protected R visitTable(Table node, C context) {
+    protected R visitTable(Table<?> node, C context) {
         return visitQueryBody(node, context);
     }
 
@@ -264,7 +264,7 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
-    public R visitAssignment(Assignment node, C context) {
+    public R visitAssignment(Assignment<?> node, C context) {
         return visitNode(node, context);
     }
 
@@ -348,11 +348,11 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitGenericProperties(GenericProperties node, C context) {
+    public R visitGenericProperties(GenericProperties<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitGenericProperty(GenericProperty node, C context) {
+    public R visitGenericProperty(GenericProperty<?> node, C context) {
         return visitNode(node, context);
     }
 
@@ -492,7 +492,7 @@ public abstract class AstVisitor<R, C> {
         return visitTableElement(node, context);
     }
 
-    public R visitInsertFromValues(InsertFromValues node, C context) {
+    public R visitInsertFromValues(InsertFromValues<?> node, C context) {
         return visitInsert(node, context);
     }
 
@@ -500,7 +500,7 @@ public abstract class AstVisitor<R, C> {
         return visitLiteral(node, context);
     }
 
-    public R visitInsertFromSubquery(InsertFromSubquery node, C context) {
+    public R visitInsertFromSubquery(InsertFromSubquery<?> node, C context) {
         return visitInsert(node, context);
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -272,7 +272,7 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitCreateTable(CreateTable node, C context) {
+    public R visitCreateTable(CreateTable<?> node, C context) {
         return visitStatement(node, context);
     }
 
@@ -312,39 +312,39 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitClusteredBy(ClusteredBy node, C context) {
+    public R visitClusteredBy(ClusteredBy<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitColumnDefinition(ColumnDefinition node, C context) {
+    public R visitColumnDefinition(ColumnDefinition<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitColumnType(ColumnType node, C context) {
+    public R visitColumnType(ColumnType<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitObjectColumnType(ObjectColumnType node, C context) {
+    public R visitObjectColumnType(ObjectColumnType<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitColumnConstraint(ColumnConstraint node, C context) {
+    public R visitColumnConstraint(ColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitPrimaryKeyColumnConstraint(PrimaryKeyColumnConstraint node, C context) {
+    public R visitPrimaryKeyColumnConstraint(PrimaryKeyColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitNotNullColumnConstraint(NotNullColumnConstraint node, C context) {
+    public R visitNotNullColumnConstraint(NotNullColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitIndexColumnConstraint(IndexColumnConstraint node, C context) {
+    public R visitIndexColumnConstraint(IndexColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitColumnStorageDefinition(ColumnStorageDefinition node, C context) {
+    public R visitColumnStorageDefinition(ColumnStorageDefinition<?> node, C context) {
         return visitNode(node, context);
     }
 
@@ -356,15 +356,15 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitPrimaryKeyConstraint(PrimaryKeyConstraint node, C context) {
+    public R visitPrimaryKeyConstraint(PrimaryKeyConstraint<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitIndexDefinition(IndexDefinition node, C context) {
+    public R visitIndexDefinition(IndexDefinition<?> node, C context) {
         return visitNode(node, context);
     }
 
-    public R visitCollectionColumnType(CollectionColumnType node, C context) {
+    public R visitCollectionColumnType(CollectionColumnType<?> node, C context) {
         return visitNode(node, context);
     }
 
@@ -488,7 +488,7 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitAddColumnDefinition(AddColumnDefinition node, C context) {
+    public R visitAddColumnDefinition(AddColumnDefinition<?> node, C context) {
         return visitTableElement(node, context);
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
@@ -25,23 +25,28 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.util.Optional;
+import java.util.function.Function;
 
-public final class ClusteredBy extends Node {
+public final class ClusteredBy<T> extends Node {
 
-    private final Optional<Expression> column;
-    private final Optional<Expression> numberOfShards;
+    private final Optional<T> column;
+    private final Optional<T> numberOfShards;
 
-    public ClusteredBy(Optional<Expression> column, Optional<Expression> numberOfShards) {
+    public ClusteredBy(Optional<T> column, Optional<T> numberOfShards) {
         this.column = column;
         this.numberOfShards = numberOfShards;
     }
 
-    public Optional<Expression> column() {
+    public Optional<T> column() {
         return column;
     }
 
-    public Optional<Expression> numberOfShards() {
+    public Optional<T> numberOfShards() {
         return numberOfShards;
+    }
+
+    public <U> ClusteredBy<U> map(Function<? super T, ? extends U> mapper) {
+        return new ClusteredBy<>(column.map(mapper), numberOfShards.map(mapper));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/CollectionColumnType.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CollectionColumnType.java
@@ -21,20 +21,35 @@
 
 package io.crate.sql.tree;
 
+import java.util.function.Function;
+
 /**
  * columntype that contains many values of a single type
  */
-public class CollectionColumnType extends ColumnType {
+public class CollectionColumnType<T> extends ColumnType<T> {
 
-    private final ColumnType innerType;
+    private final ColumnType<T> innerType;
 
-    public CollectionColumnType(ColumnType innerType) {
+    public CollectionColumnType(ColumnType<T> innerType) {
         super("ARRAY");
         this.innerType = innerType;
     }
 
-    public ColumnType innerType() {
+    public ColumnType<T> innerType() {
         return innerType;
+    }
+
+    @Override
+    public <U> ColumnType<U> map(Function<? super T, ? extends U> mapper) {
+        return new CollectionColumnType<>(innerType.map(mapper));
+    }
+
+    @Override
+    public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,
+                                            Function<? super T, ? extends U> mapper) {
+        CollectionColumnType<U> collectionColumnType = (CollectionColumnType<U>) mappedType;
+        return new CollectionColumnType<>(
+            innerType.mapExpressions(collectionColumnType.innerType, mapper));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnConstraint.java
@@ -21,10 +21,17 @@
 
 package io.crate.sql.tree;
 
-public abstract class ColumnConstraint extends Node {
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public abstract class ColumnConstraint<T> extends Node {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitColumnConstraint(this, context);
     }
+
+    public abstract <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper);
+
+    public abstract void visit(Consumer<? super T> consumer);
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
@@ -25,22 +25,34 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 
 import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-public class ColumnStorageDefinition extends ColumnConstraint {
+public class ColumnStorageDefinition<T> extends ColumnConstraint<T> {
 
-    private final GenericProperties properties;
+    private final GenericProperties<T> properties;
 
-    public ColumnStorageDefinition(GenericProperties properties) {
+    public ColumnStorageDefinition(GenericProperties<T> properties) {
         this.properties = properties;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<T> properties() {
         return properties;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitColumnStorageDefinition(this, context);
+    }
+
+    @Override
+    public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new ColumnStorageDefinition<>(properties.map(mapper));
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
+        properties.properties().values().forEach(consumer);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
@@ -22,7 +22,9 @@
 package io.crate.sql.tree;
 
 
-public class ColumnType extends Expression {
+import java.util.function.Function;
+
+public class ColumnType<T> extends Expression {
 
     protected final String name;
 
@@ -56,5 +58,14 @@ public class ColumnType extends Expression {
     @Override
     public int hashCode() {
         return name.hashCode();
+    }
+
+    public <U> ColumnType<U> map(Function<? super T, ? extends U> mapper) {
+        return new ColumnType<>(name);
+    }
+
+    public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,
+                                            Function<? super T, ? extends U> mapper) {
+        return mappedType;
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
@@ -28,20 +28,20 @@ import java.util.Optional;
 
 public class CopyTo extends Statement {
 
-    private final Table table;
+    private final Table<Expression> table;
     private final boolean directoryUri;
     private final Expression targetUri;
 
-    private final GenericProperties genericProperties;
+    private final GenericProperties<Expression> genericProperties;
     private final List<Expression> columns;
     private final Optional<Expression> whereClause;
 
-    public CopyTo(Table table,
+    public CopyTo(Table<Expression> table,
                   List<Expression> columns,
                   Optional<Expression> whereClause,
                   boolean directoryUri,
                   Expression targetUri,
-                  GenericProperties genericProperties) {
+                  GenericProperties<Expression> genericProperties) {
 
         this.table = table;
         this.directoryUri = directoryUri;
@@ -51,7 +51,7 @@ public class CopyTo extends Statement {
         this.whereClause = whereClause;
     }
 
-    public Table table() {
+    public Table<Expression> table() {
         return table;
     }
 
@@ -67,7 +67,7 @@ public class CopyTo extends Statement {
         return columns;
     }
 
-    public GenericProperties genericProperties() {
+    public GenericProperties<Expression> genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
@@ -24,20 +24,20 @@ package io.crate.sql.tree;
 import java.util.List;
 import java.util.Optional;
 
-public final class CreateTable extends Statement {
+public final class CreateTable<T> extends Statement {
 
-    private final Table name;
+    private final Table<T> name;
     private final List<TableElement> tableElements;
     private final Optional<PartitionedBy> partitionedBy;
     private final Optional<ClusteredBy> clusteredBy;
     private final boolean ifNotExists;
-    private final GenericProperties properties;
+    private final GenericProperties<T> properties;
 
-    public CreateTable(Table name,
+    public CreateTable(Table<T> name,
                        List<TableElement> tableElements,
                        Optional<PartitionedBy> partitionedBy,
                        Optional<ClusteredBy> clusteredBy,
-                       GenericProperties genericProperties,
+                       GenericProperties<T> genericProperties,
                        boolean ifNotExists) {
         this.name = name;
         this.tableElements = tableElements;
@@ -51,7 +51,7 @@ public final class CreateTable extends Statement {
         return ifNotExists;
     }
 
-    public Table name() {
+    public Table<T> name() {
         return name;
     }
 
@@ -67,7 +67,7 @@ public final class CreateTable extends Statement {
         return partitionedBy;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<T> properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
@@ -27,16 +27,16 @@ import java.util.Optional;
 public final class CreateTable<T> extends Statement {
 
     private final Table<T> name;
-    private final List<TableElement> tableElements;
-    private final Optional<PartitionedBy> partitionedBy;
-    private final Optional<ClusteredBy> clusteredBy;
+    private final List<TableElement<T>> tableElements;
+    private final Optional<PartitionedBy<T>> partitionedBy;
+    private final Optional<ClusteredBy<T>> clusteredBy;
     private final boolean ifNotExists;
     private final GenericProperties<T> properties;
 
     public CreateTable(Table<T> name,
-                       List<TableElement> tableElements,
-                       Optional<PartitionedBy> partitionedBy,
-                       Optional<ClusteredBy> clusteredBy,
+                       List<TableElement<T>> tableElements,
+                       Optional<PartitionedBy<T>> partitionedBy,
+                       Optional<ClusteredBy<T>> clusteredBy,
                        GenericProperties<T> genericProperties,
                        boolean ifNotExists) {
         this.name = name;
@@ -55,15 +55,15 @@ public final class CreateTable<T> extends Statement {
         return name;
     }
 
-    public List<TableElement> tableElements() {
+    public List<TableElement<T>> tableElements() {
         return tableElements;
     }
 
-    public Optional<ClusteredBy> clusteredBy() {
+    public Optional<ClusteredBy<T>> clusteredBy() {
         return clusteredBy;
     }
 
-    public Optional<PartitionedBy> partitionedBy() {
+    public Optional<PartitionedBy<T>> partitionedBy() {
         return partitionedBy;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -278,7 +278,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
     }
 
     @Override
-    public R visitInsertFromValues(InsertFromValues node, C context) {
+    public R visitInsertFromValues(InsertFromValues<?> node, C context) {
         node.table().accept(this, context);
         for (ValuesList valuesList : node.valuesLists()) {
             valuesList.accept(this, context);
@@ -331,7 +331,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
     }
 
     @Override
-    public R visitInsertFromSubquery(InsertFromSubquery node, C context) {
+    public R visitInsertFromSubquery(InsertFromSubquery<?> node, C context) {
         node.table().accept(this, context);
         node.subQuery().accept(this, context);
         return null;

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -344,7 +344,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
     }
 
     @Override
-    public R visitCreateTable(CreateTable node, C context) {
+    public R visitCreateTable(CreateTable<?> node, C context) {
         node.name().accept(this, context);
         return null;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -83,6 +85,14 @@ public class GenericProperties<T> extends Node {
 
     public boolean isEmpty() {
         return properties.isEmpty();
+    }
+
+    public <U> GenericProperties<U> map(Function<? super T, ? extends U> mapper) {
+        Map<String, U> mappedProperties = properties.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            e -> mapper.apply(e.getValue())
+        ));
+        return new GenericProperties<>(mappedProperties);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -46,25 +46,29 @@ import java.util.Set;
  * d=[1, 2, 3, 'abc']
  * </code>
  */
-public class GenericProperties extends Node {
+public class GenericProperties<T> extends Node {
 
-    public static final GenericProperties EMPTY = new GenericProperties(ImmutableMap.of());
+    private static final GenericProperties<?> EMPTY = new GenericProperties<>(ImmutableMap.of());
 
-    private final Map<String, Expression> properties;
+    public static <T> GenericProperties<T> empty() {
+        return (GenericProperties<T>) EMPTY;
+    }
+
+    private final Map<String, T> properties;
 
     public GenericProperties() {
         properties = new HashMap<>();
     }
 
-    private GenericProperties(Map<String, Expression> map) {
+    private GenericProperties(Map<String, T> map) {
         this.properties = map;
     }
 
-    public Map<String, Expression> properties() {
+    public Map<String, T> properties() {
         return Collections.unmodifiableMap(properties);
     }
 
-    public Expression get(String key) {
+    public T get(String key) {
         return properties.get(key);
     }
 
@@ -73,7 +77,7 @@ public class GenericProperties extends Node {
      *
      * @param property
      */
-    public void add(GenericProperty property) {
+    public void add(GenericProperty<T> property) {
         properties.put(property.key(), property.value());
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
@@ -34,12 +34,12 @@ import com.google.common.base.Objects;
  * Instance of {@link io.crate.sql.tree.AnalyzerElement} but frequently used in other
  * {@link io.crate.sql.tree.GenericProperties} contexts.
  */
-public class GenericProperty extends AnalyzerElement {
+public class GenericProperty<T> extends AnalyzerElement {
 
     private final String key;
-    private final Expression value;
+    private final T value;
 
-    public GenericProperty(String key, Expression value) {
+    public GenericProperty(String key, T value) {
         this.key = key;
         this.value = value;
     }
@@ -49,7 +49,7 @@ public class GenericProperty extends AnalyzerElement {
         return key;
     }
 
-    public Expression value() {
+    public T value() {
         return value;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
@@ -26,12 +26,12 @@ import com.google.common.base.Objects;
 
 public class IndexColumnConstraint extends ColumnConstraint {
 
-    public static final IndexColumnConstraint OFF = new IndexColumnConstraint("OFF", GenericProperties.EMPTY);
+    public static final IndexColumnConstraint OFF = new IndexColumnConstraint("OFF", GenericProperties.empty());
 
     private final String indexMethod;
-    private final GenericProperties properties;
+    private final GenericProperties<Expression> properties;
 
-    public IndexColumnConstraint(String indexMethod, GenericProperties properties) {
+    public IndexColumnConstraint(String indexMethod, GenericProperties<Expression> properties) {
         this.indexMethod = indexMethod;
         this.properties = properties;
     }
@@ -40,7 +40,7 @@ public class IndexColumnConstraint extends ColumnConstraint {
         return indexMethod;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<Expression> properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
@@ -24,14 +24,21 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-public class IndexColumnConstraint extends ColumnConstraint {
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-    public static final IndexColumnConstraint OFF = new IndexColumnConstraint("OFF", GenericProperties.empty());
+public class IndexColumnConstraint<T> extends ColumnConstraint<T> {
+
+    private static final IndexColumnConstraint<?> OFF = new IndexColumnConstraint<>("OFF", GenericProperties.empty());
+
+    public static <T> IndexColumnConstraint<T> off() {
+        return (IndexColumnConstraint<T>) OFF;
+    }
 
     private final String indexMethod;
-    private final GenericProperties<Expression> properties;
+    private final GenericProperties<T> properties;
 
-    public IndexColumnConstraint(String indexMethod, GenericProperties<Expression> properties) {
+    public IndexColumnConstraint(String indexMethod, GenericProperties<T> properties) {
         this.indexMethod = indexMethod;
         this.properties = properties;
     }
@@ -40,7 +47,7 @@ public class IndexColumnConstraint extends ColumnConstraint {
         return indexMethod;
     }
 
-    public GenericProperties<Expression> properties() {
+    public GenericProperties<T> properties() {
         return properties;
     }
 
@@ -73,5 +80,15 @@ public class IndexColumnConstraint extends ColumnConstraint {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitIndexColumnConstraint(this, context);
+    }
+
+    @Override
+    public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new IndexColumnConstraint<>(indexMethod, properties.map(mapper));
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
+        properties.properties().values().forEach(consumer);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
@@ -23,17 +23,20 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-public class IndexDefinition extends TableElement {
+public class IndexDefinition<T> extends TableElement<T> {
 
     private final String ident;
     private final String method;
-    private final List<Expression> columns;
-    private final GenericProperties properties;
+    private final List<T> columns;
+    private final GenericProperties<T> properties;
 
-    public IndexDefinition(String ident, String method, List<Expression> columns, GenericProperties properties) {
+    public IndexDefinition(String ident, String method, List<T> columns, GenericProperties<T> properties) {
         this.ident = ident;
         this.method = method;
         this.columns = columns;
@@ -48,11 +51,11 @@ public class IndexDefinition extends TableElement {
         return method;
     }
 
-    public List<Expression> columns() {
+    public List<T> columns() {
         return columns;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<T> properties() {
         return properties;
     }
 
@@ -89,5 +92,21 @@ public class IndexDefinition extends TableElement {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitIndexDefinition(this, context);
+    }
+
+    @Override
+    public <U> TableElement<U> map(Function<? super T, ? extends U> mapper) {
+        return new IndexDefinition<>(
+            ident,
+            method,
+            Lists2.map(columns, mapper),
+            properties.map(mapper)
+        );
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
+        columns.forEach(consumer);
+        properties.properties().values().forEach(consumer);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -26,13 +26,13 @@ import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.List;
 
-public abstract class Insert extends Statement {
+public abstract class Insert<T> extends Statement {
 
-    protected final Table table;
-    private final DuplicateKeyContext duplicateKeyContext;
+    protected final Table<T> table;
+    private final DuplicateKeyContext<T> duplicateKeyContext;
     protected final List<String> columns;
 
-    Insert(Table table, List<String> columns, DuplicateKeyContext duplicateKeyContext) {
+    Insert(Table<T> table, List<String> columns, DuplicateKeyContext<T> duplicateKeyContext) {
         this.table = table;
         this.columns = columns;
         this.duplicateKeyContext = duplicateKeyContext;
@@ -46,7 +46,7 @@ public abstract class Insert extends Statement {
         return columns;
     }
 
-    public DuplicateKeyContext getDuplicateKeyContext() {
+    public DuplicateKeyContext<T> getDuplicateKeyContext() {
         return duplicateKeyContext;
     }
 
@@ -76,10 +76,14 @@ public abstract class Insert extends Statement {
     }
 
 
-    public static class DuplicateKeyContext {
+    public static class DuplicateKeyContext<T> {
 
-        public static final DuplicateKeyContext NONE =
-            new DuplicateKeyContext(Type.NONE, Collections.emptyList(), Collections.emptyList());
+        private static final DuplicateKeyContext<?> NONE =
+            new DuplicateKeyContext<>(Type.NONE, Collections.emptyList(), Collections.emptyList());
+
+        public static <T> DuplicateKeyContext<T> none() {
+            return (DuplicateKeyContext<T>) NONE;
+        }
 
         public enum Type {
             ON_CONFLICT_DO_UPDATE_SET,
@@ -88,11 +92,11 @@ public abstract class Insert extends Statement {
         }
 
         private final Type type;
-        private final List<Assignment> onDuplicateKeyAssignments;
+        private final List<Assignment<T>> onDuplicateKeyAssignments;
         private final List<String> constraintColumns;
 
         public DuplicateKeyContext(Type type,
-                                   List<Assignment> onDuplicateKeyAssignments,
+                                   List<Assignment<T>> onDuplicateKeyAssignments,
                                    List<String> constraintColumns) {
             this.type = type;
             this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
@@ -103,7 +107,7 @@ public abstract class Insert extends Statement {
             return type;
         }
 
-        public List<Assignment> getAssignments() {
+        public List<Assignment<T>> getAssignments() {
             return onDuplicateKeyAssignments;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
@@ -26,14 +26,14 @@ import com.google.common.base.Objects;
 
 import java.util.List;
 
-public class InsertFromSubquery extends Insert {
+public class InsertFromSubquery<T> extends Insert<T> {
 
     private final Query subQuery;
 
-    public InsertFromSubquery(Table table,
+    public InsertFromSubquery(Table<T> table,
                               Query subQuery,
                               List<String> columns,
-                              DuplicateKeyContext duplicateKeyContext) {
+                              DuplicateKeyContext<T> duplicateKeyContext) {
         super(table, columns, duplicateKeyContext);
         this.subQuery = subQuery;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
@@ -26,15 +26,15 @@ import com.google.common.base.Objects;
 
 import java.util.List;
 
-public class InsertFromValues extends Insert {
+public class InsertFromValues<T> extends Insert<T> {
 
     private final List<ValuesList> valuesLists;
     private final int maxValuesLength;
 
-    public InsertFromValues(Table table,
+    public InsertFromValues(Table<T> table,
                             List<ValuesList> valuesLists,
                             List<String> columns,
-                            DuplicateKeyContext duplicateKeyContext) {
+                            DuplicateKeyContext<T> duplicateKeyContext) {
         super(table, columns, duplicateKeyContext);
         this.valuesLists = valuesLists;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
@@ -31,13 +31,13 @@ public class MatchPredicate extends Expression {
 
     private final List<MatchPredicateColumnIdent> idents;
     private final Expression value;
-    private final GenericProperties properties;
+    private final GenericProperties<Expression> properties;
     private final String matchType;
 
     public MatchPredicate(List<MatchPredicateColumnIdent> idents,
                           Expression value,
                           @Nullable String matchType,
-                          GenericProperties properties) {
+                          GenericProperties<Expression> properties) {
         Preconditions.checkArgument(idents.size() > 0, "at least one ident must be given");
         Preconditions.checkNotNull(value, "query_term is null");
         this.idents = idents;
@@ -59,7 +59,7 @@ public class MatchPredicate extends Expression {
         return matchType;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<Expression> properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/NamedProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/NamedProperties.java
@@ -27,9 +27,9 @@ import com.google.common.base.Objects;
 public class NamedProperties extends Node {
 
     private final String ident;
-    private final GenericProperties properties;
+    private final GenericProperties<Expression> properties;
 
-    public NamedProperties(String ident, GenericProperties properties) {
+    public NamedProperties(String ident, GenericProperties<Expression> properties) {
         this.ident = ident;
         this.properties = properties;
     }
@@ -38,7 +38,7 @@ public class NamedProperties extends Node {
         return ident;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<Expression> properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
@@ -22,7 +22,10 @@
 
 package io.crate.sql.tree;
 
-public class NotNullColumnConstraint extends ColumnConstraint {
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class NotNullColumnConstraint<T> extends ColumnConstraint<T> {
 
     private static final String NAME = "NOT NULL";
 
@@ -45,5 +48,14 @@ public class NotNullColumnConstraint extends ColumnConstraint {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitNotNullColumnConstraint(this, context);
+    }
+
+    @Override
+    public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new NotNullColumnConstraint<>();
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/PartitionedBy.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/PartitionedBy.java
@@ -22,19 +22,26 @@
 package io.crate.sql.tree;
 
 
+import io.crate.common.collections.Lists2;
+
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
-public final class PartitionedBy extends Node {
+public final class PartitionedBy<T> extends Node {
 
-    private final List<Expression> columns;
+    private final List<T> columns;
 
-    public PartitionedBy(List<Expression> columns) {
+    public PartitionedBy(List<T> columns) {
         this.columns = columns;
     }
 
-    public List<Expression> columns() {
+    public List<T> columns() {
         return columns;
+    }
+
+    public <U> PartitionedBy<U> map(Function<? super T, ? extends U> mapper) {
+        return new PartitionedBy<>(Lists2.map(columns, mapper));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
@@ -21,7 +21,10 @@
 
 package io.crate.sql.tree;
 
-public class PrimaryKeyColumnConstraint extends ColumnConstraint {
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class PrimaryKeyColumnConstraint<T> extends ColumnConstraint<T> {
 
     private static final String NAME = "PRIMARY_KEY";
 
@@ -46,5 +49,14 @@ public class PrimaryKeyColumnConstraint extends ColumnConstraint {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitPrimaryKeyColumnConstraint(this, context);
+    }
+
+    @Override
+    public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new PrimaryKeyColumnConstraint<>();
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
@@ -23,18 +23,21 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-public class PrimaryKeyConstraint extends TableElement {
+public class PrimaryKeyConstraint<T> extends TableElement<T> {
 
-    private final List<Expression> columns;
+    private final List<T> columns;
 
-    public PrimaryKeyConstraint(List<Expression> columns) {
+    public PrimaryKeyConstraint(List<T> columns) {
         this.columns = columns;
     }
 
-    public List<Expression> columns() {
+    public List<T> columns() {
         return columns;
     }
 
@@ -63,5 +66,15 @@ public class PrimaryKeyConstraint extends TableElement {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitPrimaryKeyConstraint(this, context);
+    }
+
+    @Override
+    public <U> TableElement<U> map(Function<? super T, ? extends U> mapper) {
+        return new PrimaryKeyConstraint<>(Lists2.map(columns, mapper));
+    }
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
+        columns.forEach(consumer);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
@@ -40,20 +40,20 @@ public class SetStatement extends Statement {
 
     private final Scope scope;
     private final SettingType settingType;
-    private final List<Assignment> assignments;
+    private final List<Assignment<Expression>> assignments;
 
-    public SetStatement(Scope scope, List<Assignment> assignments) {
+    public SetStatement(Scope scope, List<Assignment<Expression>> assignments) {
         this(scope, SettingType.TRANSIENT, assignments);
     }
 
-    public SetStatement(Scope scope, SettingType settingType, List<Assignment> assignments) {
+    public SetStatement(Scope scope, SettingType settingType, List<Assignment<Expression>> assignments) {
         Preconditions.checkNotNull(assignments, "assignments are null");
         this.scope = scope;
         this.settingType = settingType;
         this.assignments = assignments;
     }
 
-    public SetStatement(Scope scope, Assignment assignment) {
+    public SetStatement(Scope scope, Assignment<Expression> assignment) {
         Preconditions.checkNotNull(assignment, "assignment is null");
         this.scope = scope;
         this.settingType = SettingType.TRANSIENT;
@@ -64,7 +64,7 @@ public class SetStatement extends Statement {
         return scope;
     }
 
-    public List<Assignment> assignments() {
+    public List<Assignment<Expression>> assignments() {
         return assignments;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Table.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Table.java
@@ -23,8 +23,10 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class Table<T> extends QueryBody {
 
@@ -58,6 +60,14 @@ public class Table<T> extends QueryBody {
 
     public List<Assignment<T>> partitionProperties() {
         return partitionProperties;
+    }
+
+    public <U> Table<U> map(Function<? super T, ? extends U> mapper) {
+        if (partitionProperties.isEmpty()) {
+            return new Table<>(name, excludePartitions);
+        } else {
+            return new Table<>(name, Lists2.map(partitionProperties, x -> x.map(mapper)));
+        }
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Table.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Table.java
@@ -26,10 +26,11 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-public class Table extends QueryBody {
+public class Table<T> extends QueryBody {
+
     private final QualifiedName name;
     private final boolean excludePartitions;
-    private final List<Assignment> partitionProperties;
+    private final List<Assignment<T>> partitionProperties;
 
     public Table(QualifiedName name) {
         this(name, true);
@@ -41,7 +42,7 @@ public class Table extends QueryBody {
         this.partitionProperties = ImmutableList.of();
     }
 
-    public Table(QualifiedName name, List<Assignment> partitionProperties) {
+    public Table(QualifiedName name, List<Assignment<T>> partitionProperties) {
         this.name = name;
         this.excludePartitions = false;
         this.partitionProperties = partitionProperties;
@@ -55,7 +56,7 @@ public class Table extends QueryBody {
         return excludePartitions;
     }
 
-    public List<Assignment> partitionProperties() {
+    public List<Assignment<T>> partitionProperties() {
         return partitionProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/TableElement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/TableElement.java
@@ -21,10 +21,36 @@
 
 package io.crate.sql.tree;
 
-public abstract class TableElement extends Node {
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public abstract class TableElement<T> extends Node {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitTableElement(this, context);
     }
+
+    /**
+     * Map all generic properties using the given mapper.
+     * If a table element contains any expressions which should not be mapped in general (e.g. generated/default
+     * expression), NULL them here and use the concrete {@link #mapExpressions(TableElement, Function)}
+     * to map them using a concrete mapper.
+     */
+    public abstract <U> TableElement<U> map(Function<? super T, ? extends U> mapper);
+
+    /**
+     * Map any expressions which were NOT processed by the {@link #map(Function)} function in general
+     * like e.g. generated or default expressions.
+     *
+     * @param mappedElement     An already mapped table element were some expressions were left out.
+     * @param mapper            The mapper function
+     * @return                  The mapped table element including possible newly mapped expressions.
+     */
+    public <U> TableElement<U> mapExpressions(TableElement<U> mappedElement,
+                                              Function<? super T, ? extends U> mapper) {
+        return mappedElement;
+    }
+
+    public abstract void visit(Consumer<? super T> consumer);
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Tokenizer.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Tokenizer.java
@@ -32,7 +32,7 @@ public class Tokenizer extends AnalyzerElement {
         this.namedProperties = namedProperties;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<Expression> properties() {
         return namedProperties.properties();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Update.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Update.java
@@ -31,10 +31,10 @@ import java.util.Optional;
 public class Update extends Statement {
 
     private final Relation relation;
-    private final List<Assignment> assignments;
+    private final List<Assignment<Expression>> assignments;
     private final Optional<Expression> where;
 
-    public Update(Relation relation, List<Assignment> assignments, Optional<Expression> where) {
+    public Update(Relation relation, List<Assignment<Expression>> assignments, Optional<Expression> where) {
         Preconditions.checkNotNull(relation, "relation is null");
         Preconditions.checkNotNull(assignments, "assignments are null");
         this.relation = relation;
@@ -46,7 +46,7 @@ public class Update extends Statement {
         return relation;
     }
 
-    public List<Assignment> assignments() {
+    public List<Assignment<Expression>> assignments() {
         return assignments;
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1024,9 +1024,9 @@ public class TestStatementBuilder {
         printStatement("insert into t (a, b, c) values (1, 2), (3, 4) on conflict (c) do update set a = excluded.a + 1, b = 4");
         printStatement("insert into t (a, b, c) values (1, 2), (3, 4) on conflict (c) do update set a = excluded.a + 1, b = excluded.b - 2");
 
-        InsertFromValues insert = (InsertFromValues) SqlParser.createStatement(
+        InsertFromValues<Expression> insert = (InsertFromValues<Expression>) SqlParser.createStatement(
                 "insert into test_generated_column (id, ts) values (?, ?) on conflict (id) do update set ts = ?");
-        Assignment onDuplicateAssignment = insert.getDuplicateKeyContext().getAssignments().get(0);
+        Assignment<Expression> onDuplicateAssignment = insert.getDuplicateKeyContext().getAssignments().get(0);
         assertThat(onDuplicateAssignment.expression(), instanceOf(ParameterExpression.class));
         assertThat(onDuplicateAssignment.expressions().get(0).toString(), is("$3"));
 

--- a/sql/src/main/java/io/crate/analyze/AbstractInsertAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractInsertAnalyzer.java
@@ -26,6 +26,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Schemas;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Insert;
 
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ abstract class AbstractInsertAnalyzer {
                 actual, expected));
     }
 
-    void handleInsertColumns(Insert node, int maxInsertValues, AbstractInsertAnalyzedStatement context) {
+    void handleInsertColumns(Insert<Expression> node, int maxInsertValues, AbstractInsertAnalyzedStatement context) {
         // allocate columnsLists
         int numColumns;
 
@@ -57,7 +58,7 @@ abstract class AbstractInsertAnalyzer {
             if (maxInsertValues > numColumns) {
                 throw tooManyValuesException(maxInsertValues, numColumns);
             }
-            context.columns(new ArrayList<Reference>(numColumns));
+            context.columns(new ArrayList<>(numColumns));
 
             int i = 0;
             for (Reference columnInfo : context.tableInfo().columns()) {
@@ -73,7 +74,7 @@ abstract class AbstractInsertAnalyzer {
             if (maxInsertValues > numColumns) {
                 throw tooManyValuesException(maxInsertValues, numColumns);
             }
-            context.columns(new ArrayList<Reference>(numColumns));
+            context.columns(new ArrayList<>(numColumns));
             for (int i = 0; i < node.columns().size(); i++) {
                 addColumn(ColumnIdent.fromNameSafe(node.columns().get(i)), context, i);
             }

--- a/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
@@ -22,16 +22,19 @@
 package io.crate.analyze;
 
 import io.crate.metadata.doc.DocTableInfo;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
 
 public class AddColumnAnalyzedStatement implements DDLStatement {
 
     private final DocTableInfo tableInfo;
-    private final AnalyzedTableElements analyzedTableElements;
+    private final AnalyzedTableElements<Object> analyzedTableElements;
     private final boolean newPrimaryKeys;
     private final boolean hasNewGeneratedColumns;
 
     protected AddColumnAnalyzedStatement(DocTableInfo tableInfo,
-                                         AnalyzedTableElements tableElements,
+                                         AnalyzedTableElements<Object> tableElements,
                                          boolean newPrimaryKeys,
                                          boolean hasNewGeneratedColumns) {
         this.tableInfo = tableInfo;
@@ -49,7 +52,7 @@ public class AddColumnAnalyzedStatement implements DDLStatement {
         return visitor.visitAddColumnStatement(this, context);
     }
 
-    public AnalyzedTableElements analyzedTableElements() {
+    public AnalyzedTableElements<Object> analyzedTableElements() {
         return this.analyzedTableElements;
     }
 
@@ -59,5 +62,13 @@ public class AddColumnAnalyzedStatement implements DDLStatement {
 
     public boolean hasNewGeneratedColumns() {
         return hasNewGeneratedColumns;
+    }
+
+    public Map<String, Object> mapping() {
+        return AnalyzedTableElements.toMapping(analyzedTableElements);
+    }
+
+    public Settings settings() {
+        return analyzedTableElements.settings();
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -31,6 +31,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableRename;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Table;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
@@ -49,7 +50,7 @@ public class AlterTableAnalyzer {
     }
 
     public AlterTableAnalyzedStatement analyze(AlterTable node, Row parameters, SessionContext sessionContext) {
-        Table table = node.table();
+        Table<Expression> table = node.table();
         DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(), Operation.ALTER_BLOCKS,
             sessionContext.searchPath());
         PartitionName partitionName = createPartitionName(table.partitionProperties(), docTableInfo, parameters);
@@ -123,7 +124,7 @@ public class AlterTableAnalyzer {
      * @return An instance of PartitionName based on the supplied partition properties, table info and params.
      */
     @Nullable
-    public static PartitionName createPartitionName(List<Assignment> partitionsProperties,
+    public static PartitionName createPartitionName(List<Assignment<Expression>> partitionsProperties,
                                                     DocTableInfo tableInfo,
                                                     Row parameters) {
         if (partitionsProperties.isEmpty()) {

--- a/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -68,22 +68,22 @@ public class AlterTableRerouteAnalyzer {
         }
         tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_REROUTE);
         return node.rerouteOption().accept(rerouteOptionVisitor, new Context(
-                tableInfo,
-                node.table().partitionProperties(),
-                context.transactionContext(),
-                context.paramTypeHints()
-            ));
+            tableInfo,
+            node.table().partitionProperties(),
+            context.transactionContext(),
+            context.paramTypeHints()
+        ));
     }
 
-    private class Context {
+    private static class Context {
 
         private final ShardedTable tableInfo;
-        private final List<Assignment> partitionProperties;
+        private final List<Assignment<Expression>> partitionProperties;
         private final CoordinatorTxnCtx txnCtx;
         private final ParamTypeHints paramTypeHints;
 
         private Context(ShardedTable tableInfo,
-                        List<Assignment> partitionProperties,
+                        List<Assignment<Expression>> partitionProperties,
                         CoordinatorTxnCtx txnCtx,
                         ParamTypeHints paramTypeHints) {
             this.tableInfo = tableInfo;

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -53,8 +53,7 @@ public class AlterUserAnalyzer {
         );
 
         Map<String, Symbol> rows = new HashMap<>();
-        GenericProperties genericProperties = node.genericProperties();
-
+        GenericProperties<Expression> genericProperties = node.genericProperties();
         for (Map.Entry<String, Expression> expr : genericProperties.properties().entrySet()) {
             Symbol valueSymbol = expressionAnalyzer.convert(expr.getValue(), exprContext);
             rows.put(expr.getKey(), valueSymbol);

--- a/sql/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.CreateTable;
+import io.crate.sql.tree.TableElement;
+
+import java.util.function.Consumer;
+
+public class AnalyzedCreateTable implements DDLStatement {
+
+    private final RelationName relationName;
+    private final CreateTable<Symbol> createTable;
+    private final AnalyzedTableElements<Symbol> analyzedTableElements;
+    private final AnalyzedTableElements<Symbol> analyzedTableElementsWithExpressions;
+
+    public AnalyzedCreateTable(RelationName relationName,
+                               CreateTable<Symbol> createTable,
+                               AnalyzedTableElements<Symbol> analyzedTableElements,
+                               AnalyzedTableElements<Symbol> analyzedTableElementsWithExpressions) {
+        this.relationName = relationName;
+        this.createTable = createTable;
+        this.analyzedTableElements = analyzedTableElements;
+        this.analyzedTableElementsWithExpressions = analyzedTableElementsWithExpressions;
+    }
+
+    public CreateTable<Symbol> createTable() {
+        return createTable;
+    }
+
+    public RelationName relationName() {
+        return relationName;
+    }
+
+    public AnalyzedTableElements<Symbol> analyzedTableElements() {
+        return analyzedTableElements;
+    }
+
+    public AnalyzedTableElements<Symbol> analyzedTableElementsWithExpressions() {
+        return analyzedTableElementsWithExpressions;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (Assignment<Symbol> partitionProperty : createTable.name().partitionProperties()) {
+            consumer.accept(partitionProperty.expression());
+            partitionProperty.expressions().forEach(consumer);
+        }
+        for (TableElement<Symbol> tableElement : createTable.tableElements()) {
+            tableElement.visit(consumer);
+        }
+        createTable.clusteredBy().ifPresent(x -> {
+            x.column().ifPresent(consumer);
+            x.numberOfShards().ifPresent(consumer);
+        });
+        createTable.partitionedBy().ifPresent(x -> x.columns().forEach(consumer));
+        createTable.properties().properties().values().forEach(consumer);
+    }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitCreateTable(this, context);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -242,4 +242,8 @@ public class AnalyzedStatementVisitor<C, R> {
     public R visitDropTable(DropTableAnalyzedStatement<?> dropTable, C context) {
         return visitDDLStatement(dropTable, context);
     }
+
+    public R visitCreateTable(AnalyzedCreateTable createTable, C context) {
+        return visitDDLStatement(createTable, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -275,7 +275,7 @@ class CopyAnalyzer {
         return Enum.valueOf(settingsEnum, settingValue.toUpperCase(Locale.ENGLISH));
     }
 
-    private static List<String> resolvePartitions(List<Assignment> partitionProperties, Row parameters, DocTableInfo table) {
+    private static List<String> resolvePartitions(List<Assignment<Expression>> partitionProperties, Row parameters, DocTableInfo table) {
         if (partitionProperties.isEmpty()) {
             return Collections.emptyList();
         }

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private AnalyzedTableElements analyzedTableElements;
+    private AnalyzedTableElements<Object> analyzedTableElements;
     private Map<String, Object> mapping;
     private ColumnIdent routingColumn;
     private RelationName relationName;
@@ -101,21 +101,21 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
     }
 
     @SuppressWarnings("unchecked")
-    public Map<String, Object> mappingProperties() {
+    Map<String, Object> mappingProperties() {
         return (Map) mapping().get("properties");
     }
 
     public Collection<String> primaryKeys() {
-        return analyzedTableElements.primaryKeys();
+        return AnalyzedTableElements.primaryKeys(analyzedTableElements);
     }
 
     public Collection<String> notNullColumns() {
-        return analyzedTableElements.notNullColumns();
+        return AnalyzedTableElements.notNullColumns(analyzedTableElements);
     }
 
     public Map<String, Object> mapping() {
         if (mapping == null) {
-            mapping = analyzedTableElements.toMapping();
+            mapping = AnalyzedTableElements.toMapping(analyzedTableElements);
             Map<String, Object> metaMap = (Map<String, Object>) mapping.get("_meta");
             if (routingColumn != null) {
                 metaMap.put("routing", routingColumn.fqn());
@@ -145,16 +145,16 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
     /**
      * return true if a columnDefinition with name <code>columnIdent</code> exists
      */
-    public boolean hasColumnDefinition(ColumnIdent columnIdent) {
+    boolean hasColumnDefinition(ColumnIdent columnIdent) {
         return (analyzedTableElements().columnIdents().contains(columnIdent) ||
                 columnIdent.name().equalsIgnoreCase("_id"));
     }
 
-    public void analyzedTableElements(AnalyzedTableElements analyze) {
+    public void analyzedTableElements(AnalyzedTableElements<Object> analyze) {
         this.analyzedTableElements = analyze;
     }
 
-    public AnalyzedTableElements analyzedTableElements() {
+    AnalyzedTableElements<Object> analyzedTableElements() {
         return analyzedTableElements;
     }
 

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -56,7 +56,7 @@ public final class CreateTableStatementAnalyzer {
         this.numberOfShards = numberOfShards;
     }
 
-    public CreateTableAnalyzedStatement analyze(CreateTable createTable,
+    public CreateTableAnalyzedStatement analyze(CreateTable<Expression> createTable,
                                                 ParameterContext parameterContext,
                                                 CoordinatorTxnCtx coordinatorTxnCtx) {
         CreateTableAnalyzedStatement statement = new CreateTableAnalyzedStatement();

--- a/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -39,12 +39,12 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
 
     private static final DataTypeAnalyzer INSTANCE = new DataTypeAnalyzer();
 
-    public static DataType convert(ColumnType columnType) {
+    public static DataType convert(ColumnType<?> columnType) {
         return columnType.accept(INSTANCE, null);
     }
 
     @Override
-    public DataType<?> visitColumnType(ColumnType node, Void context) {
+    public DataType<?> visitColumnType(ColumnType<?> node, Void context) {
         String typeName = node.name();
         if (typeName == null) {
             return DataTypes.NOT_SUPPORTED;
@@ -54,10 +54,11 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
     }
 
     @Override
-    public DataType<?> visitObjectColumnType(ObjectColumnType node, Void context) {
+    public DataType<?> visitObjectColumnType(ObjectColumnType<?> node, Void context) {
+        ObjectColumnType<?> objectColumnType = node;
         ObjectType.Builder builder = ObjectType.builder();
-        for (ColumnDefinition columnDefinition : node.nestedColumns()) {
-            ColumnType type = columnDefinition.type();
+        for (ColumnDefinition<?> columnDefinition : objectColumnType.nestedColumns()) {
+            ColumnType<?> type = columnDefinition.type();
             // can be null for generated columns, as then the type is inferred from the expression.
             builder.setInnerType(
                 columnDefinition.ident(),
@@ -68,7 +69,7 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
     }
 
     @Override
-    public DataType<?> visitCollectionColumnType(CollectionColumnType node, Void context) {
+    public DataType<?> visitCollectionColumnType(CollectionColumnType<?> node, Void context) {
         DataType<?> innerType = node.innerType().accept(this, context);
         return new ArrayType<>(innerType);
     }

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -62,28 +62,28 @@ public class GenericPropertiesConverter {
     }
 
     private static void genericPropertiesToSettings(Settings.Builder builder,
-                                                    GenericProperties genericProperties,
+                                                    GenericProperties<Expression> genericProperties,
                                                     Row parameters) {
         for (Map.Entry<String, Expression> entry : genericProperties.properties().entrySet()) {
             genericPropertyToSetting(builder, entry.getKey(), entry.getValue(), parameters);
         }
     }
 
-    static Settings genericPropertiesToSettings(GenericProperties genericProperties, Row parameters) {
+    static Settings genericPropertiesToSettings(GenericProperties<Expression> genericProperties, Row parameters) {
         Settings.Builder builder = Settings.builder();
         genericPropertiesToSettings(builder, genericProperties, parameters);
         return builder.build();
     }
 
 
-    static Settings.Builder settingsFromProperties(GenericProperties properties,
+    static Settings.Builder settingsFromProperties(GenericProperties<Expression> properties,
                                                    Row parameters,
                                                    Map<String, Setting<?>> supportedSettings) {
 
         return settingsFromProperties(properties, parameters, supportedSettings, true);
     }
 
-    public static Settings.Builder settingsFromProperties(GenericProperties properties,
+    public static Settings.Builder settingsFromProperties(GenericProperties<Expression> properties,
                                                           Row parameters,
                                                           Map<String, Setting<?>> supportedSettings,
                                                           boolean setDefaults) {
@@ -94,7 +94,7 @@ public class GenericPropertiesConverter {
     }
 
     static void settingsFromProperties(Settings.Builder builder,
-                                       GenericProperties properties,
+                                       GenericProperties<Expression> properties,
                                        Row parameters,
                                        Map<String, Setting<?>> supportedSettings,
                                        boolean setDefaults,

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -61,18 +61,27 @@ public class GenericPropertiesConverter {
         }
     }
 
-    private static void genericPropertiesToSettings(Settings.Builder builder,
-                                                    GenericProperties<Expression> genericProperties,
-                                                    Row parameters) {
-        for (Map.Entry<String, Expression> entry : genericProperties.properties().entrySet()) {
-            genericPropertyToSetting(builder, entry.getKey(), entry.getValue(), parameters);
+    private static void genericPropertyToSetting(Settings.Builder builder,
+                                                 String name,
+                                                 Object value) {
+        if (value instanceof String[]) {
+            builder.putList(name, (String[]) value);
+        } else {
+            builder.put(name, value.toString());
         }
     }
 
-    static Settings genericPropertiesToSettings(GenericProperties<Expression> genericProperties, Row parameters) {
+    public static Settings genericPropertiesToSettings(GenericProperties<Object> genericProperties) {
         Settings.Builder builder = Settings.builder();
-        genericPropertiesToSettings(builder, genericProperties, parameters);
+        genericPropertiesToSettings(builder, genericProperties);
         return builder.build();
+    }
+
+    private static void genericPropertiesToSettings(Settings.Builder builder,
+                                                    GenericProperties<Object> genericProperties) {
+        for (Map.Entry<String, Object> entry : genericProperties.properties().entrySet()) {
+            builder.put(entry.getKey(), entry.getValue().toString());
+        }
     }
 
 
@@ -117,6 +126,32 @@ public class GenericPropertiesConverter {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH, invalidMessage, entry.getKey()));
             }
             settingHolder.apply(builder, entry.getValue(), parameters);
+        }
+    }
+
+    static void settingsFromProperties(Settings.Builder builder,
+                                       GenericProperties<Object> properties,
+                                       Map<String, Setting<?>> supportedSettings,
+                                       boolean setDefaults,
+                                       Predicate<String> ignoreProperty,
+                                       String invalidMessage) {
+        if (setDefaults) {
+            setDefaults(builder, supportedSettings);
+        }
+        for (Map.Entry<String, Object> entry : properties.properties().entrySet()) {
+            String settingName = entry.getKey();
+            if (ignoreProperty.test(settingName)) {
+                continue;
+            }
+            String groupName = getPossibleGroup(settingName);
+            if (groupName != null && ignoreProperty.test(groupName)) {
+                continue;
+            }
+            SettingHolder settingHolder = getSupportedSetting(supportedSettings, settingName);
+            if (settingHolder == null) {
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, invalidMessage, entry.getKey()));
+            }
+            settingHolder.apply(builder, entry.getValue());
         }
     }
 
@@ -220,6 +255,23 @@ public class GenericPropertiesConverter {
             }
             Settings.Builder singleSettingBuilder = Settings.builder();
             genericPropertyToSetting(singleSettingBuilder, setting.getKey(), valueExpression, parameters);
+            Object value = setting.get(singleSettingBuilder.build());
+            if (value instanceof Settings) {
+                builder.put((Settings) value);
+            } else {
+                builder.put(setting.getKey(), value.toString());
+            }
+
+        }
+
+        void apply(Settings.Builder builder, Object valueSymbol) {
+            if (isAffixSetting) {
+                // only concrete affix settings are supported otherwise it's not possible to parse values
+                throw new IllegalArgumentException(
+                    "Cannot change a dynamic group setting, only concrete settings allowed.");
+            }
+            Settings.Builder singleSettingBuilder = Settings.builder();
+            genericPropertyToSetting(singleSettingBuilder, setting.getKey(), valueSymbol);
             Object value = setting.get(singleSettingBuilder.build());
             if (value instanceof Settings) {
                 builder.put((Settings) value);

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -47,6 +47,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Insert;
 import io.crate.sql.tree.InsertFromSubquery;
 import io.crate.sql.tree.ParameterExpression;
@@ -242,7 +243,7 @@ class InsertFromSubQueryAnalyzer {
                                                        ExpressionAnalyzer exprAnalyzer,
                                                        CoordinatorTxnCtx txnCtx,
                                                        Function<ParameterExpression, Symbol> paramConverter,
-                                                       Insert.DuplicateKeyContext duplicateKeyContext) {
+                                                       Insert.DuplicateKeyContext<Expression> duplicateKeyContext) {
         if (duplicateKeyContext.getAssignments().isEmpty()) {
             return Collections.emptyMap();
         }
@@ -258,7 +259,7 @@ class InsertFromSubQueryAnalyzer {
         var expressionAnalyzer = new ExpressionAnalyzer(functions, txnCtx, paramConverter, fieldProvider, null);
         var normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, targetTable);
         Map<Reference, Symbol> updateAssignments = new HashMap<>(duplicateKeyContext.getAssignments().size());
-        for (Assignment assignment : duplicateKeyContext.getAssignments()) {
+        for (Assignment<Expression> assignment : duplicateKeyContext.getAssignments()) {
             Reference targetCol = requireNonNull(
                 targetTable.resolveField((Field) exprAnalyzer.convert(assignment.columnName(), exprCtx)),
                 "resolveField must work on a field that was just resolved"

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -112,7 +112,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
     }
 
 
-    public AnalyzedInsertStatement analyze(InsertFromValues insert, ParamTypeHints typeHints, CoordinatorTxnCtx txnCtx) {
+    public AnalyzedInsertStatement analyze(InsertFromValues<Expression> insert, ParamTypeHints typeHints, CoordinatorTxnCtx txnCtx) {
         if (insert.valuesLists().isEmpty()) {
             throw new IllegalArgumentException("VALUES clause must not be empty");
         }
@@ -165,7 +165,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         return new AnalyzedInsertStatement(rows, onDuplicateKeyAssignments);
     }
 
-    public AnalyzedStatement analyze(InsertFromValues node, Analysis analysis) {
+    public AnalyzedStatement analyze(InsertFromValues<Expression> node, Analysis analysis) {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(node.table().getName(), Operation.INSERT,
             analysis.sessionContext().searchPath());
 
@@ -277,7 +277,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                                ValuesResolver valuesResolver,
                                ExpressionAnalyzer valuesAwareExpressionAnalyzer,
                                ValuesList node,
-                               List<Assignment> onDuplicateKeyAssignments,
+                               List<Assignment<Expression>> onDuplicateKeyAssignments,
                                InsertFromValuesAnalyzedStatement statement,
                                ParameterContext parameterContext,
                                ReferenceToLiteralConverter refToLiteral) {
@@ -339,7 +339,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                            ValuesResolver valuesResolver,
                            ExpressionAnalyzer valuesAwareExpressionAnalyzer,
                            ValuesList node,
-                           List<Assignment> onDuplicateKeyAssignments,
+                           List<Assignment<Expression>> onDuplicateKeyAssignments,
                            InsertFromValuesAnalyzedStatement context,
                            ReferenceToLiteralConverter refToLiteral,
                            int numPrimaryKeys,
@@ -416,7 +416,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             Symbol[] onDupKeyAssignments = new Symbol[onDuplicateKeyAssignments.size()];
             valuesResolver.assignmentColumns = new ArrayList<>(onDuplicateKeyAssignments.size());
             for (int i = 0; i < onDuplicateKeyAssignments.size(); i++) {
-                Assignment assignment = onDuplicateKeyAssignments.get(i);
+                Assignment<Expression> assignment = onDuplicateKeyAssignments.get(i);
                 Reference columnName = tableRelation.resolveField(
                     (Field) expressionAnalyzer.convert(assignment.columnName(), expressionAnalysisContext));
                 assert columnName != null : "columnName must not be null";

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -89,8 +89,8 @@ public class MetaDataToASTNodeResolver {
             return new Table<>(QualifiedName.of(tableInfo.ident().fqn()), false);
         }
 
-        private List<TableElement> extractTableElements() {
-            List<TableElement> elements = new ArrayList<>();
+        private List<TableElement<Expression>> extractTableElements() {
+            List<TableElement<Expression>> elements = new ArrayList<>();
             // column definitions
             elements.addAll(extractColumnDefinitions(null));
             // primary key constraint
@@ -101,9 +101,9 @@ public class MetaDataToASTNodeResolver {
             return elements;
         }
 
-        private List<ColumnDefinition> extractColumnDefinitions(@Nullable ColumnIdent parent) {
+        private List<ColumnDefinition<Expression>> extractColumnDefinitions(@Nullable ColumnIdent parent) {
             Iterator<Reference> referenceIterator = tableInfo.iterator();
-            List<ColumnDefinition> elements = new ArrayList<>();
+            List<ColumnDefinition<Expression>> elements = new ArrayList<>();
             while (referenceIterator.hasNext()) {
                 Reference info = referenceIterator.next();
                 ColumnIdent ident = info.column();
@@ -116,12 +116,12 @@ public class MetaDataToASTNodeResolver {
 
                 ColumnType columnType;
                 if (info.valueType().id() == ObjectType.ID) {
-                    columnType = new ObjectColumnType(info.columnPolicy().name(), extractColumnDefinitions(ident));
+                    columnType = new ObjectColumnType<>(info.columnPolicy().name(), extractColumnDefinitions(ident));
                 } else if (info.valueType().id() == ArrayType.ID) {
                     DataType innerType = ((ArrayType) info.valueType()).innerType();
                     ColumnType innerColumnType;
                     if (innerType.id() == ObjectType.ID) {
-                        innerColumnType = new ObjectColumnType(info.columnPolicy().name(), extractColumnDefinitions(ident));
+                        innerColumnType = new ObjectColumnType<>(info.columnPolicy().name(), extractColumnDefinitions(ident));
                     } else {
                         innerColumnType = new ColumnType(innerType.getName());
                     }
@@ -130,35 +130,35 @@ public class MetaDataToASTNodeResolver {
                     columnType = new ColumnType(info.valueType().getName());
                 }
 
-                List<ColumnConstraint> constraints = new ArrayList<>();
+                List<ColumnConstraint<Expression>> constraints = new ArrayList<>();
                 if (!info.isNullable()) {
-                    constraints.add(new NotNullColumnConstraint());
+                    constraints.add(new NotNullColumnConstraint<>());
                 }
                 if (info.indexType().equals(Reference.IndexType.NO)
                     && info.valueType().id() != ObjectType.ID
                     && !(info.valueType().id() == ArrayType.ID &&
                          ((ArrayType) info.valueType()).innerType().id() == ObjectType.ID)) {
-                    constraints.add(IndexColumnConstraint.OFF);
+                    constraints.add(IndexColumnConstraint.off());
                 } else if (info.indexType().equals(Reference.IndexType.ANALYZED)) {
                     String analyzer = tableInfo.getAnalyzerForColumnIdent(ident);
-                    GenericProperties properties = new GenericProperties();
+                    GenericProperties<Expression> properties = new GenericProperties<>();
                     if (analyzer != null) {
-                        properties.add(new GenericProperty(FulltextAnalyzerResolver.CustomType.ANALYZER.getName(), new StringLiteral(analyzer)));
+                        properties.add(new GenericProperty<>(FulltextAnalyzerResolver.CustomType.ANALYZER.getName(), new StringLiteral(analyzer)));
                     }
-                    constraints.add(new IndexColumnConstraint("fulltext", properties));
+                    constraints.add(new IndexColumnConstraint<>("fulltext", properties));
                 } else if (info.valueType().equals(DataTypes.GEO_SHAPE)) {
                     GeoReference geoReference = (GeoReference) info;
-                    GenericProperties properties = new GenericProperties();
+                    GenericProperties<Expression> properties = new GenericProperties<>();
                     if (geoReference.distanceErrorPct() != null) {
-                        properties.add(new GenericProperty("distance_error_pct", StringLiteral.fromObject(geoReference.distanceErrorPct())));
+                        properties.add(new GenericProperty<>("distance_error_pct", StringLiteral.fromObject(geoReference.distanceErrorPct())));
                     }
                     if (geoReference.precision() != null) {
-                        properties.add(new GenericProperty("precision", StringLiteral.fromObject(geoReference.precision())));
+                        properties.add(new GenericProperty<>("precision", StringLiteral.fromObject(geoReference.precision())));
                     }
                     if (geoReference.treeLevels() != null) {
-                        properties.add(new GenericProperty("tree_levels", StringLiteral.fromObject(geoReference.treeLevels())));
+                        properties.add(new GenericProperty<>("tree_levels", StringLiteral.fromObject(geoReference.treeLevels())));
                     }
-                    constraints.add(new IndexColumnConstraint(geoReference.geoTree(), properties));
+                    constraints.add(new IndexColumnConstraint<>(geoReference.geoTree(), properties));
                 }
 
                 Expression generatedExpression = null;
@@ -173,13 +173,13 @@ public class MetaDataToASTNodeResolver {
                 }
 
                 if (info.isColumnStoreDisabled()) {
-                    GenericProperties properties = new GenericProperties();
-                    properties.add(new GenericProperty("columnstore", BooleanLiteral.fromObject(false)));
-                    constraints.add(new ColumnStorageDefinition(properties));
+                    GenericProperties<Expression> properties = new GenericProperties<>();
+                    properties.add(new GenericProperty<>("columnstore", BooleanLiteral.fromObject(false)));
+                    constraints.add(new ColumnStorageDefinition<>(properties));
                 }
 
                 String columnName = ident.isTopLevel() ? ident.name() : ident.path().get(ident.path().size() - 1);
-                elements.add(new ColumnDefinition(
+                elements.add(new ColumnDefinition<>(
                     columnName,
                     defaultExpression,
                     generatedExpression,
@@ -190,18 +190,18 @@ public class MetaDataToASTNodeResolver {
             return elements;
         }
 
-        private PrimaryKeyConstraint extractPrimaryKeyConstraint() {
+        private PrimaryKeyConstraint<Expression> extractPrimaryKeyConstraint() {
             if (!tableInfo.primaryKey().isEmpty()) {
                 if (tableInfo.primaryKey().size() == 1 && tableInfo.primaryKey().get(0).isSystemColumn()) {
                     return null;
                 }
-                return new PrimaryKeyConstraint(expressionsFromColumns(tableInfo.primaryKey()));
+                return new PrimaryKeyConstraint<>(expressionsFromColumns(tableInfo.primaryKey()));
             }
             return null;
         }
 
-        private List<IndexDefinition> extractIndexDefinitions() {
-            List<IndexDefinition> elements = new ArrayList<>();
+        private List<IndexDefinition<Expression>> extractIndexDefinitions() {
+            List<IndexDefinition<Expression>> elements = new ArrayList<>();
             Iterator indexColumns = tableInfo.indexColumns();
             if (indexColumns != null) {
                 while (indexColumns.hasNext()) {
@@ -214,30 +214,30 @@ public class MetaDataToASTNodeResolver {
                         if (analyzer != null) {
                             properties.add(new GenericProperty<>(FulltextAnalyzerResolver.CustomType.ANALYZER.getName(), new StringLiteral(analyzer)));
                         }
-                        elements.add(new IndexDefinition(name, "fulltext", columns, properties));
+                        elements.add(new IndexDefinition<>(name, "fulltext", columns, properties));
                     } else if (indexRef.indexType().equals(Reference.IndexType.NOT_ANALYZED)) {
-                        elements.add(new IndexDefinition(name, "plain", columns, GenericProperties.empty()));
+                        elements.add(new IndexDefinition<>(name, "plain", columns, GenericProperties.empty()));
                     }
                 }
             }
             return elements;
         }
 
-        private Optional<PartitionedBy> createPartitionedBy() {
+        private Optional<PartitionedBy<Expression>> createPartitionedBy() {
             if (tableInfo.partitionedBy().isEmpty()) {
                 return Optional.empty();
             } else {
-                return Optional.of(new PartitionedBy(expressionsFromColumns(tableInfo.partitionedBy())));
+                return Optional.of(new PartitionedBy<>(expressionsFromColumns(tableInfo.partitionedBy())));
             }
         }
 
-        private Optional<ClusteredBy> createClusteredBy() {
+        private Optional<ClusteredBy<Expression>> createClusteredBy() {
             ColumnIdent clusteredByColumn = tableInfo.clusteredBy();
             Expression clusteredBy = clusteredByColumn == null || clusteredByColumn.isSystemColumn()
                 ? null
                 : expressionFromColumn(clusteredByColumn);
             Expression numShards = new LongLiteral(Integer.toString(tableInfo.numberOfShards()));
-            return Optional.of(new ClusteredBy(Optional.ofNullable(clusteredBy), Optional.of(numShards)));
+            return Optional.of(new ClusteredBy<>(Optional.ofNullable(clusteredBy), Optional.of(numShards)));
         }
 
         private GenericProperties<Expression> extractTableProperties() {
@@ -268,9 +268,9 @@ public class MetaDataToASTNodeResolver {
 
         private CreateTable<Expression> extractCreateTable() {
             Table<Expression> table = extractTable();
-            List<TableElement> tableElements = extractTableElements();
-            Optional<PartitionedBy> partitionedBy = createPartitionedBy();
-            Optional<ClusteredBy> clusteredBy = createClusteredBy();
+            List<TableElement<Expression>> tableElements = extractTableElements();
+            Optional<PartitionedBy<Expression>> partitionedBy = createPartitionedBy();
+            Optional<ClusteredBy<Expression>> clusteredBy = createClusteredBy();
             return new CreateTable<>(table, tableElements, partitionedBy, clusteredBy, extractTableProperties(), true);
         }
 

--- a/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
@@ -31,6 +31,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -42,10 +43,10 @@ import java.util.Map;
 
 public class PartitionPropertiesAnalyzer {
 
-    public static Map<ColumnIdent, Object> assignmentsToMap(List<Assignment> assignments,
+    public static Map<ColumnIdent, Object> assignmentsToMap(List<Assignment<Expression>> assignments,
                                                             Row parameters) {
         Map<ColumnIdent, Object> map = new HashMap<>(assignments.size());
-        for (Assignment assignment : assignments) {
+        for (Assignment<Expression> assignment : assignments) {
             map.put(
                 ColumnIdent.fromPath(ExpressionToStringVisitor.convert(assignment.columnName(), parameters)),
                 ExpressionToObjectVisitor.convert(assignment.expression(), parameters)
@@ -55,7 +56,7 @@ public class PartitionPropertiesAnalyzer {
     }
 
     public static PartitionName toPartitionName(DocTableInfo tableInfo,
-                                                List<Assignment> partitionProperties,
+                                                List<Assignment<Expression>> partitionProperties,
                                                 Row parameters) {
         Preconditions.checkArgument(tableInfo.isPartitioned(), "table '%s' is not partitioned", tableInfo.ident().fqn());
         Preconditions.checkArgument(partitionProperties.size() == tableInfo.partitionedBy().size(),
@@ -85,7 +86,7 @@ public class PartitionPropertiesAnalyzer {
 
     public static PartitionName toPartitionName(RelationName relationName,
                                                 @Nullable DocTableInfo docTableInfo,
-                                                List<Assignment> partitionProperties,
+                                                List<Assignment<Expression>> partitionProperties,
                                                 Row parameters) {
         if (docTableInfo != null) {
             return toPartitionName(docTableInfo, partitionProperties, parameters);
@@ -103,7 +104,7 @@ public class PartitionPropertiesAnalyzer {
     }
 
     public static String toPartitionIdent(DocTableInfo tableInfo,
-                                          List<Assignment> partitionProperties,
+                                          List<Assignment<Expression>> partitionProperties,
                                           Row parameters) {
         return toPartitionName(tableInfo, partitionProperties, parameters).ident();
     }

--- a/sql/src/main/java/io/crate/analyze/PromoteReplicaStatement.java
+++ b/sql/src/main/java/io/crate/analyze/PromoteReplicaStatement.java
@@ -25,6 +25,7 @@ package io.crate.analyze;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -36,7 +37,7 @@ public class PromoteReplicaStatement extends RerouteAnalyzedStatement {
     private final Symbol node;
 
     public PromoteReplicaStatement(ShardedTable tableInfo,
-                                   List<Assignment> partitionProperties,
+                                   List<Assignment<Expression>> partitionProperties,
                                    Symbol node,
                                    Symbol shardId,
                                    Symbol acceptDataLoss) {

--- a/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
@@ -34,7 +34,7 @@ public class RerouteAllocateReplicaShardAnalyzedStatement extends RerouteAnalyze
     private final Expression nodeId;
 
     public RerouteAllocateReplicaShardAnalyzedStatement(ShardedTable tableInfo,
-                                                        List<Assignment> partitionProperties,
+                                                        List<Assignment<Expression>> partitionProperties,
                                                         Expression shardId,
                                                         Expression nodeId) {
         super(tableInfo, partitionProperties);

--- a/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
@@ -24,16 +24,16 @@ package io.crate.analyze;
 
 import io.crate.metadata.table.ShardedTable;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 
 import java.util.List;
 
 public abstract class RerouteAnalyzedStatement implements DDLStatement {
 
-
     private final ShardedTable tableInfo;
-    private final List<Assignment> partitionProperties;
+    private final List<Assignment<Expression>> partitionProperties;
 
-    public RerouteAnalyzedStatement(ShardedTable tableInfo, List<Assignment> partitionProperties) {
+    public RerouteAnalyzedStatement(ShardedTable tableInfo, List<Assignment<Expression>> partitionProperties) {
         this.tableInfo = tableInfo;
         this.partitionProperties = partitionProperties;
     }
@@ -42,7 +42,7 @@ public abstract class RerouteAnalyzedStatement implements DDLStatement {
         return tableInfo;
     }
 
-    public List<Assignment> partitionProperties() {
+    public List<Assignment<Expression>> partitionProperties() {
         return partitionProperties;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
@@ -33,13 +33,13 @@ public class RerouteCancelShardAnalyzedStatement extends RerouteAnalyzedStatemen
 
     private final Expression shardId;
     private final Expression nodeId;
-    private final GenericProperties properties;
+    private final GenericProperties<Expression> properties;
 
     public RerouteCancelShardAnalyzedStatement(ShardedTable tableInfo,
-                                               List<Assignment> partitionProperties,
+                                               List<Assignment<Expression>> partitionProperties,
                                                Expression shardId,
                                                Expression nodeId,
-                                               GenericProperties properties) {
+                                               GenericProperties<Expression> properties) {
         super(tableInfo, partitionProperties);
         this.shardId = shardId;
         this.nodeId = nodeId;
@@ -59,7 +59,7 @@ public class RerouteCancelShardAnalyzedStatement extends RerouteAnalyzedStatemen
         return nodeId;
     }
 
-    public GenericProperties properties() {
+    public GenericProperties<Expression> properties() {
         return properties;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
@@ -35,7 +35,7 @@ public class RerouteMoveShardAnalyzedStatement extends RerouteAnalyzedStatement 
     private final Expression toNodeIdOrName;
 
     public RerouteMoveShardAnalyzedStatement(ShardedTable tableInfo,
-                                             List<Assignment> partitionProperties,
+                                             List<Assignment<Expression>> partitionProperties,
                                              Expression shardId,
                                              Expression fromNodeIdOrName,
                                              Expression toNodeIdOrName) {

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -35,8 +35,8 @@ import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.SetStatement;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,7 +54,7 @@ class SetStatementAnalyzer {
 
         boolean isPersistent = node.settingType().equals(SetStatement.SettingType.PERSISTENT);
         Map<String, List<Expression>> settings = new HashMap<>();
-        Assignment assignment;
+        Assignment<Expression> assignment;
 
         switch (node.scope()) {
             case LICENSE:
@@ -67,7 +67,7 @@ class SetStatementAnalyzer {
 
                 return new SetLicenseAnalyzedStatement(licenseKey);
             case GLOBAL:
-                for (Assignment anAssignment : node.assignments()) {
+                for (Assignment<Expression> anAssignment : node.assignments()) {
                     for (String setting : ExpressionToSettingNameListVisitor.convert(anAssignment)) {
                         CrateSettings.checkIfRuntimeSetting(setting);
                     }
@@ -120,9 +120,10 @@ class SetStatementAnalyzer {
         }
 
         @Override
-        public Collection<String> visitAssignment(Assignment node, String context) {
-            String left = ExpressionToStringVisitor.convert(node.columnName(), Row.EMPTY);
-            return node.expression().accept(this, left);
+        public Collection<String> visitAssignment(Assignment<?> node, String context) {
+            Assignment<Expression> assignment = (Assignment<Expression>) node;
+            String left = ExpressionToStringVisitor.convert(assignment.columnName(), Row.EMPTY);
+            return assignment.expression().accept(this, left);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/TableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableAnalyzer.java
@@ -26,6 +26,7 @@ import io.crate.exceptions.PartitionUnknownException;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +36,7 @@ import java.util.List;
 final class TableAnalyzer {
 
     static Collection<String> filteredIndices(ParameterContext parameterContext,
-                                              List<Assignment> partitionProperties,
+                                              List<Assignment<Expression>> partitionProperties,
                                               DocTableInfo tableInfo) {
         if (partitionProperties.isEmpty()) {
             return Arrays.asList(tableInfo.concreteOpenIndices());

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -305,7 +305,8 @@ public class TableElementsAnalyzer {
             context.analyzedColumnDefinition.geoSettings(geoSettings);
         }
 
-        private void setAnalyzer(GenericProperties properties, ColumnDefinitionContext context,
+        private void setAnalyzer(GenericProperties<Expression> properties,
+                                 ColumnDefinitionContext context,
                                  String indexMethod) {
             context.analyzedColumnDefinition.indexConstraint(Reference.IndexType.ANALYZED);
 

--- a/sql/src/main/java/io/crate/analyze/TableParameter.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameter.java
@@ -34,7 +34,7 @@ public class TableParameter {
     private Settings settings;
     private Map<String, Object> mappings;
 
-    TableParameter() {
+    public TableParameter() {
         settingsBuilder = Settings.builder();
         mappingsBuilder = Settings.builder();
     }

--- a/sql/src/main/java/io/crate/analyze/TableParameters.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameters.java
@@ -128,7 +128,7 @@ public class TableParameters {
 
     private static final Map<String, Setting<?>> SUPPORTED_MAPPINGS_DEFAULT = Map.of("column_policy", COLUMN_POLICY);
 
-    static final TableParameters TABLE_CREATE_PARAMETER_INFO
+    public static final TableParameters TABLE_CREATE_PARAMETER_INFO
         = new TableParameters(SUPPORTED_SETTINGS_DEFAULT, SUPPORTED_MAPPINGS_DEFAULT);
 
     static final TableParameters TABLE_ALTER_PARAMETER_INFO

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -69,6 +69,30 @@ public final class TablePropertiesAnalyzer {
             INVALID_MESSAGE);
     }
 
+    public static void analyzeWithBoundValues(TableParameter tableParameter,
+                                              TableParameters tableParameters,
+                                              GenericProperties<Object> properties,
+                                              boolean withDefaults) {
+        Map<String, Setting<?>> settingMap = tableParameters.supportedSettings();
+        Map<String, Setting<?>> mappingsMap = tableParameters.supportedMappings();
+
+        GenericPropertiesConverter.settingsFromProperties(
+            tableParameter.settingsBuilder(),
+            properties,
+            settingMap,
+            withDefaults,
+            mappingsMap::containsKey,
+            INVALID_MESSAGE);
+
+        GenericPropertiesConverter.settingsFromProperties(
+            tableParameter.mappingsBuilder(),
+            properties,
+            mappingsMap,
+            withDefaults,
+            settingMap::containsKey,
+            INVALID_MESSAGE);
+    }
+
     /**
      * Processes the property names which should be reset and updates the settings or mappings with the related
      * default value.

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -26,8 +26,10 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.CreateTable;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.Explain;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.InsertFromSubquery;
 import io.crate.sql.tree.InsertFromValues;
 import io.crate.sql.tree.Query;
@@ -58,7 +60,8 @@ class UnboundAnalyzer {
                     UpdateAnalyzer updateAnalyzer,
                     InsertFromValuesAnalyzer insertFromValuesAnalyzer,
                     InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer,
-                    ExplainStatementAnalyzer explainStatementAnalyzer) {
+                    ExplainStatementAnalyzer explainStatementAnalyzer,
+                    CreateTableStatementAnalyzer createTableAnalyzer) {
         this.dispatcher = new UnboundDispatcher(
             relationAnalyzer,
             showCreateTableAnalyzer,
@@ -67,7 +70,8 @@ class UnboundAnalyzer {
             updateAnalyzer,
             insertFromValuesAnalyzer,
             insertFromSubQueryAnalyzer,
-            explainStatementAnalyzer
+            explainStatementAnalyzer,
+            createTableAnalyzer
         );
     }
 
@@ -87,6 +91,7 @@ class UnboundAnalyzer {
         private final InsertFromValuesAnalyzer insertFromValuesAnalyzer;
         private final InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer;
         private final ExplainStatementAnalyzer explainStatementAnalyzer;
+        private final CreateTableStatementAnalyzer createTableAnalyzer;
 
         UnboundDispatcher(RelationAnalyzer relationAnalyzer,
                           ShowCreateTableAnalyzer showCreateTableAnalyzer,
@@ -95,7 +100,8 @@ class UnboundAnalyzer {
                           UpdateAnalyzer updateAnalyzer,
                           InsertFromValuesAnalyzer insertFromValuesAnalyzer,
                           InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer,
-                          ExplainStatementAnalyzer explainStatementAnalyzer) {
+                          ExplainStatementAnalyzer explainStatementAnalyzer,
+                          CreateTableStatementAnalyzer createTableAnalyzer) {
             this.relationAnalyzer = relationAnalyzer;
             this.showCreateTableAnalyzer = showCreateTableAnalyzer;
             this.showStatementAnalyzer = showStatementAnalyzer;
@@ -104,6 +110,12 @@ class UnboundAnalyzer {
             this.insertFromValuesAnalyzer = insertFromValuesAnalyzer;
             this.insertFromSubQueryAnalyzer = insertFromSubQueryAnalyzer;
             this.explainStatementAnalyzer = explainStatementAnalyzer;
+            this.createTableAnalyzer = createTableAnalyzer;
+        }
+
+        @Override
+        public AnalyzedStatement visitCreateTable(CreateTable node, Analysis analysis) {
+            return createTableAnalyzer.analyze((CreateTable<Expression>) node, analysis.paramTypeHints(), analysis.transactionContext());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -121,7 +121,7 @@ public final class UpdateAnalyzer {
         return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery);
     }
 
-    private HashMap<Reference, Symbol> getAssignments(List<Assignment> assignments,
+    private HashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,
                                                       ParamTypeHints typeHints,
                                                       CoordinatorTxnCtx txnCtx,
                                                       AbstractTableRelation table,
@@ -142,7 +142,7 @@ public final class UpdateAnalyzer {
             : "assignments should implement RandomAccess for indexed loop to avoid iterator allocations";
         TableInfo tableInfo = table.tableInfo();
         for (int i = 0; i < assignments.size(); i++) {
-            Assignment assignment = assignments.get(i);
+            Assignment<Expression> assignment = assignments.get(i);
             AssignmentNameValidator.ensureNoArrayElementUpdate(assignment.columnName());
 
             Symbol target = normalizer.normalize(targetExprAnalyzer.convert(assignment.columnName(), exprCtx), txnCtx);

--- a/sql/src/main/java/io/crate/analyze/ddl/GeoSettingsApplier.java
+++ b/sql/src/main/java/io/crate/analyze/ddl/GeoSettingsApplier.java
@@ -23,6 +23,8 @@
 package io.crate.analyze.ddl;
 
 import com.google.common.collect.ImmutableSet;
+import io.crate.analyze.GenericPropertiesConverter;
+import io.crate.sql.tree.GenericProperties;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -37,7 +39,8 @@ public class GeoSettingsApplier {
     private static final Set<String> SUPPORTED_OPTIONS = ImmutableSet.of(
         "precision", "distance_error_pct", "tree_levels");
 
-    public static void applySettings(Map<String, Object> mapping, Settings geoSettings, @Nullable String geoTree) {
+    public static void applySettings(Map<String, Object> mapping, GenericProperties<Object> properties, @Nullable String geoTree) {
+        Settings geoSettings = GenericPropertiesConverter.genericPropertiesToSettings(properties);
         validate(geoSettings);
         if (geoTree != null) {
             mapping.put("tree", geoTree);

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -69,6 +69,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.expression.symbol.format.SymbolFormatter;
+import io.crate.interval.IntervalParser;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -127,7 +128,6 @@ import io.crate.sql.tree.WindowFrame;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.interval.IntervalParser;
 import io.crate.types.ObjectType;
 import io.crate.types.UndefinedType;
 import org.joda.time.Period;
@@ -1046,12 +1046,12 @@ public class ExpressionAnalyzer {
         return allocateFunction(functionName, arguments, null, context, functions, coordinatorTxnCtx);
     }
 
-    static Symbol allocateFunction(String functionName,
-                                   List<Symbol> arguments,
-                                   Symbol filter,
-                                   ExpressionAnalysisContext context,
-                                   Functions functions,
-                                   CoordinatorTxnCtx coordinatorTxnCtx) {
+    public static Symbol allocateFunction(String functionName,
+                                          List<Symbol> arguments,
+                                          Symbol filter,
+                                          ExpressionAnalysisContext context,
+                                          Functions functions,
+                                          CoordinatorTxnCtx coordinatorTxnCtx) {
         return allocateBuiltinOrUdfFunction(
             null, functionName, arguments, filter, context, functions, null, coordinatorTxnCtx);
     }

--- a/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -21,7 +21,9 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
@@ -37,4 +39,6 @@ public interface FieldProvider<T extends Symbol> {
             "Columns cannot be used in this context. " +
             "Maybe you wanted to use a string literal which requires single quotes: '" + qualifiedName + "'");
     };
+
+    FieldProvider<Literal> FIELDS_AS_LITERAL = ((qualifiedName, path, operation) -> Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
 }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
@@ -55,7 +55,7 @@ public class RepositoryParamValidator {
         Map<String, Setting<?>> allSettings = typeSettings.all();
 
         // create string settings for all dynamic settings
-        GenericProperties dynamicProperties = typeSettings.dynamicProperties(genericProperties);
+        GenericProperties<?> dynamicProperties = typeSettings.dynamicProperties(genericProperties);
         if (!dynamicProperties.isEmpty()) {
             // allSettings are immutable by default, copy map
             allSettings = Maps.newHashMap(allSettings);

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -72,15 +72,15 @@ public class RepositorySettingsModule extends AbstractModule {
             .build()) {
 
         @Override
-        public GenericProperties dynamicProperties(GenericProperties genericProperties) {
+        public GenericProperties<Expression> dynamicProperties(GenericProperties<Expression> genericProperties) {
             if (genericProperties.isEmpty()) {
                 return genericProperties;
             }
-            GenericProperties dynamicProperties = new GenericProperties();
+            GenericProperties<Expression> dynamicProperties = new GenericProperties<>();
             for (Map.Entry<String, Expression> entry : genericProperties.properties().entrySet()) {
                 String key = entry.getKey();
                 if (key.startsWith("conf.")) {
-                    dynamicProperties.add(new GenericProperty(key, entry.getValue()));
+                    dynamicProperties.add(new GenericProperty<>(key, entry.getValue()));
                 }
             }
             return dynamicProperties;

--- a/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
@@ -23,6 +23,7 @@
 package io.crate.analyze.repositories;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -58,7 +59,7 @@ public class TypeSettings {
     /**
      * Return possible dynamic GenericProperties which will not be validated.
      */
-    public GenericProperties dynamicProperties(GenericProperties genericProperties) {
-        return GenericProperties.EMPTY;
+    public GenericProperties<Expression> dynamicProperties(GenericProperties<Expression> genericProperties) {
+        return GenericProperties.empty();
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
@@ -35,7 +35,6 @@ import io.crate.analyze.CreateBlobTableAnalyzedStatement;
 import io.crate.analyze.CreateFunctionAnalyzedStatement;
 import io.crate.analyze.CreateRepositoryAnalyzedStatement;
 import io.crate.analyze.CreateSnapshotAnalyzedStatement;
-import io.crate.analyze.CreateTableAnalyzedStatement;
 import io.crate.analyze.CreateUserAnalyzedStatement;
 import io.crate.analyze.DropFunctionAnalyzedStatement;
 import io.crate.analyze.DropRepositoryAnalyzedStatement;
@@ -166,11 +165,6 @@ public class DDLStatementDispatcher {
         @Override
         protected CompletableFuture<Long> visitAnalyzedStatement(AnalyzedStatement analyzedStatement, Ctx ctx) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "Can't handle \"%s\"", analyzedStatement));
-        }
-
-        @Override
-        public CompletableFuture<Long> visitCreateTableStatement(CreateTableAnalyzedStatement analysis, Ctx ctx) {
-            return tableCreator.create(analysis);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
+++ b/sql/src/main/java/io/crate/execution/ddl/RerouteActions.java
@@ -39,6 +39,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.types.DataTypes;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
@@ -170,7 +171,7 @@ public final class RerouteActions {
         return shardedTable.concreteIndices()[0];
     }
 
-    static boolean validateCancelRerouteProperty(String propertyKey, GenericProperties properties, Row parameters) throws IllegalArgumentException {
+    static boolean validateCancelRerouteProperty(String propertyKey, GenericProperties<Expression> properties, Row parameters) throws IllegalArgumentException {
         if (properties != null) {
             for (String key : properties.keys()) {
                 if (propertyKey.equals(key)) {

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -346,8 +346,8 @@ public class AlterTableOperation {
                 null,
                 analysis.table().isPartitioned(),
                 false,
-                analysis.analyzedTableElements().settings(),
-                analysis.analyzedTableElements().toMapping()
+                analysis.settings(),
+                analysis.mapping()
             );
             transportAlterTableAction.execute(request, result);
             return result;

--- a/sql/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Literal.java
@@ -87,7 +87,7 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
         value = type.streamer().readValueFrom(in);
     }
 
-    private Literal(DataType type, ReturnType value) {
+    protected Literal(DataType type, ReturnType value) {
         assert typeMatchesValue(type, value) :
             String.format(Locale.ENGLISH, "value %s is not of type %s", value, type.getName());
         this.type = type;

--- a/sql/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/sql/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -32,6 +32,7 @@ import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.PhasesTaskFactory;
 import io.crate.license.LicenseService;
+import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -63,6 +64,7 @@ public class DependencyCarrier {
     private final TransportDropViewAction dropViewAction;
     private final TransportSwapRelationsAction swapRelationsAction;
     private final LicenseService licenseService;
+    private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
 
     @Inject
     public DependencyCarrier(Settings settings,
@@ -78,7 +80,8 @@ public class DependencyCarrier {
                              TransportDropTableAction transportDropTableAction,
                              TransportCreateViewAction createViewAction,
                              TransportDropViewAction dropViewAction,
-                             TransportSwapRelationsAction swapRelationsAction) {
+                             TransportSwapRelationsAction swapRelationsAction,
+                             FulltextAnalyzerResolver fulltextAnalyzerResolver) {
         this.settings = settings;
         this.transportActionProvider = transportActionProvider;
         this.phasesTaskFactory = phasesTaskFactory;
@@ -94,6 +97,7 @@ public class DependencyCarrier {
         this.createViewAction = createViewAction;
         this.dropViewAction = dropViewAction;
         this.swapRelationsAction = swapRelationsAction;
+        this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
     }
 
     public Schemas schemas() {
@@ -162,5 +166,9 @@ public class DependencyCarrier {
 
     public TransportDropViewAction dropViewAction() {
         return dropViewAction;
+    }
+
+    public FulltextAnalyzerResolver fulltextAnalyzerResolver() {
+        return fulltextAnalyzerResolver;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.analyze.AnalyzedColumnDefinition;
+import io.crate.analyze.AnalyzedCreateTable;
+import io.crate.analyze.AnalyzedTableElements;
+import io.crate.analyze.CreateTableAnalyzedStatement;
+import io.crate.analyze.NumberOfShards;
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.analyze.TableParameter;
+import io.crate.analyze.TableParameters;
+import io.crate.analyze.TablePropertiesAnalyzer;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
+import io.crate.execution.ddl.tables.TableCreator;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.FulltextAnalyzerResolver;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryAndParamBinder;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.ClusteredBy;
+import io.crate.sql.tree.CreateTable;
+import io.crate.sql.tree.GenericProperties;
+import io.crate.sql.tree.PartitionedBy;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+
+import javax.annotation.Nullable;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.crate.data.SentinelRow.SENTINEL;
+
+public class CreateTablePlan implements Plan {
+
+    private static final String CLUSTERED_BY_IN_PARTITIONED_ERROR = "Cannot use CLUSTERED BY column in PARTITIONED BY clause";
+
+    private final AnalyzedCreateTable createTable;
+    private final NumberOfShards numberOfShards;
+    private final TableCreator tableCreator;
+    private final Schemas schemas;
+
+    public CreateTablePlan(AnalyzedCreateTable createTable,
+                           NumberOfShards numberOfShards,
+                           TableCreator tableCreator,
+                           Schemas schemas) {
+        this.createTable = createTable;
+        this.numberOfShards = numberOfShards;
+        this.tableCreator = tableCreator;
+        this.schemas = schemas;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) {
+        CreateTableAnalyzedStatement stmt = createStatement(
+            createTable,
+            plannerContext.transactionContext(),
+            plannerContext.functions(),
+            params,
+            subQueryResults,
+            numberOfShards,
+            schemas,
+            dependencies.fulltextAnalyzerResolver());
+
+        if (stmt.noOp()) {
+            consumer.accept(InMemoryBatchIterator.empty(SENTINEL), null);
+            return;
+        }
+
+        tableCreator.create(stmt)
+            .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
+    }
+
+    @VisibleForTesting
+    public static CreateTableAnalyzedStatement createStatement(AnalyzedCreateTable createTable,
+                                                               CoordinatorTxnCtx txnCtx,
+                                                               Functions functions,
+                                                               Row params,
+                                                               SubQueryResults subQueryResults,
+                                                               NumberOfShards numberOfShards,
+                                                               Schemas schemas,
+                                                               FulltextAnalyzerResolver fulltextAnalyzerResolver) {
+        Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
+            txnCtx,
+            functions,
+            x,
+            params,
+            subQueryResults
+        );
+        CreateTable<Symbol> table = createTable.createTable();
+        RelationName relationName = createTable.relationName();
+        GenericProperties<Object> properties = table.properties().map(eval);
+
+        CreateTableAnalyzedStatement stmt = new CreateTableAnalyzedStatement();
+        stmt.table(relationName, table.ifNotExists(), schemas);
+        TableParameter tableParameter = stmt.tableParameter();
+
+        // apply default in case it is not specified in the genericProperties,
+        // if it is it will get overwritten afterwards.
+        TablePropertiesAnalyzer.analyzeWithBoundValues(
+            tableParameter,
+            TableParameters.TABLE_CREATE_PARAMETER_INFO,
+            properties,
+            true
+        );
+        AnalyzedTableElements<Object> tableElements = createTable.analyzedTableElements().map(eval);
+        AnalyzedTableElements<Symbol> tableElementsWithExpressions =
+            createTable.analyzedTableElementsWithExpressions().map(x -> SubQueryAndParamBinder.convert(x, params, subQueryResults));
+
+        // validate table elements
+        Map<String, Object> tableElementsMapping = AnalyzedTableElements.finalizeAndValidate(
+            relationName,
+            tableElementsWithExpressions,
+            tableElements,
+            functions);
+
+        stmt.analyzedTableElements(tableElements);
+
+        // update table settings
+        Settings tableSettings = AnalyzedTableElements.validateAndBuildSettings(
+            tableElements, fulltextAnalyzerResolver);
+        tableParameter.settingsBuilder().put(tableSettings);
+        tableParameter.settingsBuilder().put(
+            IndexMetaData.SETTING_NUMBER_OF_SHARDS, numberOfShards.defaultNumberOfShards());
+
+        ColumnIdent routingColumn = null;
+        if (table.clusteredBy().isPresent()) {
+            Optional<ClusteredBy<Object>> clusteredByOptional = table.clusteredBy().map(x -> x.map(eval));
+            ClusteredBy<Object> clusteredBy = clusteredByOptional.get();
+            routingColumn = resolveRoutingFromClusteredBy(clusteredBy, tableElements);
+            if (routingColumn != null) {
+                stmt.routing(routingColumn);
+            }
+            if (clusteredBy.numberOfShards().isPresent()) {
+                tableParameter.settingsBuilder().put(
+                    IndexMetaData.SETTING_NUMBER_OF_SHARDS,
+                    numberOfShards.fromClusteredByClause(clusteredBy)
+                );
+            }
+        }
+        final ColumnIdent finalRouting = routingColumn;
+
+        Optional<PartitionedBy<Object>> partitionedByOptional = table.partitionedBy().map(x -> x.map(eval));
+        partitionedByOptional.ifPresent(partitionedBy -> processPartitionedBy(partitionedByOptional.get(),
+                                                                              tableElements,
+                                                                              relationName,
+                                                                              finalRouting));
+
+        return stmt;
+    }
+
+    private static ColumnIdent resolveRoutingFromClusteredBy(ClusteredBy<Object> clusteredBy,
+                                                             AnalyzedTableElements<Object> tableElements) {
+        if (clusteredBy.column().isPresent()) {
+            Object routingColumnValue = clusteredBy.column().get();
+            assert routingColumnValue instanceof String;
+            ColumnIdent routingColumn = ColumnIdent.fromPath((String) routingColumnValue);
+
+            for (AnalyzedColumnDefinition<Object> column : tableElements.partitionedByColumns) {
+                if (column.ident().equals(routingColumn)) {
+                    throw new IllegalArgumentException(CLUSTERED_BY_IN_PARTITIONED_ERROR);
+                }
+            }
+            if (!hasColumnDefinition(tableElements, routingColumn)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Invalid or non-existent routing column \"%s\"",
+                                  routingColumn));
+            }
+            if (AnalyzedTableElements.primaryKeys(tableElements).size() > 0 &&
+                !AnalyzedTableElements.primaryKeys(tableElements).contains(routingColumn.fqn())) {
+                throw new IllegalArgumentException("Clustered by column must be part of primary keys");
+            }
+
+            if (routingColumn.name().equalsIgnoreCase("_id") == false) {
+                return routingColumn;
+            }
+        }
+        return null;
+    }
+
+    private static void processPartitionedBy(PartitionedBy<Object> node,
+                                             AnalyzedTableElements<Object> tableElements,
+                                             RelationName relationName,
+                                             @Nullable ColumnIdent routing) {
+        for (Object partitionByColumn : node.columns()) {
+            assert partitionByColumn instanceof String;
+            ColumnIdent partitionedByIdent = ColumnIdent.fromPath((String) partitionByColumn);
+
+            AnalyzedTableElements.changeToPartitionedByColumn(tableElements, partitionedByIdent, false, relationName);
+            if (routing != null && routing.equals(partitionedByIdent)) {
+                throw new IllegalArgumentException(CLUSTERED_BY_IN_PARTITIONED_ERROR);
+            }
+        }
+    }
+
+    private static boolean hasColumnDefinition(AnalyzedTableElements tableElements, ColumnIdent columnIdent) {
+        return (tableElements.columnIdents().contains(columnIdent) ||
+                columnIdent.name().equalsIgnoreCase("_id"));
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.repositories.RepositoryParamValidator;
 import io.crate.analyze.repositories.RepositorySettingsModule;
+import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GenericProperty;
 import io.crate.sql.tree.StringLiteral;
@@ -49,7 +50,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
     public void testValidate() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid repository type \"invalid_type\"");
-        validator.convertAndValidate("invalid_type", GenericProperties.EMPTY, ParameterContext.EMPTY);
+        validator.convertAndValidate("invalid_type", GenericProperties.empty(), ParameterContext.EMPTY);
     }
 
     @Test
@@ -57,35 +58,35 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
             "The following required parameters are missing to create a repository of type \"fs\": [location]");
-        validator.convertAndValidate("fs", GenericProperties.EMPTY, ParameterContext.EMPTY);
+        validator.convertAndValidate("fs", GenericProperties.empty(), ParameterContext.EMPTY);
     }
 
     @Test
     public void testInvalidSetting() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("setting 'yay' not supported");
-        GenericProperties genericProperties = new GenericProperties();
-        genericProperties.add(new GenericProperty("location", new StringLiteral("foo")));
-        genericProperties.add(new GenericProperty("yay", new StringLiteral("invalid")));
+        GenericProperties<Expression> genericProperties = new GenericProperties<>();
+        genericProperties.add(new GenericProperty<>("location", new StringLiteral("foo")));
+        genericProperties.add(new GenericProperty<>("yay", new StringLiteral("invalid")));
         validator.convertAndValidate("fs", genericProperties, ParameterContext.EMPTY);
     }
 
     @Test
     public void testHdfsDynamicConfParam() throws Exception {
-        GenericProperties genericProperties = new GenericProperties();
-        genericProperties.add(new GenericProperty("path", new StringLiteral("/data")));
-        genericProperties.add(new GenericProperty("conf.foobar", new StringLiteral("bar")));
+        GenericProperties<Expression> genericProperties = new GenericProperties<>();
+        genericProperties.add(new GenericProperty<>("path", new StringLiteral("/data")));
+        genericProperties.add(new GenericProperty<>("conf.foobar", new StringLiteral("bar")));
         Settings settings = validator.convertAndValidate("hdfs", genericProperties, ParameterContext.EMPTY);
         assertThat(settings.get("conf.foobar"), is("bar"));
     }
 
     @Test
     public void testHdfsSecurityPrincipal() throws Exception {
-        GenericProperties genericProperties = new GenericProperties();
-        genericProperties.add(new GenericProperty("uri", new StringLiteral("hdfs://ha-name:8020")));
-        genericProperties.add(new GenericProperty("security.principal", new StringLiteral("myuserid@REALM.DOMAIN")));
-        genericProperties.add(new GenericProperty("path", new StringLiteral("/user/name/data")));
-        genericProperties.add(new GenericProperty("conf.foobar", new StringLiteral("bar")));
+        GenericProperties<Expression> genericProperties = new GenericProperties<>();
+        genericProperties.add(new GenericProperty<>("uri", new StringLiteral("hdfs://ha-name:8020")));
+        genericProperties.add(new GenericProperty<>("security.principal", new StringLiteral("myuserid@REALM.DOMAIN")));
+        genericProperties.add(new GenericProperty<>("path", new StringLiteral("/user/name/data")));
+        genericProperties.add(new GenericProperty<>("conf.foobar", new StringLiteral("bar")));
         Settings settings = validator.convertAndValidate("hdfs", genericProperties, ParameterContext.EMPTY);
         assertThat(settings.get("security.principal"), is("myuserid@REALM.DOMAIN"));
         assertThat(settings.get("uri"), is("hdfs://ha-name:8020"));
@@ -93,19 +94,19 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
 
     @Test
     public void testS3ConfigParams() throws Exception {
-        GenericProperties genericProperties = new GenericProperties();
-        genericProperties.add(new GenericProperty("access_key", new StringLiteral("foobar")));
-        genericProperties.add(new GenericProperty("base_path", new StringLiteral("/data")));
-        genericProperties.add(new GenericProperty("bucket", new StringLiteral("myBucket")));
-        genericProperties.add(new GenericProperty("buffer_size", new StringLiteral("5mb")));
-        genericProperties.add(new GenericProperty("canned_acl", new StringLiteral("cannedACL")));
-        genericProperties.add(new GenericProperty("chunk_size", new StringLiteral("4g")));
-        genericProperties.add(new GenericProperty("compress", new StringLiteral("true")));
-        genericProperties.add(new GenericProperty("endpoint", new StringLiteral("myEndpoint")));
-        genericProperties.add(new GenericProperty("max_retries", new StringLiteral("8")));
-        genericProperties.add(new GenericProperty("protocol", new StringLiteral("http")));
-        genericProperties.add(new GenericProperty("secret_key", new StringLiteral("thisIsASecretKey")));
-        genericProperties.add(new GenericProperty("server_side_encryption", new StringLiteral("false")));
+        GenericProperties<Expression> genericProperties = new GenericProperties<>();
+        genericProperties.add(new GenericProperty<>("access_key", new StringLiteral("foobar")));
+        genericProperties.add(new GenericProperty<>("base_path", new StringLiteral("/data")));
+        genericProperties.add(new GenericProperty<>("bucket", new StringLiteral("myBucket")));
+        genericProperties.add(new GenericProperty<>("buffer_size", new StringLiteral("5mb")));
+        genericProperties.add(new GenericProperty<>("canned_acl", new StringLiteral("cannedACL")));
+        genericProperties.add(new GenericProperty<>("chunk_size", new StringLiteral("4g")));
+        genericProperties.add(new GenericProperty<>("compress", new StringLiteral("true")));
+        genericProperties.add(new GenericProperty<>("endpoint", new StringLiteral("myEndpoint")));
+        genericProperties.add(new GenericProperty<>("max_retries", new StringLiteral("8")));
+        genericProperties.add(new GenericProperty<>("protocol", new StringLiteral("http")));
+        genericProperties.add(new GenericProperty<>("secret_key", new StringLiteral("thisIsASecretKey")));
+        genericProperties.add(new GenericProperty<>("server_side_encryption", new StringLiteral("false")));
         Settings settings = validator.convertAndValidate("s3", genericProperties, ParameterContext.EMPTY);
         assertThat(settings.get("access_key"), is("foobar"));
         assertThat(settings.get("base_path"), is("/data"));

--- a/sql/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
@@ -63,7 +63,7 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
                     .patterns(template.patterns())
                     .putMapping(
                         Constants.DEFAULT_MAPPING_TYPE,
-                        Strings.toString(JsonXContent.contentBuilder().map(addXLong.analyzedTableElements().toMapping()))))
+                        Strings.toString(JsonXContent.contentBuilder().map(addXLong.mapping()))))
                 .build()
             ).build();
 
@@ -72,7 +72,7 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
             NamedXContentRegistry.EMPTY,
             stateWithXLong,
             templateName,
-            addXString.analyzedTableElements().toMapping()
+            addXString.mapping()
         );
     }
 

--- a/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -49,7 +49,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -77,7 +76,7 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
                 consumer.accept(InMemoryBatchIterator.of(params, null), null);
             }
         };
-        Planner planner = new Planner(Settings.EMPTY, clusterService, sqlExecutor.functions(), new TableStats(), () -> true) {
+        Planner planner = new Planner(Settings.EMPTY, clusterService, sqlExecutor.functions(), new TableStats(), null, null, sqlExecutor.schemas(), () -> true) {
             @Override
             public Plan plan(AnalyzedStatement analyzedStatement, PlannerContext plannerContext) {
                 return insertPlan;


### PR DESCRIPTION
This implementation is based on generic typed expressions of AST nodes which will be mapped to Symbols. By doing this we can re-used AST nodes instead of duplicated the AST nodes with analyzed ones. In case of table creation, we still create dedicated analyzed column definitions as multiple AST nodes can result in 1 column definition. 
When the statement is bound, all parameter symbols are replaced and all symbols are evaluated using mappers.

See the first commit message for more details on the generic expression approach.