### PR TITLE
Docs: Correct _node column description for sys.shards

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -867,11 +867,12 @@ Table schema
 | Column Name                        | Description                                        | Return Type |
 +====================================+====================================================+=============+
 +------------------------------------+----------------------------------------------------+-------------+
-| ``_node``                          | Information about the node the shard is located    | ``OBJECT``  |
+| ``node``                           | Information about the node the shard is located    | ``OBJECT``  |
 |                                    | at.                                                |             |
-|                                    |                                                    |             |
-|                                    | Contains the same information as the ``sys.nodes`` |             |
-|                                    | table.                                             |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``node['name']``                   | The name of the node the shard is located at.      | ``TEXT``    |
++------------------------------------+----------------------------------------------------+-------------+
+| ``node['id']``                     | The id of the node the shard is located at.        | ``TEXT``    |
 +------------------------------------+----------------------------------------------------+-------------+
 | ``blob_path``                      | Path to the directory which contains the blob      | ``TEXT``    |
 |                                    | files of the shard, or null if the shard is not a  |             |


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)