### PR TITLE
CI: Increase timeout on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent any
   options {
-    timeout(time: 30, unit: 'MINUTES') 
+    timeout(time: 45, unit: 'MINUTES') 
   }
   environment {
     CI_RUN = 'true'


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Sometimes it takes a bit longer to get a slot on a build slave, in which
case the total duration of the job can exceed 30 minutes.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)