### PR TITLE
Fix verify call in snapshotFile method

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -187,6 +187,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could prevent ``CREATE SNAPSHOT`` from succeeding,
+  resulting in a partial snapshot which contained failure messages incorrectly
+  indicating that the index is corrupt.
+
 - Fixed an issue resulting in a parsing exception on ``SHOW TABLE`` statements
   when a default expression is implicitly cast to the related column type and
   the column type contains a ``SPACE`` character (like e.g. ``double precision``).

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1340,9 +1340,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         inputStream = new AbortableInputStream(inputStream, fileInfo.physicalName());
                         blobContainer.writeBlob(fileInfo.partName(i), inputStream, partBytes, true);
                     }
-                    Store.verify(indexInput);
-                    snapshotStatus.addProcessedFile(fileInfo.length());
                 }
+                Store.verify(indexInput);
+                snapshotStatus.addProcessedFile(fileInfo.length());
             } catch (Exception t) {
                 failStoreIfCorrupted(t);
                 snapshotStatus.addProcessedFile(0);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In https://github.com/crate/crate/commit/db89c9c06c649a1b0b1a90ba9262b511521380ef
the `verify` call was accidentally moved into the for loop, which broke
the verify logic and could lead to incorrectly failing the snapshotting
with a `CorruptIndexException`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)