### PR TITLE
Make Snapshot Logic Write Metadata after Segments Backport

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -194,4 +194,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an resiliency issue on snapshot creation while dynamic columns are
+  created concurrently which may result in incompatibility problems on restore.

--- a/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.io;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStream;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -147,6 +148,17 @@ public abstract class Streams {
             read += r;
         }
         return read;
+    }
+
+    /**
+     * Reads all bytes from the given {@link InputStream} and closes it afterwards.
+     */
+    public static BytesReference readFully(InputStream in) throws IOException {
+        try (InputStream inputStream = in) {
+            BytesStreamOutput out = new BytesStreamOutput();
+            copy(inputStream, out);
+            return out.bytes();
+        }
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -114,7 +114,11 @@ public interface Repository extends LifecycleComponent {
      * @param snapshotId snapshot id
      * @param indices    list of indices to be snapshotted
      * @param metaData   cluster metadata
+     *
+     * @deprecated this method is only used when taking snapshots in a mixed version cluster where a master node older than
+     *             {@link org.elasticsearch.snapshots.SnapshotsService#NO_REPO_INITIALIZE_VERSION} is present.
      */
+    @Deprecated
     void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData);
 
     /**
@@ -132,8 +136,15 @@ public interface Repository extends LifecycleComponent {
      * @param includeGlobalState include cluster global state
      * @return snapshot description
      */
-    SnapshotInfo finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
-                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId, boolean includeGlobalState);
+    SnapshotInfo finalizeSnapshot(SnapshotId snapshotId,
+                                  List<IndexId> indices,
+                                  long startTime,
+                                  String failure,
+                                  int totalShards,
+                                  List<SnapshotShardFailure> shardFailures,
+                                  long repositoryStateId,
+                                  final MetaData clusterMetaData,
+                                  boolean includeGlobalState);
 
     /**
      * Deletes snapshot

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -23,62 +23,69 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.core.internal.io.Streams;
 import org.elasticsearch.gateway.CorruptStateException;
+import org.elasticsearch.snapshots.SnapshotInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Snapshot metadata file format used in v2.0 and above
  */
-public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat<T> {
+public final class ChecksumBlobStoreFormat<T extends ToXContent> {
 
-    private static final XContentType DEFAULT_X_CONTENT_TYPE = XContentType.SMILE;
+    // Serialization parameters to specify correct context for metadata serialization
+    private static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
+
+    static {
+        Map<String, String> snapshotOnlyParams = new HashMap<>();
+        // when metadata is serialized certain elements of the metadata shouldn't be included into snapshot
+        // exclusion of these elements is done by setting MetaData.CONTEXT_MODE_PARAM to MetaData.CONTEXT_MODE_SNAPSHOT
+        snapshotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);
+        // serialize SnapshotInfo using the SNAPSHOT mode
+        snapshotOnlyParams.put(SnapshotInfo.CONTEXT_MODE_PARAM, SnapshotInfo.CONTEXT_MODE_SNAPSHOT);
+        SNAPSHOT_ONLY_FORMAT_PARAMS = new ToXContent.MapParams(snapshotOnlyParams);
+    }
 
     // The format version
     public static final int VERSION = 1;
 
     private static final int BUFFER_SIZE = 4096;
 
-    protected final XContentType xContentType;
-
-    protected final boolean compress;
+    private final boolean compress;
 
     private final String codec;
 
-    /**
-     * @param codec          codec name
-     * @param blobNameFormat format of the blobname in {@link String#format} format
-     * @param reader         prototype object that can deserialize T from XContent
-     * @param compress       true if the content should be compressed
-     * @param xContentType   content type that should be used for write operations
-     */
-    public ChecksumBlobStoreFormat(String codec, String blobNameFormat, CheckedFunction<XContentParser, T, IOException> reader,
-                                   NamedXContentRegistry namedXContentRegistry, boolean compress, XContentType xContentType) {
-        super(blobNameFormat, reader, namedXContentRegistry);
-        this.xContentType = xContentType;
-        this.compress = compress;
-        this.codec = codec;
-    }
+    private final String blobNameFormat;
+
+    private final CheckedFunction<XContentParser, T, IOException> reader;
+
+    private final NamedXContentRegistry namedXContentRegistry;
 
     /**
      * @param codec          codec name
@@ -88,7 +95,34 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      */
     public ChecksumBlobStoreFormat(String codec, String blobNameFormat, CheckedFunction<XContentParser, T, IOException> reader,
                                    NamedXContentRegistry namedXContentRegistry, boolean compress) {
-        this(codec, blobNameFormat, reader, namedXContentRegistry, compress, DEFAULT_X_CONTENT_TYPE);
+        this.reader = reader;
+        this.blobNameFormat = blobNameFormat;
+        this.namedXContentRegistry = namedXContentRegistry;
+        this.compress = compress;
+        this.codec = codec;
+    }
+
+    /**
+     * Reads and parses the blob with given name, applying name translation using the {link #blobName} method
+     *
+     * @param blobContainer blob container
+     * @param name          name to be translated into
+     * @return parsed blob object
+     */
+    public T read(BlobContainer blobContainer, String name) throws IOException {
+        String blobName = blobName(name);
+        return readBlob(blobContainer, blobName);
+    }
+
+    /**
+     * Deletes obj in the blob container
+     */
+    public void delete(BlobContainer blobContainer, String name) throws IOException {
+        blobContainer.deleteBlob(blobName(name));
+    }
+
+    public String blobName(String name) {
+        return String.format(Locale.ROOT, blobNameFormat, name);
     }
 
     /**
@@ -98,22 +132,21 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      * @param blobName blob name
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
-        try (InputStream inputStream = blobContainer.readBlob(blobName)) {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Streams.copy(inputStream, out);
-            final byte[] bytes = out.toByteArray();
-            final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
-            try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(resourceDesc, bytes)) {
-                CodecUtil.checksumEntireFile(indexInput);
-                CodecUtil.checkHeader(indexInput, codec, VERSION, VERSION);
-                long filePointer = indexInput.getFilePointer();
-                long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
-                BytesReference bytesReference = new BytesArray(bytes, (int) filePointer, (int) contentSize);
-                return read(bytesReference);
-            } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
-                // we trick this into a dedicated exception with the original stacktrace
-                throw new CorruptStateException(ex);
+        final BytesReference bytes = Streams.readFully(blobContainer.readBlob(blobName));
+        final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
+        try (ByteArrayIndexInput indexInput =
+                 new ByteArrayIndexInput(resourceDesc, BytesReference.toBytes(bytes))) {
+            CodecUtil.checksumEntireFile(indexInput);
+            CodecUtil.checkHeader(indexInput, codec, VERSION, VERSION);
+            long filePointer = indexInput.getFilePointer();
+            long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
+            try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                                                     bytes.slice((int) filePointer, (int) contentSize), XContentType.SMILE)) {
+                return reader.apply(parser);
             }
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // we trick this into a dedicated exception with the original stacktrace
+            throw new CorruptStateException(ex);
         }
     }
 
@@ -142,28 +175,39 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      * <p>
      * The blob will be compressed and checksum will be written if required.
      *
-     * @param obj           object to be serialized
-     * @param blobContainer blob container
-     * @param name          blob name
+     * @param obj                 object to be serialized
+     * @param blobContainer       blob container
+     * @param name                blob name
+     * @param failIfAlreadyExists Whether to fail if the blob already exists
      */
-    public void write(T obj, BlobContainer blobContainer, String name) throws IOException {
+    public void write(T obj, BlobContainer blobContainer, String name, boolean failIfAlreadyExists) throws IOException {
         final String blobName = blobName(name);
         writeTo(obj, blobName, bytesArray -> {
             try (InputStream stream = bytesArray.streamInput()) {
-                blobContainer.writeBlob(blobName, stream, bytesArray.length(), true);
+                blobContainer.writeBlob(blobName, stream, bytesArray.length(), failIfAlreadyExists);
             }
         });
     }
 
     private void writeTo(final T obj, final String blobName, final CheckedConsumer<BytesArray, IOException> consumer) throws IOException {
-        final BytesReference bytes = write(obj);
+        final BytesReference bytes;
+        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
+            if (compress) {
+                try (StreamOutput compressedStreamOutput = CompressorFactory.COMPRESSOR.streamOutput(bytesStreamOutput)) {
+                    write(obj, compressedStreamOutput);
+                }
+            } else {
+                write(obj, bytesStreamOutput);
+            }
+            bytes = bytesStreamOutput.bytes();
+        }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             final String resourceDesc = "ChecksumBlobStoreFormat.writeBlob(blob=\"" + blobName + "\")";
             try (OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput(resourceDesc, blobName, outputStream, BUFFER_SIZE)) {
                 CodecUtil.writeHeader(indexOutput, codec, VERSION);
                 try (OutputStream indexOutputOutputStream = new IndexOutputOutputStream(indexOutput) {
                     @Override
-                    public void close() throws IOException {
+                    public void close() {
                         // this is important since some of the XContentBuilders write bytes on close.
                         // in order to write the footer we need to prevent closing the actual index input.
                     }
@@ -176,21 +220,8 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
         }
     }
 
-    protected BytesReference write(T obj) throws IOException {
-        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
-            if (compress) {
-                try (StreamOutput compressedStreamOutput = CompressorFactory.COMPRESSOR.streamOutput(bytesStreamOutput)) {
-                    write(obj, compressedStreamOutput);
-                }
-            } else {
-                write(obj, bytesStreamOutput);
-            }
-            return bytesStreamOutput.bytes();
-        }
-    }
-
-    protected void write(T obj, StreamOutput streamOutput) throws IOException {
-        try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput)) {
+    private void write(T obj, StreamOutput streamOutput) throws IOException {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.SMILE, streamOutput)) {
             builder.startObject();
             obj.toXContent(builder, SNAPSHOT_ONLY_FORMAT_PARAMS);
             builder.endObject();

--- a/es/es-server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -66,6 +67,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -112,6 +114,8 @@ import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
  */
 public class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
+
+    public static final Version NO_REPO_INITIALIZE_VERSION = Version.V_4_1_0;
 
     private final ClusterService clusterService;
 
@@ -400,24 +404,29 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 assert initializingSnapshots.contains(snapshot.snapshot());
                 Repository repository = repositoriesService.repository(snapshot.snapshot().getRepository());
 
-                MetaData metaData = clusterState.metaData();
-                if (!snapshot.includeGlobalState()) {
-                    // Remove global state from the cluster state
-                    MetaData.Builder builder = MetaData.builder();
-                    for (IndexId index : snapshot.indices()) {
-                        builder.put(metaData.index(index.getName()), false);
-                    }
-                    metaData = builder.build();
+                if (repository.isReadOnly()) {
+                    throw new RepositoryException(repository.getMetadata().name(), "cannot create snapshot in a readonly repository");
                 }
-
-                repository.initializeSnapshot(snapshot.snapshot().getSnapshotId(), snapshot.indices(), metaData);
+                final String snapshotName = snapshot.snapshot().getSnapshotId().getName();
+                // check if the snapshot name already exists in the repository
+                if (repository.getRepositoryData().getSnapshotIds().stream().anyMatch(s -> s.getName().equals(snapshotName))) {
+                    throw new InvalidSnapshotNameException(
+                        repository.getMetadata().name(), snapshotName, "snapshot with the same name already exists");
+                }
+                if (clusterState.nodes().getMinNodeVersion().onOrAfter(NO_REPO_INITIALIZE_VERSION) == false) {
+                    // In mixed version clusters we initialize the snapshot in the repository so that in case of a master failover to an
+                    // older version master node snapshot finalization (that assumes initializeSnapshot was called) produces a valid
+                    // snapshot.
+                    repository.initializeSnapshot(
+                        snapshot.snapshot().getSnapshotId(), snapshot.indices(), metaDataForSnapshot(snapshot, clusterState.metaData()));
+                }
                 snapshotCreated = true;
 
                 logger.info("snapshot [{}] started", snapshot.snapshot());
                 if (snapshot.indices().isEmpty()) {
                     // No indices in this snapshot - we are done
                     userCreateSnapshotListener.onResponse(snapshot.snapshot());
-                    endSnapshot(snapshot);
+                    endSnapshot(snapshot, clusterState.metaData());
                     return;
                 }
                 clusterService.submitStateUpdateTask("update_snapshot [" + snapshot.snapshot() + "]", new ClusterStateUpdateTask() {
@@ -500,7 +509,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             assert snapshotsInProgress != null;
                             final SnapshotsInProgress.Entry entry = snapshotsInProgress.snapshot(snapshot.snapshot());
                             assert entry != null;
-                            endSnapshot(entry);
+                            endSnapshot(entry, newState.metaData());
                         }
                     }
                 });
@@ -551,22 +560,22 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 try {
                     repositoriesService.repository(snapshot.snapshot().getRepository())
                         .finalizeSnapshot(snapshot.snapshot().getSnapshotId(),
-                            snapshot.indices(),
-                            snapshot.startTime(),
-                            ExceptionsHelper.detailedMessage(exception),
-                            0,
-                            Collections.emptyList(),
-                            snapshot.getRepositoryStateId(),
-                            snapshot.includeGlobalState());
+                                          snapshot.indices(),
+                                          snapshot.startTime(),
+                                          ExceptionsHelper.detailedMessage(exception),
+                                          0,
+                                          Collections.emptyList(),
+                                          snapshot.getRepositoryStateId(),
+                                          metaDataForSnapshot(snapshot, clusterService.state().metaData()),
+                                          snapshot.includeGlobalState());
                 } catch (Exception inner) {
                     inner.addSuppressed(exception);
                     logger.warn(() -> new ParameterizedMessage("[{}] failed to close snapshot in repository",
-                        snapshot.snapshot()), inner);
+                                                               snapshot.snapshot()), inner);
                 }
             }
             userCreateSnapshotListener.onFailure(e);
         }
