### PR TITLE
Make Snapshot Logic Write Metadata after Segments Backport

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.io;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStream;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -147,6 +148,17 @@ public abstract class Streams {
             read += r;
         }
         return read;
+    }
+
+    /**
+     * Reads all bytes from the given {@link InputStream} and closes it afterwards.
+     */
+    public static BytesReference readFully(InputStream in) throws IOException {
+        try (InputStream inputStream = in) {
+            BytesStreamOutput out = new BytesStreamOutput();
+            copy(inputStream, out);
+            return out.bytes();
+        }
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -150,6 +150,10 @@ public abstract class Streams {
         return read;
     }
 
+    public static int readFully(InputStream reader, byte[] dest) throws IOException {
+        return readFully(reader, dest, 0, dest.length);
+    }
+
     /**
      * Reads all bytes from the given {@link InputStream} and closes it afterwards.
      */

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -402,14 +402,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
 
             // Write Global MetaData
-            globalMetaDataFormat.write(clusterMetaData, blobContainer(), snapshotId.getUUID());
+            globalMetaDataFormat.write(clusterMetaData, blobContainer(), snapshotId.getUUID(), true);
 
             // write the index metadata for each index in the snapshot
             for (IndexId index : indices) {
                 final IndexMetaData indexMetaData = clusterMetaData.index(index.getName());
                 final BlobPath indexPath = basePath().add("indices").add(index.getId());
                 final BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
-                indexMetaDataFormat.write(indexMetaData, indexMetaDataBlobContainer, snapshotId.getUUID());
+                indexMetaDataFormat.write(indexMetaData, indexMetaDataBlobContainer, snapshotId.getUUID(), true);
             }
         } catch (IOException ex) {
             throw new SnapshotCreationException(metadata.name(), snapshotId, ex);
@@ -550,7 +550,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             startTime, failure, System.currentTimeMillis(), totalShards, shardFailures,
             includeGlobalState);
         try {
-            snapshotFormat.write(blobStoreSnapshot, blobContainer(), snapshotId.getUUID());
+            snapshotFormat.write(blobStoreSnapshot, blobContainer(), snapshotId.getUUID(), true);
             final RepositoryData repositoryData = getRepositoryData();
             writeIndexGen(repositoryData.addSnapshot(snapshotId, blobStoreSnapshot.state(), indices), repositoryStateId);
         } catch (FileAlreadyExistsException ex) {
@@ -928,7 +928,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             ']';
     }
 
-    BlobStoreFormat<BlobStoreIndexShardSnapshot> indexShardSnapshotFormat(Version version) {
+    ChecksumBlobStoreFormat<BlobStoreIndexShardSnapshot> indexShardSnapshotFormat(Version version) {
         return indexShardSnapshotFormat;
     }
 
@@ -1299,7 +1299,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             //TODO: The time stored in snapshot doesn't include cleanup time.
             LOGGER.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);
             try {
-                indexShardSnapshotFormat.write(snapshot, blobContainer, snapshotId.getUUID());
+                indexShardSnapshotFormat.write(snapshot, blobContainer, snapshotId.getUUID(), true);
             } catch (IOException e) {
                 throw new IndexShardSnapshotFailedException(shardId, "Failed to write commit point", e);
             }

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -23,62 +23,69 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.core.internal.io.Streams;
 import org.elasticsearch.gateway.CorruptStateException;
+import org.elasticsearch.snapshots.SnapshotInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Snapshot metadata file format used in v2.0 and above
  */
