### PR TITLE
Advance max_seq_no before add operation to Lucene

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -979,6 +979,7 @@ public class InternalEngine extends Engine {
                 }
             }
         }
+        markSeqNoAsSeen(index.seqNo());
         return plan;
     }
 
@@ -1346,6 +1347,7 @@ public class InternalEngine extends Engine {
                     delete.seqNo(), delete.version());
             }
         }
+        markSeqNoAsSeen(delete.seqNo());
         return plan;
     }
 
@@ -2480,6 +2482,13 @@ public class InternalEngine extends Engine {
     @Override
     public void waitForOpsToComplete(long seqNo) throws InterruptedException {
         localCheckpointTracker.waitForProcessedOpsToComplete(seqNo);
+    }
+
+    /**
+     * Marks the given seq_no as seen and advances the max_seq_no of this engine to at least that value.
+     */
+    protected final void markSeqNoAsSeen(long seqNo) {
+        localCheckpointTracker.advanceMaxSeqNo(seqNo);
     }
 
     /**


### PR DESCRIPTION
This commit fixes the issue of potential mismatches between the max_seq_no in
the commit's user_data and the seq_no of some documents in the Lucene commit.
The mismatch could arise when processing an operation on a replica engine, as
we first added it to Lucene, then to the translog, to finally mark seq_no as
completed. If a flush occurred after step1, but before the marking, then the
max_seq_no in the commit's user_data would be smaller than the seq_no of some
documents in the Lucene commit.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
