### PR TITLE
Utilize column stats to approximate selectivity of the where clause

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,10 @@ Deprecations
 Changes
 =======
 
+- The optimizer now utilizes internal statistics to approximate the number of
+  rows returned by various parts of a query plan. This should result in more
+  efficient execution plans for joins.
+
 - Added a :ref:`ANALYZE <analyze>` command that can be used to update
   statistical data about the contents of the tables in the CrateDB cluster.
   This data is visible in a newly added :ref:`pg_stats <pg_stats>` table.

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -23,7 +23,6 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -31,6 +30,7 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;

--- a/sql/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
+++ b/sql/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.selectivity;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.operator.EqOperator;
+import io.crate.expression.operator.OrOperator;
+import io.crate.expression.predicate.NotPredicate;
+import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.statistics.Stats;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Used to estimate the number of rows returned after applying a given query.
+ *
+ * The numbers, heuristic and logic here is heavily inspired by PostgreSQL.
+ * See `src/backend/optimizer/path/clausesel.c` `clause_selectivity`
+ */
+public class SelectivityFunctions {
+
+    private static final double DEFAULT_EQ_SEL = 0.005;
+    /**
+     * For all cases where we don't have a concrete selectivity logic we use this magic number.
+     * It seems to have worked for PostgreSQL quite well so far.
+     */
+    private static final double MAGIC_SEL = 0.333;
+
+    public static long estimateNumRows(Stats stats, Symbol query) {
+        return (long) (stats.numDocs() * query.accept(SelectivityEstimator.INSTANCE, stats));
+    }
+
+    static class SelectivityEstimator extends SymbolVisitor<Stats, Double> {
+
+        static final SelectivityEstimator INSTANCE = new SelectivityEstimator();
+
+        @Override
+        protected Double visitSymbol(Symbol symbol, Stats stats) {
+            return 1.0;
+        }
+
+        @Override
+        public Double visitLiteral(Literal literal, Stats stats) {
+            Object value = literal.value();
+            if (value instanceof Boolean) {
+                Boolean val = (Boolean) value;
+                return (val == null || !val)
+                    ? 0.0
+                    : 1.0;
+            }
+            return super.visitLiteral(literal, stats);
+        }
+
+        @Override
+        public Double visitFunction(Function function, Stats stats) {
+            switch (function.info().ident().name()) {
+                case AndOperator.NAME: {
+                    double selectivity = 1.0;
+                    for (Symbol argument : function.arguments()) {
+                        selectivity *= argument.accept(this, stats);
+                    }
+                    return selectivity;
+                }
+
+                case OrOperator.NAME: {
+                    double sel1 = 1.0;
+                    for (Symbol argument : function.arguments()) {
+                        double sel2 = argument.accept(this, stats);
+                        sel1 = sel1 + sel2 - sel1 * sel2;
+                    }
+                    return sel1;
+                }
+
+                case EqOperator.NAME: {
+                    List<Symbol> arguments = function.arguments();
+                    return eqSelectivity(arguments.get(0), arguments.get(1), stats);
+                }
+
+                case NotPredicate.NAME: {
+                    return 1.0 - function.arguments().get(0).accept(this, stats);
+                }
+
+                default:
+                    return MAGIC_SEL;
+            }
+        }
+    }
+
+    private static double eqSelectivity(Symbol leftArg, Symbol rightArg, Stats stats) {
+        ColumnIdent column = getColumn(leftArg);
+        if (column == null) {
+            return DEFAULT_EQ_SEL;
+        }
+        var columnStats = stats.statsByColumn().get(column);
+        if (columnStats == null) {
+            return DEFAULT_EQ_SEL;
+        }
+        if (!(rightArg instanceof Literal)) {
+            return 1.0 / columnStats.approxDistinct();
+        }
+        var value = ((Literal<?>) rightArg).value();
+        if (value == null) {
+            // x = null -> is always false
+            return 0.0;
+        }
+        var mcv = columnStats.mostCommonValues();
+        int idx = Arrays.asList(mcv.values()).indexOf(value);
+        if (idx < 0) {
+            return 1.0 / columnStats.approxDistinct();
+        } else {
+            return mcv.frequencies()[idx];
+        }
+    }
+
+    @Nullable
+    private static ColumnIdent getColumn(Symbol symbol) {
+        if (symbol instanceof Reference) {
+            return ((Reference) symbol).column();
+        } else if (symbol instanceof Field) {
+            return ((Field) symbol).path();
+        } else {
+            return null;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/statistics/ColumnStats.java
+++ b/sql/src/main/java/io/crate/statistics/ColumnStats.java
@@ -157,6 +157,16 @@ public final class ColumnStats<T> implements Writeable {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "ColumnStats{" +
+            "nullFraction=" + nullFraction +
+            ", approxDistinct=" + approxDistinct +
+            ", mcv=" + Arrays.toString(mostCommonValues.values()) +
+            ", frequencies=" + Arrays.toString(mostCommonValues.frequencies()) + '}';
+    }
+
+
     /**
      * @param samples sorted sample values (must exclude any null values that might have been sampled)
      * @param nullCount Number of null values that have been excluded from the samples

--- a/sql/src/main/java/io/crate/statistics/Stats.java
+++ b/sql/src/main/java/io/crate/statistics/Stats.java
@@ -35,6 +35,8 @@ import java.util.Map;
 @VisibleForTesting
 public class Stats implements Writeable {
 
+    public static final Stats EMPTY = new Stats();
+
     @VisibleForTesting
     final long numDocs;
     @VisibleForTesting
@@ -42,7 +44,7 @@ public class Stats implements Writeable {
 
     private final Map<ColumnIdent, ColumnStats> statsByColumn;
 
-    Stats() {
+    private Stats() {
         numDocs = -1;
         sizeInBytes = -1;
         statsByColumn = Map.of();
@@ -73,6 +75,14 @@ public class Stats implements Writeable {
             entry.getKey().writeTo(out);
             entry.getValue().writeTo(out);
         }
+    }
+
+    public long numDocs() {
+        return numDocs;
+    }
+
+    public long sizeInBytes() {
+        return sizeInBytes;
     }
 
     public Map<ColumnIdent, ColumnStats> statsByColumn() {

--- a/sql/src/main/java/io/crate/statistics/TableStats.java
+++ b/sql/src/main/java/io/crate/statistics/TableStats.java
@@ -33,8 +33,6 @@ import java.util.Set;
  */
 public class TableStats {
 
-    private static final Stats EMPTY_STATS = new Stats();
-
     private volatile Map<RelationName, Stats> tableStats = new HashMap<>();
 
     public void updateTableStats(Map<RelationName, Stats> tableStats) {
@@ -50,7 +48,7 @@ public class TableStats {
      * Returns -1 if the table isn't in the cache
      */
     public long numDocs(RelationName relationName) {
-        return tableStats.getOrDefault(relationName, EMPTY_STATS).numDocs;
+        return tableStats.getOrDefault(relationName, Stats.EMPTY).numDocs;
     }
 
     /**
@@ -62,7 +60,7 @@ public class TableStats {
      * Returns 0 if the table isn't in the cache
      */
     private long sizeInBytes(RelationName relationName) {
-        return tableStats.getOrDefault(relationName, EMPTY_STATS).sizeInBytes;
+        return tableStats.getOrDefault(relationName, Stats.EMPTY).sizeInBytes;
     }
 
     /**
@@ -90,5 +88,9 @@ public class TableStats {
                     .map(columnEntry ->
                         new ColumnStatsEntry(tableEntry.getKey(), columnEntry.getKey(), columnEntry.getValue()));
             }).iterator();
+    }
+
+    public Stats getStats(RelationName relationName) {
+        return tableStats.getOrDefault(relationName, Stats.EMPTY);
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.statistics.ColumnStats;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+
+public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServiceUnitTest {
+
+
+    @Test
+    public void test_collect_operator_adapts_expected_row_count_based_on_selectivity_calculation() throws Throwable {
+        var columnStats = new HashMap<ColumnIdent, ColumnStats>();
+        long totalNumRows = 20000;
+        var numbers = IntStream.range(1, 20001)
+            .boxed()
+            .collect(Collectors.toList());
+        columnStats.put(
+            new ColumnIdent("x"),
+            ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, totalNumRows)
+        );
+        Stats stats = new Stats(totalNumRows, DataTypes.INTEGER.fixedSize(), columnStats);
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .setTableStats(tableStats)
+            .addTable("create table doc.tbl (x int)")
+            .build();
+
+        LogicalPlan plan = e.logicalPlan("select * from doc.tbl where x = 10");
+        assertThat(plan.numExpectedRows(), Matchers.is(1L));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -91,4 +91,14 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
         Stats stats = new Stats(20_000, 16, Map.of(new ColumnIdent("x"), columnStats));
         assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(19999L));
     }
+
+    @Test
+    public void test_col_is_null_uses_null_fraction_as_selectivity() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("x is null");
+        var columnStats = ColumnStats.fromSortedValues(List.of(1, 2), DataTypes.INTEGER, 2, 4);
+        assertThat(columnStats.nullFraction(), Matchers.is(0.5));
+        Stats stats = new Stats(100, 16, Map.of(new ColumnIdent("x"), columnStats));
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(50L));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -1,0 +1,94 @@
+
+
+
+package io.crate.planner.selectivity;
+
+import io.crate.common.collections.Lists2;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.statistics.ColumnStats;
+import io.crate.statistics.Stats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+import io.crate.types.DataTypes;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_eq_not_in_mcv_is_based_on_approx_distinct() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("x = 10");
+        var statsByColumn = new HashMap<ColumnIdent, ColumnStats>();
+        var numbers = IntStream.range(1, 20_001)
+            .boxed()
+            .collect(Collectors.toList());
+        var columnStats = ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, 20_000L);
+        statsByColumn.put(new ColumnIdent("x"), columnStats);
+        Stats stats = new Stats(20_000, 16, statsByColumn);
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(1L));
+    }
+
+    @Test
+    public void test_eq_null_value_is_always_0() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("x = null");
+        var numbers = IntStream.range(1, 50)
+            .boxed()
+            .collect(Collectors.toList());
+        var columnStats = ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, 20_000L);
+        var statsByColumn = new HashMap<ColumnIdent, ColumnStats>();
+        statsByColumn.put(new ColumnIdent("x"), columnStats);
+        Stats stats = new Stats(20_000, 16, statsByColumn);
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(0L));
+    }
+
+    @Test
+    public void test_column_eq_column_uses_approx_distinct_for_selectivity_approximation() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("x = y");
+        var numbers = Lists2.concat(
+            List.of(1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10),
+            IntStream.range(11, 15).boxed().collect(Collectors.toList())
+        );
+        var columnStats = ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, numbers.size());
+        var statsByColumn = Map.<ColumnIdent, ColumnStats>of(new ColumnIdent("x"), columnStats);
+        Stats stats = new Stats(numbers.size(), 16, statsByColumn);
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(3L));
+    }
+
+    @Test
+    public void test_eq_value_that_is_present_in_mcv_uses_mcv_frequency_as_selectivity() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("x = 10");
+        var numbers = Lists2.concat(
+            List.of(1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10),
+            IntStream.range(11, 15).boxed().collect(Collectors.toList())
+        );
+        var columnStats = ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, numbers.size());
+        double frequencyOf10 = columnStats.mostCommonValues().frequencies()[0];
+        var statsByColumn = Map.<ColumnIdent, ColumnStats>of(new ColumnIdent("x"), columnStats);
+        Stats stats = new Stats(numbers.size(), 16, statsByColumn);
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is((long) (frequencyOf10 * numbers.size())));
+    }
+
+    @Test
+    public void test_not_reverses_selectivity_of_inner_function() {
+        SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        Symbol query = expressions.asSymbol("NOT (x = 10)");
+        var numbers = IntStream.range(1, 20_001)
+            .boxed()
+            .collect(Collectors.toList());
+        var columnStats = ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, 20_000L);
+        Stats stats = new Stats(20_000, 16, Map.of(new ColumnIdent("x"), columnStats));
+        assertThat(SelectivityFunctions.estimateNumRows(stats, query), Matchers.is(19999L));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a first step to start utilization of the statistics that we've
available.

This first implementation only handles `AND`, `OR`, `NOT` and `=`. All
other functions or operator default to a magic selectivity value.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)