### PR TITLE
Schedule at most one ANALYZE at a time

### DIFF
--- a/sql/src/test/java/io/crate/statistics/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/statistics/TableStatsServiceTest.java
@@ -59,7 +59,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
 
         Assert.assertThat(statsService.refreshInterval,
                           Matchers.is(TimeValue.timeValueMinutes(0)));
-        Assert.assertThat(statsService.refreshScheduledTask, Matchers.is(Matchers.nullValue()));
+        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(Matchers.nullValue()));
 
         // Default setting
         statsService = new TableStatsService(
@@ -70,7 +70,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
 
         Assert.assertThat(statsService.refreshInterval,
                           Matchers.is(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault()));
-        Assert.assertThat(statsService.refreshScheduledTask, Matchers.is(IsNull.notNullValue()));
+        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(IsNull.notNullValue()));
 
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
 
@@ -79,7 +79,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             .put(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getKey(), "10m").build());
 
         Assert.assertThat(statsService.refreshInterval, Matchers.is(TimeValue.timeValueMinutes(10)));
-        Assert.assertThat(statsService.refreshScheduledTask,
+        Assert.assertThat(statsService.scheduledRefresh,
                           Matchers.is(IsNull.notNullValue()));
 
         // Disable
@@ -87,7 +87,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             .put(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getKey(), 0).build());
 
         Assert.assertThat(statsService.refreshInterval, Matchers.is(TimeValue.timeValueMillis(0)));
-        Assert.assertThat(statsService.refreshScheduledTask,
+        Assert.assertThat(statsService.scheduledRefresh,
                           Matchers.is(Matchers.nullValue()));
 
         // Reset setting
@@ -95,7 +95,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
 
         Assert.assertThat(statsService.refreshInterval,
                           Matchers.is(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault()));
-        Assert.assertThat(statsService.refreshScheduledTask, Matchers.is(IsNull.notNullValue()));
+        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(IsNull.notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With the recent changes to use `ANALYZE` for the periodic stats update
the operation may also take a bit longer.

We want to make sure that we don't run multiple ANALYZE operations in
parallel, even if a user lowers the period refresh interval to a low
value.

So this changes the logic that the next update is scheduled after
the previous one completed.

So instead of

    |-----|-----|
          >+++  >+++

We have:

    |----->+++|----->

Where:

    | indicates a schedule start
    > indicates ANALYZE start
    + indicates ANALYZE running


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)