### PR TITLE
Fix exception handling at timestamp type parsing

### DIFF
--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
@@ -135,8 +136,13 @@ public final class TimestampType extends DataType<Long>
         try {
             return Long.parseLong(timestamp);
         } catch (NumberFormatException e) {
-            TemporalAccessor dt = TIMESTAMP_PARSER.parseBest(
-                timestamp, OffsetDateTime::from, LocalDateTime::from, LocalDate::from);
+            TemporalAccessor dt;
+            try {
+                dt = TIMESTAMP_PARSER.parseBest(
+                    timestamp, OffsetDateTime::from, LocalDateTime::from, LocalDate::from);
+            } catch (DateTimeParseException e1) {
+                throw new IllegalArgumentException(e1.getMessage());
+            }
 
             if (dt instanceof LocalDateTime) {
                 LocalDateTime localDateTime = LocalDateTime.from(dt);
@@ -155,8 +161,13 @@ public final class TimestampType extends DataType<Long>
         try {
             return Long.parseLong(timestamp);
         } catch (NumberFormatException e) {
-            TemporalAccessor dt = TIMESTAMP_PARSER.parseBest(
-                timestamp, LocalDateTime::from, LocalDate::from);
+            TemporalAccessor dt;
+            try {
+                dt = TIMESTAMP_PARSER.parseBest(
+                    timestamp, LocalDateTime::from, LocalDate::from);
+            } catch (DateTimeParseException e1) {
+                throw new IllegalArgumentException(e1.getMessage());
+            }
 
             if (dt instanceof LocalDate) {
                 LocalDate localDate = LocalDate.from(dt);

--- a/common/src/test/java/io/crate/types/TimestampTypesTest.java
+++ b/common/src/test/java/io/crate/types/TimestampTypesTest.java
@@ -4,8 +4,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.time.format.DateTimeParseException;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -81,56 +79,56 @@ public class TimestampTypesTest {
 
     @Test
     public void testTimestampWithZoneUsingDoubleSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestamp("1999-01-08  04:00:00");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingDoubleSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestampIgnoreTimeZone("1999-01-08  04:00:00");
     }
 
     @Test
     public void testTimestampWithZoneNothingBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestamp("1999-01-0804:00:00");
     }
 
     @Test
     public void testTimestampWithoutZoneNothingBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestampIgnoreTimeZone("1999-01-0804:00:00");
     }
 
     @Test
     public void testTimestampWithZoneUsingSpaceAndTBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestamp("1999-01-08 T04:00:00");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingSpaceAndTBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestampIgnoreTimeZone("1999-01-08 T04:00:00");
     }
 
     @Test
     public void testTimestampWithZoneUsingTAndSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestamp("1999-01-08T 04:00:00");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingTAndSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
         TimestampType.parseTimestampIgnoreTimeZone("1999-01-08T 04:00:00");
     }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue when using ``try_cast('invalid-ts' as timestamp)``
+  which resulted in a parsing exception instead of an expected
+  ``NULL`` value.
+
 - Improved the handling of ``NULL`` values in ``SET GLOBAL`` statement. They
   now no longer cause a ``NullPointerException`` but instead advice users to
   use ``RESET GLOBAL`` to reset settings to their default value.

--- a/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -122,7 +122,7 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidTimestamp() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Text 'NO TIMESTAMP' could not be parsed");
         assertEvaluate("date_format('%d.%m.%Y', 'NO TIMESTAMP')", null);
     }

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -133,4 +133,14 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
                        978310861000L,
                        Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2001-01-01T01:01:01Z")));
     }
+
+    /**
+     * Only {@link io.crate.exceptions.ConversionException} are caught on try_cast, cast will only convert
+     * {@link ClassCastException} and {@link IllegalArgumentException}.
+     * This test ensures that parsing exceptions at {@link io.crate.types.TimestampType} will be converted into these.
+     */
+    @Test
+    public void test_try_cast_invalid_timestamp_returns_null() {
+        assertEvaluate("try_cast('0000:00:00' as timestamp)", null);
+    }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -69,9 +69,9 @@ public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateInvalidTimestamp() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
-            "Text 'not_a_timestamp' could not be parsed at index 0");
+            "Cannot cast 'not_a_timestamp' to type timestamp with time zone");
         assertEvaluate("timezone('Europe/Madrid', 'not_a_timestamp')", null);
     }
 


### PR DESCRIPTION
Convert parsing exception into IllegalArgumentException so ``try_cast`` works as expected (returning NULL on parsing exceptions).