### PR TITLE
[Jenkins] Pin adopt JDK to 1.12.0-2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     CI_RUN = 'true'
     JDK_11 = 'openjdk@1.11.0'
     JDK_12 = 'openjdk@1.12.0'
-    ADOPT_JDK_12 = 'adopt@1.12.33-0'
+    ADOPT_JDK_12 = 'adopt@1.12.0-2'
   }
   stages {
     stage('Parallel') {


### PR DESCRIPTION
adopt@1.12.33 JDK is not available anymore via jabba and using
alias or ranges seems not to work with jabba and adopt.
E.g. using "adopt@~1.12" or "adopt@>=1.12.0 <1.13.0" does not work.