### PR TITLE
Don't trip parent circuit breaker on low child breaker usage

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,9 @@ Changes
 Fixes
 =====
 
+- Tuned the circuit breaker mechanism to reduce the change of it rejecting
+  queries under low cluster load.
+
 - Closed some gaps in the memory accounting used for the circuit breaker
   mechanism. This should help prevent memory intense queries from triggering
   long GC pauses as they'll be rejected earlier.

--- a/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -51,6 +51,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     private static final String CHILD_LOGGER_PREFIX = "org.elasticsearch.indices.breaker.";
 
     private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
+    private static final double PARENT_BREAKER_ESCAPE_HATCH_PERCENTAGE = 0.30;
 
     private final ConcurrentMap<String, CircuitBreaker> breakers = new ConcurrentHashMap<>();
 
@@ -249,6 +250,14 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         long totalUsed = parentUsed(newBytesReserved);
         long parentLimit = this.parentSettings.getLimit();
         if (totalUsed > parentLimit) {
+            long breakersTotalUsed = breakers.values().stream()
+                .mapToLong(x -> (long) (x.getUsed() * x.getOverhead()))
+                .sum();
+            // if the individual breakers hardly use any memory we assume that there is a lot of heap usage by objects which can be GCd.
+            // We want to allow the query so that it triggers GCs
+            if ((breakersTotalUsed + newBytesReserved) < (parentLimit * PARENT_BREAKER_ESCAPE_HATCH_PERCENTAGE)) {
+                return;
+            }
             this.parentTripCount.incrementAndGet();
             final StringBuilder message = new StringBuilder("[parent] Data too large, data for [" + label + "]" +
                     " would be [" + totalUsed + "/" + new ByteSizeValue(totalUsed) + "]" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Due to the switch of using the real used heap memory in
44e6b78b1cc2383920f596e13875d4fd0ca081ae it could happen that queries
are rejected without there being any load on a cluster. Some queries can
lead to high heap usage (and get aborted), but then nothing will trigger
GCs as any subsequent queries will be rejected due to the parent
breaker.

In fe544cc90d0c0fd9eb08a20e015ef7fdc3fd22bb we already updated the
recommended GC settings to avoid that to some degree, but it can still
happen.

This change introduces some kind of workaround. We avoid tripping the
breaker if all the individual breaker account for less than 30 percent
of the limit.


Before this change, the parent breaker usage looked like follows. The flat line indicates that it reached the "reject queries" threshold and that no queries were allowed anymore which would trigger the GC

![image](https://user-images.githubusercontent.com/38700/67301398-9ffc8b80-f4ef-11e9-80db-66bee0999663.png)

With this change it looks as follows:


![image](https://user-images.githubusercontent.com/38700/67301491-c1f60e00-f4ef-11e9-8e6e-2b05bcd62ece.png)




## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)