### PR TITLE
Make memory accounting of fixedSize types more accurate

### DIFF
--- a/common/src/main/java/io/crate/types/DoubleType.java
+++ b/common/src/main/java/io/crate/types/DoubleType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -31,6 +32,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
     public static final DoubleType INSTANCE = new DoubleType();
     public static final int ID = 6;
+    private static final int DOUBLE_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Double.class);
 
     private DoubleType() {
     }
@@ -89,6 +91,6 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
     @Override
     public int fixedSize() {
-        return 16; // 8 object overhead + 8 for double
+        return DOUBLE_SIZE;
     }
 }

--- a/common/src/main/java/io/crate/types/FloatType.java
+++ b/common/src/main/java/io/crate/types/FloatType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -31,6 +32,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
 
     public static final FloatType INSTANCE = new FloatType();
     public static final int ID = 7;
+    private static final int FLOAT_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Float.class);
 
     private FloatType() {
     }
@@ -93,6 +95,6 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
 
     @Override
     public int fixedSize() {
-        return 16; // object overhead + float
+        return FLOAT_SIZE;
     }
 }

--- a/common/src/main/java/io/crate/types/IntegerType.java
+++ b/common/src/main/java/io/crate/types/IntegerType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -31,6 +32,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
 
     public static final IntegerType INSTANCE = new IntegerType();
     public static final int ID = 9;
+    private static final int INTEGER_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Integer.class);
 
     private IntegerType() {
     }
@@ -94,6 +96,6 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
 
     @Override
     public int fixedSize() {
-        return 16; // object overhead + 4 byte for int + 4 byte padding
+        return INTEGER_SIZE;
     }
 }

--- a/common/src/main/java/io/crate/types/LongType.java
+++ b/common/src/main/java/io/crate/types/LongType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -31,6 +32,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
 
     public static final LongType INSTANCE = new LongType();
     public static final int ID = 10;
+    public static final int LONG_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Long.class);
 
     @Override
     public int id() {
@@ -86,7 +88,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
 
     @Override
     public int fixedSize() {
-        return 16; // 8 object overhead, 8 long
+        return LONG_SIZE;
     }
 }
 

--- a/common/src/main/java/io/crate/types/ShortType.java
+++ b/common/src/main/java/io/crate/types/ShortType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -31,6 +32,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
 
     public static final ShortType INSTANCE = new ShortType();
     public static final int ID = 8;
+    private static final int SHORT_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Short.class);
 
     private ShortType() {
     }
@@ -93,7 +95,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
 
     @Override
     public int fixedSize() {
-        return 16; // object overhead + 2 byte for short + 6 byte padding
+        return SHORT_SIZE;
     }
 }
 

--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import io.crate.Streamer;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -127,7 +128,7 @@ public final class TimestampType extends DataType<Long>
 
     @Override
     public int fixedSize() {
-        return 16; // 8 object overhead, 8 long
+        return LongType.LONG_SIZE;
     }
 
     static long parseTimestamp(String timestamp) {

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -31,6 +31,7 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FixedWidthType;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -102,6 +103,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
         public static final int ID = 1024;
         private static final AverageStateType INSTANCE = new AverageStateType();
+        private static final int AVERAGE_STATE_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(AverageState.class);
 
         @Override
         public int id() {
@@ -150,7 +152,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
         @Override
         public int fixedSize() {
-            return DataTypes.LONG.fixedSize() + DataTypes.DOUBLE.fixedSize();
+            return AVERAGE_STATE_SIZE;
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Utilizes RamUsageEstimator which is a bit smarter as it takes object
alignments and things like UseCompressedOops into consideration.

It may still be wrong, especially if a JVM other than OpenJDK/Oracle is
used, but should be an improvement over what we did before.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)