-public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat<T> {
+public final class ChecksumBlobStoreFormat<T extends ToXContent> {
 
-    private static final XContentType DEFAULT_X_CONTENT_TYPE = XContentType.SMILE;
+    // Serialization parameters to specify correct context for metadata serialization
+    private static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
+
+    static {
+        Map<String, String> snapshotOnlyParams = new HashMap<>();
+        // when metadata is serialized certain elements of the metadata shouldn't be included into snapshot
+        // exclusion of these elements is done by setting MetaData.CONTEXT_MODE_PARAM to MetaData.CONTEXT_MODE_SNAPSHOT
+        snapshotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);
+        // serialize SnapshotInfo using the SNAPSHOT mode
+        snapshotOnlyParams.put(SnapshotInfo.CONTEXT_MODE_PARAM, SnapshotInfo.CONTEXT_MODE_SNAPSHOT);
+        SNAPSHOT_ONLY_FORMAT_PARAMS = new ToXContent.MapParams(snapshotOnlyParams);
+    }
 
     // The format version
     public static final int VERSION = 1;
 
     private static final int BUFFER_SIZE = 4096;
 
-    protected final XContentType xContentType;
-
-    protected final boolean compress;
+    private final boolean compress;
 
     private final String codec;
 
-    /**
-     * @param codec          codec name
-     * @param blobNameFormat format of the blobname in {@link String#format} format
-     * @param reader         prototype object that can deserialize T from XContent
-     * @param compress       true if the content should be compressed
-     * @param xContentType   content type that should be used for write operations
-     */
-    public ChecksumBlobStoreFormat(String codec, String blobNameFormat, CheckedFunction<XContentParser, T, IOException> reader,
-                                   NamedXContentRegistry namedXContentRegistry, boolean compress, XContentType xContentType) {
-        super(blobNameFormat, reader, namedXContentRegistry);
-        this.xContentType = xContentType;
-        this.compress = compress;
-        this.codec = codec;
-    }
+    private final String blobNameFormat;
+
+    private final CheckedFunction<XContentParser, T, IOException> reader;
+
+    private final NamedXContentRegistry namedXContentRegistry;
 
     /**
      * @param codec          codec name
@@ -88,7 +95,34 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      */
     public ChecksumBlobStoreFormat(String codec, String blobNameFormat, CheckedFunction<XContentParser, T, IOException> reader,
                                    NamedXContentRegistry namedXContentRegistry, boolean compress) {
-        this(codec, blobNameFormat, reader, namedXContentRegistry, compress, DEFAULT_X_CONTENT_TYPE);
+        this.reader = reader;
+        this.blobNameFormat = blobNameFormat;
+        this.namedXContentRegistry = namedXContentRegistry;
+        this.compress = compress;
+        this.codec = codec;
+    }
+
+    /**
+     * Reads and parses the blob with given name, applying name translation using the {link #blobName} method
+     *
+     * @param blobContainer blob container
+     * @param name          name to be translated into
+     * @return parsed blob object
+     */
+    public T read(BlobContainer blobContainer, String name) throws IOException {
+        String blobName = blobName(name);
+        return readBlob(blobContainer, blobName);
+    }
+
+    /**
+     * Deletes obj in the blob container
+     */
+    public void delete(BlobContainer blobContainer, String name) throws IOException {
+        blobContainer.deleteBlob(blobName(name));
+    }
+
+    public String blobName(String name) {
+        return String.format(Locale.ROOT, blobNameFormat, name);
     }
 
     /**
@@ -98,22 +132,21 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      * @param blobName blob name
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
-        try (InputStream inputStream = blobContainer.readBlob(blobName)) {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Streams.copy(inputStream, out);
-            final byte[] bytes = out.toByteArray();
-            final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
-            try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(resourceDesc, bytes)) {
-                CodecUtil.checksumEntireFile(indexInput);
-                CodecUtil.checkHeader(indexInput, codec, VERSION, VERSION);
-                long filePointer = indexInput.getFilePointer();
-                long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
-                BytesReference bytesReference = new BytesArray(bytes, (int) filePointer, (int) contentSize);
-                return read(bytesReference);
-            } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
-                // we trick this into a dedicated exception with the original stacktrace
-                throw new CorruptStateException(ex);
+        final BytesReference bytes = Streams.readFully(blobContainer.readBlob(blobName));
+        final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
+        try (ByteArrayIndexInput indexInput =
+                 new ByteArrayIndexInput(resourceDesc, BytesReference.toBytes(bytes))) {
+            CodecUtil.checksumEntireFile(indexInput);
+            CodecUtil.checkHeader(indexInput, codec, VERSION, VERSION);
+            long filePointer = indexInput.getFilePointer();
+            long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
+            try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                                                     bytes.slice((int) filePointer, (int) contentSize), XContentType.SMILE)) {
+                return reader.apply(parser);
             }
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // we trick this into a dedicated exception with the original stacktrace
+            throw new CorruptStateException(ex);
         }
     }
 
@@ -142,28 +175,39 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      * <p>
      * The blob will be compressed and checksum will be written if required.
      *
-     * @param obj           object to be serialized
-     * @param blobContainer blob container
-     * @param name          blob name
+     * @param obj                 object to be serialized
+     * @param blobContainer       blob container
+     * @param name                blob name
+     * @param failIfAlreadyExists Whether to fail if the blob already exists
      */
-    public void write(T obj, BlobContainer blobContainer, String name) throws IOException {
+    public void write(T obj, BlobContainer blobContainer, String name, boolean failIfAlreadyExists) throws IOException {
         final String blobName = blobName(name);
         writeTo(obj, blobName, bytesArray -> {
             try (InputStream stream = bytesArray.streamInput()) {
-                blobContainer.writeBlob(blobName, stream, bytesArray.length(), true);
+                blobContainer.writeBlob(blobName, stream, bytesArray.length(), failIfAlreadyExists);
             }
         });
     }
 
     private void writeTo(final T obj, final String blobName, final CheckedConsumer<BytesArray, IOException> consumer) throws IOException {
-        final BytesReference bytes = write(obj);
+        final BytesReference bytes;
+        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
+            if (compress) {
+                try (StreamOutput compressedStreamOutput = CompressorFactory.COMPRESSOR.streamOutput(bytesStreamOutput)) {
+                    write(obj, compressedStreamOutput);
+                }
+            } else {
+                write(obj, bytesStreamOutput);
+            }
+            bytes = bytesStreamOutput.bytes();
+        }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             final String resourceDesc = "ChecksumBlobStoreFormat.writeBlob(blob=\"" + blobName + "\")";
             try (OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput(resourceDesc, blobName, outputStream, BUFFER_SIZE)) {
                 CodecUtil.writeHeader(indexOutput, codec, VERSION);
                 try (OutputStream indexOutputOutputStream = new IndexOutputOutputStream(indexOutput) {
                     @Override
-                    public void close() throws IOException {
+                    public void close() {
                         // this is important since some of the XContentBuilders write bytes on close.
                         // in order to write the footer we need to prevent closing the actual index input.
                     }
@@ -176,24 +220,18 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
         }
     }
 
-    protected BytesReference write(T obj) throws IOException {
-        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
-            if (compress) {
-                try (StreamOutput compressedStreamOutput = CompressorFactory.COMPRESSOR.streamOutput(bytesStreamOutput)) {
-                    write(obj, compressedStreamOutput);
-                }
-            } else {
-                write(obj, bytesStreamOutput);
-            }
-            return bytesStreamOutput.bytes();
-        }
-    }
-
-    protected void write(T obj, StreamOutput streamOutput) throws IOException {
-        try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput)) {
+    private void write(T obj, StreamOutput streamOutput) throws IOException {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.SMILE, streamOutput)) {
             builder.startObject();
             obj.toXContent(builder, SNAPSHOT_ONLY_FORMAT_PARAMS);
             builder.endObject();
         }
+    }
+
+    /**
+     * Checks obj in the blob container
+     */
+    public boolean exists(BlobContainer blobContainer, String name) throws IOException {
+        return blobContainer.blobExists(blobName(name));
     }
 }

