### PR TITLE
Include root cause error message in CREATE REPOSITORY error messages

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,4 +177,6 @@ Changes
 Fixes
 =====
 
-None
+- Changed the error message returned when a :ref:`CREATE REPOSITORY
+  <ref-create-repository>` statement fails so that it includes more information
+  about the cause of the failure.

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -341,7 +341,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     } catch (RepositoryException e) {
                         throw e;
                     } catch (Exception e) {
-                        throw new RepositoryException(metadata.name(), "cannot create blob store" , e);
+                        throw new RepositoryException(metadata.name(), "cannot create blob store: " + e.getMessage() , e);
                     }
                     blobStore.set(store);
                 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Before:

    cr> create REPOSITORY s3_test type s3 with (secret_key = 'foo', access_key = 'bar');
    SQLActionException[RepositoryException: [] [s3_test] cannot create blob store]

After:

    cr> create REPOSITORY s3_test type s3 with (secret_key = 'foo', access_key = 'bar');
    SQLActionException[RepositoryException: [] [s3_test] cannot create blob store: you do not have permissions to access the bucket []]


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)