### PR TITLE
Fix case sensitivity of unquoted column names in conflict clauses

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -198,5 +198,7 @@ Changes
 Fixes
 =====
 
+- Fixed case sensitivity of unquoted column names inside ``ON CONFLICT`` clauses.
+
 - Fixed an resiliency issue on snapshot creation while dynamic columns are
   created concurrently which may result in incompatibility problems on restore.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -453,7 +453,7 @@ onConflict
    ;
 
 conflictTarget
-   : '(' qname (',' qname)* ')'
+   : '(' ident (',' ident)* ')'
    ;
 
 values

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -183,7 +183,6 @@ import io.crate.sql.tree.WhenClause;
 import io.crate.sql.tree.Window;
 import io.crate.sql.tree.WindowFrame;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
@@ -586,8 +585,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             SqlBaseParser.OnConflictContext onConflictContext = context.onConflict();
             final List<String> conflictColumns;
             if (onConflictContext.conflictTarget() != null) {
-                conflictColumns = onConflictContext.conflictTarget().qname().stream()
-                    .map(RuleContext::getText)
+                conflictColumns = onConflictContext.conflictTarget().ident().stream()
+                    .map(this::getIdentText)
                     .collect(toList());
             } else {
                 conflictColumns = emptyList();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The query `INSERT into test (a, b) values (1, 2) ON CONFLICT (A) DO UPDATE SET b = excluded.b;` will return the error `ColumnUnknownException: Column A unknown` as described in https://github.com/crate/crate/issues/9332.

This fixes the error where a column name was not found in a ``ON CONFLICT`` clause, because the column name was handled case sensitive.   

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
