### PR TITLE
Fix generated column evaluation based on default constraint.

### DIFF
--- a/common/src/main/java/io/crate/common/TriConsumer.java
+++ b/common/src/main/java/io/crate/common/TriConsumer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.common;
+
+/**
+ * An operation that accepts three input arguments and returns no result.
+ *
+ * @param <K> type of the first argument
+ * @param <V> type of the second argument
+ * @param <S> type of the third argument
+ */
+public interface TriConsumer<K, V, S> {
+
+    /**
+     * Performs the operation given the specified arguments.
+     * @param k the first input argument
+     * @param v the second input argument
+     * @param s the third input argument
+     */
+    void accept(K k, V v, S s);
+}

--- a/common/src/main/java/io/crate/common/collections/Maps.java
+++ b/common/src/main/java/io/crate/common/collections/Maps.java
@@ -22,6 +22,7 @@
 package io.crate.common.collections;
 
 import io.crate.common.StringUtils;
+import io.crate.common.TriConsumer;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -92,9 +93,23 @@ public final class Maps {
     /**
      * Inserts a value into source under the given key+path
      */
-    public static void mergeInto(Map<String, Object> source, String key, List<String> path, Object value) {
+    public static void mergeInto(Map<String, Object> source,
+                                 String key,
+                                 List<String> path,
+                                 Object value) {
+        mergeInto(source, key, path, value, Map::put);
+    }
+
+    /**
+     * Inserts a value into source under the given key+path
+     */
+    public static void mergeInto(Map<String, Object> source,
+                                 String key,
+                                 List<String> path,
+                                 Object value,
+                                 TriConsumer<Map<String, Object>, String, Object> writer) {
         if (path.isEmpty()) {
-            source.put(key, value);
+            writer.accept(source, key, value);
         } else {
             if (source.containsKey(key)) {
                 Map<String, Object> contents = (Map<String, Object>) source.get(key);
@@ -103,9 +118,9 @@ public final class Maps {
                     source.put(key, contents);
                 }
                 String nextKey = path.get(0);
-                mergeInto(contents, nextKey, path.subList(1, path.size()), value);
+                mergeInto(contents, nextKey, path.subList(1, path.size()), value, writer);
             } else {
-                source.put(key, nestedMaps(path, value));
+                writer.accept(source, key, nestedMaps(path, value));
             }
         }
     }

--- a/dex/src/main/java/io/crate/data/BiArrayRow.java
+++ b/dex/src/main/java/io/crate/data/BiArrayRow.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+/**
+ * A {@link ArrayRow} variant which uses 2 backing arrays which can be changed.
+ */
+public class BiArrayRow implements Row {
+
+    private Object[] firstCells;
+    private Object[] secondCells;
+
+    public void firstCells(Object[] cells) {
+        this.firstCells = cells;
+    }
+
+    public void secondCells(Object[] cells) {
+        this.secondCells = cells;
+    }
+
+    @Override
+    public int numColumns() {
+        return firstCells.length + secondCells.length;
+    }
+
+    @Override
+    public Object get(int index) {
+        int firstCellsSize = firstCells.length;
+        if (index >= firstCellsSize) {
+            return secondCells[index - firstCellsSize];
+        }
+        return firstCells[index];
+    }
+
+    @Override
+    public Object[] materialize() {
+        Object[] copy = new Object[numColumns()];
+        System.arraycopy(firstCells, 0, copy, 0, firstCells.length);
+        System.arraycopy(secondCells, 0, copy, firstCells.length, secondCells.length);
+        return copy;
+    }
+}

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,10 @@ Changes
 Fixes
 =====
 
+- Fixed evaluation of generated columns when they are based on columns
+  with default constraints and no user given values. Default
+  contraints where not taken into account before.
+
 - Fixed an issue when using ``try_cast('invalid-ts' as timestamp)``
   which resulted in a parsing exception instead of an expected
   ``NULL`` value.

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
@@ -44,39 +44,30 @@ public final class GeneratedColumns<T> {
         VALUE_MATCH
     }
 
-    private static final GeneratedColumns EMPTY = new GeneratedColumns();
+    private static final GeneratedColumns EMPTY = new GeneratedColumns<>();
 
+    @SuppressWarnings("unchecked")
     public static <T> GeneratedColumns<T> empty() {
-        //noinspection unchecked
-        return EMPTY;
+        return (GeneratedColumns<T>) EMPTY;
     }
 
     private final Map<Reference, Input<?>> toValidate;
     private final Map<Reference, Input<?>> generatedToInject;
-    private final Map<Reference, Input<?>> defaultsToInject;
     private final List<CollectExpression<T, ?>> expressions;
 
     private GeneratedColumns() {
         toValidate = Collections.emptyMap();
         generatedToInject = Collections.emptyMap();
-        defaultsToInject = Collections.emptyMap();
         expressions = Collections.emptyList();
     }
 
-    public GeneratedColumns(InputFactory inputFactory,
-                            TransactionContext txnCtx,
-                            Validation validation,
-                            ReferenceResolver<CollectExpression<T, ?>> refResolver,
-                            Collection<Reference> presentColumns,
-                            List<GeneratedReference> allGeneratedColumns,
-                            List<Reference> allDefaultExpressionColumns) {
+    GeneratedColumns(InputFactory inputFactory,
+                     TransactionContext txnCtx,
+                     Validation validation,
+                     ReferenceResolver<CollectExpression<T, ?>> refResolver,
+                     Collection<Reference> presentColumns,
+                     List<GeneratedReference> allGeneratedColumns) {
         InputFactory.Context<CollectExpression<T, ?>> ctx = inputFactory.ctxForRefs(txnCtx, refResolver);
-        defaultsToInject = new HashMap<>();
-        for (Reference colWithDefault : allDefaultExpressionColumns) {
-            if (!presentColumns.contains(colWithDefault)) {
-                defaultsToInject.put(colWithDefault, ctx.add(colWithDefault.defaultExpression()));
-            }
-        }
         generatedToInject = new HashMap<>();
         for (GeneratedReference generatedCol : allGeneratedColumns) {
             if (!presentColumns.contains(generatedCol)) {
@@ -107,7 +98,7 @@ public final class GeneratedColumns<T> {
         }
     }
 
-    public void validateValues(HashMap<String, Object> source) {
+    void validateValues(HashMap<String, Object> source) {
         for (var entry : toValidate.entrySet()) {
             Reference ref = entry.getKey();
             Object providedValue = ValueExtractors.fromMap(source, ref.column());
@@ -132,11 +123,7 @@ public final class GeneratedColumns<T> {
         }
     }
 
-    public Iterable<? extends Map.Entry<Reference, Input<?>>> generatedToInject() {
+    Iterable<? extends Map.Entry<Reference, Input<?>>> generatedToInject() {
         return generatedToInject.entrySet();
-    }
-
-    public Iterable<? extends Map.Entry<Reference, Input<?>>> defaultsToInject() {
-        return defaultsToInject.entrySet();
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -34,9 +34,9 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -44,7 +44,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -104,8 +103,7 @@ final class UpdateSourceGen {
                 GeneratedColumns.Validation.VALUE_MATCH,
                 refResolver,
                 this.updateColumns,
-                table.generatedColumns(),
-                List.of()
+                table.generatedColumns()
             );
         }
     }

--- a/sql/src/main/java/io/crate/metadata/ReferenceToLiteralConverter.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceToLiteralConverter.java
@@ -37,12 +37,20 @@ import java.util.function.Function;
 
 public class ReferenceToLiteralConverter implements Function<Reference, Symbol> {
 
+    private final List<Reference> insertColumns;
+    private final Collection<Reference> allReferencedReferences;
     private final Map<Reference, InputColumn> referenceInputColumnMap;
-    private final BitSet inputIsMap;
+    private BitSet inputIsMap;
     private Object[] values;
 
     public ReferenceToLiteralConverter(List<Reference> insertColumns, Collection<Reference> allReferencedReferences) {
+        this.insertColumns = insertColumns;
+        this.allReferencedReferences = allReferencedReferences;
         referenceInputColumnMap = new HashMap<>(allReferencedReferences.size());
+        rebuildReferenceMap();
+    }
+
+    public void rebuildReferenceMap() {
         inputIsMap = new BitSet(insertColumns.size());
         for (Reference reference : allReferencedReferences) {
             int idx = 0;

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -153,7 +153,13 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
                 "  color text," +
                 "  routing_col int generated always as o['serial_number'] + 1" +
                 ")" +
-                " clustered by (routing_col)");
+                " clustered by (routing_col)")
+            .addTable(
+                "create table generated_based_on_default (" +
+                " id int," +
+                " x int default 1," +
+                " y as x + 1" +
+                ")");
 
         e = executorBuilder.build();
     }
@@ -1470,5 +1476,18 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
 
         Object[] values = stmt.sourceMaps().get(0);
         assertThat(values[0], is(Map.of("x", 5, "y", 2)));
+    }
+
+    @Test
+    public void test_generated_based_on_default() {
+        InsertFromValuesAnalyzedStatement analysis = e.analyze(
+            "insert into generated_based_on_default (id) values (1)");
+        assertThat(analysis.sourceMaps(), hasSize(1));
+
+        var res = analysis.sourceMaps().get(0);
+        assertThat(res.length, is(3));
+        assertThat(res[0], is(1));
+        assertThat(res[1], is(1));
+        assertThat(res[2], is(2));
     }
 }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.common.collections.Maps;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table generated_based_on_default (x int default 1, y as x + 1)")
+            .build();
+    }
+
+    @Test
+    public void test_generated_based_on_default() throws Exception {
+        DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
+        GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
+            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+        BytesReference source = insertSource.generateSource(new Object[]{"{}"});
+        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        assertThat(Maps.getByPath(map, "x"), is(1));
+        assertThat(Maps.getByPath(map, "y"), is(2));
+    }
+
+    @Test
+    public void test_value_is_not_overwritten_by_default() throws Exception {
+        DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
+        GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
+            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+        BytesReference source = insertSource.generateSource(new Object[]{"{\"x\":2}"});
+        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        assertThat(Maps.getByPath(map, "x"), is(2));
+        assertThat(Maps.getByPath(map, "y"), is(3));
+    }
+}

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -60,8 +60,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
             GeneratedColumns.Validation.NONE,
             new DocRefResolver(Collections.emptyList()),
             Collections.emptyList(),
-            table.generatedColumns(),
-            table.defaultExpressionColumns()
+            table.generatedColumns()
         );
 
         BytesReference bytes = BytesReference.bytes(XContentFactory.jsonBuilder()

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -61,7 +61,6 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     private Reference z;
     private DocTableInfo t2;
     private Reference obj;
-    private Reference b;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
@@ -72,6 +71,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             .addPartitionedTable("create table t3 (p int not null) partitioned by (p)")
             .addTable("create table t4 (x int, y text default 'crate')")
             .addTable("create table t5 (obj object as (x int default 0, y int))")
+            .addTable("create table t6 (x int default 1, y as x + 1)")
             .build();
         QueriedSelectRelation<DocTableRelation> relation = e.normalize("select x, y, z from t1");
         t1 = relation.subRelation().tableInfo();
@@ -82,7 +82,6 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         relation = e.normalize("select obj, b from t2");
         t2 = relation.subRelation().tableInfo();
         obj = (Reference) relation.outputs().get(0);
-        b = (Reference) relation.outputs().get(1);
     }
 
     @Test
@@ -236,7 +235,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(obj, Matchers.notNullValue());
         List<Reference> targets = List.of(obj);
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
+            txnCtx, e.functions(), t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
         BytesReference source = sourceFromCells.generateSource(new Object[]{providedValueForObj});
@@ -244,5 +243,17 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(Maps.getByPath(map, "obj.x"), is(2));
+    }
+
+    @Test
+    public void test_generated_based_on_default() throws Exception {
+        DocTableInfo t6 = e.resolveTableInfo("t6");
+        InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
+            txnCtx, e.functions(), t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
+        BytesReference source = sourceFromCells.generateSource(new Object[0]);
+        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        assertThat(Maps.getByPath(map, "x"), is(1));
+        assertThat(Maps.getByPath(map, "y"), is(2));
     }
 }


### PR DESCRIPTION
When evaluating generated columns, possible default constraints of referenced columns must be taken into account.
