### PR TITLE
Tests: Close created sessions after use

### DIFF
--- a/app/src/test/java/io/crate/node/NodeSettingsTest.java
+++ b/app/src/test/java/io/crate/node/NodeSettingsTest.java
@@ -22,12 +22,12 @@
 package io.crate.node;
 
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.InternalSettingsPreparer;
@@ -121,12 +121,14 @@ public class NodeSettingsTest extends CrateUnitTest {
      */
     @Test
     public void testClusterName() {
-        SQLResponse response = SQLTransportExecutor.execute(
-            "select name from sys.cluster",
-            new Object[0],
-            sqlOperations.newSystemSession())
-            .actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
-        assertThat(response.rows()[0][0], is("crate"));
+        try (Session session = sqlOperations.newSystemSession()) {
+            SQLResponse response = SQLTransportExecutor.execute(
+                "select name from sys.cluster",
+                new Object[0],
+                session)
+                .actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
+            assertThat(response.rows()[0][0], is("crate"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Not an issue, but `Session` instances should be closed after use.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)