### PR TITLE
Take memory usage into consideration when building result request pages

### DIFF
--- a/dex/src/main/java/io/crate/breaker/RamAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/RamAccounting.java
@@ -35,6 +35,11 @@ public interface RamAccounting {
         }
 
         @Override
+        public long totalBytes() {
+            return 0;
+        }
+
+        @Override
         public void release() {
         }
 
@@ -48,6 +53,8 @@ public interface RamAccounting {
      * @throws CircuitBreakingException if too many bytes have been added.
      */
     void addBytes(long bytes);
+
+    long totalBytes();
 
     /**
      * Stops accounting for previously accounted rows.

--- a/dex/src/main/java/io/crate/data/Paging.java
+++ b/dex/src/main/java/io/crate/data/Paging.java
@@ -23,6 +23,7 @@
 package io.crate.data;
 
 import javax.annotation.Nullable;
+import java.lang.management.ManagementFactory;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -30,6 +31,7 @@ public class Paging {
 
     // this must not be final so tests could adjust it
     public static int PAGE_SIZE = 500_000;
+    public static final long MAX_PAGE_BYTES = (long) (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() * 0.10);
     private static final double OVERHEAD_FACTOR = 1.5;
 
     public static int getWeightedPageSize(@Nullable Integer limit, double weight) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactory.java
@@ -70,11 +70,9 @@ public class OrderedLuceneBatchIteratorFactory {
         private final PagingIterator<ShardId, Row> pagingIterator;
         private final Map<ShardId, OrderedDocCollector> collectorsByShardId;
 
-        private BatchPagingIterator<ShardId> batchPagingIterator;
-
         Factory(List<OrderedDocCollector> orderedDocCollectors,
                 Comparator<Row> rowComparator,
-                RowAccounting rowAccounting,
+                RowAccounting<Row> rowAccounting,
                 Executor executor,
                 IntSupplier availableThreads,
                 boolean requiresScroll) {
@@ -96,13 +94,12 @@ public class OrderedLuceneBatchIteratorFactory {
         }
 
         BatchIterator<Row> create() {
-            batchPagingIterator = new BatchPagingIterator<>(
+            return new BatchPagingIterator<>(
                 pagingIterator,
                 this::tryFetchMore,
                 this::allExhausted,
                 throwable -> close()
             );
-            return batchPagingIterator;
         }
 
         private CompletableFuture<List<KeyIterable<ShardId, Row>>> tryFetchMore(ShardId shardId) {

--- a/sql/src/main/java/io/crate/execution/engine/distribution/BroadcastingBucketBuilder.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/BroadcastingBucketBuilder.java
@@ -51,6 +51,11 @@ public class BroadcastingBucketBuilder implements MultiBucketBuilder {
     }
 
     @Override
+    public long ramBytesUsed() {
+        return bucketBuilder.ramBytesUsed();
+    }
+
+    @Override
     public void build(StreamBucket[] buckets) {
         assert buckets.length == numBuckets : "length of the provided array must match numBuckets";
         StreamBucket bucket = bucketBuilder.build();

--- a/sql/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.distribution;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.data.BatchIterator;
+import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
@@ -116,7 +117,7 @@ public class DistributingConsumer implements RowConsumer {
         try {
             while (it.moveNext()) {
                 multiBucketBuilder.add(it.currentElement());
-                if (multiBucketBuilder.size() >= pageSize) {
+                if (multiBucketBuilder.size() >= pageSize || multiBucketBuilder.ramBytesUsed() >= Paging.MAX_PAGE_BYTES) {
                     forwardResults(it, false);
                     return;
                 }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/ModuloBucketBuilder.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/ModuloBucketBuilder.java
@@ -90,4 +90,13 @@ public class ModuloBucketBuilder implements MultiBucketBuilder {
         }
         return value.hashCode();
     }
+
+    @Override
+    public long ramBytesUsed() {
+        long sum = 0;
+        for (int i = 0; i < bucketBuilders.size(); i++) {
+            sum += bucketBuilders.get(i).ramBytesUsed();
+        }
+        return sum;
+    }
 }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/MultiBucketBuilder.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/MultiBucketBuilder.java
@@ -23,11 +23,12 @@
 package io.crate.execution.engine.distribution;
 
 import io.crate.data.Row;
+import org.apache.lucene.util.Accountable;
 
 /**
  * Builder used to build one or more buckets
  */
-public interface MultiBucketBuilder {
+public interface MultiBucketBuilder extends Accountable {
 
     /**
      * add a row to the page

--- a/sql/src/main/java/io/crate/execution/engine/distribution/StreamBucket.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/StreamBucket.java
@@ -27,6 +27,7 @@ import io.crate.breaker.RamAccounting;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,7 +49,7 @@ public class StreamBucket implements Bucket, Writeable {
     private int size = -1;
     private BytesReference bytes;
 
-    public static class Builder {
+    public static class Builder implements Accountable {
 
         private static final int INITIAL_PAGE_SIZE = 1024;
         private final RamAccounting ramAccounting;
@@ -95,6 +96,11 @@ public class StreamBucket implements Bucket, Writeable {
 
         public int size() {
             return size;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return ramAccounting.totalBytes();
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Our default page size is rather large. There are two reasons for this:

- To avoid extra latency caused by internal pagination requests
- To avoid expensive operations (like `searchMore` in
`LuceneOrderedDocCollector`, retrieving additional pages for sorted
operations is costly)

But if individual records are large this can use up a significant
portition of the heap, so this commit introduces the used memory as a
second criteria for the internal request (page) building.


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)