### PR TITLE
hll: Avoid BytesRef instance creation to get bytes of String

### DIFF
--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -39,7 +39,6 @@ import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.hash.MurmurHash3;
@@ -51,6 +50,7 @@ import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlus
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -306,8 +306,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
 
             @Override
             long hash(Object val) {
-                final BytesRef bytes = new BytesRef(DataTypes.STRING.value(val));
-                MurmurHash3.hash128(bytes.bytes, bytes.offset, bytes.length, 0, hash);
+                byte[] bytes = DataTypes.STRING.value(val).getBytes(StandardCharsets.UTF_8);
+                MurmurHash3.hash128(bytes, 0, bytes.length, 0, hash);
                 return hash.h1;
             }
         }


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)