### PR TITLE
Drop _all mapping in template and index upgraders

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,11 @@ Changes
 Fixes
 =====
 
+- Improved the migration logic for partitioned tables which have been created
+  in CrateDB 2.x. If all current partitions of a partitioned tables have been
+  created in CrateDB 3.x, the table won't have to be re-indexed anymore to
+  upgrade to CrateDB 4.0+. 
+
 - Changed the error message returned when a :ref:`CREATE REPOSITORY
   <ref-create-repository>` statement fails so that it includes more information
   about the cause of the failure.

--- a/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -93,10 +93,8 @@ public class MetaDataIndexUpgradeService {
         // we have to run this first otherwise in we try to create IndexSettings
         // with broken settings and fail in checkMappingsCompatibility
         newMetaData = archiveBrokenIndexSettings(newMetaData);
-        // only run the check with the upgraded settings!!
-        checkMappingsCompatibility(newMetaData);
-        // apply plugin checks
         newMetaData = upgraders.apply(newMetaData);
+        checkMappingsCompatibility(newMetaData);
         return markAsUpgraded(newMetaData);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will allow users to upgrade to CrateDB 4.0+ without re-indexing
partitioned tables that have been created in CrateDB 2.x if all current
partitions were created in CrateDB 3.x.

This is a common case: Storing events partitioned by time, with a
retention period of e.g. 30 days. So after 30 days all partitions have
been rolled through.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)