### PR TITLE
Expose `indices.breaker.total.limit`

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -171,6 +171,8 @@ applied cluster settings.
     | settings['indices']['breaker']['request']                                         | object           |
     | settings['indices']['breaker']['request']['limit']                                | text             |
     | settings['indices']['breaker']['request']['overhead']                             | double precision |
+    | settings['indices']['breaker']['total']                                           | object           |
+    | settings['indices']['breaker']['total']['limit']                                  | text             |
     | settings['indices']['recovery']                                                   | object           |
     | settings['indices']['recovery']['internal_action_long_timeout']                   | text             |
     | settings['indices']['recovery']['internal_action_timeout']                        | text             |

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,10 @@ Changes
 Fixes
 =====
 
+- Made the documented :ref:`indices.breaker.total.limit
+  <indices.breaker.total.limit>` setting public, so that it can be adjusted
+  using :ref:`SET GLOBAL <ref-set>`.
+
 - Improved the migration logic for partitioned tables which have been created
   in CrateDB 2.x. If all current partitions of a partitioned tables have been
   created in CrateDB 3.x, the table won't have to be re-indexed anymore to

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1015,6 +1015,8 @@ each of them, the breaker limit can be set.
   error message and clears the :ref:`sys.operations_log <sys-logs>` table
   completely.
 
+.. _indices.breaker.total.limit:
+
 Total circuit breaker
 ---------------------
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -173,7 +173,8 @@ public final class CrateSettings implements ClusterStateListener {
             CrateSetting.of(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING, DataTypes.STRING),
             CrateSetting.of(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_OVERHEAD_SETTING, DataTypes.DOUBLE),
             CrateSetting.of(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, DataTypes.STRING),
-            CrateSetting.of(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING, DataTypes.DOUBLE)
+            CrateSetting.of(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING, DataTypes.DOUBLE),
+            CrateSetting.of(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING, DataTypes.STRING)
         );
 
 

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -588,7 +588,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(701, response.rowCount());
+        assertEquals(703, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We documented the setting in https://github.com/crate/crate/pull/8709
but it couldn't be changed using `SET GLOBAL`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)