### PR TITLE
Add internal cast functions for geo and object array types.

### DIFF
--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -22,7 +22,6 @@
 package io.crate.types;
 
 import io.crate.Streamer;
-import io.crate.common.collections.Lists2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
@@ -110,9 +109,6 @@ public final class DataTypes {
         INTEGER,
         LONG
     );
-
-    public static final List<DataType> NUMERIC_AND_TIMESTAMP_TYPES = Lists2.concat(NUMERIC_PRIMITIVE_TYPES,
-                                                                                   List.of(TIMESTAMPZ, TIMESTAMP));
 
     /**
      * Type registry mapping type ids to the according data type instance.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,10 @@ Deprecations
 Changes
 =======
 
+- Added support for casting to :ref:`geo_point_data_type`,
+  :ref:`geo_shape_data_type` and :ref:`object_data_type` array data types.
+  For example: ``cast(['POINT(2 3)','POINT(1 3)'] AS array(geo_point))``
+
 - Added a ``failures`` column to the :ref:`sys.snapshots <sys-snapshots>`
   table.
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1547,16 +1547,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testInvalidTryCastExpression() {
-        expectedException.expect(Exception.class);
-        expectedException.expectMessage("No cast function found for return type object");
-        analyze("select try_cast(name as array(object)) from users");
-    }
-
-    @Test
     public void testInvalidCastExpression() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("No cast function found for return type object");
+        expectedException.expectMessage("Cannot cast text to type object_array");
         analyze("select cast(name as array(object)) from users");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -74,7 +74,7 @@ public class CastIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidCastExpression() throws Exception {
         expectedException.expect(Exception.class);
-        expectedException.expectMessage("No cast function found for return type object");
-        execute("select try_cast(name as array(object)) from sys.cluster");
+        expectedException.expectMessage("Cannot cast text to type object_array");
+        execute("select cast(name as array(object)) from sys.cluster");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It is possible to convert geo and object types to and from other
types if the conversion is allowed. Therefore, there is no reason
not to allow conversion geo and object array types.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
