### PR TITLE
Use G1GC by default instead of CMS

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -38,10 +38,7 @@ REM Enable aggressive optimizations in the JVM
 REM    - Disabled by default as it might cause the JVM to crash
 REM set JAVA_OPTS=%JAVA_OPTS% -XX:+AggressiveOpts
 
-set JAVA_OPTS=%JAVA_OPTS% -XX:+UseConcMarkSweepGC
-
-set JAVA_OPTS=%JAVA_OPTS% -XX:CMSInitiatingOccupancyFraction=75
-set JAVA_OPTS=%JAVA_OPTS% -XX:+UseCMSInitiatingOccupancyOnly
+set JAVA_OPTS=%JAVA_OPTS% -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30
 
 REM GC logging default values
 SET GC_LOG_DIR=%CRATE_HOME%\logs

--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -53,9 +53,7 @@ if [ "x$CRATE_USE_IPV4" != "x" ]; then
 fi
 
 ## GC configuration
-JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
-JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
-JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30"
 
 # GC logging options
 # Set CRATE_DISABLE_GC_LOGGING=1 to disable GC logging

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,9 @@ Deprecations
 Changes
 =======
 
+- Changed the default garbage collector that is being used from Concurrent Mark
+  Sweep to G1GC.
+
 - Added support for CIDR notation comparisons through special purpose
   operator ``<<`` associated with type ip.
   Statements like ``192.168.0.0 << 192.168.0.1/24`` are true,

--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -118,19 +118,22 @@ General
 
       Make sure there is enough disk space available for heap dumps.
 
+.. _garbage-collection:
+
 Garbage collection
 ------------------
 
 Collector
 ~~~~~~~~~
 
-CrateDB uses the `Concurrent Mark Sweep`_ garbage collector by default.
-When running CrateBD with a **JVM >= 10**, using the `G1`_ garbage collector may result
-in better latency.
+CrateDB uses the `G1`_ garbage collector by default.
 
-Example of using :ref:`CRATE_JAVA_OPTS <conf-env-java-opts>` to enable the `G1`_::
+Before CrateDB 4.1 it defaulted to use the `Concurrent Mark Sweep` garbage
+collector. If you'd like to continue using CMS, you can switch setting the
+following :ref:`CRATE_JAVA_OPTS <conf-env-java-opts>`::
 
-  export CRATE_JAVA_OPTS="-XX:-UseConcMarkSweepGC -XX:-UseCMSInitiatingOccupancyOnly -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30"
+
+  export CRATE_JAVA_OPTS="-XX:-UseG1GC -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseConcMarkSweepGC"
 
 
 Logging


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There is a JEP out (https://openjdk.java.net/jeps/363) that proposes to
remove the Concurrent Mark Sweep GC in JDK 14.

We recently did various work-load tests in an attempt to find gaps in
our circuit breaker logic and in these tests we already focused on using
G1GC.

Overall it seemed as the latency (especially tail latency) is overall
better with G1GC in the workloads we tried. So I think it is time to
change the default.

Users could still change back by changing the options manually in case
they experience a regression with their particular workload.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)