### PR TITLE
Avoid iterator allocations in ScoreDocRowFunction

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
@@ -28,6 +28,7 @@ import io.crate.data.Row;
 import io.crate.execution.engine.distribution.merge.KeyIterable;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -38,7 +39,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopFieldCollector;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.lucene.MinimumScoreCollector;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -65,9 +65,8 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     private final DummyScorer scorer;
     private final IndexSearcher searcher;
 
-
     @Nullable
-    private volatile FieldDoc lastDoc = null;
+    private FieldDoc lastDoc = null;
 
     public LuceneOrderedDocCollector(ShardId shardId,
                                      IndexSearcher searcher,

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
@@ -30,10 +30,11 @@ import java.util.Collections;
 import java.util.function.Supplier;
 
 public abstract class OrderedDocCollector implements Supplier<KeyIterable<ShardId, Row>>, AutoCloseable {
+
     private final ShardId shardId;
     private final KeyIterable<ShardId, Row> empty;
 
-    volatile boolean exhausted = false;
+    boolean exhausted = false;
 
     OrderedDocCollector(ShardId shardId) {
         this.shardId = shardId;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`apply` of the `ScoreDocRowFunction` is called in an inner loop.
Avoiding the iterator allocations should reduce GC pressure a bit.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)