### PR TITLE
Fix regression in RemoteCollectorFactory

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -124,7 +124,8 @@ public class RemoteCollectorFactory {
         String nodeId = activePrimaryRouting.currentNodeId();
         String localNodeId = clusterService.localNode().getId();
         if (localNodeId.equalsIgnoreCase(nodeId)) {
-            var indexShard = indicesService.indexServiceSafe(activePrimaryRouting.index()).getShard(activePrimaryRouting.shardId().id());
+            var indexShard = indicesService.indexServiceSafe(activePrimaryRouting.index())
+                .getShard(activePrimaryRouting.shardId().id());
             var collectorProvider = shardCollectorProviderFactory.create(indexShard);
             BatchIterator<Row> it;
             try {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The ShardStateObserver returned too early in some cases, which could
lead to a ShardNotFoundException in the following local collect.

The decommission tests were flaky because of this.
Regression was introduced in bef03ab8996071e6bf430758e55b191531a8eff8


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)