--- a/es/es-server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/es/es-server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.ElasticsearchCorruptionException;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.blobstore.fs.FsBlobStore;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.translog.BufferedChecksumStreamOutput;
+import org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat;
+import org.elasticsearch.snapshots.mockstore.BlobContainerWrapper;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class BlobStoreFormatIT extends ESIntegTestCase {
+
+    public static final String BLOB_CODEC = "blob";
+
+    private static class BlobObj implements ToXContentFragment {
+
+        private final String text;
+
+        BlobObj(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public static BlobObj fromXContent(XContentParser parser) throws IOException {
+            String text = null;
+            XContentParser.Token token = parser.currentToken();
+            if (token == null) {
+                token = parser.nextToken();
+            }
+            if (token == XContentParser.Token.START_OBJECT) {
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token != XContentParser.Token.FIELD_NAME) {
+                        throw new ElasticsearchParseException("unexpected token [{}]", token);
+                    }
+                    String currentFieldName = parser.currentName();
+                    token = parser.nextToken();
+                    if (token.isValue()) {
+                        if ("text" .equals(currentFieldName)) {
+                            text = parser.text();
+                        } else {
+                            throw new ElasticsearchParseException("unexpected field [{}]", currentFieldName);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("unexpected token [{}]", token);
+                    }
+                }
+            }
+            if (text == null) {
+                throw new ElasticsearchParseException("missing mandatory parameter text");
+            }
+            return new BlobObj(text);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.field("text", getText());
+            return builder;
+        }
+    }
+
+    public void testBlobStoreOperations() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        ChecksumBlobStoreFormat<BlobObj> checksumSMILE = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                       xContentRegistry(), false);
+        ChecksumBlobStoreFormat<BlobObj> checksumSMILECompressed = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                                 xContentRegistry(), true);
+
+        // Write blobs in different formats
+        checksumSMILE.write(new BlobObj("checksum smile"), blobContainer, "check-smile", true);
+        checksumSMILECompressed.write(new BlobObj("checksum smile compressed"), blobContainer, "check-smile-comp", true);
+
+        // Assert that all checksum blobs can be read by all formats
+        assertEquals(checksumSMILE.read(blobContainer, "check-smile").getText(), "checksum smile");
+        assertEquals(checksumSMILE.read(blobContainer, "check-smile-comp").getText(), "checksum smile compressed");
+    }
+
+    public void testCompressionIsApplied() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        StringBuilder veryRedundantText = new StringBuilder();
+        for (int i = 0; i < randomIntBetween(100, 300); i++) {
+            veryRedundantText.append("Blah ");
+        }
+        ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                        xContentRegistry(), false);
+        ChecksumBlobStoreFormat<BlobObj> checksumFormatComp = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                            xContentRegistry(), true);
+        BlobObj blobObj = new BlobObj(veryRedundantText.toString());
+        checksumFormatComp.write(blobObj, blobContainer, "blob-comp", true);
+        checksumFormat.write(blobObj, blobContainer, "blob-not-comp", true);
+        Map<String, BlobMetaData> blobs = blobContainer.listBlobsByPrefix("blob-");
+        assertEquals(blobs.size(), 2);
+        assertThat(blobs.get("blob-not-comp").length(), greaterThan(blobs.get("blob-comp").length()));
+    }
+
+    public void testBlobCorruption() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        String testString = randomAlphaOfLength(randomInt(10000));
+        BlobObj blobObj = new BlobObj(testString);
+        ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                        xContentRegistry(), randomBoolean());
+        checksumFormat.write(blobObj, blobContainer, "test-path", true);
+        assertEquals(checksumFormat.read(blobContainer, "test-path").getText(), testString);
+        randomCorruption(blobContainer, "test-path");
+        try {
+            checksumFormat.read(blobContainer, "test-path");
+            fail("Should have failed due to corruption");
+        } catch (ElasticsearchCorruptionException ex) {
+            assertThat(ex.getMessage(), containsString("test-path"));
+        } catch (EOFException ex) {
+            // This can happen if corrupt the byte length
+        }
+    }
+
+    public void testAtomicWrite() throws Exception {
+        final BlobStore blobStore = createTestBlobStore();
+        final BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        String testString = randomAlphaOfLength(randomInt(10000));
+        final CountDownLatch block = new CountDownLatch(1);
+        final CountDownLatch unblock = new CountDownLatch(1);
+        final BlobObj blobObj = new BlobObj(testString) {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+                super.toXContent(builder, params);
+                // Block before finishing writing
+                try {
+                    block.countDown();
+                    unblock.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                return builder;
+            }
+        };
+        final ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                              xContentRegistry(), randomBoolean());
+        ExecutorService threadPool = Executors.newFixedThreadPool(1);
+        try {
+            Future<Void> future = threadPool.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    checksumFormat.writeAtomic(blobObj, blobContainer, "test-blob");
+                    return null;
+                }
+            });
+            // signalling
+            block.await(5, TimeUnit.SECONDS);
+            assertFalse(blobExists(blobContainer, "test-blob"));
+            unblock.countDown();
+            future.get();
+            assertTrue(blobExists(blobContainer, "test-blob"));
+        } finally {
+            threadPool.shutdown();
+        }
+    }
+
+    public void testAtomicWriteFailures() throws Exception {
+        final String name = randomAlphaOfLength(10);
+        final BlobObj blobObj = new BlobObj("test");
+        final ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
+                                                                                              xContentRegistry(), randomBoolean());
+
+        final BlobStore blobStore = createTestBlobStore();
+        final BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+
+        {
+            IOException writeBlobException = expectThrows(IOException.class, () -> {
+                BlobContainer wrapper = new BlobContainerWrapper(blobContainer) {
+                    @Override
+                    public void writeBlobAtomic(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists)
+                        throws IOException {
+                        throw new IOException("Exception thrown in writeBlobAtomic() for " + blobName);
+                    }
+                };
+                checksumFormat.writeAtomic(blobObj, wrapper, name);
+            });
+
+            assertEquals("Exception thrown in writeBlobAtomic() for " + name, writeBlobException.getMessage());
+            assertEquals(0, writeBlobException.getSuppressed().length);
+        }
+    }
+
+    protected BlobStore createTestBlobStore() throws IOException {
+        return new FsBlobStore(Settings.EMPTY, randomRepoPath());
+    }
+
+    protected void randomCorruption(BlobContainer blobContainer, String blobName) throws IOException {
+        byte[] buffer = new byte[(int) blobContainer.listBlobsByPrefix(blobName).get(blobName).length()];
+        long originalChecksum = checksum(buffer);
+        try (InputStream inputStream = blobContainer.readBlob(blobName)) {
+            Streams.readFully(inputStream, buffer);
+        }
+        do {
+            int location = randomIntBetween(0, buffer.length - 1);
+            buffer[location] = (byte) (buffer[location] ^ 42);
+        } while (originalChecksum == checksum(buffer));
+        BytesArray bytesArray = new BytesArray(buffer);
+        try (StreamInput stream = bytesArray.streamInput()) {
+            blobContainer.writeBlob(blobName, stream, bytesArray.length(), false);
+        }
+    }
+
+    private long checksum(byte[] buffer) throws IOException {
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            try (BufferedChecksumStreamOutput checksumOutput = new BufferedChecksumStreamOutput(streamOutput)) {
+                checksumOutput.write(buffer);
+                return checksumOutput.getChecksum();
+            }
+        }
+    }
+
+    public static boolean blobExists(BlobContainer container, String blobName) throws IOException {
+        try (InputStream ignored = container.readBlob(blobName)) {
+            return true;
+        } catch (NoSuchFileException e) {
+            return false;
+        }
+    }
+
+}

