### PR TITLE
Fix some spelling mistakes

### DIFF
--- a/azure-discovery/src/test/java/io/crate/azure/discovery/AzureSeedHostsProviderTest.java
+++ b/azure-discovery/src/test/java/io/crate/azure/discovery/AzureSeedHostsProviderTest.java
@@ -57,7 +57,7 @@ public class AzureSeedHostsProviderTest {
 
     private static final String rgName = "my_resourcegroup";
     private static final String vnetName = "myVnet";
-    private static final String subnetname = "mySubnet2";
+    private static final String subnetName = "mySubnet2";
     private Logger logger;
 
     private NetworkResourceProviderClient providerClient = mock(NetworkResourceProviderClientImpl.class);
@@ -146,18 +146,18 @@ public class AzureSeedHostsProviderTest {
         when(publicIpAddressOperations.get(rgName, "ip_public1")).thenReturn(publicIpAddressGetResponse);
         when(publicIpAddressGetResponse.getPublicIpAddress()).thenReturn(publicIpAddress);
 
-        List<String> networkAddresses = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetname, "subnet",
+        List<String> networkAddresses = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetName, "subnet",
                                                                                AzureSeedHostsProvider.HostType.PRIVATE_IP, logger);
         assertEquals(networkAddresses.size(), 1);
         assertEquals(networkAddresses.get(0), "10.0.0.5");
 
-        List<String> networkAddresses2 = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetname, "vnet",
+        List<String> networkAddresses2 = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetName, "vnet",
                                                                                 AzureSeedHostsProvider.HostType.PRIVATE_IP, logger);
         assertEquals(networkAddresses2.size(), 2);
         assertEquals(networkAddresses2.contains("10.0.0.5"), true);
         assertEquals(networkAddresses2.contains("10.0.0.4"), true);
 
-        List<String> networkAddresses3 = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetname, "vnet",
+        List<String> networkAddresses3 = AzureSeedHostsProvider.listIPAddresses(providerClient, rgName, vnetName, subnetName, "vnet",
                                                                                 AzureSeedHostsProvider.HostType.PUBLIC_IP, logger);
         assertEquals(networkAddresses3.size(), 1);
         assertEquals(networkAddresses3.contains("33.33.33.33"), true);

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
@@ -38,10 +38,10 @@ import java.util.concurrent.CompletionStage;
  * A helper {@link #activeIt} variable points to the currently active iterator thus making
  * transparent to the consumer of this BatchIterator, which calls the methods {@link #allLoaded()}
  * and {@link #loadNextBatch()}, which of the sides (left or right) are currently processed.
- * Usually those methods don't need to be overriden.
+ * Usually those methods don't need to be overridden.
  * <p>
  * The methods {@link #close()} and {@link #kill(Throwable)} are closing or killing the
- * left and right iterators and usually don't need to be overriden.
+ * left and right iterators and usually don't need to be overridden.
  */
 public abstract class JoinBatchIterator<L, R, C> implements BatchIterator<C> {
 

--- a/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
@@ -56,7 +56,7 @@ public class FlatMapBatchIteratorTest {
     }
 
     @Test
-    public void testFlatMapBatchIteratorFullfillsContracts() throws Exception {
+    public void testFlatMapBatchIteratorFullFillsContracts() throws Exception {
         Function<Row, Iterator<Row>> duplicateRow =
             row -> Arrays.<Row>asList(new RowN(row.materialize()), new RowN(row.materialize())).iterator();
         BatchIteratorTester tester = new BatchIteratorTester(() -> {

--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -83,7 +83,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
     }
 
     @Test
-    public void testCallWithInvalidPrecisionResultsinAnError() throws Exception {
+    public void testCallWithInvalidPrecisionResultsInAnError() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("precision must be >= 4 and <= 18");
         executeAggregationWithPrecision(DataTypes.INTEGER, new Object[][]{{4, 1}});
@@ -102,7 +102,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
     }
 
     @Test
-    public void testMurmu3HashCalculationsForAllTypes() throws Exception {
+    public void testMurmur3HashCalculationsForAllTypes() throws Exception {
         // double types
         assertThat(HyperLogLogDistinctAggregation.Murmur3Hash.getForType(DataTypes.DOUBLE).hash(1.3d),
             is(3706823019612663850L));

--- a/enterprise/licensing/src/test/java/io/crate/license/LicenseConverterTest.java
+++ b/enterprise/licensing/src/test/java/io/crate/license/LicenseConverterTest.java
@@ -52,7 +52,7 @@ public class LicenseConverterTest {
     }
 
     @Test
-    public void testLicenseDataSerialisationAndDeserialisation() throws IOException {
+    public void testLicenseDataSerializationAndDeserialization() throws IOException {
         final long expiryDate = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
         final int numNodes = 3;
         LicenseData licenseData = new LicenseData(expiryDate, "crate", numNodes);
@@ -65,7 +65,7 @@ public class LicenseConverterTest {
     }
 
     @Test
-    public void testThatDeserialisationOfV2LicenseNoMaxNodesThrowsException() throws IOException {
+    public void testThatDeserializationOfV2LicenseNoMaxNodesThrowsException() throws IOException {
         byte[] data = createV1JsonLicense(Long.MAX_VALUE, "crate");
 
         expectedException.expect(IllegalStateException.class);
@@ -74,7 +74,7 @@ public class LicenseConverterTest {
     }
 
     @Test
-    public void testDeserialisationFromV1SerialisedData() throws IOException {
+    public void testDeserializationFromV1SerialisedData() throws IOException {
         final long expiryDate = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);
         byte[] data = createV1JsonLicense(expiryDate, "crate");
         LicenseData licenseDataFromByteArray =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up #9130

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
