### PR TITLE
Replace NPE on SET GLOBAL with more meaningful error

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,10 @@ Changes
 Fixes
 =====
 
+- Improved the handling of ``NULL`` values in ``SET GLOBAL`` statement. They
+  now no longer cause a ``NullPointerException`` but instead advice users to
+  use ``RESET GLOBAL`` to reset settings to their default value.
+
 - Tuned the circuit breaker mechanism to reduce the change of it rejecting
   queries under low cluster load.
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -222,6 +222,10 @@ public final class CrateSettings implements ClusterStateListener {
             for (Map.Entry<String, Object> setting : ((Map<String, Object>) value).entrySet()) {
                 flattenSettings(settingsBuilder, DOT_JOINER.join(key, setting.getKey()), setting.getValue());
             }
+        } else if (value == null) {
+            throw new IllegalArgumentException(
+                "Cannot set \"" + key + "\" to `null`. Use `RESET [GLOBAL] \"" + key +
+                "\"` to reset a setting to its default value");
         } else {
             settingsBuilder.put(key, value.toString());
         }

--- a/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.NullLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateUnitTest;
@@ -100,6 +101,13 @@ public class UpdateSettingsPlanTest extends CrateUnitTest {
         Map<String, List<Expression>> settings = new HashMap<String, List<Expression>>() {{
             put("unsupported_setting", ImmutableList.of(new StringLiteral("foo")));
         }};
+        buildSettingsFrom(settings, Row.EMPTY);
+    }
+
+    @Test
+    public void test_build_settings_with_null_value() {
+        expectedException.expectMessage("Cannot set \"cluster.routing.allocation.exclude._id\" to `null`. Use `RESET [GLOBAL] \"cluster.routing.allocation.exclude._id\"` to reset a setting to its default value");
+        Map<String, List<Expression>> settings = Map.of("cluster.routing.allocation.exclude._id", List.of(NullLiteral.INSTANCE));
         buildSettingsFrom(settings, Row.EMPTY);
     }
 }


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)