### PR TITLE
Make sure to flush channel if client sends flush request

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -202,6 +202,10 @@ Changes
 Fixes
 =====
 
+- Fixed an incompatibility in the ``PostgreSQL`` wire protocol which could
+  cause queries being sent using the ``asyncpg`` python client to get stuck.
+  (Using version 0.20 of the client).
+
 - Fixed two display issues in the Admin UI:
 
   - ``0`` values in the partitions view for tables could be incorrectly

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -679,6 +679,10 @@ public class Session implements AutoCloseable {
         preparedStatements.clear();
     }
 
+    public boolean hasDeferredExecutions() {
+        return !deferredExecutionsByStmt.isEmpty();
+    }
+
     public void resetDeferredExecutions() {
         for (var deferredExecutions : deferredExecutionsByStmt.values()) {
             for (DeferredExecution deferredExecution : deferredExecutions) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`asyncpg` broke with the latest 0.20 update. They added support for
PgBouncer which resulted in a change to replace a `sync` after a
`parse/describe` sequence to a `flush`.

(See https://github.com/MagicStack/asyncpg/commit/b043fbd3303272580f54d5aa89932384ec5fb973)

Our `flush` handling was a no-op so far if there wasn't an `execute`
before, but we're supposed to flush the channel.

Before this commit the communication looked as follows and then got
stuck:

    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=parse stmtName= query=CREATE TABLE t1 (x int primary key, y int) paramTypes=[]
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=bind portalName= statementName= params=[]
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=describe type=P portalOrStatement=
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=execute portalName= maxRows=0
    [INFO ][o.e.c.m.MetaDataCreateIndexService] [Hinterer Geißstein] [t1] creating index, cause [api], templates [crate_defaults], shards [4]/[0], mappings [default]
    [TRACE][i.c.p.p.Messages         ] [Hinterer Geißstein] sentCommandComplete
    [TRACE][i.c.p.p.Messages         ] [Hinterer Geißstein] sentReadyForQuery
    [TRACE][i.c.p.p.PostgresWireProtocol] [Hinterer Geißstein] msg=P msgLength=51 readableBytes=51
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=parse stmtName=__asyncpg_stmt_1__ query=INSERT INTO t1 (x) VALUES (?) paramTypes=[]
    [TRACE][i.c.p.p.PostgresWireProtocol] [Hinterer Geißstein] msg=D msgLength=20 readableBytes=20
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=describe type=S portalOrStatement=__asyncpg_stmt_1__
    [TRACE][i.c.p.p.PostgresWireProtocol] [Hinterer Geißstein] msg=H msgLength=0 readableBytes=0
    [DEBUG][i.c.a.s.SQLOperations    ] [Hinterer Geißstein] method=sync deferredExecutions=0


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)