### PR TITLE
Remove separate lastThrowable attribute from IncrementalPageBucketReceiver

### DIFF
--- a/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -23,7 +23,6 @@
 package io.crate.execution;
 
 import io.crate.Streamer;
-import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
 import io.crate.data.CollectingBatchIterator;
@@ -31,9 +30,9 @@ import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.execution.jobs.PageResultListener;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.GuardedBy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,11 +50,8 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
     private final Executor executor;
     private final Streamer<?>[] streamers;
 
-    private volatile Throwable lastThrowable = null;
     private final BatchIterator<Row> lazyBatchIterator;
-    @GuardedBy("accumulateRowsFunction")
     private CompletableFuture<?> currentlyAccumulating;
-    private final Function<Bucket, Void> accumulateRowsFunction;
 
     public IncrementalPageBucketReceiver(Collector<Row, T, Iterable<Row>> collector,
                                          RowConsumer rowConsumer,
@@ -74,43 +70,45 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
             () -> processingFuture,
             true);
         rowConsumer.accept(lazyBatchIterator, null);
-        accumulateRowsFunction = (Bucket rows) -> {
-            try {
-                for (Row row : rows) {
-                    accumulator.accept(state, row);
-                }
-            } catch (Throwable e) {
-                lastThrowable = e;
-                throw e;
-            }
-            return null;
-        };
+    }
+
+    private void processRows(Bucket rows) {
+        for (Row row : rows) {
+            accumulator.accept(state, row);
+        }
     }
 
     @Override
     public void setBucket(int bucketIdx, Bucket rows, boolean isLast, PageResultListener pageResultListener) {
-        pageResultListener.needMore(!isLast);
+        if (processingFuture.isCompletedExceptionally()) {
+            pageResultListener.needMore(false);
+            return;
+        } else {
+            pageResultListener.needMore(!isLast);
+        }
 
         // We make sure only one accumulation operation runs at a time because the state is not thread-safe.
-        synchronized (accumulateRowsFunction) {
+        synchronized (state) {
             if (currentlyAccumulating == null) {
-                currentlyAccumulating = CompletableFutures
-                    .supplyAsync(() -> accumulateRowsFunction.apply(rows), executor);
+                try {
+                    currentlyAccumulating = CompletableFuture.runAsync(() -> processRows(rows), executor);
+                } catch (EsRejectedExecutionException e) {
+                    processingFuture.completeExceptionally(e);
+                }
             } else {
                 currentlyAccumulating = currentlyAccumulating.whenComplete((r, t) -> {
                     if (t == null) {
-                        accumulateRowsFunction.apply(rows);
+                        processRows(rows);
                     } else if (t instanceof RuntimeException) {
-                        lastThrowable = t;
+                        processingFuture.completeExceptionally(t);
                         throw (RuntimeException) t;
                     } else {
-                        lastThrowable = t;
+                        processingFuture.completeExceptionally(t);
                         throw new RuntimeException(t);
                     }
                 });
             }
         }
-
         if (isLast) {
             if (remainingUpstreams.decrementAndGet() == 0) {
                 currentlyAccumulating.whenComplete((r, t) -> consumeRows());
@@ -130,16 +128,11 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
 
     @Override
     public void consumeRows() {
-        if (lastThrowable == null) {
-            processingFuture.complete(finisher.apply(state));
-        } else {
-            processingFuture.completeExceptionally(lastThrowable);
-        }
+        processingFuture.complete(finisher.apply(state));
     }
 
     @Override
     public void kill(@Nonnull Throwable t) {
-        lastThrowable = t;
         lazyBatchIterator.kill(t);
         processingFuture.completeExceptionally(t);
     }


### PR DESCRIPTION
Checking `isCompletedExceptionally` has about the same cost. (A volatile
read)


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)