### PR TITLE
Add a `pg_stats` table to expose column statistics

### DIFF
--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -75,6 +75,7 @@ public final class DataTypes {
     public static final GeoShapeType GEO_SHAPE = GeoShapeType.INSTANCE;
 
     public static final ArrayType<Double> DOUBLE_ARRAY = new ArrayType<>(DOUBLE);
+    public static final ArrayType<Float> FLOAT_ARRAY = new ArrayType<>(FLOAT);
     public static final ArrayType<String> STRING_ARRAY = new ArrayType<>(STRING);
     public static final ArrayType<Integer> INTEGER_ARRAY = new ArrayType<>(INTEGER);
     public static final ArrayType<Short> SHORT_ARRAY = new ArrayType<>(SHORT);

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1989,5 +1989,83 @@ their own job logs entries, while a user with superuser privileges has access
 to all.
 
 
+.. _pg_stats:
+
+pg_stats
+========
+
+The ``pg_stats`` table in the ``pg_catalog`` system schema contains statistical
+data about the contents of the CrateDB cluster.
+
+Entries are periodically created or updated in the interval configured with the
+:ref:`stats.service.interval <stats.service.interval>` setting.
+
+Alternatively the statistics can also be updated using the :ref:`ANALYZE
+<analyze>` command.
+
+
+The table contains 1 entry per column for each table in the cluster which has
+been analyzed.
+
+.. list-table:: pg_stats schema
+    :header-rows: 1
+
+    * - Name
+      - Type
+      - Description
+    * - schemaname
+      - text
+      - Name of the schema containing the table.
+    * - tablename
+      - text
+      - Name of the table.
+    * - attname
+      - text
+      - Name of the column.
+    * - inherited
+      - bool
+      - Always false in CrateDB; For compatibility with PostgreSQL.
+    * - null_frac
+      - real
+      - Fraction of column entries that are null.
+    * - avg_width
+      - integer
+      - Average size in bytes of column's entries.
+    * - n_distinct
+      - real
+      - An approximation of the number of distinct values in a column.
+    * - most_common_vals
+      - string[]
+      - A list of the most common values in the column. null if no values seem.
+        more common than others.
+    * - most_common_freqs
+      - real[]
+      - A list of the frequencies of the most common values. The size of the
+        array always matches most_common_vals. If most_common_vals is null this
+        is null as well.
+    * - histogram_bounds
+      - string[]
+      - A list of values that divide the column's values into groups of
+        approximately equal population. The values in most_common_vals, if
+        present, are omitted from this histogram calculation.
+    * - correlation
+      - real
+      - Always 0.0. This column exists for PostgreSQL compatibility.
+    * - most_common_elems
+      - string[]
+      - Always null. Exists for PostgreSQL compatibility.
+    * - most_common_elem_freqs
+      - real[]
+      - Always null. Exists for PostgreSQL compatibility.
+    * - elem_count_histogram
+      - real[]
+      - Always null. Exists for PostgreSQL compatibility.
+
+
+.. note:: 
+
+    Not all data types support creating statistics. So some columns may not
+    show up in the table.
+
 .. _configuration: ../configuration.html
 .. _Enterprise Edition: https://crate.io/enterprise/

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,10 @@ Deprecations
 Changes
 =======
 
+- Added a :ref:`ANALYZE <analyze>` command that can be used to update
+  statistical data about the contents of the tables in the CrateDB cluster.
+  This data is visible in a newly added :ref:`pg_stats <pg_stats>` table.
+
 - Added support for casting to :ref:`geo_point_data_type`,
   :ref:`geo_shape_data_type` and :ref:`object_data_type` array data types.
   For example: ``cast(['POINT(2 3)','POINT(1 3)'] AS array(geo_point))``

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -89,6 +89,7 @@ number of replicas.
     | pg_catalog         | pg_index                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_namespace            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_settings             | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
     | sys                | allocations             | BASE TABLE |             NULL | NULL               |
     | sys                | checks                  | BASE TABLE |             NULL | NULL               |
@@ -109,7 +110,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 42 rows in set (... sec)
+    SELECT 43 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/docs/sql/statements/analyze.rst
+++ b/docs/sql/statements/analyze.rst
@@ -1,0 +1,30 @@
+.. highlight:: psql
+.. _analyze:
+
+===========
+``ANALYZE``
+===========
+
+Synopsis
+========
+
+::
+
+    ANALYZE
+
+
+Description
+===========
+
+
+The ``ANALYZE`` command can be used to collect statistics about the contents of
+the tables in the CrateDB cluster. 
+
+The generated statistics can be viewed in the :ref:`pg_catalog.pg_stats
+<pg_stats>` table.
+
+The query optimizer uses some of those statistics to generate better execution
+plans.
+
+The statistics are also periodically updated. How often can be configured with
+the :ref:`stats.service.interval <stats.service.interval>` setting.

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -10,6 +10,7 @@ SQL Statements
     alter-cluster
     alter-table
     alter-user
+    analyze
     begin
     commit
     copy-from

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -50,6 +50,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
         this.udfService = udfService;
         this.pgClassTable = PgClassTable.create(tableStats);
         tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
+            .put(PgStatsTable.NAME.name(), new PgStatsTable())
             .put(PgTypeTable.IDENT.name(), new PgTypeTable())
             .put(PgClassTable.IDENT.name(), pgClassTable)
             .put(PgNamespaceTable.IDENT.name(), new PgNamespaceTable())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgStatsTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgStatsTable.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.statistics.ColumnStatsEntry;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.cluster.ClusterState;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+
+public class PgStatsTable extends StaticTableInfo<ColumnStatsEntry> {
+
+    public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_stats");
+    private static final ColumnRegistrar<ColumnStatsEntry> COLUMN_REGISTRY = columnRegistry();
+
+    public PgStatsTable() {
+        super(NAME, COLUMN_REGISTRY);
+    }
+
+    public static Map<ColumnIdent, RowCollectExpressionFactory<ColumnStatsEntry>> expressions() {
+        return COLUMN_REGISTRY.expressions();
+    }
+
+    private static ColumnRegistrar<ColumnStatsEntry> columnRegistry() {
+        return new ColumnRegistrar<ColumnStatsEntry>(NAME, RowGranularity.DOC)
+            .register("schemaname", DataTypes.STRING, () -> forFunction(x -> x.relation().schema()))
+            .register("tablename", DataTypes.STRING, () -> forFunction(x -> x.relation().name()))
+            .register("attname", DataTypes.STRING, () -> forFunction(x -> x.column().sqlFqn()))
+            .register("inherited", DataTypes.BOOLEAN, () -> constant(false))
+            .register("null_frac", DataTypes.FLOAT, () -> forFunction(x -> (float) x.columnStats().nullFraction()))
+            .register("avg_width", DataTypes.INTEGER, () -> forFunction(x -> (int) x.columnStats().averageSizeInBytes()))
+            .register("n_distinct", DataTypes.FLOAT, () -> forFunction(x -> (float) x.columnStats().approxDistinct()))
+
+            // The arrays have the `anyarray` type in PostgreSQL, which are pseudo-types / polymorphic types
+            // (their actual type depends on in which context the columns are used)
+            // See https://www.postgresql.org/docs/current/extend-type-system.html
+            // We lack the capabilities to decide "on-use" which type to use, so we use a string array as most types can be casted to string.
+            .register(
+                "most_common_vals",
+                DataTypes.STRING_ARRAY,
+                () -> forFunction(x -> DataTypes.STRING_ARRAY.value(x.columnStats().mostCommonValues().values()))
+            )
+            .register(
+                "most_common_freqs",
+                DataTypes.FLOAT_ARRAY,
+                () -> forFunction(x -> {
+                    double[] frequencies = x.columnStats().mostCommonValues().frequencies();
+                    ArrayList<Float> values = new ArrayList<>(frequencies.length);
+                    for (double frequency : frequencies) {
+                        values.add((float) frequency);
+                    }
+                    return values;
+                })
+            )
+            .register(
+                "histogram_bounds",
+                DataTypes.STRING_ARRAY,
+                () -> forFunction(x -> DataTypes.STRING_ARRAY.value(x.columnStats().histogram()))
+            )
+            .register("correlation", DataTypes.FLOAT, () -> constant(0.0f))
+            .register("most_common_elems", DataTypes.STRING_ARRAY, () -> constant(null))
+            .register("most_common_elem_freqs", new ArrayType<>(DataTypes.FLOAT), () -> constant(null))
+            .register("elem_count_histogram", new ArrayType<>(DataTypes.FLOAT), () -> constant(null));
+    }
+
+    @Override
+    public Routing getRouting(ClusterState state,
+                              RoutingProvider routingProvider,
+                              WhereClause whereClause,
+                              RoutingProvider.ShardSelection shardSelection,
+                              SessionContext sessionContext) {
+        return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
+    }
+
+    @Override
+    public RowGranularity rowGranularity() {
+        return RowGranularity.DOC;
+    }
+
+}

--- a/sql/src/main/java/io/crate/statistics/ColumnStats.java
+++ b/sql/src/main/java/io/crate/statistics/ColumnStats.java
@@ -267,6 +267,9 @@ public final class ColumnStats<T> implements Writeable {
 
     static <T> List<T> generateHistogram(int numBins, List<T> sortedValues) {
         int numHist = Math.min(numBins, sortedValues.size());
+        if (numHist < 2) {
+            return List.of();
+        }
         ArrayList<T> histogram = new ArrayList<>(numHist);
         int delta = (sortedValues.size() - 1) / (numHist - 1);
         int position = 0;

--- a/sql/src/main/java/io/crate/statistics/ColumnStatsEntry.java
+++ b/sql/src/main/java/io/crate/statistics/ColumnStatsEntry.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.statistics;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+
+public final class ColumnStatsEntry {
+
+    private final RelationName relation;
+    private final ColumnIdent column;
+    private final ColumnStats<?> columnStats;
+
+    ColumnStatsEntry(RelationName relation, ColumnIdent column, ColumnStats<?> columnStats) {
+        this.relation = relation;
+        this.column = column;
+        this.columnStats = columnStats;
+    }
+
+    public RelationName relation() {
+        return relation;
+    }
+
+    public ColumnIdent column() {
+        return column;
+    }
+
+    public ColumnStats<?> columnStats() {
+        return columnStats;
+    }
+}

--- a/sql/src/main/java/io/crate/statistics/Stats.java
+++ b/sql/src/main/java/io/crate/statistics/Stats.java
@@ -74,4 +74,8 @@ public class Stats implements Writeable {
             entry.getValue().writeTo(out);
         }
     }
+
+    public Map<ColumnIdent, ColumnStats> statsByColumn() {
+        return statsByColumn;
+    }
 }

--- a/sql/src/main/java/io/crate/statistics/TableStats.java
+++ b/sql/src/main/java/io/crate/statistics/TableStats.java
@@ -26,6 +26,7 @@ import io.crate.metadata.RelationName;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Holds table statistics that are updated periodically by {@link TableStatsService}.
@@ -80,4 +81,14 @@ public class TableStats {
         return sizeInBytes(relationName) / numDocs(relationName);
     }
 
+    public Iterable<ColumnStatsEntry> statsEntries() {
+        Set<Map.Entry<RelationName, Stats>> entries = tableStats.entrySet();
+        return () -> entries.stream()
+            .flatMap(tableEntry -> {
+                Stats stats = tableEntry.getValue();
+                return stats.statsByColumn().entrySet().stream()
+                    .map(columnEntry ->
+                        new ColumnStatsEntry(tableEntry.getKey(), columnEntry.getKey(), columnEntry.getValue()));
+            }).iterator();
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(36L, response.rowCount());
+        assertEquals(37L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
@@ -83,6 +83,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_index| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_namespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_settings| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| allocations| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| checks| sys| BASE TABLE| NULL\n" +
@@ -213,13 +214,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(36L, response.rowCount());
+        assertEquals(37L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(37L, response.rowCount());
+        assertEquals(38L, response.rowCount());
     }
 
     @Test
@@ -588,7 +589,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(704, response.rowCount());
+        assertEquals(718, response.rowCount());
     }
 
     @Test
@@ -823,7 +824,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureYellow();
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(39L, response.rows()[0][0]);
+        assertEquals(40L, response.rows()[0][0]);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -91,7 +91,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(36L, response.rowCount());
+        assertEquals(37L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://www.postgresql.org/docs/current/view-pg-stats.html


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)