### PR TITLE
Move subquery paramers binding down to FetchOrEval#toInputColOrFetchRef.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,10 @@ None
 Fixes
 =====
 
+- Fixed an issue that prevented subqueries from being used in select item
+  expressions that also contain a reference accessed via a relation alias.
+  For example: ``SELECT t.y IN (SELECT x FROM t2) FROM t1 t``
+
 - Fail the storage engine if indexing on a replica shard fails after it was
   successfully done on a primary shard. It prevents replica and primary shards
   from going out of sync.

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -715,4 +715,14 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is("3\n" +
                                                      "2\n"));
     }
+
+    @Test
+    public void test_select_item_expression_with_subselect_and_reference_accessed_via_relation_alias() {
+        execute("CREATE TABLE t1 (x LONG)");
+        execute("INSERT INTO t1 (x) VALUES (1)");
+        execute("REFRESH TABLE t1");
+
+        execute("SELECT t.x IN (SELECT x FROM t1) FROM t1 t");
+        assertThat(printedTable(response.rows()), is("true\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, due to the early binding of subquery parameters `FetchOrEval`
would not process `SelectSymbols` in certain cases. For example, if an
execution plan contains the `RootBoundaries` operator and the `FetchOrEval`
operator with `SelectSymbols` in its outputs it might happen that subquery
binding won't even happen. This change fixes this corner case.

Resolves https://github.com/crate/crate/issues/9158

Commit that fixes the same issue on master https://github.com/crate/crate/commit/cd804c3eccad1597aace55be25552adb1ea51c82

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
