### PR TITLE
Include a reason in the job killed exception

### DIFF
--- a/sql/src/main/java/io/crate/exceptions/JobKilledException.java
+++ b/sql/src/main/java/io/crate/exceptions/JobKilledException.java
@@ -21,11 +21,21 @@
 
 package io.crate.exceptions;
 
+import javax.annotation.Nullable;
+
 public class JobKilledException extends RuntimeException implements UnscopedException {
 
     public static final String MESSAGE = "Job killed";
 
-    public JobKilledException() {
+    public static JobKilledException of(@Nullable String reason) {
+        return reason == null ? new JobKilledException() : new JobKilledException(reason);
+    }
+
+    private JobKilledException(String reason) {
+        super("Job killed. " + reason);
+    }
+
+    private JobKilledException() {
         super(MESSAGE);
     }
 

--- a/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -214,7 +214,7 @@ public class SQLExceptions {
         } else if (unwrappedError instanceof org.elasticsearch.common.breaker.CircuitBreakingException) {
             return new CircuitBreakingException(unwrappedError.getMessage());
         } else if (unwrappedError instanceof InterruptedException) {
-            return new JobKilledException();
+            return JobKilledException.of(unwrappedError.getMessage());
         } else if (unwrappedError instanceof RepositoryMissingException) {
             return new RepositoryUnknownException(((RepositoryMissingException) unwrappedError).repository());
         } else if (unwrappedError instanceof InvalidSnapshotNameException) {

--- a/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -91,8 +91,12 @@ class InterceptingRowConsumer implements RowConsumer {
             assert iterator != null : "iterator must be present";
             ThreadPools.forceExecute(executor, () -> consumer.accept(iterator, null));
         } else {
+            KillJobsRequest killRequest = new KillJobsRequest(
+                List.of(jobId),
+                "An error was encountered: " + failure
+            );
             transportKillJobsNodeAction.broadcast(
-                new KillJobsRequest(Collections.singletonList(jobId)), new ActionListener<Long>() {
+                killRequest, new ActionListener<>() {
                     @Override
                     public void onResponse(Long numKilled) {
                         if (LOGGER.isTraceEnabled()) {

--- a/sql/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -224,7 +224,7 @@ public class RootTask implements CompletionListenable<Void> {
      *
      * @return the number of tasks on which kill was called
      */
-    public long kill() {
+    public long kill(@Nullable String reason) {
         int numKilled = 0;
         if (!closed.getAndSet(true)) {
             logger.trace("kill called on Task {}", jobId);
@@ -237,7 +237,7 @@ public class RootTask implements CompletionListenable<Void> {
                     if (traceEnabled) {
                         logger.trace("Task kill id={} ctx={}", task.id(), task);
                     }
-                    task.kill(new JobKilledException());
+                    task.kill(JobKilledException.of(reason));
                     numKilled++;
                 }
             }

--- a/sql/src/main/java/io/crate/execution/jobs/kill/TransportKillJobsNodeAction.java
+++ b/sql/src/main/java/io/crate/execution/jobs/kill/TransportKillJobsNodeAction.java
@@ -43,7 +43,7 @@ public class TransportKillJobsNodeAction extends TransportKillNodeAction<KillJob
 
     @Override
     protected CompletableFuture<Integer> doKill(KillJobsRequest request) {
-        return tasksService.killJobs(request.toKill());
+        return tasksService.killJobs(request.toKill(), request.reason());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -118,7 +118,8 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
                 deadNode.getId());
         }
         List<String> excludedNodeIds = Collections.singletonList(deadNode.getId());
-        killJobsNodeAction.broadcast(new KillJobsRequest(affectedJobs), new ActionListener<Long>() {
+        KillJobsRequest killRequest = new KillJobsRequest(affectedJobs, "Participating node=" + deadNode.getName() + " disconnected.");
+        killJobsNodeAction.broadcast(killRequest, new ActionListener<>() {
             @Override
             public void onResponse(Long numKilled) {
             }
@@ -150,7 +151,7 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
         if (jobsStartedByDeadNode.isEmpty()) {
             return;
         }
-        tasksService.killJobs(jobsStartedByDeadNode);
+        tasksService.killJobs(jobsStartedByDeadNode, "Participating node=" + deadNode.getName() + " disconnected.");
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Killed {} jobs started by disconnected node={}", jobsStartedByDeadNode.size(), deadNode.getId());
         }

--- a/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -109,7 +109,7 @@ public class KillPlan implements Plan {
                  RowConsumer consumer) {
         if (jobId != null) {
             killJobsNodeAction.broadcast(
-                new KillJobsRequest(List.of(jobId)),
+                new KillJobsRequest(List.of(jobId), "KILL invoked by user"),
                 new OneRowActionListener<>(consumer, Row1::new));
         } else {
             killAllNodeAction.broadcast(

--- a/sql/src/test/java/io/crate/execution/engine/FailureOnlyResponseListenerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/FailureOnlyResponseListenerTest.java
@@ -37,11 +37,11 @@ public class FailureOnlyResponseListenerTest extends CrateUnitTest {
         InitializationTracker tracker = new InitializationTracker(1);
         FailureOnlyResponseListener listener = new FailureOnlyResponseListener(Collections.emptyList(), tracker);
 
-        listener.onFailure(new JobKilledException());
+        listener.onFailure(JobKilledException.of("because reasons"));
 
         assertThat(tracker.future.isCompletedExceptionally(), Matchers.is(true));
 
-        expectedException.expectMessage("Job killed");
+        expectedException.expectMessage("Job killed. because reasons");
         tracker.future.get(1, TimeUnit.SECONDS);
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -125,7 +125,7 @@ public class CollectTaskTest extends RandomizedTest {
             .thenReturn(batchIterator);
         jobCtx.prepare();
         jobCtx.start();
-        jobCtx.kill(new JobKilledException());
+        jobCtx.kill(JobKilledException.of("because reasons"));
 
         verify(batchIterator, times(1)).kill(any(JobKilledException.class));
         verify(mock1, times(1)).close();

--- a/sql/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
@@ -43,7 +43,7 @@ public class AbstractTaskTest extends CrateUnitTest {
     private Runnable killRunnable = new Runnable() {
         @Override
         public void run() {
-            testingTask.kill(new JobKilledException());
+            testingTask.kill(JobKilledException.of("dummy"));
         }
     };
 

--- a/sql/src/test/java/io/crate/execution/jobs/CountTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/CountTaskTest.java
@@ -29,8 +29,8 @@ import io.crate.execution.engine.collect.count.CountOperation;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Routing;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.test.CauseMatcher;
 import io.crate.test.integration.CrateUnitTest;
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -99,7 +98,7 @@ public class CountTaskTest extends CrateUnitTest {
 
         countTask.prepare();
         countTask.start();
-        countTask.kill(new JobKilledException());
+        countTask.kill(JobKilledException.of("dummy"));
 
         verify(future, times(1)).cancel(true);
         assertTrue(countTask.isClosed());

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -88,8 +88,8 @@ public class RootTaskTest extends CrateUnitTest {
         builder.addTask(ctx2);
         RootTask rootTask = builder.build();
 
-        assertThat(rootTask.kill(), is(2L));
-        assertThat(rootTask.kill(), is(0L)); // second call is ignored, only killed once
+        assertThat(rootTask.kill(null), is(2L));
+        assertThat(rootTask.kill(null), is(0L)); // second call is ignored, only killed once
 
         assertThat(ctx1.numKill.get(), is(1));
         assertThat(ctx2.numKill.get(), is(1));
@@ -188,7 +188,7 @@ public class RootTaskTest extends CrateUnitTest {
         // fake execution time so we can sure the measurement is > 0
         Thread.sleep(5L);
         // kill because the testing subcontexts would run infinitely
-        rootTask.kill();
+        rootTask.kill(null);
         assertThat(rootTask.executionTimes(), hasKey("1-TestingTask"));
         assertThat(
             ((double) rootTask.executionTimes().get("1-TestingTask")),

--- a/sql/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -166,7 +167,7 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
         @SuppressWarnings("unchecked")
         Map<UUID, RootTask> activeTasks = (Map<UUID, RootTask>) activeTasksField.get(tasksService);
         assertThat(activeTasks.size(), is(2));
-        assertThat(tasksService.killJobs(ImmutableList.of(jobId)).get(5L, TimeUnit.SECONDS), is(1));
+        assertThat(tasksService.killJobs(List.of(jobId), null).get(5L, TimeUnit.SECONDS), is(1));
 
         assertThat(killCalled.get(), is(true));
         assertThat(kill2Called.get(), is(false));
@@ -223,6 +224,6 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
         builder = tasksService.newBuilder(UUID.randomUUID());
         builder.addTask(new DummyTask());
         tasksService.createTask(builder);
-        assertThat(tasksService.killJobs(jobsToKill).get(5L, TimeUnit.SECONDS), is(1));
+        assertThat(tasksService.killJobs(jobsToKill, null).get(5L, TimeUnit.SECONDS), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
@@ -31,13 +31,14 @@ import org.junit.Test;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class KillJobsRequestTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
         ImmutableList<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
-        KillJobsRequest r = new KillJobsRequest(toKill);
+        KillJobsRequest r = new KillJobsRequest(toKill, "just because");
 
         BytesStreamOutput out = new BytesStreamOutput();
         r.writeTo(out);
@@ -46,5 +47,6 @@ public class KillJobsRequestTest extends CrateUnitTest {
         KillJobsRequest r2 = new KillJobsRequest(in);
 
         assertThat(r.toKill(), equalTo(r2.toKill()));
+        assertThat(r.reason(), is(r2.reason()));
     }
 }

--- a/sql/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
@@ -52,7 +52,7 @@ public class TransportKillJobsNodeActionTest extends CrateDummyClusterServiceUni
 
         List<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
 
-        transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill)).get(5, TimeUnit.SECONDS);
-        verify(tasksService, times(1)).killJobs(toKill);
+        transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill, null)).get(5, TimeUnit.SECONDS);
+        verify(tasksService, times(1)).killJobs(toKill, null);
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -471,8 +471,8 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testKillExceptionSendsReadyForQuery() {
-        submitQueriesThroughSimpleQueryMode("some statement;", new JobKilledException());
-        readErrorResponse(channel, (byte) 104);
+        submitQueriesThroughSimpleQueryMode("some statement;", JobKilledException.of("with fire"));
+        readErrorResponse(channel, (byte) 75);
         readReadyForQueryMessage(channel);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In some cases we internally trigger a kill for a job. We've seen on some
clusters that this happened but it was difficult to figure out the exact
cause.

By adding a reason to the exception it will be easier to determine the
cause of a KILL operation.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)