### PR TITLE
Use NON_RECYCLING_INSTANCE BigArrays for hyperloglog_distinct

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -165,6 +165,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could prevent accounted memory from being properly
+  de-accounted on queries using ``hyperloglog_distinct``, leading clients to
+  eventually receive ``CircuitBreakingException`` error messages and also
+  breaking internal recovery operations.
+
 - Fixed an issue that caused the users list in the privileges tab to not
   displayed when the CrateDB Admin UI is not served from ``/``.
 

--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -30,7 +30,6 @@ import io.crate.types.IntegerType;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlusPlus;
 import org.junit.Before;
 import org.junit.Test;
@@ -134,9 +133,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
 
     @Test
     public void testStreaming() throws Exception {
-        HyperLogLogDistinctAggregation.HllState hllState1 = new HyperLogLogDistinctAggregation.HllState(
-            BigArrays.NON_RECYCLING_INSTANCE,
-            DataTypes.IP);
+        HyperLogLogDistinctAggregation.HllState hllState1 = new HyperLogLogDistinctAggregation.HllState(DataTypes.IP);
         hllState1.init(HyperLogLogPlusPlus.DEFAULT_PRECISION);
         BytesStreamOutput out = new BytesStreamOutput();
         Streamer streamer = HyperLogLogDistinctAggregation.HllStateType.INSTANCE.streamer();


### PR DESCRIPTION
We've an error scenario where the `HllState` / `HyperLogLogPlusPlus`
instances and therefore the underlying `BigArrays` wouldn't be closed
properly.

This can lead to request breaker over-accounting as the accounted bytes
are never released.

The error scenario is that the components using the aggregation
functions initiate a new state but never get to call `reduce` /
`terminatePartial` due to other runtime errors.

This switches to a `NON_RECYCLING_INSTANCE` which doesn't use a
`CircuitBreakerService`, and therefore skips accounting.

We still do account the used memory via the `RamAccountingContext`
instance:

    ramAccountingContext.addBytes(HyperLogLogPlusPlus.memoryUsage(precision));

(This one is being released in error scenarios, as it is part of a
`CollectTask`)

Benchmarks indicate that this has no impact:

    Q: select hyperloglog_distinct("cCode") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      242.028 ±   40.899 |    220.007 |    227.926 |    238.933 |    401.131 |
    |   V2    |      230.048 ±   23.691 |    216.598 |    226.355 |    230.648 |    387.358 |
    mean:   -   5.08%
    median: -   0.69%
    Likely NOT significant

    Q: select hyperloglog_distinct("visitDate") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       73.615 ±   13.959 |     62.685 |     66.762 |     77.021 |    118.424 |
    |   V2    |       72.230 ±   15.620 |     58.605 |     65.624 |     73.728 |    123.976 |
    mean:   -   1.90%
    median: -   1.72%


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)