### PR TITLE
Add test case to protect against accidentally introducing new keywords

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/Identifiers.java
+++ b/sql-parser/src/main/java/io/crate/sql/Identifiers.java
@@ -41,7 +41,7 @@ public class Identifiers {
     private static final Pattern ESCAPE_REPLACE_RE = Pattern.compile("\"", Pattern.LITERAL);
     private static final String ESCAPE_REPLACEMENT = Matcher.quoteReplacement("\"\"");
 
-    private static final Set<String> KEYWORDS = identifierCandidates().stream()
+    static final Set<String> KEYWORDS = identifierCandidates().stream()
         .filter(Identifiers::reserved)
         .collect(Collectors.toSet());
 

--- a/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -31,6 +31,13 @@ import static org.hamcrest.core.Is.is;
 public class IdentifiersTest {
 
     @Test
+    public void test_number_of_keywords() {
+        // If this test is failing you are introducing a new reserved keyword which is a breaking change.
+        // Either add the new term to `nonReserved` in `SqlBase.4g` or add a breaking changes entry and adapt this test.
+        assertThat(Identifiers.KEYWORDS.size(), is(95));
+    }
+
+    @Test
     public void testEscape() {
         assertThat(Identifiers.escape(""), is(""));
         assertThat(Identifiers.escape("\""), is("\"\""));


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)