-
     }
 
     private static SnapshotInfo inProgressSnapshot(SnapshotsInProgress.Entry entry) {
@@ -714,7 +723,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         entry -> entry.state().completed()
                             || initializingSnapshots.contains(entry.snapshot()) == false
                             && (entry.state() == State.INIT || completed(entry.shards().values()))
-                    ).forEach(this::endSnapshot);
+                    ).forEach(entry -> endSnapshot(entry, event.state().metaData()));
                 }
                 if (newMaster) {
                     finalizeSnapshotDeletionFromPreviousMaster(event);
@@ -961,7 +970,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      *
      * @param entry snapshot
      */
-    private void endSnapshot(final SnapshotsInProgress.Entry entry) {
+    private void endSnapshot(final SnapshotsInProgress.Entry entry, final MetaData metaData) {
         if (endingSnapshots.add(entry.snapshot()) == false) {
             return;
         }
@@ -988,7 +997,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     entry.shards().size(),
                     unmodifiableList(shardFailures),
                     entry.getRepositoryStateId(),
-                    entry.includeGlobalState());
+                    metaDataForSnapshot(entry, metaData),
+                    entry.includeGlobalState()
+                    );
                 removeSnapshotFromClusterState(snapshot, snapshotInfo, null);
                 logger.info("snapshot [{}] completed with state [{}]", snapshot, snapshotInfo.state());
             }
