### PR TITLE
Optimize DISTINCT with LIMIT

### DIFF
--- a/dex/src/main/java/io/crate/data/ArrayRow.java
+++ b/dex/src/main/java/io/crate/data/ArrayRow.java
@@ -60,4 +60,22 @@ public class ArrayRow implements Row {
                "cells=" + Arrays.toString(cells) +
                '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ArrayRow arrayRow = (ArrayRow) o;
+        return Arrays.equals(cells, arrayRow.cells);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(cells);
+    }
 }

--- a/dex/src/main/java/io/crate/data/BiArrayRow.java
+++ b/dex/src/main/java/io/crate/data/BiArrayRow.java
@@ -22,6 +22,8 @@
 
 package io.crate.data;
 
+import java.util.Arrays;
+
 /**
  * A {@link ArrayRow} variant which uses 2 backing arrays which can be changed.
  */
@@ -58,5 +60,28 @@ public class BiArrayRow implements Row {
         System.arraycopy(firstCells, 0, copy, 0, firstCells.length);
         System.arraycopy(secondCells, 0, copy, firstCells.length, secondCells.length);
         return copy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BiArrayRow that = (BiArrayRow) o;
+        if (!Arrays.equals(firstCells, that.firstCells)) {
+            return false;
+        }
+        return Arrays.equals(secondCells, that.secondCells);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(firstCells);
+        result = 31 * result + Arrays.hashCode(secondCells);
+        return result;
     }
 }

