### PR TITLE
Add a try_cast test for all primitive types and random values

### DIFF
--- a/sql/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
@@ -24,6 +24,8 @@ package io.crate.expression.symbol;
 
 import io.crate.common.collections.Sorted;
 import io.crate.sql.Literals;
+import org.joda.time.Period;
+import org.locationtech.spatial4j.shape.Point;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -49,12 +51,13 @@ public class LiteralValueFormatter {
             formatIterable(Arrays.asList((Object[]) value), builder);
         } else if (value.getClass().isArray()) {
             formatArray(value, builder);
-        } else if (value instanceof String) {
-            builder.append(Literals.quoteStringLiteral((String) value));
+        } else if (value instanceof String
+                   || value instanceof Point
+                   || value instanceof Period) {
+            builder.append(Literals.quoteStringLiteral(value.toString()));
         } else {
             builder.append(value.toString());
         }
-
     }
 
     private void formatIterable(Iterable<?> iterable, StringBuilder builder) {

--- a/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -29,8 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.time.format.DateTimeParseException;
-
 public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
 
     @Rule


### PR DESCRIPTION
This ensures that all DataType.value() calls are throwing the correct exceptions which are caught and transformed into NULL by `TRY_CAST``.