@@ -1000,6 +1011,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 removeSnapshotFromClusterState(snapshot, null, e);
             }
         });
+    }
+
+    private static MetaData metaDataForSnapshot(SnapshotsInProgress.Entry snapshot, MetaData metaData) {
+        if (snapshot.includeGlobalState() == false) {
+            // Remove global state from the cluster state
+            MetaData.Builder builder = MetaData.builder();
+            for (IndexId index : snapshot.indices()) {
+                builder.put(metaData.index(index.getName()), false);
+            }
+            metaData = builder.build();
+        }
+        return metaData;
     }
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -24,9 +24,13 @@ package io.crate.integrationtests;
 
 import com.google.common.base.Joiner;
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.snapshots.Snapshot;
@@ -40,9 +44,11 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest {
 
@@ -265,6 +271,57 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
             "bar| 1.4\n" +
             "baz| 1.2\n" +
             "foo| 1.2\n"));
+    }
+
+    @Test
+    public void testSnapshotWithMetadataConcurrentlyModified() throws Exception {
+        int shards = randomFrom(1, 3, 5);
+        int replicas = randomIntBetween(2, 10);
+        long documents = randomLongBetween(2, 100);
+
+        execute("CREATE TABLE test (" +
+                "  id long primary key)" +
+                "clustered into " + shards + " shards with (column_policy = 'dynamic', number_of_replicas=" + replicas +
+                ")");
+
+        ensureYellow();
+
+        ActionFuture<SQLResponse> createSnapshot = null;
+        // Insert data with dynamic column creation so we trigger a dynamic mapping update for each of them
+        for (var i = 0; i < documents; i++) {
+            execute("INSERT INTO test (id, field_" + i + ") VALUES (?, ?)", new Object[][]{{i, "value_" + i},});
+            execute("REFRESH TABLE test");
+            if (createSnapshot == null) {
+                createSnapshot = sqlExecutor.execute(
+                    "CREATE SNAPSHOT " + snapshotName() + " TABLE test with (wait_for_completion=true)", null);
+            }
+        }
+
+        if (createSnapshot != null) {
+            createSnapshot.actionGet();
+        }
+
+        execute("DROP table test");
+
+        execute("select state from sys.snapshots where name=?", new Object[]{SNAPSHOT_NAME});
+        assertThat(response.rows()[0][0], is("SUCCESS"));
+
+        execute("RESTORE SNAPSHOT " + snapshotName() + " ALL with (wait_for_completion=true)");
+
+        waitNoPendingTasksOnAll();
+
+        SnapshotsInProgress finalSnapshotsInProgress = clusterService().state().custom(SnapshotsInProgress.TYPE);
+        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+
+        ImmutableOpenMap<String, IndexMetaData> state = clusterService().state().metaData().indices();
+        IndexMetaData indexMetaData = state.values().iterator().next().value;
+        int sizeOfProperties = ((Map<?, ?>) indexMetaData.getMappings().values().iterator().next().value.sourceAsMap().get("properties")).size();
+
+        execute("select count(*) from test");
+
+        assertThat(
+            "Documents were restored but the restored index mapping was older than some documents and misses some of their fields",
+            (Long)response.rows()[0][0], lessThanOrEqualTo((long) sizeOfProperties));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of elastic/elasticsearch#45689
Write metadata during snapshot finalization after segment files
to prevent outdated metadata in case of dynamic mapping updates.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
