### PR TITLE
Create a table function relation for values with a distinguishable name.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -112,6 +112,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.crate.expression.tablefunctions.TableFunctionFactory.VALUES_TABLE_FUNCTION_NAME;
+
 @Singleton
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
@@ -784,7 +786,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         TableFunctionImplementation tableFunc = TableFunctionFactory.from(implementation);
         TableInfo tableInfo = tableFunc.createTableInfo();
         Operation.blockedRaiseException(tableInfo, context.currentOperation());
-        QualifiedName qualifiedName = new QualifiedName(UnnestFunction.NAME);
+        QualifiedName qualifiedName = new QualifiedName(VALUES_TABLE_FUNCTION_NAME);
         TableFunctionRelation relation = new TableFunctionRelation(
             tableInfo,
             tableFunc,

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -50,6 +50,8 @@ import java.util.Map;
 
 public class TableFunctionFactory {
 
+    public static final String VALUES_TABLE_FUNCTION_NAME = "values";
+
     public static TableFunctionImplementation from(FunctionImplementation functionImplementation) {
 
         TableFunctionImplementation tableFunction;

--- a/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static io.crate.expression.tablefunctions.TableFunctionFactory.VALUES_TABLE_FUNCTION_NAME;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -54,4 +56,14 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                                      "from information_schema.tables");
         assertThat(relation.fields().get(0).path().sqlFqn(), is("'foo' = ANY(partitioned_by)"));
     }
+
+    @Test
+    public void test_process_values_result_in_table_function_with_values_name() {
+        AnalyzedRelation relation = executor.analyze("VALUES (1, 'a')");
+        assertThat(relation, instanceOf(TableFunctionRelation.class));
+
+        TableFunctionRelation tableFuncRelation = (TableFunctionRelation) relation;
+        assertThat(tableFuncRelation.getQualifiedName().toString(), is(VALUES_TABLE_FUNCTION_NAME));
+    }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The idea was to implement a dedicated row-oriented values
table function instead of doing the rewrite from values to
the column-oriented unnest function in order to distinguish
between unnest and values at later stages.

The problem with creating the row-oriented values table
function is that currently our type system cannot describe
the type of the function  `values(array(array))` argument or
any other similar type that would enable row-orient approach
to work. Therefore, at the moment we go with the column
oriented approach as it was before, but use different table
function name to be able to distinguish between unnest and
values. Afterwards, we can follow up with introducing a dedicated
row type and implementing the row-oriented values table function.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
