### PR TITLE
Include similar schema names on SchemaUnknownException

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -63,7 +63,10 @@ class AlterTableAnalyzer {
 
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
 
-        DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(alterTable.table().getName(), Operation.ALTER_BLOCKS,
+        DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(
+            alterTable.table().getName(),
+            Operation.ALTER_BLOCKS,
+            txnCtx.sessionContext().user(),
             txnCtx.sessionContext().searchPath());
 
         return new AnalyzedAlterTable(docTableInfo, alterTable);

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -337,8 +337,8 @@ public class Analyzer {
             return refreshTableAnalyzer.analyze(
                 (RefreshStatement<Expression>) node,
                 context.paramTypeHints(),
-                context.transactionContext(),
-                context.sessionContext().searchPath());
+                context.transactionContext()
+            );
         }
 
         @Override
@@ -361,7 +361,6 @@ public class Analyzer {
         public AnalyzedStatement visitAlterTableAddColumnStatement(AlterTableAddColumn node, Analysis analysis) {
             return alterTableAddColumnAnalyzer.analyze(
                 (AlterTableAddColumn<Expression>) node,
-                analysis.sessionContext().searchPath(),
                 analysis.paramTypeHints(),
                 analysis.transactionContext());
         }
@@ -465,8 +464,7 @@ public class Analyzer {
             return optimizeTableAnalyzer.analyze(
                 (OptimizeStatement<Expression>) node,
                 context.paramTypeHints(),
-                context.transactionContext(),
-                context.sessionContext().searchPath());
+                context.transactionContext());
         }
 
         @Override
@@ -514,8 +512,7 @@ public class Analyzer {
             return swapTableAnalyzer.analyze(
                 swapTable,
                 analysis.transactionContext(),
-                analysis.paramTypeHints(),
-                analysis.sessionContext().searchPath()
+                analysis.paramTypeHints()
             );
         }
 

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -101,8 +101,12 @@ class CopyAnalyzer {
     }
 
     CopyFromAnalyzedStatement convertCopyFrom(CopyFrom node, Analysis analysis) {
-        DocTableInfo tableInfo = (DocTableInfo)
-            schemas.resolveTableInfo(node.table().getName(), Operation.INSERT, analysis.sessionContext().searchPath());
+        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+                node.table().getName(),
+                Operation.INSERT,
+                analysis.sessionContext().user(),
+                analysis.sessionContext().searchPath()
+        );
         DocTableRelation tableRelation = new DocTableRelation(tableInfo);
 
         String partitionIdent = null;
@@ -177,8 +181,12 @@ class CopyAnalyzer {
             throw new UnsupportedOperationException("Using COPY TO without specifying a DIRECTORY is not supported");
         }
 
-        TableInfo tableInfo =
-            schemas.resolveTableInfo(node.table().getName(), Operation.COPY_TO, analysis.sessionContext().searchPath());
+        TableInfo tableInfo = schemas.resolveTableInfo(
+            node.table().getName(),
+            Operation.COPY_TO,
+            analysis.sessionContext().user(),
+            analysis.sessionContext().searchPath()
+        );
         Operation.blockedRaiseException(tableInfo, Operation.READ);
         DocTableRelation tableRelation = new DocTableRelation((DocTableInfo) tableInfo);
 

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -36,8 +36,8 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.CreateSnapshot;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -88,8 +88,12 @@ class CreateSnapshotAnalyzer {
             for (Table table : node.tableList()) {
                 DocTableInfo docTableInfo;
                 try {
-                    docTableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(), Operation.CREATE_SNAPSHOT,
-                        analysis.sessionContext().searchPath());
+                    docTableInfo = (DocTableInfo) schemas.resolveTableInfo(
+                        table.getName(),
+                        Operation.CREATE_SNAPSHOT,
+                        analysis.sessionContext().user(),
+                        analysis.sessionContext().searchPath()
+                    );
                 } catch (ResourceUnknownException e) {
                     if (ignoreUnavailable) {
                         LOGGER.info("ignoring: {}", e.getMessage());

--- a/sql/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -65,7 +65,7 @@ class DropTableAnalyzer {
         T tableInfo;
         try {
             //noinspection unchecked
-            tableInfo = (T) schemas.resolveTableInfo(name, Operation.DROP, sessionContext.searchPath());
+            tableInfo = (T) schemas.resolveTableInfo(name, Operation.DROP, sessionContext.user(), sessionContext.searchPath());
         } catch (SchemaUnknownException | RelationUnknown e) {
             if (dropIfExists) {
                 tableInfo = null;

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -107,8 +107,12 @@ class InsertFromSubQueryAnalyzer {
     }
 
     public AnalyzedInsertStatement analyze(InsertFromSubquery insert, ParamTypeHints typeHints, CoordinatorTxnCtx txnCtx) {
-        DocTableInfo targetTable = (DocTableInfo) schemas.resolveTableInfo(insert.table().getName(), Operation.INSERT,
-            txnCtx.sessionContext().searchPath());
+        DocTableInfo targetTable = (DocTableInfo) schemas.resolveTableInfo(
+            insert.table().getName(),
+            Operation.INSERT,
+            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().searchPath()
+        );
         DocTableRelation tableRelation = new DocTableRelation(targetTable);
 
         AnalyzedRelation subQueryRelation =
@@ -131,8 +135,12 @@ class InsertFromSubQueryAnalyzer {
     }
 
     public AnalyzedStatement analyze(InsertFromSubquery node, Analysis analysis) {
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(node.table().getName(), Operation.INSERT,
-            analysis.sessionContext().searchPath());
+        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+            node.table().getName(),
+            Operation.INSERT,
+            analysis.sessionContext().user(),
+            analysis.sessionContext().searchPath()
+        );
 
         DocTableRelation tableRelation = new DocTableRelation(tableInfo);
         FieldProvider fieldProvider = new NameFieldProvider(tableRelation);

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -117,8 +117,12 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             throw new IllegalArgumentException("VALUES clause must not be empty");
         }
 
-        DocTableInfo targetTable = (DocTableInfo) schemas.resolveTableInfo(insert.table().getName(), Operation.INSERT,
-            txnCtx.sessionContext().searchPath());
+        DocTableInfo targetTable = (DocTableInfo) schemas.resolveTableInfo(
+            insert.table().getName(),
+            Operation.INSERT,
+            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().searchPath()
+        );
         DocTableRelation tableRelation = new DocTableRelation(targetTable);
 
         ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
@@ -166,7 +170,10 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
     }
 
     public AnalyzedStatement analyze(InsertFromValues<Expression> node, Analysis analysis) {
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(node.table().getName(), Operation.INSERT,
+        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+            node.table().getName(),
+            Operation.INSERT,
+            analysis.sessionContext().user(),
             analysis.sessionContext().searchPath());
 
         DocTableRelation tableRelation = new DocTableRelation(tableInfo);

--- a/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -29,7 +29,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Expression;
@@ -52,8 +51,7 @@ public class OptimizeTableAnalyzer {
 
     public AnalyzedOptimizeTable analyze(OptimizeStatement<Expression> statement,
                                          Function<ParameterExpression, Symbol> convertParamFunction,
-                                         CoordinatorTxnCtx txnCtx,
-                                         SearchPath searchPath) {
+                                         CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             functions, txnCtx, convertParamFunction, FieldProvider.FIELDS_AS_LITERAL, null);
 
@@ -66,7 +64,9 @@ public class OptimizeTableAnalyzer {
             TableInfo tableInfo = schemas.resolveTableInfo(
                 table.getName(),
                 Operation.OPTIMIZE,
-                searchPath);
+                txnCtx.sessionContext().user(),
+                txnCtx.sessionContext().searchPath()
+            );
             analyzedOptimizeTables.put(table, tableInfo);
         }
         return new AnalyzedOptimizeTable(analyzedOptimizeTables, analyzedStatement.properties());

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -28,7 +28,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Expression;
@@ -51,8 +50,7 @@ class RefreshTableAnalyzer {
 
     public AnalyzedRefreshTable analyze(RefreshStatement<Expression> refreshStatement,
                                         Function<ParameterExpression, Symbol> convertParamFunction,
-                                        CoordinatorTxnCtx txnCtx,
-                                        SearchPath searchPath) {
+                                        CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             functions, txnCtx, convertParamFunction, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
@@ -65,7 +63,8 @@ class RefreshTableAnalyzer {
             var tableInfo = (DocTableInfo) schemas.resolveTableInfo(
                 table.getName(),
                 Operation.REFRESH,
-                searchPath);
+                txnCtx.sessionContext().user(),
+                txnCtx.sessionContext().searchPath());
             analyzedTables.put(analyzedTable, tableInfo);
         }
         return new AnalyzedRefreshTable(analyzedTables);

--- a/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.auth.user.User;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
@@ -88,6 +89,7 @@ class ShowStatementAnalyzer {
     public AnalyzedStatement analyzeShowCreateTable(Table table, Analysis analysis) {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(table.getName(),
                                                                          Operation.SHOW_CREATE,
+                                                                         User.CRATE_USER,
                                                                          analysis.sessionContext().searchPath());
         AnalyzedShowCreateTable analyzedStatement = new AnalyzedShowCreateTable(tableInfo);
         analysis.rootRelation(analyzedStatement);

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -218,8 +218,8 @@ class UnboundAnalyzer {
             return optimizeTableAnalyzer.analyze(
                 (OptimizeStatement<Expression>) node,
                 context.paramTypeHints(),
-                context.transactionContext(),
-                context.sessionContext().searchPath());
+                context.transactionContext()
+            );
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -644,7 +644,12 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         AnalyzedRelation relation;
         TableInfo tableInfo;
         try {
-            tableInfo = schemas.resolveTableInfo(tableQualifiedName, context.currentOperation(), searchPath);
+            tableInfo = schemas.resolveTableInfo(
+                tableQualifiedName,
+                context.currentOperation(),
+                context.sessionContext().user(),
+                searchPath
+            );
             if (tableInfo instanceof DocTableInfo) {
                 // Dispatching of doc relations is based on the returned class of the schema information.
                 relation = new DocTableRelation((DocTableInfo) tableInfo);

--- a/sql/src/main/java/io/crate/exceptions/SchemaUnknownException.java
+++ b/sql/src/main/java/io/crate/exceptions/SchemaUnknownException.java
@@ -21,7 +21,11 @@
 
 package io.crate.exceptions;
 
+import io.crate.sql.Identifiers;
+
+import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 public class SchemaUnknownException extends ResourceUnknownException implements SchemaScopeException {
 
@@ -29,8 +33,30 @@ public class SchemaUnknownException extends ResourceUnknownException implements 
 
     private final String schemaName;
 
+    public static SchemaUnknownException of(String schema, List<String> candidates) {
+        switch (candidates.size()) {
+            case 0:
+                return new SchemaUnknownException(schema);
+
+            case 1:
+                return new SchemaUnknownException(
+                    schema,
+                    "Schema '" + schema + "' unknown. Maybe you meant '" + Identifiers.quoteIfNeeded(candidates.get(0)) + "'");
+
+            default:
+                String errorMsg = "Schema '" + schema + "' unknown. Maybe you meant one of: " + candidates.stream()
+                    .map(Identifiers::quoteIfNeeded)
+                    .collect(Collectors.joining(", "));
+                return new SchemaUnknownException(schema, errorMsg);
+        }
+    }
+
     public SchemaUnknownException(String schema) {
-        super(String.format(Locale.ENGLISH, MESSAGE_TMPL, schema));
+        this(schema, String.format(Locale.ENGLISH, MESSAGE_TMPL, schema));
+    }
+
+    private SchemaUnknownException(String schema, String errorMessage) {
+        super(errorMessage);
         this.schemaName = schema;
     }
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2034,4 +2034,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.outputs().get(0),
                    fieldPointsToReferenceOf("friends['id']", "doc.users"));
     }
+
+    @Test
+    public void test_select_from_unknown_schema_has_suggestion_for_correct_schema() {
+        expectedException.expectMessage("Schema 'Doc' unknown. Maybe you meant 'doc'");
+        analyze("select * from \"Doc\".users");
+    }
 }

--- a/sql/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasTest.java
@@ -22,6 +22,7 @@
 package io.crate.metadata;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.action.sql.SessionContext;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
@@ -147,8 +148,9 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(tableIdent, "doc", "schema").build();
 
         QualifiedName fqn = QualifiedName.of("schema", "t");
+        SessionContext sessionContext = sqlExecutor.getSessionContext();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(fqn, Operation.READ, sqlExecutor.getSessionContext().searchPath());
+            .resolveTableInfo(fqn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));
@@ -166,9 +168,10 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t")).build();
         QualifiedName invalidFqn = QualifiedName.of("bogus_schema", "t");
 
+        SessionContext sessionContext = sqlExecutor.getSessionContext();
         expectedException.expect(SchemaUnknownException.class);
         expectedException.expectMessage("Schema 'bogus_schema' unknown");
-        sqlExecutor.schemas().resolveTableInfo(invalidFqn, Operation.READ, sqlExecutor.getSessionContext().searchPath());
+        sqlExecutor.schemas().resolveTableInfo(invalidFqn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
     }
 
     @Test
@@ -176,9 +179,10 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t")).build();
         QualifiedName table = QualifiedName.of("missing_table");
 
+        SessionContext sessionContext = sqlExecutor.getSessionContext();
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'missing_table' unknown");
-        sqlExecutor.schemas().resolveTableInfo(table, Operation.READ, sqlExecutor.getSessionContext().searchPath());
+        sqlExecutor.schemas().resolveTableInfo(table, Operation.READ, sessionContext.user(), sessionContext.searchPath());
     }
 
     @Test
@@ -186,8 +190,9 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t"), "doc", "schema")
             .build();
         QualifiedName tableQn = QualifiedName.of("t");
+        SessionContext sessionContext = sqlExecutor.getSessionContext();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(tableQn, Operation.READ, sqlExecutor.getSessionContext().searchPath());
+            .resolveTableInfo(tableQn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -797,6 +797,6 @@ public class SQLExecutor {
     public <T extends TableInfo> T resolveTableInfo(String tableName) {
         IndexParts indexParts = new IndexParts(tableName);
         QualifiedName qualifiedName = QualifiedName.of(indexParts.getSchema(), indexParts.getTable());
-        return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionContext.searchPath());
+        return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionContext.user(), sessionContext.searchPath());
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should help users who miss quoting and therefore can't match a case
sensitive schema, or who simply have a typo.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)