### PR TITLE
Handle array values in SET GLOBAL statements correctly

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -178,6 +178,8 @@ Changes
 Fixes
 =====
 
+- Fixed the handling of array values when used in the ``SET GLOBAL`` statement.
+
 - Fixed evaluation of generated columns when they are based on columns
   with default constraints and no user given values. Default
   contraints where not taken into account before.

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -32,6 +32,7 @@ import io.crate.expression.NestableInput;
 import io.crate.expression.reference.NestedObjectExpression;
 import io.crate.planner.TableStatsService;
 import io.crate.settings.CrateSetting;
+import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.udc.service.UDCService;
@@ -226,6 +227,10 @@ public final class CrateSettings implements ClusterStateListener {
             throw new IllegalArgumentException(
                 "Cannot set \"" + key + "\" to `null`. Use `RESET [GLOBAL] \"" + key +
                 "\"` to reset a setting to its default value");
+        } else if (value.getClass().isArray()) {
+            ArrayType<String> strArray = new ArrayType<>(DataTypes.STRING);
+            List<String> values = strArray.value(value);
+            settingsBuilder.put(key, String.join(",", values));
         } else {
             settingsBuilder.put(key, value.toString());
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously we'd call `.toString()` on an array which would write
something like `[Ljava.lang.Object;@2139f2d3` as setting.

This changes the logic to create a comma separated string. This allows
users to for example set `cluster.routing.allocation.exclude._id` to an
array of ids instead of creating a comma separated list on the client.


Changing the `Setting` definition to support both object arrays and
strings is currently not possible. The validator or parser both receive
a string value as input instead of the raw object value.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)