### PR TITLE
Remove BigArrays argument to AggregationFunction.newState

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -34,7 +34,6 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -75,7 +74,6 @@ public class AggregateCollectorBenchmark {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAggregation },
             Version.CURRENT,
-            BigArrays.NON_RECYCLING_INSTANCE,
             new Input[][] { {inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -59,7 +59,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.util.BigArrays;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -135,8 +134,7 @@ public class GroupingLongCollectorBenchmark {
             RAM_ACCOUNTING_CONTEXT,
             keyInputs.get(0),
             DataTypes.LONG,
-            Version.CURRENT,
-            BigArrays.NON_RECYCLING_INSTANCE
+            Version.CURRENT
         );
     }
 

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -42,7 +42,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.util.BigArrays;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -106,8 +105,7 @@ public class GroupingStringCollectorBenchmark {
             RAM_ACCOUNTING_CONTEXT,
             keyInputs.get(0),
             DataTypes.STRING,
-            Version.CURRENT,
-            BigArrays.NON_RECYCLING_INSTANCE
+            Version.CURRENT
         );
     }
 

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -85,7 +85,6 @@ public class HyperLogLogDistinctAggregationBenchmark {
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { hllAggregation },
             Version.CURRENT,
-            BigArrays.NON_RECYCLING_INSTANCE,
             new Input[][] { {inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );

--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -85,9 +85,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
 
     @Nullable
     @Override
-    public HllState newState(RamAccountingContext ramAccountingContext,
-                             Version indexVersionCreated,
-                             BigArrays bigArrays) {
+    public HllState newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated) {
         return new HllState(dataType);
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
@@ -22,15 +22,14 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.data.RowN;
-import io.crate.expression.InputCondition;
-import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.InputCondition;
+import io.crate.expression.symbol.AggregateMode;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,25 +49,22 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
     private final RamAccountingContext ramAccounting;
     private final AggregationFunction[] aggregations;
     private final Version indexVersionCreated;
-    private final BigArrays bigArrays;
     private final Input<Boolean>[] filters;
     private final Input[][] inputs;
     private final BiConsumer<Object[], Row> accumulator;
     private final Function<Object[], Iterable<Row>> finisher;
 
     public AggregateCollector(List<? extends CollectExpression<Row, ?>> expressions,
-                       RamAccountingContext ramAccounting,
-                       AggregateMode mode,
-                       AggregationFunction[] aggregations,
-                       Version indexVersionCreated,
-                       BigArrays bigArrays,
-                       Input[][] inputs,
-                       Input<Boolean>[] filters) {
+                              RamAccountingContext ramAccounting,
+                              AggregateMode mode,
+                              AggregationFunction[] aggregations,
+                              Version indexVersionCreated,
+                              Input[][] inputs,
+                              Input<Boolean>[] filters) {
         this.expressions = expressions;
         this.ramAccounting = ramAccounting;
         this.aggregations = aggregations;
         this.indexVersionCreated = indexVersionCreated;
-        this.bigArrays = bigArrays;
         this.filters = filters;
         this.inputs = inputs;
         switch (mode) {
@@ -122,7 +118,7 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
     private Object[] prepareState() {
         Object[] states = new Object[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
-            states[i] = aggregations[i].newState(ramAccounting, indexVersionCreated, bigArrays);
+            states[i] = aggregations[i].newState(ramAccounting, indexVersionCreated);
         }
         return states;
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -28,7 +28,6 @@ import io.crate.metadata.FunctionImplementation;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 
@@ -45,13 +44,10 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
      *
      * @param ramAccountingContext used to account the memory used for the state.
      * @param indexVersionCreated the version the current index was created on, this is useful for BWC
-     * @param bigArrays the BigArrays singleton instance of the current node
      * @return a new state instance or null
      */
     @Nullable
-    public abstract TPartial newState(RamAccountingContext ramAccountingContext,
-                                      Version indexVersionCreated,
-                                      BigArrays bigArrays);
+    public abstract TPartial newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated);
 
     /**
      * the "aggregate" function.

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -31,7 +31,6 @@ import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import java.util.List;
 
@@ -43,8 +42,7 @@ public class AggregationPipe implements Projector {
                            AggregateMode aggregateMode,
                            AggregationContext[] aggregations,
                            RamAccountingContext ramAccountingContext,
-                           Version indexVersionCreated,
-                           BigArrays bigArrays) {
+                           Version indexVersionCreated) {
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
         Input[][] inputs = new Input[aggregations.length][];
         Input[] filters = new Input[aggregations.length];
@@ -61,7 +59,6 @@ public class AggregationPipe implements Projector {
             aggregateMode,
             functions,
             indexVersionCreated,
-            bigArrays,
             inputs,
             filters
         );

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -35,7 +35,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import java.util.List;
 import java.util.stream.Collector;
@@ -53,8 +52,7 @@ public class GroupingProjector implements Projector {
                              AggregateMode mode,
                              AggregationContext[] aggregations,
                              RamAccountingContext ramAccountingContext,
-                             Version indexVersionCreated,
-                             BigArrays bigArrays) {
+                             Version indexVersionCreated) {
         assert keys.size() == keyInputs.size() : "number of key types must match with number of key inputs";
         ensureAllTypesSupported(keys);
 
@@ -78,8 +76,7 @@ public class GroupingProjector implements Projector {
                 ramAccountingContext,
                 keyInputs.get(0),
                 key.valueType(),
-                indexVersionCreated,
-                bigArrays
+                indexVersionCreated
             );
         } else {
             //noinspection unchecked
@@ -92,8 +89,7 @@ public class GroupingProjector implements Projector {
                 ramAccountingContext,
                 keyInputs,
                 typeView(keys),
-                indexVersionCreated,
-                bigArrays
+                indexVersionCreated
             );
         }
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -32,7 +32,6 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 
@@ -69,8 +68,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     @Nullable
     @Override
     public Object newState(RamAccountingContext ramAccountingContext,
-                           Version indexVersionCreated,
-                           BigArrays bigArrays) {
+                           Version indexVersionCreated) {
         return null;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -34,7 +34,6 @@ import io.crate.types.FixedWidthType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -211,8 +210,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     @Nullable
     @Override
     public AverageState newState(RamAccountingContext ramAccountingContext,
-                                 Version indexVersionCreated,
-                                 BigArrays bigArrays) {
+                                 Version indexVersionCreated) {
         ramAccountingContext.addBytes(AverageStateType.INSTANCE.fixedSize());
         return new AverageState();
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -35,7 +35,6 @@ import io.crate.types.DataTypes;
 import io.crate.types.UncheckedObjectType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -104,8 +103,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
     @Nullable
     @Override
     public Map<Object, Object> newState(RamAccountingContext ramAccountingContext,
-                                        Version indexVersionCreated,
-                                        BigArrays bigArrays) {
+                                        Version indexVersionCreated) {
         ramAccountingContext.addBytes(RamAccountingContext.roundUp(64L)); // overhead for HashMap: 32 * 0 + 16 * 4 bytes
         return new HashMap<>();
     }
@@ -168,8 +166,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         @Nullable
         @Override
         public Map<Object, Long> newState(RamAccountingContext ramAccountingContext,
-                                          Version indexVersionCreated,
-                                          BigArrays bigArrays) {
+                                          Version indexVersionCreated) {
             ramAccountingContext.addBytes(RamAccountingContext.roundUp(64L)); // overhead for HashMap: 32 * 0 + 16 * 4 bytes
             return new HashMap<>();
         }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -43,7 +43,6 @@ import io.crate.types.FixedWidthType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -120,8 +119,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     @Nullable
     @Override
     public LongState newState(RamAccountingContext ramAccountingContext,
-                              Version indexVersionCreated,
-                              BigArrays bigArrays) {
+                              Version indexVersionCreated) {
         ramAccountingContext.addBytes(LongStateType.INSTANCE.fixedSize());
         return new LongState();
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -182,8 +181,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     @Nullable
     @Override
     public GeometricMeanState newState(RamAccountingContext ramAccountingContext,
-                                       Version indexVersionCreated,
-                                       BigArrays bigArrays) {
+                                       Version indexVersionCreated) {
         ramAccountingContext.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
         return new GeometricMeanState();
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -34,7 +34,6 @@ import io.crate.types.DataTypes;
 import io.crate.types.FixedWidthType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 
@@ -69,8 +68,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         @Nullable
         @Override
         public Comparable newState(RamAccountingContext ramAccountingContext,
-                                   Version indexVersionCreated,
-                                   BigArrays bigArrays) {
+                                   Version indexVersionCreated) {
             ramAccountingContext.addBytes(size);
             return null;
         }
@@ -102,8 +100,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         @Nullable
         @Override
         public Comparable newState(RamAccountingContext ramAccountingContext,
-                                   Version indexVersionCreated,
-                                   BigArrays bigArrays) {
+                                   Version indexVersionCreated) {
             return null;
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -34,7 +34,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FixedWidthType;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 
@@ -69,8 +68,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         @Nullable
         @Override
         public Comparable newState(RamAccountingContext ramAccountingContext,
-                                   Version indexVersionCreated,
-                                   BigArrays bigArrays) {
+                                   Version indexVersionCreated) {
             return null;
         }
 
@@ -105,8 +103,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         @Nullable
         @Override
         public Comparable newState(RamAccountingContext ramAccountingContext,
-                                   Version indexVersionCreated,
-                                   BigArrays bigArrays) {
+                                   Version indexVersionCreated) {
             ramAccountingContext.addBytes(size);
             return null;
         }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -32,7 +32,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -71,8 +70,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     @Nullable
     @Override
     public TDigestState newState(RamAccountingContext ramAccountingContext,
-                                 Version indexVersionCreated,
-                                 BigArrays bigArrays) {
+                                 Version indexVersionCreated) {
         return TDigestState.createEmptyState();
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -36,7 +36,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -121,8 +120,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     @Nullable
     @Override
     public StandardDeviation newState(RamAccountingContext ramAccountingContext,
-                                Version indexVersionCreated,
-                                BigArrays bigArrays) {
+                                      Version indexVersionCreated) {
         ramAccountingContext.addBytes(StdDevStateType.INSTANCE.fixedSize());
         return new StandardDeviation();
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.util.BigArrays;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -131,7 +130,8 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     }
 
     @Override
-    public StringAggState newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated, BigArrays bigArrays) {
+    public StringAggState newState(RamAccountingContext ramAccountingContext,
+                                   Version indexVersionCreated) {
         return new StringAggState();
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -31,7 +31,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -86,7 +85,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
     @Nullable
     @Override
-    public T newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated, BigArrays bigArrays) {
+    public T newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated) {
         ramAccountingContext.addBytes(bytesSize);
         return null;
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -36,7 +36,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -123,8 +122,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     @Nullable
     @Override
     public Variance newState(RamAccountingContext ramAccountingContext,
-                                  Version indexVersionCreated,
-                                  BigArrays bigArrays) {
+                             Version indexVersionCreated) {
         ramAccountingContext.addBytes(VarianceStateType.INSTANCE.fixedSize());
         return new Variance();
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -291,7 +291,7 @@ final class GroupByOptimizedIterator {
                         long ord = values.nextOrd();
                         Object[] states = statesByOrd.get(ord);
                         if (states == null) {
-                            statesByOrd.set(ord, initStates(bigArrays, aggregations, ramAccounting));
+                            statesByOrd.set(ord, initStates(aggregations, ramAccounting));
                         } else {
                             aggregateValues(aggregations, ramAccounting, states);
                         }
@@ -300,7 +300,7 @@ final class GroupByOptimizedIterator {
                         }
                     } else {
                         if (nullStates == null) {
-                            nullStates = initStates(bigArrays, aggregations, ramAccounting);
+                            nullStates = initStates(aggregations, ramAccounting);
                         } else {
                             aggregateValues(aggregations, ramAccounting, nullStates);
                         }
@@ -359,15 +359,13 @@ final class GroupByOptimizedIterator {
         }
     }
 
-    private static Object[] initStates(BigArrays bigArrays,
-                                       List<AggregationContext> aggregations,
-                                       RamAccountingContext ramAccounting) {
+    private static Object[] initStates(List<AggregationContext> aggregations, RamAccountingContext ramAccounting) {
         Object[] states = new Object[aggregations.size()];
         for (int i = 0; i < aggregations.size(); i++) {
             AggregationContext aggregation = aggregations.get(i);
             AggregationFunction function = aggregation.function();
 
-            var newState = function.newState(ramAccounting, Version.CURRENT, bigArrays);
+            var newState = function.newState(ramAccounting, Version.CURRENT);
             if (InputCondition.matches(aggregation.filter())) {
                 //noinspection unchecked
                 states[i] = function.iterate(

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -292,8 +292,7 @@ public class ProjectionToProjectorVisitor
             projection.mode(),
             ctx.aggregations().toArray(new AggregationContext[0]),
             context.ramAccountingContext,
-            indexVersionCreated,
-            bigArrays
+            indexVersionCreated
         );
     }
 
@@ -311,8 +310,8 @@ public class ProjectionToProjectorVisitor
             projection.mode(),
             ctx.aggregations().toArray(new AggregationContext[0]),
             context.ramAccountingContext,
-            indexVersionCreated,
-            bigArrays);
+            indexVersionCreated
+        );
     }
 
     @Override
@@ -627,7 +626,6 @@ public class ProjectionToProjectorVisitor
             inputFactory,
             context.txnCtx,
             context.ramAccountingContext,
-            bigArrays,
             indexVersionCreated,
             ThreadPools.numIdleThreads(searchThreadPool, numProcessors),
             searchThreadPool

--- a/sql/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -34,7 +34,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -47,7 +46,6 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     private final ExpressionsInput<Row, Boolean> filter;
     private final RamAccountingContext ramAccountingContext;
     private final Version indexVersionCreated;
-    private final BigArrays bigArrays;
     private Object accumulatedState;
 
     private int seenFrameLowerBound = -1;
@@ -57,14 +55,12 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     AggregateToWindowFunctionAdapter(AggregationFunction aggregationFunction,
                                      ExpressionsInput<Row, Boolean> filter,
                                      Version indexVersionCreated,
-                                     BigArrays bigArrays,
                                      RamAccountingContext ramAccountingContext) {
         this.aggregationFunction = aggregationFunction.optimizeForExecutionAsWindowFunction();
         this.filter = filter;
         this.ramAccountingContext = ramAccountingContext;
         this.indexVersionCreated = indexVersionCreated;
-        this.bigArrays = bigArrays;
-        this.accumulatedState = this.aggregationFunction.newState(ramAccountingContext, indexVersionCreated, bigArrays);
+        this.accumulatedState = this.aggregationFunction.newState(ramAccountingContext, indexVersionCreated);
     }
 
     @Override
@@ -127,7 +123,7 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     private void recomputeFunction(WindowFrameState frame,
                                    List<? extends CollectExpression<Row, ?>> expressions,
                                    Input[] args) {
-        accumulatedState = aggregationFunction.newState(ramAccountingContext, indexVersionCreated, bigArrays);
+        accumulatedState = aggregationFunction.newState(ramAccountingContext, indexVersionCreated);
         seenFrameUpperBound = -1;
         seenFrameLowerBound = -1;
         executeAggregateForFrame(frame, expressions, args);

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -44,7 +44,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.WindowFrame;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -67,7 +66,6 @@ public class WindowProjector {
                                            InputFactory inputFactory,
                                            TransactionContext txnCtx,
                                            RamAccountingContext ramAccountingContext,
-                                           BigArrays bigArrays,
                                            Version indexVersionCreated,
                                            IntSupplier numThreads,
                                            Executor executor) {
@@ -102,7 +100,6 @@ public class WindowProjector {
                         (AggregationFunction) impl,
                         filter,
                         indexVersionCreated,
-                        bigArrays,
                         ramAccountingContext)
                 );
             } else if (impl instanceof WindowFunction) {

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -33,7 +33,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -67,7 +66,7 @@ public class CollectSetAggregationTest extends AggregationTest {
         AggregationFunction impl = (AggregationFunction) functions.get(
                 null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
 
-        Object state = impl.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+        Object state = impl.newState(ramAccountingContext, Version.CURRENT);
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         impl.partialType().streamer().writeValueTo(streamOutput, state);
@@ -83,7 +82,7 @@ public class CollectSetAggregationTest extends AggregationTest {
         AggregationFunction aggregationFunction = impl.optimizeForExecutionAsWindowFunction();
 
         Object state = aggregationFunction.newState(
-            ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+            ramAccountingContext, Version.CURRENT);
         state = aggregationFunction.iterate(ramAccountingContext, state, Literal.of(10));
         state = aggregationFunction.iterate(ramAccountingContext, state, Literal.of(10));
 

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -32,7 +32,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -199,7 +198,7 @@ public class PercentileAggregationTest extends AggregationTest {
             new FunctionIdent(NAME, Arrays.asList(DataTypes.LONG, doubleArray)));
 
         RamAccountingContext memoryCtx = new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"));
-        Object state = impl.newState(memoryCtx, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+        Object state = impl.newState(memoryCtx, Version.CURRENT);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), doubleArray);
         impl.iterate(memoryCtx, state, Literal.of(10L), fractions);
         impl.iterate(memoryCtx, state, Literal.of(20L), fractions);

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -26,7 +26,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.util.BigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -69,11 +68,11 @@ public class StringAggTest extends AggregationTest {
     @Test
     public void testMergeOf2States() throws Exception {
         var stringAgg = new StringAgg();
-        var state1 = stringAgg.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+        var state1 = stringAgg.newState(ramAccountingContext, Version.CURRENT);
         stringAgg.iterate(ramAccountingContext, state1, Literal.of("a"), Literal.of(","));
         stringAgg.iterate(ramAccountingContext, state1, Literal.of("b"), Literal.of(";"));
 
-        var state2 = stringAgg.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
+        var state2 = stringAgg.newState(ramAccountingContext, Version.CURRENT);
         stringAgg.iterate(ramAccountingContext, state2, Literal.of("c"), Literal.of(","));
         stringAgg.iterate(ramAccountingContext, state2, Literal.of("d"), Literal.of(";"));
 

--- a/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -23,9 +23,7 @@
 package io.crate.execution.engine.window;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.FrameBoundDefinition;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.WindowFrameDefinition;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.auth.user.User;
@@ -76,19 +74,9 @@ import java.util.stream.Collectors;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 import static io.crate.execution.engine.sort.Comparators.createComparator;
-import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
-import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
-import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
-import static org.elasticsearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
 import static org.hamcrest.Matchers.instanceOf;
 
 public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServiceUnitTest {
-
-    static final WindowFrameDefinition RANGE_CURRENT_ROW_UNBOUNDED_FOLLOWING = new WindowFrameDefinition(
-        RANGE,
-        new FrameBoundDefinition(CURRENT_ROW, Literal.NULL),
-        new FrameBoundDefinition(UNBOUNDED_FOLLOWING, Literal.NULL)
-    );
 
     private RamAccountingContext RAM_ACCOUNTING_CONTEXT = new RamAccountingContext
         ("dummy", new NoopCircuitBreaker(CircuitBreaker.FIELDDATA));
@@ -159,7 +147,6 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
                 (AggregationFunction) impl,
                 new ExpressionsInput<>(Literal.BOOLEAN_TRUE, List.of()),
                 Version.CURRENT,
-                NON_RECYCLING_INSTANCE,
                 RAM_ACCOUNTING_CONTEXT
             );
         } else {

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -40,7 +40,6 @@ import io.crate.types.DataType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -84,13 +83,13 @@ public abstract class AggregationTest extends CrateUnitTest {
         }
         AggregationFunction impl = (AggregationFunction) functions.getQualified(fi);
         List<Object> states = new ArrayList<>();
-        states.add(impl.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE));
+        states.add(impl.newState(ramAccountingContext, Version.CURRENT));
         for (Row row : new ArrayBucket(data)) {
             for (InputCollectExpression input : inputs) {
                 input.setNextRow(row);
             }
             if (randomIntBetween(1, 4) == 1) {
-                states.add(impl.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE));
+                states.add(impl.newState(ramAccountingContext, Version.CURRENT));
             }
             int idx = states.size() - 1;
             states.set(idx, impl.iterate(ramAccountingContext, states.get(idx), inputs));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Given that `newState` doesn't have explicit support for the release of
resources that might be created using `BigArrays`, we want to prevent
the usage of it altogether.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)