### PR TITLE
Tune thread pool usage for collect phase

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -99,7 +99,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeBatchIterator(Blackhole blackhole) {
-        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         while (it.moveNext()) {
             blackhole.consume(it.currentElement().get(0));
         }
@@ -107,7 +107,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeCloseAssertingIterator(Blackhole blackhole) {
-        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> itCloseAsserting = new CloseAssertingBatchIterator<>(it);
         while (itCloseAsserting.moveNext()) {
             blackhole.consume(itCloseAsserting.currentElement().get(0));
@@ -116,7 +116,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeSkippingBatchIterator(Blackhole blackhole) {
-        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> skippingIt = new SkippingBatchIterator<>(it, 100);
         while (skippingIt.moveNext()) {
             blackhole.consume(skippingIt.currentElement().get(0));
@@ -126,8 +126,8 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeNestedLoopJoin(Blackhole blackhole) {
         BatchIterator<Row> crossJoin = JoinBatchIterators.crossJoinNL(
-            InMemoryBatchIterator.of(oneThousandRows, SENTINEL),
-            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1)
         );
         while (crossJoin.moveNext()) {
@@ -138,8 +138,8 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeBlockNestedLoopJoin(Blackhole blackhole) {
         BatchIterator<Row> crossJoin = JoinBatchIterators.crossJoinBlockNL(
-            InMemoryBatchIterator.of(oneThousandRows, SENTINEL),
-            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
             () -> 1000,
             new NoRowAccounting()
@@ -152,8 +152,8 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeNestedLoopLeftJoin(Blackhole blackhole) {
         BatchIterator<Row> leftJoin = JoinBatchIterators.leftJoin(
-            InMemoryBatchIterator.of(oneThousandRows, SENTINEL),
-            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
             row -> Objects.equals(row.get(0), row.get(1))
         );
@@ -165,8 +165,8 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeHashInnerJoin(Blackhole blackhole) {
         BatchIterator<Row> leftJoin = new HashInnerJoinBatchIterator(
-            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL), rowAccounting),
-            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true), rowAccounting),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
@@ -181,8 +181,8 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeHashInnerJoinWithHashCollisions(Blackhole blackhole) {
         BatchIterator<Row> leftJoin = new HashInnerJoinBatchIterator(
-            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL), rowAccounting),
-            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true), rowAccounting),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> {
@@ -203,7 +203,7 @@ public class RowsBatchIteratorBenchmark {
     public void measureConsumeWindowBatchIterator(Blackhole blackhole) throws Exception{
         InputCollectExpression input = new InputCollectExpression(0);
         BatchIterator<Row> batchIterator = WindowFunctionBatchIterator.of(
-            new InMemoryBatchIterator<>(rows, SENTINEL),
+            new InMemoryBatchIterator<>(rows, SENTINEL, false),
             new NoRowAccounting(),
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -140,7 +140,7 @@ public class GroupingLongCollectorBenchmark {
 
     @Benchmark
     public void measureGroupBySumLong(Blackhole blackhole) throws Exception {
-        var rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL);
+        var rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
         blackhole.consume(BatchIterators.collect(rowsIterator, groupBySumCollector).get());
     }
 

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -111,7 +111,7 @@ public class GroupingStringCollectorBenchmark {
 
     @Benchmark
     public void measureGroupByMinString(Blackhole blackhole) throws Exception {
-        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL);
+        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
         blackhole.consume(BatchIterators.collect(rowsIterator, groupByMinCollector).get());
     }
 }

--- a/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
@@ -92,14 +92,14 @@ public class SortingTopNCollectorBenchmark {
 
     @Benchmark
     public Object measureBoundedSortingCollector() {
-        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, boundedSortingCollector);
         return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();
     }
 
     @Benchmark
     public Object measureUnboundedSortingCollector() {
-        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
+        BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, unboundedSortingCollector);
         return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();
     }

--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -178,10 +178,10 @@ class JmxIntegrationTest(unittest.TestCase):
             '\n'.join((line.strip() for line in stdout.split('\n'))),
             '''\
 active:          0
-completed:       2
-largestPoolSize: 2
+completed:       1
+largestPoolSize: 1
 name:            search
-poolSize:        2
+poolSize:        1
 queueSize:       0
 rejected:        0
 

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -38,32 +38,35 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
 
     private final Iterable<? extends T> items;
     private final T sentinel;
+    private final boolean involvesIO;
 
     private Iterator<? extends T> it;
     private T current;
 
     public static <T> BatchIterator<T> empty(@Nullable T sentinel) {
-        return of(Collections.emptyList(), sentinel);
+        return of(Collections.emptyList(), sentinel, false);
     }
 
     public static <T> BatchIterator<T> of(T item, @Nullable T sentinel) {
-        return of(Collections.singletonList(item), sentinel);
+        return of(Collections.singletonList(item), sentinel, false);
     }
 
     /**
      * @param items An iterable over the items. It has to be repeatable if {@code moveToStart()} is used.
      * @param sentinel the value for {@link #currentElement()} if un-positioned
+     * @param involvesIO true if consuming the items or properties of the items can involve disk or network IO
      */
-    public static <T> BatchIterator<T> of(Iterable<? extends T> items, @Nullable T sentinel) {
-        return new CloseAssertingBatchIterator<>(new InMemoryBatchIterator<>(items, sentinel));
+    public static <T> BatchIterator<T> of(Iterable<? extends T> items, @Nullable T sentinel, boolean involvesIO) {
+        return new CloseAssertingBatchIterator<>(new InMemoryBatchIterator<>(items, sentinel, involvesIO));
     }
 
     @VisibleForTesting
-    public InMemoryBatchIterator(Iterable<? extends T> items, T sentinel) {
+    public InMemoryBatchIterator(Iterable<? extends T> items, T sentinel, boolean involvesIO) {
         this.items = items;
         this.it = items.iterator();
         this.current = sentinel;
         this.sentinel = sentinel;
+        this.involvesIO = involvesIO;
     }
 
     @Override
@@ -108,6 +111,6 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
 
     @Override
     public boolean involvesIO() {
-        return false;
+        return involvesIO;
     }
 }

--- a/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
+++ b/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
@@ -51,7 +51,8 @@ public class BatchIteratorsTest {
 
     @Test
     public void testBatchBySize() throws Exception {
-        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null);
+        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null,
+                                                                        true);
         BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add, r -> false);
 
         assertThat(batchedIt.moveNext(), is(true));
@@ -65,7 +66,7 @@ public class BatchIteratorsTest {
     @Test
     public void testBatchBySizeWithBatchedSource() throws Exception {
         BatchIterator<Integer> batchIterator = new BatchSimulatingIterator<>(
-            InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null),
+            InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, true),
             3,
             2,
             null
@@ -82,7 +83,8 @@ public class BatchIteratorsTest {
 
     @Test
     public void testBatchBySizeWithDynamicLimiter() throws Exception {
-        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null);
+        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null,
+                                                                        true);
         final AtomicInteger rowCount = new AtomicInteger();
         BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add,
             r -> rowCount.incrementAndGet() == 3);

--- a/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
+++ b/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
@@ -51,8 +51,7 @@ public class BatchIteratorsTest {
 
     @Test
     public void testBatchBySize() throws Exception {
-        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null,
-                                                                        true);
+        var batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, false);
         BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add, r -> false);
 
         assertThat(batchedIt.moveNext(), is(true));
@@ -66,7 +65,7 @@ public class BatchIteratorsTest {
     @Test
     public void testBatchBySizeWithBatchedSource() throws Exception {
         BatchIterator<Integer> batchIterator = new BatchSimulatingIterator<>(
-            InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, true),
+            InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, false),
             3,
             2,
             null
@@ -83,8 +82,7 @@ public class BatchIteratorsTest {
 
     @Test
     public void testBatchBySizeWithDynamicLimiter() throws Exception {
-        BatchIterator<Integer> batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null,
-                                                                        true);
+        var batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, false);
         final AtomicInteger rowCount = new AtomicInteger();
         BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add,
             r -> rowCount.incrementAndGet() == 3);

--- a/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
@@ -40,7 +40,7 @@ public class FlatMapBatchIteratorTest {
 
     @Test
     public void testFlatMap() throws Exception {
-        InMemoryBatchIterator<Integer> source = new InMemoryBatchIterator<>(Arrays.asList(1, 2, 3), null);
+        InMemoryBatchIterator<Integer> source = new InMemoryBatchIterator<>(Arrays.asList(1, 2, 3), null, false);
         FlatMapBatchIterator<Integer, Integer[]> twiceAsArray =
             new FlatMapBatchIterator<>(source, x -> Arrays.asList(new Integer[] {x, x}, new Integer[] {x, x}).iterator());
 

--- a/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
@@ -38,7 +38,8 @@ public class InMemoryBatchIteratorTest {
     @Test
     public void testCollectRows() throws Exception {
         List<Row> rows = Arrays.asList(new Row1(10), new Row1(20));
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL);
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL,
+                                                                                            true);
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         List<Object[]> expectedResult = Arrays.asList(new Object[]{10}, new Object[]{20});
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -49,7 +50,7 @@ public class InMemoryBatchIteratorTest {
         Iterable<Row> rows = RowGenerator.range(0, 50);
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new CloseAssertingBatchIterator<>(
             new BatchSimulatingIterator<>(
-                InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL),
+                InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, true),
                 10,
                 5,
                 null

--- a/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
@@ -38,8 +38,7 @@ public class InMemoryBatchIteratorTest {
     @Test
     public void testCollectRows() throws Exception {
         List<Row> rows = Arrays.asList(new Row1(10), new Row1(20));
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL,
-                                                                                            true);
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, false);
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         List<Object[]> expectedResult = Arrays.asList(new Object[]{10}, new Object[]{20});
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -50,7 +49,7 @@ public class InMemoryBatchIteratorTest {
         Iterable<Row> rows = RowGenerator.range(0, 50);
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new CloseAssertingBatchIterator<>(
             new BatchSimulatingIterator<>(
-                InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, true),
+                InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, false),
                 10,
                 5,
                 null

--- a/dex/src/test/java/io/crate/testing/TestingBatchIterators.java
+++ b/dex/src/test/java/io/crate/testing/TestingBatchIterators.java
@@ -39,7 +39,7 @@ public class TestingBatchIterators {
      * Returns a batch iterator containing a range of integers.
      */
     public static BatchIterator<Row> range(int startInclusive, int endExclusive) {
-        return InMemoryBatchIterator.of(RowGenerator.range(startInclusive, endExclusive), SENTINEL);
+        return InMemoryBatchIterator.of(RowGenerator.range(startInclusive, endExclusive), SENTINEL, true);
     }
 
     /**
@@ -48,11 +48,11 @@ public class TestingBatchIterators {
     public static BatchIterator<Row> range(long startInclusive, long endExclusive) {
         Iterable<Row> rows = RowGenerator.fromSingleColValues(
             () -> LongStream.range(startInclusive, endExclusive).iterator());
-        return InMemoryBatchIterator.of(rows, SENTINEL);
+        return InMemoryBatchIterator.of(rows, SENTINEL, true);
     }
 
     public static <T> BatchIterator<Row> ofValues(List<T> values) {
         List<RowN> rows = values.stream().map(i -> new RowN(new Object[]{i})).collect(Collectors.toList());
-        return InMemoryBatchIterator.of(rows, SENTINEL);
+        return InMemoryBatchIterator.of(rows, SENTINEL, true);
     }
 }

--- a/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
@@ -86,13 +86,19 @@ public class UserManagerService implements UserManager, ClusterStateListener {
         this.transportAlterUserAction = transportAlterUserAction;
         this.transportPrivilegesAction = transportPrivilegesAction;
         clusterService.addListener(this);
-        sysTableRegistry.registerSysTable(new SysUsersTableInfo(),
+        sysTableRegistry.registerSysTable(
+            new SysUsersTableInfo(),
             () -> CompletableFuture.completedFuture(users()),
-            SysUsersTableInfo.expressions());
+            SysUsersTableInfo.expressions(),
+            false
+        );
 
-        sysTableRegistry.registerSysTable(new SysPrivilegesTableInfo(),
+        sysTableRegistry.registerSysTable(
+            new SysPrivilegesTableInfo(),
             () -> CompletableFuture.completedFuture(SysPrivilegesTableInfo.buildPrivilegesRows(users())),
-            SysPrivilegesTableInfo.expressions());
+            SysPrivilegesTableInfo.expressions(),
+            false
+        );
 
         ddlClusterStateService.addModifier(DDL_MODIFIER);
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -78,7 +78,8 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
     protected BatchIterator<Row> getUnorderedIterator(RoutedCollectPhase collectPhase,
                                                       boolean requiresScroll,
                                                       CollectTask collectTask) {
-        return InMemoryBatchIterator.of(getBlobRows(collectTask.txnCtx(), collectPhase, requiresScroll), SentinelRow.SENTINEL);
+        return InMemoryBatchIterator.of(getBlobRows(collectTask.txnCtx(), collectPhase, requiresScroll), SentinelRow.SENTINEL,
+                                        true);
     }
 
     private Iterable<Row> getBlobRows(TransactionContext txnCtx, RoutedCollectPhase collectPhase, boolean requiresRepeat) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -173,7 +173,6 @@ public class CollectTask extends AbstractTask {
                 return ThreadPool.Names.GET;
             }
         }
-
         // Anything else like doc tables, INFORMATION_SCHEMA tables or sys.cluster table collector, partition collector
         return ThreadPool.Names.SEARCH;
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/MapSideDataCollectOperation.java
@@ -33,7 +33,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * collect local data from node/shards/docs on nodes where the data resides (aka Mapper nodes)
@@ -60,10 +59,6 @@ public class MapSideDataCollectOperation {
 
     public void launch(Runnable runnable, String threadPoolName) throws RejectedExecutionException {
         Executor executor = threadPool.executor(threadPoolName);
-        if (executor instanceof ThreadPoolExecutor) {
-            executor.execute(runnable);
-        } else {
-            runnable.run();
-        }
+        executor.execute(runnable);
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -109,7 +109,7 @@ public final class PKLookupOperation {
         } else {
             getResultIterable = getResultStream::iterator;
         }
-        return InMemoryBatchIterator.of(getResultIterable, null);
+        return InMemoryBatchIterator.of(getResultIterable, null, true);
     }
 
     @Nullable
@@ -207,7 +207,7 @@ public final class PKLookupOperation {
             } else {
                 rowIterable = rowStream::iterator;
             }
-            iterators.add(projectors.wrap(InMemoryBatchIterator.of(rowIterable, SentinelRow.SENTINEL)));
+            iterators.add(projectors.wrap(InMemoryBatchIterator.of(rowIterable, SentinelRow.SENTINEL, true)));
         }
         @SuppressWarnings("unchecked")
         BatchIterator<Row> batchIterator = CompositeBatchIterator.seqComposite(iterators.toArray(new BatchIterator[0]));

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/SqlFeaturesIterable.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/SqlFeaturesIterable.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 public class SqlFeaturesIterable implements Iterable<SqlFeatureContext> {
 
-    private static List<SqlFeatureContext> featuresList;
+    private final List<SqlFeatureContext> featuresList;
     private static final Splitter TAB_SPLITTER = Splitter.on("\t");
 
     public SqlFeaturesIterable() throws IOException {

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -274,7 +274,7 @@ public class ShardCollectSource implements CollectSource {
 
         if (collectPhase.maxRowGranularity() == RowGranularity.SHARD) {
             return projectors.wrap(InMemoryBatchIterator.of(
-                getShardsIterator(collectTask.txnCtx(), collectPhase, localNodeId), SentinelRow.SENTINEL));
+                getShardsIterator(collectTask.txnCtx(), collectPhase, localNodeId), SentinelRow.SENTINEL, true));
         }
         OrderBy orderBy = collectPhase.orderBy();
         if (collectPhase.maxRowGranularity() == RowGranularity.DOC && orderBy != null) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/SysTableRegistry.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/SysTableRegistry.java
@@ -22,13 +22,13 @@
 
 package io.crate.execution.engine.collect.sources;
 
+import io.crate.expression.reference.StaticTableDefinition;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.sys.SysTableDefinitions;
 import io.crate.metadata.table.TableInfo;
-import io.crate.expression.reference.StaticTableDefinition;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
@@ -51,11 +51,12 @@ public class SysTableRegistry {
 
     public <R> void registerSysTable(TableInfo tableInfo,
                                      Supplier<CompletableFuture<? extends Iterable<R>>> iterableSupplier,
-                                     Map<ColumnIdent, ? extends RowCollectExpressionFactory<R>> expressionFactories) {
+                                     Map<ColumnIdent, ? extends RowCollectExpressionFactory<R>> expressionFactories,
+                                     boolean involvesIO) {
         RelationName ident = tableInfo.ident();
         sysSchemaInfo.registerSysTable(tableInfo);
-        tableDefinitions.registerTableDefinition(ident, new StaticTableDefinition<>(
-            iterableSupplier, expressionFactories));
+        tableDefinitions.registerTableDefinition(
+            ident, new StaticTableDefinition<>(iterableSupplier, expressionFactories, involvesIO));
     }
 
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -145,8 +145,7 @@ public class SystemCollectSource implements CollectSource {
                             records
                         )
                     ),
-            // Most system resources are in-memory but some are not and involves IO.
-            true
+            tableDefinition.involvesIO()
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -89,6 +89,6 @@ public class TableFunctionCollectSource implements CollectSource {
         if (orderBy != null) {
             rows = RowsTransformer.sortRows(Iterables.transform(rows, Row::materialize), phase);
         }
-        return InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL);
+        return InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, false);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -83,8 +83,8 @@ public class InformationSchemaTableDefinitions {
         ));
         tableDefinitions.put(InformationSqlFeaturesTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(informationSchemaIterables.features()),
-            InformationSqlFeaturesTableInfo.expressions()
-        ));
+            InformationSqlFeaturesTableInfo.expressions(),
+            false));
         tableDefinitions.put(InformationKeyColumnUsageTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::keyColumnUsage,
             (user, k) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, k.getFQN()),
@@ -92,8 +92,8 @@ public class InformationSchemaTableDefinitions {
         ));
         tableDefinitions.put(InformationReferentialConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(informationSchemaIterables.referentialConstraintsInfos()),
-            InformationReferentialConstraintsTableInfo.expressions()
-        ));
+            InformationReferentialConstraintsTableInfo.expressions(),
+            false));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -49,8 +49,8 @@ public class PgCatalogTableDefinitions {
 
         tableDefinitions.put(PgTypeTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(PGTypes.pgTypes()),
-            PgTypeTable.expressions()
-        ));
+            PgTypeTable.expressions(),
+            false));
         tableDefinitions.put(PgClassTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::relations,
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident().fqn())
@@ -60,8 +60,8 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgDatabaseTable.NAME, new StaticTableDefinition<>(
             () -> completedFuture(singletonList(null)),
-            PgDatabaseTable.expressions()
-        ));
+            PgDatabaseTable.expressions(),
+            false));
         tableDefinitions.put(PgNamespaceTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::schemas,
             (user, s) -> user.hasAnyPrivilege(Privilege.Clazz.SCHEMA, s.name()),
@@ -69,8 +69,8 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgAttrDefTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(Collections.emptyList()),
-            PgAttrDefTable.expressions()
-        ));
+            PgAttrDefTable.expressions(),
+            false));
         tableDefinitions.put(PgAttributeTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
             (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.tableInfo.ident().fqn())
@@ -79,8 +79,8 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgIndexTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(Collections.emptyList()),
-            PgIndexTable.expressions()
-        ));
+            PgIndexTable.expressions(),
+            false));
         tableDefinitions.put(PgConstraintTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relationName().fqn()),
@@ -88,7 +88,8 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgDescriptionTable.NAME, new StaticTableDefinition<>(
             () -> completedFuture(emptyList()),
-            PgDescriptionTable.expressions())
+            PgDescriptionTable.expressions(),
+            false)
         );
 
         Iterable<NamedSessionSetting> sessionSettings =

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -63,40 +63,40 @@ public class SysTableDefinitions {
         tableDefinitions.put(SysJobsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.activeJobs()),
             SysJobsTableInfo.expressions(localNode),
-            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username())
-        ));
+            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username()),
+            false));
         tableDefinitions.put(SysJobsLogTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.jobsLog()),
             SysJobsLogTableInfo.expressions(localNode),
-            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username())
-        ));
+            (user, jobCtx) -> user.isSuperUser() || user.name().equals(jobCtx.username()),
+            false));
         tableDefinitions.put(SysOperationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.activeOperations()),
-            SysOperationsTableInfo.expressions(localNode)
-        ));
+            SysOperationsTableInfo.expressions(localNode),
+            false));
         tableDefinitions.put(SysOperationsLogTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.operationsLog()),
-            SysOperationsLogTableInfo.expressions()
-        ));
+            SysOperationsLogTableInfo.expressions(),
+            false));
 
         SysChecker<SysCheck> sysChecker = new SysChecker<>(sysChecks);
         tableDefinitions.put(SysChecksTableInfo.IDENT, new StaticTableDefinition<>(
             sysChecker::computeResultAndGet,
-            SysChecksTableInfo.expressions()
-        ));
+            SysChecksTableInfo.expressions(),
+            true));
 
         tableDefinitions.put(SysNodeChecksTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysNodeChecks),
-            SysNodeChecksTableInfo.expressions()
-        ));
+            SysNodeChecksTableInfo.expressions(),
+            true));
         tableDefinitions.put(SysRepositoriesTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(repositoriesService.getRepositoriesList()),
-            SysRepositoriesTableInfo.expressions(clusterService.getClusterSettings().maskedSettings())
-        ));
+            SysRepositoriesTableInfo.expressions(clusterService.getClusterSettings().maskedSettings()),
+            false));
         tableDefinitions.put(SysSnapshotsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysSnapshots.currentSnapshots()),
-            SysSnapshotsTableInfo.expressions()
-        ));
+            SysSnapshotsTableInfo.expressions(),
+            true));
 
         tableDefinitions.put(SysAllocationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> sysAllocations,
@@ -107,22 +107,22 @@ public class SysTableDefinitions {
         SummitsIterable summits = new SummitsIterable();
         tableDefinitions.put(SysSummitsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(summits),
-            SysSummitsTableInfo.expressions()
-        ));
+            SysSummitsTableInfo.expressions(),
+            false));
 
         tableDefinitions.put(SysHealthTableInfo.IDENT, new StaticTableDefinition<>(
             tableHealthService::computeResults,
             SysHealthTableInfo.expressions(),
-            (user, tableHealth) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, tableHealth.fqn())
-        ));
+            (user, tableHealth) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, tableHealth.fqn()),
+            true));
         tableDefinitions.put(SysMetricsTableInfo.NAME, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.metrics()),
-            SysMetricsTableInfo.expressions(localNode)
-        ));
+            SysMetricsTableInfo.expressions(localNode),
+            false));
         tableDefinitions.put(SysSegmentsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(shardSegmentInfos),
-            SysSegmentsTableInfo.expressions(clusterService::localNode)
-        ));
+            SysSegmentsTableInfo.expressions(clusterService::localNode),
+            true));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -134,7 +134,7 @@ public class CollectTaskTest extends RandomizedTest {
 
     @Test
     public void testThreadPoolNameForDocTables() throws Exception {
-        String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
+        String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
         assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
     }
 
@@ -147,29 +147,29 @@ public class CollectTaskTest extends RandomizedTest {
 
         // sys.cluster (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.CLUSTER);
-        String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
+        String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
         assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
 
         // partition values only of a partitioned doc table (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.PARTITION);
-        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
+        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
         assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
 
         // sys.nodes (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.NODE);
-        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
+        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
         assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
 
         // sys.shards
         when(routing.containsShards(localNodeId)).thenReturn(true);
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.SHARD);
-        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
+        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
         assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
         when(routing.containsShards(localNodeId)).thenReturn(false);
 
         // information_schema.*
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
-        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
+        threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, false);
+        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SAME));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
@@ -57,7 +57,7 @@ public class FileWriterProjectorTest extends CrateUnitTest {
     private Supplier<BatchIterator> sourceSupplier = () -> InMemoryBatchIterator.of(RowGenerator.fromSingleColValues(
         IntStream.range(0, 5)
             .mapToObj(i -> String.format(Locale.ENGLISH, "input line %02d", i))
-            .collect(Collectors.toList())), SENTINEL);
+            .collect(Collectors.toList())), SENTINEL, true);
 
     @Test
     public void testWriteRawToFile() throws Exception {

--- a/sql/src/test/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutorTest.java
@@ -24,7 +24,6 @@ package io.crate.execution.engine.indexing;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
-import io.crate.execution.engine.indexing.BatchIteratorBackpressureExecutor;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.BatchSimulatingIterator;
 import org.elasticsearch.action.bulk.BackoffPolicy;
@@ -64,7 +63,7 @@ public class BatchIteratorBackpressureExecutorTest extends CrateUnitTest {
 
     @Test
     public void testPauseOnFirstBatch() throws Exception {
-        BatchIterator<Integer> numbersBi = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), -1);
+        BatchIterator<Integer> numbersBi = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), -1, true);
         BatchSimulatingIterator<Integer> it = new BatchSimulatingIterator<>(numbersBi, 2, 5, executor);
         AtomicInteger numRows = new AtomicInteger(0);
         AtomicInteger numPauses = new AtomicInteger(0);

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -116,7 +116,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
 
         BatchIterator rowsIterator = InMemoryBatchIterator.of(IntStream.range(0, 100)
             .mapToObj(i -> new RowN(new Object[]{i, "{\"id\": " + i + ", \"name\": \"Arthur\"}"}))
-            .collect(Collectors.toList()), SENTINEL);
+            .collect(Collectors.toList()), SENTINEL, true);
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(writerProjector.apply(rowsIterator), null);

--- a/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -124,7 +124,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
             UpsertResultContext.forRowCount());
 
         RowN rowN = new RowN(new Object[]{new BytesRef("{\"y\": \"x\"}"), null});
-        BatchIterator<Row> batchIterator = InMemoryBatchIterator.of(Collections.singletonList(rowN), SENTINEL);
+        BatchIterator<Row> batchIterator = InMemoryBatchIterator.of(Collections.singletonList(rowN), SENTINEL, true);
         batchIterator = indexWriter.apply(batchIterator);
 
         TestingRowConsumer testingBatchConsumer = new TestingRowConsumer();

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -198,8 +198,8 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
                 $("foo", 10),
                 $("bar", 20)
             )),
-            SENTINEL
-        ));
+            SENTINEL,
+            true));
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
         Bucket rows = consumer.getBucket();
@@ -251,7 +251,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         rows.add($(human, 34, male));
 
         BatchIterator<Row> batchIterator = topNProjector.apply(projector.apply(
-            InMemoryBatchIterator.of(new CollectionBucket(rows), SENTINEL)));
+            InMemoryBatchIterator.of(new CollectionBucket(rows), SENTINEL, true)));
         TestingRowConsumer consumer = new TestingRowConsumer();
 
         consumer.accept(batchIterator, null);
@@ -282,7 +282,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         rows.add($("vogon", 1));
 
         BatchIterator<Row> filteredBI = projector.apply(
-            InMemoryBatchIterator.of(new CollectionBucket(rows), SENTINEL));
+            InMemoryBatchIterator.of(new CollectionBucket(rows), SENTINEL, true));
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(filteredBI, null);
         Bucket bucket = consumer.getBucket();

--- a/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -163,7 +163,8 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
         InputColumns.SourceSymbols inputColSources = new InputColumns.SourceSymbols(sourceSymbols);
         var mappedWindowDef = windowDef.map(s -> InputColumns.create(s, inputColSources));
         BatchIterator<Row> iterator = WindowFunctionBatchIterator.of(
-            InMemoryBatchIterator.of(Arrays.stream(inputRows).map(RowN::new).collect(Collectors.toList()), SENTINEL),
+            InMemoryBatchIterator.of(Arrays.stream(inputRows).map(RowN::new).collect(Collectors.toList()), SENTINEL,
+                                     true),
             new IgnoreRowAccounting(),
             WindowProjector.createComputeStartFrameBoundary(numCellsInSourceRows, functions, txnCtx, mappedWindowDef, cmpOrderBy),
             WindowProjector.createComputeEndFrameBoundary(numCellsInSourceRows, functions, txnCtx, mappedWindowDef, cmpOrderBy),

--- a/sql/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
@@ -58,7 +58,7 @@ public class StaticTableDefinitionTest {
         StaticTableDefinition<JobContext> tableDef = new StaticTableDefinition<>(
             () -> completedFuture(actual),
             Map.of(),
-            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()));
+            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()), true);
 
         Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
         assertThat(Iterables.size(expected), is(3));
@@ -73,7 +73,7 @@ public class StaticTableDefinitionTest {
         StaticTableDefinition<JobContext> tableDef = new StaticTableDefinition<>(
             () -> completedFuture(emptyList()),
             Map.of(),
-            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()));
+            (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()), true);
 
         Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
         assertThat(Iterables.size(expected), is(0));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See individual commits.
This only affects queries on system tables, which should now be a bit
faster.

The biggest difference is visible for `sys.cluster` where there is only
a single record, and the "collect" part of this single record is tiny
compared to all the other work that takes place during a query execution


    Q: select name from sys.cluster
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.179 ±    0.158 |      0.081 |      0.141 |      0.172 |      2.932 |
    |   V2    |        0.135 ±    0.156 |      0.055 |      0.095 |      0.115 |      2.248 |
    mean:   -  28.41%
    median: -  39.56%
    Likely significant

    Q: select name from sys.cluster
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.181 ±    0.058 |      0.102 |      0.171 |      0.194 |      1.435 |
    |   V2    |        0.158 ±    0.043 |      0.082 |      0.148 |      0.170 |      0.500 |
    mean:   -  13.37%
    median: -  14.39%
    Likely significant


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)