--- a/es/es-testing/src/main/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+package org.elasticsearch.snapshots.mockstore;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.BlobPath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+public class BlobContainerWrapper implements BlobContainer {
+    private BlobContainer delegate;
+
+    public BlobContainerWrapper(BlobContainer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BlobPath path() {
+        return delegate.path();
+    }
+
+    @Override
+    public boolean blobExists(String blobName) {
+        return  delegate.blobExists(blobName);
+    }
+
+    @Override
+    public InputStream readBlob(String name) throws IOException {
+        return delegate.readBlob(name);
+    }
+
+    @Override
+    public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
+        delegate.writeBlob(blobName, inputStream, blobSize, failIfAlreadyExists);
+    }
+
+    @Override
+    public void writeBlobAtomic(final String blobName, final InputStream inputStream, final long blobSize,
+                                boolean failIfAlreadyExists) throws IOException {
+        delegate.writeBlobAtomic(blobName, inputStream, blobSize, failIfAlreadyExists);
+    }
+
+    @Override
+    public void deleteBlob(String blobName) throws IOException {
+        delegate.deleteBlob(blobName);
+    }
+
+
+    @Override
+    public void deleteBlobIgnoringIfNotExists(final String blobName) throws IOException {
+        delegate.deleteBlobIgnoringIfNotExists(blobName);
+    }
+
+    @Override
+    public Map<String, BlobMetaData> listBlobs() throws IOException {
+        return delegate.listBlobs();
+    }
+
+    @Override
+    public Map<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+        return delegate.listBlobsByPrefix(blobNamePrefix);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Backport of https://github.com/elastic/elasticsearch/pull/45689


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