--- a/dex/src/main/java/io/crate/data/Row1.java
+++ b/dex/src/main/java/io/crate/data/Row1.java
@@ -55,4 +55,21 @@ public class Row1 implements Row {
     public String toString() {
         return "Row1{" + value + '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Row1 row1 = (Row1) o;
+        return value != null ? value.equals(row1.value) : row1.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
 }

--- a/dex/src/main/java/io/crate/data/RowN.java
+++ b/dex/src/main/java/io/crate/data/RowN.java
@@ -65,4 +65,26 @@ public class RowN implements Row {
     public String toString() {
         return "RowN{" + Arrays.toString(cells) + '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RowN rowN = (RowN) o;
+        if (size != rowN.size) {
+            return false;
+        }
+        return Arrays.equals(cells, rowN.cells);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = size;
+        result = 31 * result + Arrays.hashCode(cells);
+        return result;
+    }
 }

--- a/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public final class TopNDistinctBatchIterator<T> implements BatchIterator<T> {
+
+    private final BatchIterator<T> source;
+    private final Set<T> items;
+    private final int limit;
+    private final Function<? super T, ? extends T> memoizeItem;
+
+    public TopNDistinctBatchIterator(BatchIterator<T> source, int limit, Function<? super T, ? extends T> memoizeItem) {
+        this.source = source;
+        this.items = new HashSet<>();
+        this.limit = limit;
+        this.memoizeItem = memoizeItem;
+    }
+
+    @Override
+    public void kill(@Nullable Throwable throwable) {
+        source.kill(throwable);
+    }
+
+    @Override
+    public T currentElement() {
+        return source.currentElement();
+    }
+
+    @Override
+    public void moveToStart() {
+        items.clear();
+        source.moveToStart();
+    }
+
+    @Override
+    public boolean moveNext() {
+        if (items.size() == limit) {
+            return false;
+        }
+        while (source.moveNext()) {
+            if (items.contains(source.currentElement())) {
+                continue;
+            }
+            boolean added = items.add(memoizeItem.apply(source.currentElement()));
+            assert added : ".add must return true if .contains was false";
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        source.close();
+    }
+
+    @Override
+    public CompletionStage<?> loadNextBatch() {
+        return source.loadNextBatch();
+    }
+
+    @Override
+    public boolean allLoaded() {
+        return items.size() == limit || source.allLoaded();
+    }
+
+    @Override
+    public boolean involvesIO() {
+        return source.involvesIO();
+    }
+}

--- a/dex/src/main/java/io/crate/data/UnsafeArrayRow.java
+++ b/dex/src/main/java/io/crate/data/UnsafeArrayRow.java
@@ -22,6 +22,8 @@
 
 package io.crate.data;
 
+import java.util.Arrays;
+
 /**
  * An array backed row, which returns the inner array upon materialize.
  * <p>
@@ -31,7 +33,7 @@ package io.crate.data;
  */
 public class UnsafeArrayRow implements Row {
 
-    Object[] cells;
+    private Object[] cells;
 
     public void cells(Object[] cells) {
         this.cells = cells;
@@ -55,5 +57,23 @@ public class UnsafeArrayRow implements Row {
     @Override
     public Object[] materialize() {
         return cells;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        UnsafeArrayRow that = (UnsafeArrayRow) o;
+        return Arrays.equals(cells, that.cells);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(cells);
     }
 }

--- a/dex/src/main/java/io/crate/data/join/CombinedRow.java
+++ b/dex/src/main/java/io/crate/data/join/CombinedRow.java
@@ -92,4 +92,36 @@ public class CombinedRow implements Row, ElementCombiner<Row, Row, Row> {
                ", rhs=" + right +
                '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CombinedRow that = (CombinedRow) o;
+
+        if (numCols != that.numCols) {
+            return false;
+        }
+        if (leftNumCols != that.leftNumCols) {
+            return false;
+        }
+        if (!left.equals(that.left)) {
+            return false;
+        }
+        return right.equals(that.right);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = numCols;
+        result = 31 * result + leftNumCols;
+        result = 31 * result + left.hashCode();
+        result = 31 * result + right.hashCode();
+        return result;
+    }
 }

--- a/dex/src/test/java/io/crate/data/TopNDistinctBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/TopNDistinctBatchIteratorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import io.crate.testing.BatchIteratorTester;
+
+public class TopNDistinctBatchIteratorTest {
+
+    @Test
+    public void test_topN_distinct_bi_outputs_n_distinct_items() throws Throwable {
+        var source = InMemoryBatchIterator.of(List.of(1, 1, 1, 2, 3), null, false);
+        var topNDistinct = new TopNDistinctBatchIterator<>(source, 2, x -> x);
+
+        List<Integer> integers = BatchIterators.collect(topNDistinct, Collectors.toList()).get(5, TimeUnit.SECONDS);
+        assertThat(integers, contains(1, 2));
+    }
+
+    @Test
+    public void test_topN_distinct_bi_outputs_lt_n_distinct_items_if_source_contains_less() throws Throwable {
+        var source = InMemoryBatchIterator.of(List.of(1, 1, 1, 2, 3), null, false);
+        var topNDistinct = new TopNDistinctBatchIterator<>(source, 5, x -> x);
+
+        List<Integer> integers = BatchIterators.collect(topNDistinct, Collectors.toList()).get(5, TimeUnit.SECONDS);
+        assertThat(integers, contains(1, 2, 3));
+    }
+
+    @Test
+	public void test_topn_distinct_fulfills_bi_contracts() throws Throwable {
+        var tester = new BatchIteratorTester(() -> {
+            var source = InMemoryBatchIterator.of(
+                List.<Row>of(
+                    new Row1(1),
+                    new Row1(1),
+                    new Row1(1),
+                    new Row1(2),
+                    new Row1(3),
+                    new Row1(4),
+                    new Row1(4)
+                ),
+                null,
+                false
+            );
+            return new TopNDistinctBatchIterator<>(source, 3, x -> x);
+        });
+        tester.verifyResultAndEdgeCaseBehaviour(
+            List.of(
+                new Object[] { 1 },
+                new Object[] { 2 },
+                new Object[] { 3 }
+            )
+        );
+    }
+}

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,10 @@ Deprecations
 Changes
 =======
 
+- Optimized ``SELECT DISTINCT .. LIMIT n`` queries. On high cardinality
+  columns this type of queries can now execute up to 200% faster and use
+  less memory.
+
 - The optimizer now utilizes internal statistics to approximate the number of
   rows returned by various parts of a query plan. This should result in more
   efficient execution plans for joins.

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ProjectionType.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ProjectionType.java
@@ -43,7 +43,8 @@ public enum ProjectionType {
     TOPN_ORDERED(OrderedTopNProjection::new),
     EVAL(EvalProjection::new),
     PROJECT_SET(ProjectSetProjection::new),
-    WINDOW_AGGREGATION(WindowAggProjection::new);
+    WINDOW_AGGREGATION(WindowAggProjection::new),
+    TOPN_DISTINCT(TopNDistinctProjection::new);
 
     private final Projection.ProjectionFactory factory;
 

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ProjectionVisitor.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ProjectionVisitor.java
@@ -97,5 +97,8 @@ public class ProjectionVisitor<C, R> {
     public R visitWindowAgg(WindowAggProjection windowAgg, C context) {
         return visitProjection(windowAgg, context);
     }
-}
 
+    public R visitTopNDistinct(TopNDistinctProjection topNDistinctProjection, C context) {
+        return visitProjection(topNDistinctProjection, context);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dsl/projection/TopNDistinctProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/TopNDistinctProjection.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dsl.projection;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.RowGranularity;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TopNDistinctProjection extends Projection {
+
+    private final int limit;
+    private final List<Symbol> outputs;
+    private final RowGranularity granularity;
+
+    public TopNDistinctProjection(int limit, List<Symbol> outputs, RowGranularity granularity) {
+        this.limit = limit;
+        this.outputs = outputs;
+        this.granularity = granularity;
+    }
+
+    public TopNDistinctProjection(StreamInput in) throws IOException {
+        this.limit = in.readVInt();
+        this.outputs = Symbols.listFromStream(in);
+        this.granularity = RowGranularity.fromStream(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(limit);
+        Symbols.toStream(outputs, out);
+        RowGranularity.toStream(granularity, out);
+    }
+
+    @Override
+    public RowGranularity requiredGranularity() {
+        return granularity;
+    }
+
+    public int limit() {
+        return limit;
+    }
+
+    @Override
+    public ProjectionType projectionType() {
+        return ProjectionType.TOPN_DISTINCT;
+    }
+
+    @Override
+    public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
+        return visitor.visitTopNDistinct(this, context);
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopNDistinctProjection that = (TopNDistinctProjection) o;
+        if (limit != that.limit) {
+            return false;
+        }
+        if (!outputs.equals(that.outputs)) {
+            return false;
+        }
+        return granularity == that.granularity;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + limit;
+        result = 31 * result + outputs.hashCode();
+        result = 31 * result + granularity.hashCode();
+        return result;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -51,6 +51,7 @@ import io.crate.execution.dsl.projection.ProjectionVisitor;
 import io.crate.execution.dsl.projection.SourceIndexWriterProjection;
 import io.crate.execution.dsl.projection.SourceIndexWriterReturnSummaryProjection;
 import io.crate.execution.dsl.projection.SysUpdateProjection;
+import io.crate.execution.dsl.projection.TopNDistinctProjection;
 import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.execution.dsl.projection.UpdateProjection;
 import io.crate.execution.dsl.projection.WindowAggProjection;
@@ -263,6 +264,11 @@ public class ProjectionToProjectorVisitor
             OrderingByPosition.arrayOrdering(orderByIndices, projection.reverseFlags(), projection.nullsFirst()),
             projection.offset()
         );
+    }
+
+    @Override
+    public Projector visitTopNDistinct(TopNDistinctProjection topNDistinct, Context context) {
+        return new TopNDistinctProjector(topNDistinct.limit());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/TopNDistinctProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/TopNDistinctProjector.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.pipeline;
+
+import io.crate.data.BatchIterator;
+import io.crate.data.Projector;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.data.TopNDistinctBatchIterator;
+
+public final class TopNDistinctProjector implements Projector {
+
+    private final int limit;
+
+    public TopNDistinctProjector(int limit) {
+        this.limit = limit;
+    }
+
+    @Override
+    public BatchIterator<Row> apply(BatchIterator<Row> source) {
+        return new TopNDistinctBatchIterator<>(source, limit, row -> new RowN(row.materialize()));
+    }
+
+    public boolean providesIndependentScroll() {
+        return false;
+    }
+}

--- a/sql/src/main/java/io/crate/expression/InputRow.java
+++ b/sql/src/main/java/io/crate/expression/InputRow.java
@@ -58,4 +58,21 @@ public class InputRow implements Row {
                "inputs=" + inputs +
                '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InputRow inputRow = (InputRow) o;
+        return inputs.equals(inputRow.inputs);
+    }
+
+    @Override
+    public int hashCode() {
+        return inputs.hashCode();
+    }
 }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -192,7 +192,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    BooleanSupplier hasValidLicense) {
         this.clusterService = clusterService;
         this.functions = functions;
-        this.logicalPlanner = new LogicalPlanner(functions, tableStats);
+        this.logicalPlanner = new LogicalPlanner(functions, tableStats, () -> clusterService.state().nodes().getMinNodeVersion());
         this.isStatementExecutionAllowed = new IsStatementExecutionAllowed(hasValidLicense);
         this.numberOfShards = numberOfShards;
         this.tableCreator = tableCreator;

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -139,6 +139,11 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         return numExpectedRows;
     }
 
+    public List<Function> aggregates() {
+        return aggregates;
+    }
+
+
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
                                ProjectionBuilder projectionBuilder,

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -70,6 +70,11 @@ public class Limit extends ForwardingLogicalPlan {
         this.offset = offset;
     }
 
+    public Symbol limit() {
+        return limit;
+    }
+
+
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
                                ProjectionBuilder projectionBuilder,

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -99,4 +99,8 @@ public class LogicalPlanVisitor<C, R> {
     public R visitWindowAgg(WindowAgg windowAgg, C context) {
         return visitPlan(windowAgg, context);
     }
+
+    public R visitTopNDistinct(TopNDistinct topNDistinct, C context) {
+        return visitPlan(topNDistinct, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -86,6 +86,7 @@ import io.crate.planner.optimizer.rule.RewriteCollectToGet;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToTopNDistinct;
 import io.crate.statistics.TableStats;
+import org.elasticsearch.Version;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -95,6 +96,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
 
@@ -111,30 +113,33 @@ public class LogicalPlanner {
     private final Functions functions;
     private final RelationNormalizer relationNormalizer;
 
-    public LogicalPlanner(Functions functions, TableStats tableStats) {
-        this.optimizer = new Optimizer(List.of(
-            new RemoveRedundantFetchOrEval(),
-            new MergeAggregateAndCollectToCount(),
-            new MergeFilters(),
-            new MoveFilterBeneathBoundary(),
-            new MoveFilterBeneathFetchOrEval(),
-            new MoveFilterBeneathOrder(),
-            new MoveFilterBeneathProjectSet(),
-            new MoveFilterBeneathHashJoin(),
-            new MoveFilterBeneathNestedLoop(),
-            new MoveFilterBeneathUnion(),
-            new MoveFilterBeneathGroupBy(),
-            new MoveFilterBeneathWindowAgg(),
-            new MergeFilterAndCollect(),
-            new RewriteFilterOnOuterJoinToInnerJoin(functions),
-            new MoveOrderBeneathUnion(),
-            new MoveOrderBeneathNestedLoop(),
-            new MoveOrderBeneathBoundary(),
-            new MoveOrderBeneathFetchOrEval(),
-            new DeduplicateOrder(),
-            new RewriteCollectToGet(functions),
-            new RewriteGroupByKeysLimitToTopNDistinct()
-        ));
+    public LogicalPlanner(Functions functions, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {
+        this.optimizer = new Optimizer(
+            List.of(
+                new RemoveRedundantFetchOrEval(),
+                new MergeAggregateAndCollectToCount(),
+                new MergeFilters(),
+                new MoveFilterBeneathBoundary(),
+                new MoveFilterBeneathFetchOrEval(),
+                new MoveFilterBeneathOrder(),
+                new MoveFilterBeneathProjectSet(),
+                new MoveFilterBeneathHashJoin(),
+                new MoveFilterBeneathNestedLoop(),
+                new MoveFilterBeneathUnion(),
+                new MoveFilterBeneathGroupBy(),
+                new MoveFilterBeneathWindowAgg(),
+                new MergeFilterAndCollect(),
+                new RewriteFilterOnOuterJoinToInnerJoin(functions),
+                new MoveOrderBeneathUnion(),
+                new MoveOrderBeneathNestedLoop(),
+                new MoveOrderBeneathBoundary(),
+                new MoveOrderBeneathFetchOrEval(),
+                new DeduplicateOrder(),
+                new RewriteCollectToGet(functions),
+                new RewriteGroupByKeysLimitToTopNDistinct()
+            ),
+            minNodeVersionInCluster
+        );
         this.tableStats = tableStats;
         this.functions = functions;
         this.relationNormalizer = new RelationNormalizer(functions);

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -84,6 +84,7 @@ import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
 import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import io.crate.planner.optimizer.rule.RewriteCollectToGet;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
+import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToTopNDistinct;
 import io.crate.statistics.TableStats;
 
 import java.util.Collection;
@@ -131,7 +132,8 @@ public class LogicalPlanner {
             new MoveOrderBeneathBoundary(),
             new MoveOrderBeneathFetchOrEval(),
             new DeduplicateOrder(),
-            new RewriteCollectToGet(functions)
+            new RewriteCollectToGet(functions),
+            new RewriteGroupByKeysLimitToTopNDistinct()
         ));
         this.tableStats = tableStats;
         this.functions = functions;

--- a/sql/src/main/java/io/crate/planner/operators/TopNDistinct.java
+++ b/sql/src/main/java/io/crate/planner/operators/TopNDistinct.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static io.crate.analyze.SymbolEvaluator.evaluate;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.OrderBy;
+import io.crate.common.collections.Lists2;
+import io.crate.data.Row;
+import io.crate.execution.dsl.phases.ExecutionPhases;
+import io.crate.execution.dsl.projection.TopNDistinctProjection;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RowGranularity;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.Merge;
+import io.crate.planner.PlannerContext;
+import io.crate.types.DataTypes;
+
+public final class TopNDistinct extends ForwardingLogicalPlan {
+
+    private final Symbol limit;
+    private final List<Symbol> outputs;
+
+    public TopNDistinct(LogicalPlan source, Symbol limit, List<Symbol> outputs) {
+        super(source);
+        this.limit = limit;
+        this.outputs = outputs;
+    }
+
+    public Symbol limit() {
+        return this.limit;
+    }
+
+    @Override
+    public ExecutionPlan build(PlannerContext plannerContext,
+                               ProjectionBuilder projectionBuilder,
+                               int limitHint,
+                               int offsetHint,
+                               @Nullable OrderBy order,
+                               @Nullable Integer pageSizeHint,
+                               Row params,
+                               SubQueryResults subQueryResults) {
+        var executionPlan = source.build(
+            plannerContext,
+            projectionBuilder,
+            TopN.NO_LIMIT,
+            TopN.NO_OFFSET,
+            null,
+            null,
+            params,
+            subQueryResults
+        );
+        if (executionPlan.resultDescription().hasRemainingLimitOrOffset()) {
+            executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
+        }
+        assert source.outputs().equals(outputs)
+            : "source outputs must match outputs, TopNDistinct can't re-evaluate outputs";
+        int limit = DataTypes.INTEGER.value(
+            evaluate(
+                plannerContext.transactionContext(),
+                plannerContext.functions(),
+                this.limit,
+                params,
+                subQueryResults
+            )
+        );
+        var inputColOutputs = InputColumn.mapToInputColumns(outputs);
+        executionPlan.addProjection(
+            new TopNDistinctProjection(
+                limit,
+                inputColOutputs,
+                source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.CLUSTER
+            )
+        );
+        boolean onHandler = ExecutionPhases.executesOnHandler(
+            plannerContext.handlerNode(), executionPlan.resultDescription().nodeIds());
+        if (!onHandler) {
+            executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
+            executionPlan.addProjection(
+                new TopNDistinctProjection(limit, inputColOutputs, RowGranularity.CLUSTER));
+        } else if (source.preferShardProjections()) {
+            executionPlan.addProjection(
+                new TopNDistinctProjection(limit, inputColOutputs, RowGranularity.CLUSTER));
+        }
+        return executionPlan;
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        var source = Lists2.getOnlyElement(sources);
+        return new TopNDistinct(source, limit, outputs);
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitTopNDistinct(this, context);
+    }
+}

--- a/sql/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -23,14 +23,22 @@
 package io.crate.planner.optimizer;
 
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+import org.elasticsearch.Version;
 
 public interface Rule<T> {
 
     Pattern<T> pattern();
 
     LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx);
+
+    /**
+     * @return The version all nodes in the cluster must have to be able to use this optimization.
+     */
+    default Version requiredVersion() {
+        return Version.V_4_0_0;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
@@ -22,9 +22,6 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.Limit;
@@ -35,6 +32,10 @@ import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
+import org.elasticsearch.Version;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 public final class RewriteGroupByKeysLimitToTopNDistinct implements Rule<Limit> {
 
@@ -69,5 +70,10 @@ public final class RewriteGroupByKeysLimitToTopNDistinct implements Rule<Limit> 
             limit.limit(),
             groupBy.outputs()
         );
+    }
+
+    @Override
+    public Version requiredVersion() {
+        return Version.V_4_1_0;
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.TopNDistinct;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class RewriteGroupByKeysLimitToTopNDistinct implements Rule<Limit> {
+
+    private final Pattern<Limit> pattern;
+    private final Capture<GroupHashAggregate> groupCapture;
+
+
+    public RewriteGroupByKeysLimitToTopNDistinct() {
+        this.groupCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(
+                source(),
+                typeOf(GroupHashAggregate.class)
+                    .capturedAs(groupCapture)
+                    .with(groupAggregate -> groupAggregate.aggregates().isEmpty())
+                );
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit, Captures captures, TableStats tableStats, TransactionContext txnCtx) {
+        // In SELECT DISTINCT x, y FROM tbl OFFSET 30 LIMIT 20;
+        // We can ignore a OFFSET because `tbl` is not required to have a
+        // stable sorting order.
+        GroupHashAggregate groupBy = captures.get(groupCapture);
+        return new TopNDistinct(
+            groupBy.source(),
+            limit.limit(),
+            groupBy.outputs()
+        );
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -102,7 +102,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private LogicalPlan createLogicalPlan(MultiSourceSelect mss, TableStats tableStats) {
-        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            functions,
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, plannerCtx));
         return JoinPlanBuilder.createNodes(mss, mss.where(), subqueryPlanner, functions, txnCtx)
             .build(tableStats, Set.of(), Set.of(), null);
@@ -183,7 +187,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         PlannerContext context = e.getPlannerContext(clusterService.state());
-        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            functions,
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
         LogicalPlan operator = JoinPlanBuilder.createNodes(mss, mss.where(), subqueryPlanner, e.functions(), txnCtx)
             .build(tableStats, Set.of(), Set.of(), null);
@@ -204,7 +212,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         PlannerContext context = e.getPlannerContext(clusterService.state());
         context.transactionContext().sessionContext().setHashJoinEnabled(false);
-        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            functions,
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         LogicalPlan plan = logicalPlanner.plan(e.analyze("select users.id from users, locations " +
                                                          "where users.id = locations.id order by users.id"), context);
         Merge merge = (Merge) plan.build(
@@ -401,8 +413,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         plannerCtx = e.getPlannerContext(clusterService.state());
 
         MultiSourceSelect mss = e.normalize("select * from t1, t4 order by t1.x");
-
-        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            functions,
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
         ExecutionPlan build = operator.build(plannerCtx, projectionBuilder, -1, 0, null,
             null, Row.EMPTY, SubQueryResults.EMPTY);
@@ -418,7 +433,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                             "FROM t1 t1 " +
                                             "JOIN t2 t2 on t1.a = t2.b " +
                                             "JOIN t3 t3 on t3.c = t2.b");
-        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, new TableStats());
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            functions,
+            new TableStats(),
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
 
         WindowAgg windowAggOperator = (WindowAgg) ((FetchOrEval) ((RootRelationBoundary) join).source).source;

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -460,6 +460,15 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 sb.append("]\n");
                 plan = aggregate.source;
             }
+            if (plan instanceof TopNDistinct) {
+                var topNDistinct = (TopNDistinct) plan;
+                startLine("TopNDistinct[");
+                sb.append(symbolPrinter.printUnqualified(topNDistinct.limit()));
+                sb.append(" | [");
+                addSymbolsList(topNDistinct.outputs());
+                sb.append("]\n");
+                plan = topNDistinct.source();
+            }
             if (plan instanceof NestedLoopJoin) {
                 NestedLoopJoin nestedLoopJoin = (NestedLoopJoin) plan;
                 startLine("NestedLoopJoin[\n");

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -334,7 +334,11 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                    TableStats tableStats) {
         PlannerContext context = sqlExecutor.getPlannerContext(clusterService.state());
         AnalyzedRelation relation = sqlExecutor.analyze(statement);
-        LogicalPlanner logicalPlanner = new LogicalPlanner(getFunctions(), tableStats);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(
+            getFunctions(),
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
 
         return logicalPlanner.normalizeAndPlan(relation, context, subqueryPlanner, FetchMode.MAYBE_CLEAR, Set.of());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So far we executed DISTINCT or GROUP BY (without aggregations) as a
pipeline breaker: Consume all rows from the source while keeping track
of the unique rows encountered.

The idea behind that was that if aggregates are present, we need to
consume all rows to compute the correct values. But if aggregates are
absent and we have a LIMIT present as well, we can do an early
termination after we've seen N rows.

This adds a new operator, projection, projector and BatchIterator to do
that.

    Q: select distinct "cCode" from uservisits limit 20
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      759.044 ±  556.896 |    245.728 |    503.497 |    593.555 |   2256.398 |
    |   V2    |       23.080 ±   46.996 |      1.784 |      3.432 |      4.471 |    141.736 |
    mean:   - 188.20%
    median: - 197.29%

    Q: select distinct "searchWord" from uservisits limit 20
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |     1116.272 ±  955.815 |    373.133 |    673.789 |    986.535 |   4350.002 |
    |   V2    |        3.275 ±    1.402 |      1.987 |      2.991 |      3.279 |     10.644 |
    mean:   - 198.83%
    median: - 198.23%

## TODO

- [x] Make sure all Row implementations have equals/hashCode implemented properly
- [x] Use BatchIterator testiing framework to test new BatchIterator
- [x] Only apply new optimization if all nodes are on the current version & support it?
- [x] Add test that verifies the optimization is used
- [x] Consider not optimizing for tables with low cardinality ratio

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)