### PR TITLE
Remove redundant normalization of relation in insert from subquery plan.

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -23,8 +23,6 @@ package io.crate.planner.consumer;
 
 
 import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
-import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.analyze.relations.RelationNormalizer;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.expression.symbol.InputColumn;
@@ -51,8 +49,7 @@ public final class InsertFromSubQueryPlanner {
     private InsertFromSubQueryPlanner() {
     }
 
-    public static LogicalPlan plan(RelationNormalizer relationNormalizer,
-                                   InsertFromSubQueryAnalyzedStatement statement,
+    public static LogicalPlan plan(InsertFromSubQueryAnalyzedStatement statement,
                                    PlannerContext plannerContext,
                                    LogicalPlanner logicalPlanner,
                                    SubqueryPlanner subqueryPlanner) {
@@ -72,11 +69,8 @@ public final class InsertFromSubQueryPlanner {
             statement.tableInfo().isPartitioned()
         );
 
-        AnalyzedRelation subRelation = relationNormalizer.normalize(
-            statement.subQueryRelation(), plannerContext.transactionContext());
-
         LogicalPlan plannedSubQuery = logicalPlanner.normalizeAndPlan(
-            subRelation, plannerContext, subqueryPlanner, FetchMode.NEVER_CLEAR, EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP));
+            statement.subQueryRelation(), plannerContext, subqueryPlanner, FetchMode.NEVER_CLEAR, EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP));
         EvalProjection castOutputs = createCastProjection(statement.columns(), plannedSubQuery.outputs());
         return new Insert(plannedSubQuery, indexWriterProjection, castOutputs);
     }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -449,7 +449,7 @@ public class LogicalPlanner {
         protected LogicalPlan visitInsertFromSubQueryStatement(InsertFromSubQueryAnalyzedStatement statement, PlannerContext context) {
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> planSubSelect(s, context));
             return InsertFromSubQueryPlanner.plan(
-                relationNormalizer, statement, context, LogicalPlanner.this, subqueryPlanner);
+                statement, context, LogicalPlanner.this, subqueryPlanner);
         }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The normalization is done in `LogicalPlanner#normalizeAndPlan`.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
