### PR TITLE
Add did-you-mean functionality for RelationUnknown errors

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,11 @@ Deprecations
 Changes
 =======
 
+- Improved the error messages that were returned if a relation or schema is not
+  found. They now may include suggestions for similarly named tables. This
+  should make typos more apparent and can help users figure out that they were
+  missing double quotes in case the table names contain upper case letters.
+
 - Added a ``seq_no_stats`` column to the :ref:`sys.shards <sys-shards>` table.
 
 - Added new system table :ref:`sys.segments <sys-segments>` which contains

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -108,6 +108,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         sqlExecutor = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .addTable("create table foo.users (id bigint primary key, name text)")
+            .addTable("create table fooobar (id bigint primary key, name text)")
+            .addTable("create table \"Foobaarr\" (id bigint primary key, name text)")
             .build();
     }
 
@@ -2039,5 +2041,17 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void test_select_from_unknown_schema_has_suggestion_for_correct_schema() {
         expectedException.expectMessage("Schema 'Doc' unknown. Maybe you meant 'doc'");
         analyze("select * from \"Doc\".users");
+    }
+
+    @Test
+    public void test_select_from_unkown_table_has_suggestion_for_correct_table() {
+        expectedException.expectMessage("Relation 'uusers' unknown. Maybe you meant 'users'");
+        analyze("select * from uusers");
+    }
+
+    @Test
+    public void test_select_from_unkown_table_has_suggestion_for_similar_tables() {
+        expectedException.expectMessage("Relation 'foobar' unknown. Maybe you meant one of: fooobar, \"Foobaarr\"");
+        analyze("select * from foobar");
     }
 }


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)