### PR TITLE
Fix function symbol formatting, quote if name contains spaces

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -184,4 +184,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue resulting in a parsing exception on ``SHOW TABLE`` statements
+  when a default expression is implicitly cast to the related column type and
+  the column type contains a ``SPACE`` character (like e.g. ``double precision``).

--- a/sql/src/main/java/io/crate/expression/symbol/format/FunctionFormatSpec.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/FunctionFormatSpec.java
@@ -23,6 +23,7 @@
 package io.crate.expression.symbol.format;
 
 import io.crate.expression.symbol.Function;
+import io.crate.sql.Identifiers;
 
 import static io.crate.expression.symbol.format.SymbolPrinter.Strings.PAREN_CLOSE;
 import static io.crate.expression.symbol.format.SymbolPrinter.Strings.PAREN_OPEN;
@@ -50,7 +51,8 @@ public interface FunctionFormatSpec {
     FunctionFormatSpec NAME_PARENTHESISED_ARGS = new FunctionFormatSpec() {
         @Override
         public String beforeArgs(Function function) {
-            return function.info().ident().name() + PAREN_OPEN;
+            String funcName = function.info().ident().name();
+            return Identifiers.quoteIfNeeded(funcName) + PAREN_OPEN;
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -431,7 +431,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             relation.having().query(),
             isSQL("(sum(power(" +
-                "power(to_double precision(doc.users.id), to_double precision(doc.users.id)), " +
-                "to_double precision(doc.users.id))) > 0.0)"));
+                "power(\"to_double precision\"(doc.users.id), \"to_double precision\"(doc.users.id)), " +
+                "\"to_double precision\"(doc.users.id))) > 0.0)"));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -381,7 +381,8 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
             .addTable("CREATE TABLE test (" +
                       "   col1 TEXT," +
                       "   col2 INTEGER DEFAULT 1 + 1," +
-                      "   col3 TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(3)" +
+                      "   col3 TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(3)," +
+                      "   col4 TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP(3)" +
                       ")")
             .build();
         DocTableInfo tableInfo = e.resolveTableInfo("test");
@@ -389,7 +390,8 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
         assertEquals("CREATE TABLE IF NOT EXISTS \"doc\".\"test\" (\n" +
                      "   \"col1\" TEXT,\n" +
                      "   \"col2\" INTEGER DEFAULT 2,\n" +
-                     "   \"col3\" TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp(3)\n" +
+                     "   \"col3\" TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp(3),\n" +
+                     "   \"col4\" TIMESTAMP WITHOUT TIME ZONE DEFAULT to_timestamp without time zone(current_timestamp(3))\n" +
                      ")\n" +
                      "CLUSTERED INTO 4 SHARDS\n" +
                      "WITH (\n" +

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -522,7 +522,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectDistinctWithFunction() {
         AnalyzedRelation relation = analyze("select distinct id + 1 from users");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.outputs(), isSQL("add(doc.users.id, 1)"));
+        assertThat(relation.outputs(), isSQL("\"add\"(doc.users.id, 1)"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -134,10 +134,10 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
             instanceOf(TopNProjection.class),
             instanceOf(FetchProjection.class)
         ));
-        assertThat(projections.get(2).outputs(), isSQL("INPUT(0), add(INPUT(1), INPUT(1))"));
+        assertThat(projections.get(2).outputs(), isSQL("INPUT(0), \"add\"(INPUT(1), INPUT(1))"));
         FilterProjection filterProjection = (FilterProjection) projections.get(1);
         // filter is before fetch; preFetchOutputs: [_fetchId, add(x, x)]
-        assertThat(filterProjection.query(), isSQL("(add(INPUT(1), INPUT(1)) = 10)"));
+        assertThat(filterProjection.query(), isSQL("(\"add\"(INPUT(1), INPUT(1)) = 10)"));
     }
 
     @Test


### PR DESCRIPTION
Function names containing spaces must be quoted when printed.
Fixes #9311.