### PR TITLE
Changes usage of type STRING to TEXT in the docs

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -95,7 +95,7 @@ characters are allowed. Example::
     ... );
     CREATE OK, 1 row affected (... sec)
 
-Columns of type string can also be analyzed. See :ref:`sql_ddl_index_fulltext`.
+Columns of type text can also be analyzed. See :ref:`sql_ddl_index_fulltext`.
 
 .. NOTE::
 
@@ -181,7 +181,7 @@ filtering, and aggregation.
 Example::
 
     cr> create table my_table_ips (
-    ...   fqdn string,
+    ...   fqdn text,
     ...   ip_addr ip
     ... );
     CREATE OK, 1 row affected (... sec)
@@ -869,9 +869,9 @@ Boolean type::
 
   { my_bool_column = true }
 
-String type::
+Text type::
 
-  { my_str_col = 'this is a string value' }
+  { my_str_col = 'this is a text value' }
 
 Number types::
 
@@ -883,11 +883,11 @@ Array type::
 
 Camel case keys must be quoted::
 
-  { "CamelCaseColumn" = 'this is a string value' }
+  { "CamelCaseColumn" = 'this is a text value' }
 
 Nested object::
 
-  { nested_obj_colmn = { int_col = 1234, str_col = 'string value' } }
+  { nested_obj_colmn = { int_col = 1234, str_col = 'text value' } }
 
 You can even specify a placeholder parameter for a value::
 
@@ -925,7 +925,7 @@ Array types are defined as follows::
 
 .. NOTE::
 
-    Currently arrays cannot be nested. Something like array(array(string))
+    Currently arrays cannot be nested. Something like array(array(text))
     won't work.
 
 .. _data-type-array-literals:

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -1045,8 +1045,8 @@ This is useful if used in conjunction with aggregation functions::
    subquery using :ref:`unnest`, it is then possible to use GROUP BY on the
    subquery.
 
-   GROUP BY doesn't work on columns of type :ref:`STRING <data-type-text>` if
-   the column is indexed using a fulltext analyzer. By default STRING columns
+   GROUP BY doesn't work on columns of type :ref:`TEXT <data-type-text>` if
+   the column is indexed using a fulltext analyzer. By default TEXT columns
    are indexed using a plain analyzer which allows GROUP BY operations.
 
 .. _sql_dql_having:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The data type STRING will be deprecated in future versions hence the
docs will use the supported data type.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
