### PR TITLE
Add unbound analysis for SET/RESET

### DIFF
--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -57,8 +57,8 @@ import io.crate.analyze.AnalyzedKill;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.AnalyzedPrivileges;
 import io.crate.analyze.QueriedSelectRelation;
-import io.crate.analyze.ResetAnalyzedStatement;
-import io.crate.analyze.SetAnalyzedStatement;
+import io.crate.analyze.AnalyzedResetStatement;
+import io.crate.analyze.AnalyzedSetStatement;
 import io.crate.analyze.AnalyzedShowCreateTable;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
@@ -436,7 +436,7 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        public Void visitSetStatement(SetAnalyzedStatement analysis, User user) {
+        public Void visitSetStatement(AnalyzedSetStatement analysis, User user) {
             if (analysis.scope().equals(SetStatement.Scope.GLOBAL)) {
                 Privileges.ensureUserHasPrivilege(
                     Privilege.Type.AL,
@@ -539,7 +539,7 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        public Void visitResetAnalyzedStatement(ResetAnalyzedStatement resetAnalyzedStatement, User user) {
+        public Void visitResetAnalyzedStatement(AnalyzedResetStatement resetAnalyzedStatement, User user) {
             throwRequiresSuperUserPermission(user.name());
             return null;
         }

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -629,14 +629,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitSet(SqlBaseParser.SetContext context) {
-        Assignment setAssignment = prepareSetAssignment(context);
+        Assignment<?> setAssignment = prepareSetAssignment(context);
         if (context.LOCAL() != null) {
-            return new SetStatement(SetStatement.Scope.LOCAL, setAssignment);
+            return new SetStatement<>(SetStatement.Scope.LOCAL, setAssignment);
         }
-        return new SetStatement(SetStatement.Scope.SESSION, setAssignment);
+        return new SetStatement<>(SetStatement.Scope.SESSION, setAssignment);
     }
 
-    private Assignment prepareSetAssignment(SqlBaseParser.SetContext context) {
+    private Assignment<?> prepareSetAssignment(SqlBaseParser.SetContext context) {
         Expression settingName = new QualifiedNameReference(getQualifiedName(context.qname()));
         if (context.DEFAULT() != null) {
             return new Assignment<>(settingName, ImmutableList.of());
@@ -648,11 +648,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitSetGlobal(SqlBaseParser.SetGlobalContext context) {
         var assignments = Lists2.map(context.setGlobalAssignment(), x -> (Assignment<Expression>) visit(x));
         if (context.PERSISTENT() != null) {
-            return new SetStatement(SetStatement.Scope.GLOBAL,
+            return new SetStatement<>(SetStatement.Scope.GLOBAL,
                 SetStatement.SettingType.PERSISTENT,
                 assignments);
         }
-        return new SetStatement(SetStatement.Scope.GLOBAL, assignments);
+        return new SetStatement<>(SetStatement.Scope.GLOBAL, assignments);
     }
 
     @Override
@@ -660,7 +660,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         Assignment<Expression> assignment = new Assignment<>(
             new StringLiteral("license"), (Expression) visit(ctx.stringLiteral()));
 
-        return new SetStatement(SetStatement.Scope.LICENSE,
+        return new SetStatement<>(SetStatement.Scope.LICENSE,
             SetStatement.SettingType.PERSISTENT, Collections.singletonList(assignment));
     }
 
@@ -669,12 +669,12 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         Assignment<Expression> assignment = new Assignment<>(
             new StringLiteral("transaction_mode"),
             visitCollection(ctx.setExpr(), Expression.class));
-        return new SetStatement(SetStatement.Scope.SESSION_TRANSACTION_MODE, assignment);
+        return new SetStatement<>(SetStatement.Scope.SESSION_TRANSACTION_MODE, assignment);
     }
 
     @Override
     public Node visitResetGlobal(SqlBaseParser.ResetGlobalContext context) {
-        return new ResetStatement(visitCollection(context.primaryExpression(), Expression.class));
+        return new ResetStatement<>(visitCollection(context.primaryExpression(), Expression.class));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -464,11 +464,11 @@ public abstract class AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
-    public R visitSetStatement(SetStatement node, C context) {
+    public R visitSetStatement(SetStatement<?> node, C context) {
         return visitStatement(node, context);
     }
 
-    public R visitResetStatement(ResetStatement node, C context) {
+    public R visitResetStatement(ResetStatement<?> node, C context) {
         return visitStatement(node, context);
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ResetStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ResetStatement.java
@@ -23,19 +23,27 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.function.Function;
 
-public class ResetStatement extends Statement {
+public class ResetStatement<T> extends Statement {
 
-    private final List<Expression> columns;
+    private final List<T> columns;
 
-    public ResetStatement(List<Expression> columns) {
+    public ResetStatement(List<T> columns) {
         this.columns = columns;
     }
 
-    public List<Expression> columns() {
+    public List<T> columns() {
         return columns;
+    }
+
+    public <U> ResetStatement<U> map(Function<? super T, ? extends U> mapper) {
+        return new ResetStatement<>(
+            Lists2.map(columns, mapper)
+        );
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -468,12 +468,12 @@ public class TestStatementBuilder {
 
     @Test
     public void testSetLicense() {
-        SetStatement stmt = (SetStatement) SqlParser.createStatement("set license 'LICENSE_KEY'");
+        SetStatement<?> stmt = (SetStatement) SqlParser.createStatement("set license 'LICENSE_KEY'");
         assertThat(stmt.scope(), is(SetStatement.Scope.LICENSE));
         assertThat(stmt.settingType(), is(SetStatement.SettingType.PERSISTENT));
         assertThat(stmt.assignments().size(), is(1));
 
-        Assignment assignment = stmt.assignments().get(0);
+        Assignment<?> assignment = stmt.assignments().get(0);
         assertThat(assignment.expressions().size(), is(1));
         assertThat(assignment.expressions().get(0).toString(), is("'LICENSE_KEY'"));
     }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedResetStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedResetStatement.java
@@ -22,25 +22,30 @@
 
 package io.crate.analyze;
 
-import javax.annotation.Nonnull;
+import io.crate.expression.symbol.Symbol;
 
-public class SetLicenseAnalyzedStatement implements AnalyzedStatement {
+import java.util.Set;
 
-    static final int LICENSE_TOKEN_NUM = 1;
+public class AnalyzedResetStatement implements AnalyzedStatement {
 
-    private final String licenseKey;
+    private final Set<Symbol> settingsToRemove;
 
-    SetLicenseAnalyzedStatement(@Nonnull final String licenseKey) {
-        this.licenseKey = licenseKey;
-    }
-
-    public String licenseKey() {
-        return licenseKey;
+    public AnalyzedResetStatement(Set<Symbol> settingsToRemove) {
+        this.settingsToRemove = settingsToRemove;
     }
 
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitSetLicenseStatement(this, context);
+        return analyzedStatementVisitor.visitResetAnalyzedStatement(this, context);
+    }
+
+    public Set<Symbol> settingsToRemove() {
+        return settingsToRemove;
+    }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/AnalyzedSetLicenseStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedSetLicenseStatement.java
@@ -22,23 +22,38 @@
 
 package io.crate.analyze;
 
-import java.util.Set;
+import io.crate.expression.symbol.Symbol;
 
-public class ResetAnalyzedStatement implements AnalyzedStatement {
+import javax.annotation.Nonnull;
+import java.util.function.Consumer;
 
-    private final Set<String> settingsToRemove;
+public class AnalyzedSetLicenseStatement implements AnalyzedStatement {
 
-    public ResetAnalyzedStatement(Set<String> settingsToRemove) {
-        this.settingsToRemove = settingsToRemove;
+    static final int LICENSE_TOKEN_NUM = 1;
+
+    private final Symbol licenseKey;
+
+    AnalyzedSetLicenseStatement(@Nonnull final Symbol licenseKey) {
+        this.licenseKey = licenseKey;
+    }
+
+    public Symbol licenseKey() {
+        return licenseKey;
     }
 
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitResetAnalyzedStatement(this, context);
+        return analyzedStatementVisitor.visitSetLicenseStatement(this, context);
     }
 
-    public Set<String> settingsToRemove() {
-        return settingsToRemove;
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        consumer.accept(licenseKey);
+    }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -115,11 +115,11 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitAnalyzedStatement(analysis, context);
     }
 
-    public R visitSetStatement(SetAnalyzedStatement analysis, C context) {
+    public R visitSetStatement(AnalyzedSetStatement analysis, C context) {
         return visitAnalyzedStatement(analysis, context);
     }
 
-    public R visitSetLicenseStatement(SetLicenseAnalyzedStatement analysis, C context) {
+    public R visitSetLicenseStatement(AnalyzedSetLicenseStatement analysis, C context) {
         return visitAnalyzedStatement(analysis, context);
     }
 
@@ -155,7 +155,7 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
-    public R visitResetAnalyzedStatement(ResetAnalyzedStatement resetAnalyzedStatement, C context) {
+    public R visitResetAnalyzedStatement(AnalyzedResetStatement resetAnalyzedStatement, C context) {
         return visitAnalyzedStatement(resetAnalyzedStatement, context);
     }
 

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -132,6 +132,8 @@ public class Analyzer {
     private final SwapTableAnalyzer swapTableAnalyzer;
     private final DecommissionNodeAnalyzer decommissionNodeAnalyzer;
     private final KillAnalyzer killAnalyzer;
+    private final SetStatementAnalyzer setStatementAnalyzer;
+    private final ResetStatementAnalyzer resetStatementAnalyzer;
 
     /**
      * @param relationAnalyzer is injected because we also need to inject it in
@@ -180,6 +182,8 @@ public class Analyzer {
         this.alterTableRerouteAnalyzer = new AlterTableRerouteAnalyzer(functions, schemas);
         this.privilegesAnalyzer = new PrivilegesAnalyzer(userManager.isEnabled(), schemas);
         this.copyAnalyzer = new CopyAnalyzer(schemas, functions);
+        this.setStatementAnalyzer = new SetStatementAnalyzer(functions);
+        this.resetStatementAnalyzer = new ResetStatementAnalyzer(functions);
         this.unboundAnalyzer = new UnboundAnalyzer(
             relationAnalyzer,
             showStatementAnalyzer,
@@ -211,7 +215,9 @@ public class Analyzer {
             privilegesAnalyzer,
             copyAnalyzer,
             viewAnalyzer,
-            swapTableAnalyzer
+            swapTableAnalyzer,
+            setStatementAnalyzer,
+            resetStatementAnalyzer
         );
     }
 
@@ -403,13 +409,17 @@ public class Analyzer {
         }
 
         @Override
-        public AnalyzedStatement visitSetStatement(SetStatement node, Analysis context) {
-            return SetStatementAnalyzer.analyze(node);
+        public AnalyzedStatement visitSetStatement(SetStatement<?> node, Analysis context) {
+            return setStatementAnalyzer.analyze((SetStatement<Expression>)node,
+                                                context.paramTypeHints(),
+                                                context.transactionContext());
         }
 
         @Override
-        public AnalyzedStatement visitResetStatement(ResetStatement node, Analysis context) {
-            return SetStatementAnalyzer.analyze(node);
+        public AnalyzedStatement visitResetStatement(ResetStatement<?> node, Analysis context) {
+            return resetStatementAnalyzer.analyze((ResetStatement<Expression>) node,
+                                                context.paramTypeHints(),
+                                                context.transactionContext());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.relations.FieldProvider;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Functions;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.ResetStatement;
+
+import java.util.HashSet;
+
+public class ResetStatementAnalyzer {
+
+    private final Functions functions;
+
+    public ResetStatementAnalyzer(Functions functions) {
+        this.functions = functions;
+    }
+
+    public AnalyzedResetStatement analyze(ResetStatement<Expression> node,
+                                          ParamTypeHints typeHints,
+                                          CoordinatorTxnCtx txnCtx) {
+        var exprAnalyzer = new ExpressionAnalyzer(
+            functions,
+            txnCtx,
+            typeHints,
+            FieldProvider.FIELDS_AS_LITERAL,
+            null
+        );
+
+        var statement = node.map(x -> exprAnalyzer.convert(x, new ExpressionAnalysisContext()));
+        return new AnalyzedResetStatement(new HashSet<>(statement.columns()));
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -227,7 +227,7 @@ public final class CrateSettings implements ClusterStateListener {
             throw new IllegalArgumentException(
                 "Cannot set \"" + key + "\" to `null`. Use `RESET [GLOBAL] \"" + key +
                 "\"` to reset a setting to its default value");
-        } else if (value.getClass().isArray()) {
+        } else if (value instanceof List) {
             ArrayType<String> strArray = new ArrayType<>(DataTypes.STRING);
             List<String> values = strArray.value(value);
             settingsBuilder.put(key, String.join(",", values));

--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -26,8 +26,8 @@ import io.crate.analyze.AnalyzedDecommissionNode;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QueriedSelectRelation;
-import io.crate.analyze.SetAnalyzedStatement;
-import io.crate.analyze.SetLicenseAnalyzedStatement;
+import io.crate.analyze.AnalyzedSetStatement;
+import io.crate.analyze.AnalyzedSetLicenseStatement;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.AnalyzedView;
@@ -55,12 +55,12 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
             return true;
         }
 
-        if (analyzedStatement instanceof SetLicenseAnalyzedStatement ||
+        if (analyzedStatement instanceof AnalyzedSetLicenseStatement ||
             analyzedStatement instanceof AnalyzedDecommissionNode) {
             return true;
         }
-        if (analyzedStatement instanceof SetAnalyzedStatement) {
-            switch (((SetAnalyzedStatement) analyzedStatement).scope()) {
+        if (analyzedStatement instanceof AnalyzedSetStatement) {
+            switch (((AnalyzedSetStatement) analyzedStatement).scope()) {
                 case SESSION_TRANSACTION_MODE:
                 case SESSION:
                 case LOCAL:

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -25,8 +25,8 @@ package io.crate.planner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.crate.analyze.AnalyzedAlterBlobTable;
-import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTable;
+import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterUser;
@@ -41,40 +41,40 @@ import io.crate.analyze.AnalyzedCreateRepository;
 import io.crate.analyze.AnalyzedCreateSnapshot;
 import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateUser;
+import io.crate.analyze.AnalyzedDeallocate;
 import io.crate.analyze.AnalyzedDecommissionNode;
 import io.crate.analyze.AnalyzedDeleteStatement;
+import io.crate.analyze.AnalyzedDropAnalyzer;
 import io.crate.analyze.AnalyzedDropFunction;
 import io.crate.analyze.AnalyzedDropRepository;
 import io.crate.analyze.AnalyzedDropSnapshot;
+import io.crate.analyze.AnalyzedDropTable;
 import io.crate.analyze.AnalyzedDropUser;
+import io.crate.analyze.AnalyzedDropView;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
-import io.crate.analyze.AnalyzedRefreshTable;
+import io.crate.analyze.AnalyzedKill;
 import io.crate.analyze.AnalyzedOptimizeTable;
+import io.crate.analyze.AnalyzedPromoteReplica;
+import io.crate.analyze.AnalyzedRefreshTable;
+import io.crate.analyze.AnalyzedRerouteAllocateReplicaShard;
+import io.crate.analyze.AnalyzedRerouteCancelShard;
+import io.crate.analyze.AnalyzedRerouteMoveShard;
+import io.crate.analyze.AnalyzedRerouteRetryFailed;
+import io.crate.analyze.AnalyzedResetStatement;
 import io.crate.analyze.AnalyzedRestoreSnapshot;
+import io.crate.analyze.AnalyzedSetLicenseStatement;
+import io.crate.analyze.AnalyzedSetStatement;
+import io.crate.analyze.AnalyzedShowCreateTable;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.AnalyzedSwapTable;
 import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.DCLStatement;
-import io.crate.analyze.AnalyzedDeallocate;
-import io.crate.analyze.AnalyzedDropAnalyzer;
-import io.crate.analyze.AnalyzedDropTable;
-import io.crate.analyze.AnalyzedDropView;
 import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
 import io.crate.analyze.InsertFromValuesAnalyzedStatement;
-import io.crate.analyze.AnalyzedKill;
 import io.crate.analyze.NumberOfShards;
-import io.crate.analyze.AnalyzedPromoteReplica;
-import io.crate.analyze.AnalyzedRerouteAllocateReplicaShard;
-import io.crate.analyze.AnalyzedRerouteCancelShard;
-import io.crate.analyze.AnalyzedRerouteMoveShard;
-import io.crate.analyze.AnalyzedRerouteRetryFailed;
-import io.crate.analyze.AnalyzedResetStatement;
-import io.crate.analyze.AnalyzedSetStatement;
-import io.crate.analyze.AnalyzedSetLicenseStatement;
-import io.crate.analyze.AnalyzedShowCreateTable;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.auth.user.UserManager;
 import io.crate.exceptions.LicenseViolationException;
@@ -96,12 +96,12 @@ import io.crate.planner.node.ddl.AlterTableRenameTablePlan;
 import io.crate.planner.node.ddl.AlterUserPlan;
 import io.crate.planner.node.ddl.CreateAnalyzerPlan;
 import io.crate.planner.node.ddl.CreateBlobTablePlan;
-import io.crate.planner.node.ddl.DropAnalyzerPlan;
 import io.crate.planner.node.ddl.CreateFunctionPlan;
 import io.crate.planner.node.ddl.CreateRepositoryPlan;
 import io.crate.planner.node.ddl.CreateSnapshotPlan;
 import io.crate.planner.node.ddl.CreateTablePlan;
 import io.crate.planner.node.ddl.CreateUserPlan;
+import io.crate.planner.node.ddl.DropAnalyzerPlan;
 import io.crate.planner.node.ddl.DropFunctionPlan;
 import io.crate.planner.node.ddl.DropRepositoryPlan;
 import io.crate.planner.node.ddl.DropSnapshotPlan;
@@ -135,7 +135,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BooleanSupplier;
@@ -459,14 +458,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                 return new SetSessionPlan(setStatement.settings());
             case GLOBAL:
             default:
-                if (setStatement.isPersistent()) {
-                    return new UpdateSettingsPlan(setStatement.settings());
-                } else {
-                    return new UpdateSettingsPlan(
-                        Collections.emptyList(),
-                        setStatement.settings()
-                    );
-                }
+                return new UpdateSettingsPlan(setStatement.settings(), setStatement.isPersistent());
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -446,13 +446,15 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Plan visitSetStatement(AnalyzedSetStatement setStatement, PlannerContext context) {
         switch (setStatement.scope()) {
             case LICENSE:
-                LOGGER.warn("SET LICENSE STATEMENT WILL BE IGNORED: {}", setStatement.settings());
-                return NoopPlan.INSTANCE;
+                throw new AssertionError(
+                    "`AnalyzedSetStatement` with scope `LICENSE` should have been converted to `AnalyzedSetLicenseStatement` by the analyzer");
             case LOCAL:
-                LOGGER.warn("SET LOCAL STATEMENT WILL BE IGNORED: {}", setStatement.settings());
+                LOGGER.info(
+                    "SET LOCAL `{}` statement will be ignored. " +
+                    "CrateDB has no transactions, so any `SET LOCAL` change would be dropped in the next statement.", setStatement.settings());
                 return NoopPlan.INSTANCE;
             case SESSION_TRANSACTION_MODE:
-                LOGGER.warn("'SET SESSION CHARACTERISTICS AS TRANSACTION' STATEMENT WILL BE IGNORED");
+                LOGGER.info("'SET SESSION CHARACTERISTICS AS TRANSACTION' statement will be ignored.");
                 return NoopPlan.INSTANCE;
             case SESSION:
                 return new SetSessionPlan(setStatement.settings());

--- a/sql/src/test/java/io/crate/analyze/ResetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ResetAnalyzerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import com.google.common.collect.ImmutableSet;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+
+public class ResetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor executor;
+
+    @Before
+    public void prepare() {
+        executor = SQLExecutor.builder(clusterService).build();
+    }
+
+    @Test
+    public void testReset() throws Exception {
+        AnalyzedResetStatement analysis = executor.analyze("RESET GLOBAL stats.enabled");
+        assertThat(analysis.settingsToRemove(), contains(Literal.of("stats.enabled")));
+
+        analysis = executor.analyze("RESET GLOBAL stats");
+        assertThat(analysis.settingsToRemove(), contains(Literal.of("stats")));
+    }
+
+    @Test
+    public void testResetLoggingSetting() {
+        AnalyzedResetStatement analysis = executor.analyze("RESET GLOBAL \"logger.action\"");
+        assertThat(analysis.settingsToRemove(), Matchers.<Set<Symbol>>is(ImmutableSet.of(Literal.of("logger.action"))));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1,21 +1,23 @@
 package io.crate.planner;
 
 import io.crate.action.sql.SessionContext;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RoutingProvider;
 import io.crate.planner.node.ddl.UpdateSettingsPlan;
-import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.elasticsearch.common.Randomness;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -32,8 +34,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
         UpdateSettingsPlan plan = e.plan("set GLOBAL PERSISTENT stats.jobs_log_size=1024");
 
         // set transient settings too when setting persistent ones
-        assertThat(plan.transientSettings().get("stats.jobs_log_size").get(0), Is.is(new LongLiteral("1024")));
-        assertThat(plan.persistentSettings().get("stats.jobs_log_size").get(0), Is.is(new LongLiteral("1024")));
+        assertThat(plan.transientSettings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
+        assertThat(plan.persistentSettings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
 
         plan = e.plan("set GLOBAL TRANSIENT stats.enabled=false,stats.jobs_log_size=0");
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -16,8 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -33,14 +33,13 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testSetPlan() throws Exception {
         UpdateSettingsPlan plan = e.plan("set GLOBAL PERSISTENT stats.jobs_log_size=1024");
 
-        // set transient settings too when setting persistent ones
-        assertThat(plan.transientSettings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
-        assertThat(plan.persistentSettings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
+        assertThat(plan.settings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
+        assertThat(plan.isPersistent(), is(true));
 
         plan = e.plan("set GLOBAL TRANSIENT stats.enabled=false,stats.jobs_log_size=0");
 
-        assertThat(plan.persistentSettings().size(), is(0));
-        assertThat(plan.transientSettings().size(), is(2));
+        assertThat(plan.settings().size(), is(2));
+        assertThat(plan.isPersistent(), is(false));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.data.Row;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.settings.SessionSettings;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static io.crate.planner.node.ddl.ResetSettingsPlan.buildSettingsFrom;
+import static org.hamcrest.Matchers.is;
+
+public class ResetSettingsPlanTest extends CrateUnitTest {
+
+    @Test
+    public void testResetSimple() throws Exception {
+        Set<Symbol> settings = Set.of(Literal.of("stats.enabled"));
+
+        Settings expected = Settings.builder()
+            .put("stats.enabled", (String) null)
+            .build();
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
+    }
+
+    @Test
+    public void testReset() throws Exception {
+        Set<Symbol> settings = Set.of(Literal.of("stats"));
+
+        Settings expected = Settings.builder()
+            .put("stats.breaker.log.operations.limit", (String) null)
+            .put("stats.breaker.log.operations.overhead", (String) null)
+            .put("stats.breaker.log.jobs.limit", (String) null)
+            .put("stats.breaker.log.jobs.overhead", (String) null)
+            .put("stats.enabled", (String) null)
+            .put("stats.jobs_log_size", (String) null)
+            .put("stats.jobs_log_expiration", (String) null)
+            .put("stats.jobs_log_filter", (String) null)
+            .put("stats.jobs_log_persistent_filter", (String) null)
+            .put("stats.operations_log_size", (String) null)
+            .put("stats.operations_log_expiration", (String) null)
+            .put("stats.service.interval", (String) null)
+            .build();
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
+
+    }
+
+    @Test
+    public void testResetNonRuntimeSetting() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
+
+        Set<Symbol> settings = Set.of(Literal.of("gateway"));
+
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+    }
+
+    @Test
+    public void testResetNonRuntimeSettingObject() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
+
+        Set<Symbol> settings = Set.of(Literal.of("gateway.recover_after_nodes"));
+
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+    }
+
+    @Test
+    public void testResetLoggingSetting() {
+        Set<Symbol> settings = Set.of(Literal.of("logger.action"));
+        Settings expected = Settings.builder()
+            .put("logger.action", (String) null)
+            .build();
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
+    }
+
+    private Function<Symbol, Object> symbolEvaluator(Row row) {
+        return x -> SymbolEvaluator.evaluate(
+            TransactionContext.of(new SessionSettings("", SearchPath.createSearchPathFrom(""))),
+            new Functions(Map.of(), Map.of()),
+            x,
+            row,
+            SubQueryResults.EMPTY);
+    }
+
+    @Test
+    public void testUpdateSettingsWithStringValue() throws Exception {
+        Set<Symbol> settings = Set.of(Literal.of("cluster.graceful_stop.min_availability"));
+
+        Settings expected = Settings.builder()
+            .put("cluster.graceful_stop.min_availability", (String) null)
+            .build();
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
+    }
+
+    @Test
+    public void testUpdateMultipleSettingsWithParameters() throws Exception {
+        Set<Symbol> settings = Set.of(Literal.of("stats.operations_log_size"), Literal.of("stats.jobs_log_size"));
+
+        Settings expected = Settings.builder()
+            .put("stats.operations_log_size", (String) null)
+            .put("stats.jobs_log_size", (String) null)
+            .build();
+
+        assertThat(
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
+    }
+
+    @Test
+    public void testUnsupportedSetting() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Setting 'unsupported_setting' is not supported");
+
+        Set<Symbol> settings = Set.of(Literal.of("unsupported_setting"));
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -22,77 +22,120 @@
 
 package io.crate.planner.node.ddl;
 
-import com.google.common.collect.ImmutableList;
+import io.crate.analyze.SymbolEvaluator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
-import io.crate.sql.tree.ArrayLiteral;
-import io.crate.sql.tree.Expression;
-import io.crate.sql.tree.NullLiteral;
-import io.crate.sql.tree.ParameterExpression;
-import io.crate.sql.tree.StringLiteral;
+import io.crate.expression.scalar.arithmetic.ArrayFunction;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.ParameterSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.settings.SessionSettings;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.crate.planner.node.ddl.UpdateSettingsPlan.buildSettingsFrom;
+import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class UpdateSettingsPlanTest extends CrateUnitTest {
 
+    private Function<Symbol, Object> symbolEvaluator(Row row) {
+        return x -> SymbolEvaluator.evaluate(
+            TransactionContext.of(new SessionSettings("", SearchPath.createSearchPathFrom(""))),
+            getFunctions(),
+            x,
+            row,
+            SubQueryResults.EMPTY);
+    }
+
     @Test
     public void testUpdateSettingsWithStringValue() throws Exception {
-        Map<String, List<Expression>> settings = new HashMap<String, List<Expression>>() {{
-            put("cluster.graceful_stop.min_availability", ImmutableList.of(new StringLiteral("full")));
-        }};
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("cluster.graceful_stop.min_availability"), List.of(Literal.of("full"))));
+
         Settings expected = Settings.builder()
             .put("cluster.graceful_stop.min_availability", "full")
             .build();
-        assertThat(buildSettingsFrom(settings, Row.EMPTY), is(expected));
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)), is(expected));
     }
 
     @Test
     public void testUpdateMultipleSettingsWithParameters() throws Exception {
-        Map<String, List<Expression>> settings = new HashMap<String, List<Expression>>() {{
-            put("stats.operations_log_size", ImmutableList.of(new ParameterExpression(1)));
-            put("stats.jobs_log_size", ImmutableList.of(new ParameterExpression(2)));
-        }};
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("stats.operations_log_size"), List.of(new ParameterSymbol(0, DataTypes.LONG))),
+            new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(new ParameterSymbol(1, DataTypes.LONG)))
+        );
         Settings expected = Settings.builder()
             .put("stats.operations_log_size", 10)
             .put("stats.jobs_log_size", 25)
             .build();
+
         assertThat(
-            buildSettingsFrom(settings, new RowN(new Object[]{10, 25})),
+            buildSettingsFrom(settings, symbolEvaluator(new RowN(new Object[]{10, 25}))),
             is(expected)
         );
     }
 
     @Test
     public void testUpdateObjectWithParameter() throws Exception {
-        Map<String, List<Expression>> settings = new HashMap<String, List<Expression>>() {{
-            put("stats", ImmutableList.of(new ParameterExpression(1)));
-        }};
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("stats"), List.of(new ParameterSymbol(0, DataTypes.LONG))));
+
         Map<String, Object> param = MapBuilder.<String, Object>newMapBuilder()
             .put("enabled", true)
             .put("breaker",
-                MapBuilder.newMapBuilder()
-                    .put("log", MapBuilder.newMapBuilder()
-                        .put("jobs", MapBuilder.newMapBuilder()
-                            .put("overhead", 1.05d).map()
-                        ).map()
-                    ).map()
+                 MapBuilder.newMapBuilder()
+                     .put("log", MapBuilder.newMapBuilder()
+                         .put("jobs", MapBuilder.newMapBuilder()
+                             .put("overhead", 1.05d).map()
+                         ).map()
+                     ).map()
             ).map();
 
         Settings expected = Settings.builder()
             .put("stats.enabled", true)
             .put("stats.breaker.log.jobs.overhead", 1.05d)
             .build();
-        assertThat(buildSettingsFrom(settings, new RowN(new Object[]{param})), is(expected));
+
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(new RowN(new Object[]{param}))), is(expected));
+    }
+
+    @Test
+    public void testSetNonRuntimeSettingObject() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
+
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("gateway"), List.of(Literal.of(Map.of("recover_after_nodes", 3))))
+        );
+
+
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+    }
+
+    @Test
+    public void testSetNonRuntimeSetting() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Setting 'gateway.recover_after_time' cannot be set/reset at runtime");
+
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("gateway.recover_after_time"), List.of(Literal.of("5m"))
+            ));
+
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
     }
 
     @Test
@@ -100,24 +143,29 @@ public class UpdateSettingsPlanTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Setting 'unsupported_setting' is not supported");
 
-        Map<String, List<Expression>> settings = new HashMap<String, List<Expression>>() {{
-            put("unsupported_setting", ImmutableList.of(new StringLiteral("foo")));
-        }};
-        buildSettingsFrom(settings, Row.EMPTY);
+        List<Assignment<Symbol>> settings = List.of(
+            new Assignment<>(Literal.of("unsupported_setting"), List.of(Literal.of("foo"))
+            ));
+
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
     }
 
     @Test
     public void test_build_settings_with_null_value() {
+        List<Assignment<Symbol>> settings = List.of(new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), Literal.NULL));
+
         expectedException.expectMessage("Cannot set \"cluster.routing.allocation.exclude._id\" to `null`. Use `RESET [GLOBAL] \"cluster.routing.allocation.exclude._id\"` to reset a setting to its default value");
-        Map<String, List<Expression>> settings = Map.of("cluster.routing.allocation.exclude._id", List.of(NullLiteral.INSTANCE));
-        buildSettingsFrom(settings, Row.EMPTY);
+        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
     }
 
     @Test
     public void test_array_is_implicitly_converted_to_comma_separated_string() {
-        var idsArray = new ArrayLiteral(List.of(new StringLiteral("id1"), new StringLiteral("id2")));
-        Map<String, List<Expression>> expressionsBySettingKey = Map.of("cluster.routing.allocation.exclude._id", List.of(idsArray));
-        Settings settings = buildSettingsFrom(expressionsBySettingKey, Row.EMPTY);
+        var idsArray = new io.crate.expression.symbol.Function(
+            ArrayFunction.createInfo(List.of(DataTypes.STRING, DataTypes.STRING)),
+            List.of(Literal.of("id1"), Literal.of("id2"))
+        );
+        Assignment<Symbol> assignment = new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), idsArray);
+        Settings settings = buildSettingsFrom(List.of(assignment), symbolEvaluator(Row.EMPTY));
         assertThat(settings.get("cluster.routing.allocation.exclude._id"), is("id1,id2"));
         assertThat(settings.getAsList("cluster.routing.allocation.exclude._id"), contains("id1", "id2"));
     }

--- a/sql/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.statement;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+
+import static io.crate.planner.statement.SetSessionPlan.validateSetting;
+
+public class SetSessionPlanTest extends CrateUnitTest {
+
+    @Test
+    public void testSetSessionInvalidSetting() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(
+            "GLOBAL Cluster setting 'stats.operations_log_size' cannot be used with SET SESSION / LOCAL");
+        validateSetting("stats.operations_log_size");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
