### PR TITLE
Update config module name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-from crate.theme.rtd.conf.crate_server import *
+from crate.theme.rtd.conf.crate_reference import *
 
 source_suffix = '.rst'
 site_url = 'https://crate.io/docs/crate/reference/en/latest/'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme
+crate-docs-theme>=0.7
 sphinx-csv-filter
 Pygments==2.3.1


### PR DESCRIPTION
the upstream name has changed in most recently docs theme package

- [x] add min version for theme (https://github.com/crate/crash/pull/309#discussion_r339545930)
