### PR TITLE
Speed up Snapshot Finalization

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -206,5 +206,8 @@ Changes
 Fixes
 =====
 
+- Improved performance of snapshot finalization as https://github.com/crate/crate/pull/9327
+  introduced a performance regression on the snapshot process.
+
 - Fixed a ``ClassCastException`` that could occur when using ``unnest`` on
   multi dimensional arrays.

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -42,6 +42,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotCreationException;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.net.Proxy;
 import java.net.URISyntaxException;
@@ -165,8 +166,9 @@ public class AzureRepository extends BlobStoreRepository {
 
     public AzureRepository(RepositoryMetaData metadata, Environment environment,
                            NamedXContentRegistry namedXContentRegistry,
-                           AzureStorageService storageService) {
-        super(metadata, environment.settings(), namedXContentRegistry);
+                           AzureStorageService storageService,
+                           ThreadPool threadPool) {
+        super(metadata, environment.settings(), namedXContentRegistry, threadPool);
         this.chunkSize = Repository.CHUNK_SIZE_SETTING.get(metadata.settings());
         this.storageService = storageService;
 

--- a/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/es/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -25,6 +25,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,9 +44,14 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     @Override
     public Map<String, Repository.Factory> getRepositories(Environment env,
-                                                           NamedXContentRegistry namedXContentRegistry) {
+                                                           NamedXContentRegistry namedXContentRegistry,
+                                                           ThreadPool threadPool) {
         return Collections.singletonMap(AzureRepository.TYPE,
-            (metadata) -> new AzureRepository(metadata, env, namedXContentRegistry, azureStoreService));
+                                        (metadata) -> new AzureRepository(metadata,
+                                                                          env,
+                                                                          namedXContentRegistry,
+                                                                          azureStoreService,
+                                                                          threadPool));
     }
 
     @Override

--- a/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
+++ b/es/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -42,7 +43,8 @@ public class AzureRepositorySettingsTests extends ESTestCase {
             .put(settings)
             .build();
         final AzureRepository azureRepository = new AzureRepository(new RepositoryMetaData("foo", "azure", internalSettings),
-            TestEnvironment.newEnvironment(internalSettings), NamedXContentRegistry.EMPTY, mock(AzureStorageService.class));
+            TestEnvironment.newEnvironment(internalSettings), NamedXContentRegistry.EMPTY, mock(AzureStorageService.class), mock(
+            ThreadPool.class));
         assertThat(azureRepository.getBlobStore(), is(nullValue()));
         return azureRepository;
     }

--- a/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
+++ b/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
@@ -35,6 +35,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
 
@@ -108,7 +109,13 @@ public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
     }
 
     @Override
-    public Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry) {
-        return Collections.singletonMap("hdfs", (metadata) -> new HdfsRepository(metadata, env, namedXContentRegistry));
+    public Map<String, Repository.Factory> getRepositories(Environment env,
+                                                           NamedXContentRegistry namedXContentRegistry,
+                                                           ThreadPool threadPool) {
+        return Collections.singletonMap("hdfs",
+                                        (metadata) -> new HdfsRepository(metadata,
+                                                                         env,
+                                                                         namedXContentRegistry,
+                                                                         threadPool));
     }
 }

--- a/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/es/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -66,8 +67,8 @@ public final class HdfsRepository extends BlobStoreRepository {
     private static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(100, ByteSizeUnit.KB);
 
     public HdfsRepository(RepositoryMetaData metadata, Environment environment,
-                          NamedXContentRegistry namedXContentRegistry) {
-        super(metadata, environment.settings(), namedXContentRegistry);
+                          NamedXContentRegistry namedXContentRegistry, ThreadPool threadPool) {
+        super(metadata, environment.settings(), namedXContentRegistry, threadPool);
 
         this.environment = environment;
         this.chunkSize = metadata.settings().getAsBytesSize("chunk_size", null);

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.List;
 
@@ -108,8 +109,9 @@ public class S3Repository extends BlobStoreRepository {
     S3Repository(final RepositoryMetaData metadata,
                  final Settings settings,
                  final NamedXContentRegistry namedXContentRegistry,
-                 final S3Service service) {
-        super(metadata, settings, namedXContentRegistry);
+                 final S3Service service,
+                 final ThreadPool threadPool) {
+        super(metadata, settings, namedXContentRegistry, threadPool);
         this.service = service;
 
         // Parse and validate the user's S3 Storage Class setting

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -28,6 +28,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -66,8 +67,9 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     private S3Repository createRepository(final RepositoryMetaData metadata,
                                           final Settings settings,
-                                          final NamedXContentRegistry registry) {
-        return new S3Repository(metadata, settings, registry, service);
+                                          final NamedXContentRegistry registry,
+                                          final ThreadPool threadpool) {
+        return new S3Repository(metadata, settings, registry, service, threadpool);
     }
 
     @Override
@@ -76,8 +78,8 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     }
 
     @Override
-    public Map<String, Repository.Factory> getRepositories(final Environment env, final NamedXContentRegistry registry) {
-        return Collections.singletonMap(S3Repository.TYPE, (metadata) -> createRepository(metadata, env.settings(), registry));
+    public Map<String, Repository.Factory> getRepositories(final Environment env, final NamedXContentRegistry registry, ThreadPool threadPool) {
+        return Collections.singletonMap(S3Repository.TYPE, (metadata) -> createRepository(metadata, env.settings(), registry, threadPool));
     }
 
     @Override

--- a/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/es/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -30,9 +30,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.mockito.Mockito.mock;
 
 
 public class S3RepositoryTests extends ESTestCase {
@@ -113,7 +116,7 @@ public class S3RepositoryTests extends ESTestCase {
     }
 
     private S3Repository createS3Repo(RepositoryMetaData metadata) {
-        return new S3Repository(metadata, Settings.EMPTY, NamedXContentRegistry.EMPTY, new DummyS3Service()) {
+        return new S3Repository(metadata, Settings.EMPTY, NamedXContentRegistry.EMPTY, new DummyS3Service(), mock(ThreadPool.class)) {
             @Override
             protected void assertSnapshotOrGenericThread() {
                 // eliminate thread name check as we create repo manually on test/main threads

--- a/es/es-repository-url/src/main/java/org/elasticsearch/plugin/repository/url/URLRepositoryPlugin.java
+++ b/es/es-repository-url/src/main/java/org/elasticsearch/plugin/repository/url/URLRepositoryPlugin.java
@@ -26,6 +26,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.url.URLRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +45,10 @@ public class URLRepositoryPlugin extends Plugin implements RepositoryPlugin {
     }
 
     @Override
-    public Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry) {
-        return Collections.singletonMap(URLRepository.TYPE, metadata -> new URLRepository(metadata, env, namedXContentRegistry));
+    public Map<String, Repository.Factory> getRepositories(Environment env,
+                                                           NamedXContentRegistry namedXContentRegistry,
+                                                           ThreadPool threadPool) {
+        return Collections.singletonMap(
+            URLRepository.TYPE, metadata -> new URLRepository(metadata, env, namedXContentRegistry, threadPool));
     }
 }

--- a/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/es/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -87,8 +88,8 @@ public class URLRepository extends BlobStoreRepository {
      * Constructs a read-only URL-based repository
      */
     public URLRepository(RepositoryMetaData metadata, Environment environment,
-                         NamedXContentRegistry namedXContentRegistry) {
-        super(metadata, environment.settings(), namedXContentRegistry);
+                         NamedXContentRegistry namedXContentRegistry, ThreadPool threadPool) {
+        super(metadata, environment.settings(), namedXContentRegistry, threadPool);
 
         if (URL_SETTING.exists(metadata.settings()) == false && REPOSITORIES_URL_SETTING.exists(settings) == false) {
             throw new RepositoryException(metadata.name(), "missing url");

--- a/es/es-server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action;
 
+import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 
 /**
@@ -28,6 +29,23 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 public abstract class ActionRunnable<Response> extends AbstractRunnable {
 
     protected final ActionListener<Response> listener;
+
+    /**
+     * Creates a {@link Runnable} that wraps the given listener and a consumer of it that is executed when the {@link Runnable} is run.
+     * Invokes {@link ActionListener#onFailure(Exception)} on it if an exception is thrown on executing the consumer.
+     * @param listener ActionListener to wrap
+     * @param consumer Consumer of wrapped {@code ActionListener}
+     * @param <T> Type of the given {@code ActionListener}
+     * @return Wrapped {@code Runnable}
+     */
+    public static <T> ActionRunnable<T> wrap(ActionListener<T> listener, CheckedConsumer<ActionListener<T>, Exception> consumer) {
+        return new ActionRunnable<>(listener) {
+            @Override
+            protected void doRun() throws Exception {
+                consumer.accept(listener);
+            }
+        };
+    }
 
     public ActionRunnable(ActionListener<Response> listener) {
         this.listener = listener;

--- a/es/es-server/src/main/java/org/elasticsearch/node/Node.java
+++ b/es/es-server/src/main/java/org/elasticsearch/node/Node.java
@@ -465,7 +465,7 @@ public class Node implements Closeable {
 
             modules.add(new RepositoriesModule(this.environment,
                                                pluginsService.filterPlugins(RepositoryPlugin.class),
-                                               xContentRegistry));
+                                               xContentRegistry, threadPool));
 
             final DiscoveryModule discoveryModule = new DiscoveryModule(this.settings,
                                                                         threadPool,

--- a/es/es-server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
+++ b/es/es-server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom snapshot repositories.
@@ -36,10 +37,16 @@ public interface RepositoryPlugin {
      *
      * @param env The environment for the local node, which may be used for the local settings and path.repo
      *
+     * @param namedXContentRegistry the NamedXContentRegistry used for the {@link Repository.Factory}
+     *
+     * @param threadPool the thread pool used to execute the operations in the repositories
+     *
      * The key of the returned {@link Map} is the type name of the repository and
      * the value is a factory to construct the {@link Repository} interface.
      */
-    default Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry) {
+    default Map<String, Repository.Factory> getRepositories(Environment env,
+                                                            NamedXContentRegistry namedXContentRegistry,
+                                                            ThreadPool threadPool) {
         return Collections.emptyMap();
     }
 }

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
@@ -28,6 +28,7 @@ import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.SnapshotShardsService;
 import org.elasticsearch.snapshots.SnapshotsService;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,12 +42,15 @@ public class RepositoriesModule extends AbstractModule {
 
     private final Map<String, Repository.Factory> repositoryTypes;
 
-    public RepositoriesModule(Environment env, List<RepositoryPlugin> repoPlugins, NamedXContentRegistry namedXContentRegistry) {
+    public RepositoriesModule(Environment env,
+                              List<RepositoryPlugin> repoPlugins,
+                              NamedXContentRegistry namedXContentRegistry,
+                              ThreadPool threadPool) {
         Map<String, Repository.Factory> factories = new HashMap<>();
-        factories.put(FsRepository.TYPE, (metadata) -> new FsRepository(metadata, env, namedXContentRegistry));
+        factories.put(FsRepository.TYPE, (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, threadPool));
 
         for (RepositoryPlugin repoPlugin : repoPlugins) {
-            Map<String, Repository.Factory> newRepoTypes = repoPlugin.getRepositories(env, namedXContentRegistry);
+            Map<String, Repository.Factory> newRepoTypes = repoPlugin.getRepositories(env, namedXContentRegistry, threadPool);
             for (Map.Entry<String, Repository.Factory> entry : newRepoTypes.entrySet()) {
                 if (factories.put(entry.getKey(), entry.getValue()) != null) {
                     throw new IllegalArgumentException("Repository type [" + entry.getKey() + "] is already registered");

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -20,6 +20,7 @@ package org.elasticsearch.repositories;
 
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
@@ -126,25 +127,27 @@ public interface Repository extends LifecycleComponent {
      * <p>
      * This method is called on master after all shards are snapshotted.
      *
-     * @param snapshotId    snapshot id
-     * @param indices       list of indices in the snapshot
-     * @param startTime     start time of the snapshot
-     * @param failure       global failure reason or null
-     * @param totalShards   total number of shards
-     * @param shardFailures list of shard failures
-     * @param repositoryStateId the unique id identifying the state of the repository when the snapshot began
-     * @param includeGlobalState include cluster global state
-     * @return snapshot description
+     * @param snapshotId            snapshot id
+     * @param indices               list of indices in the snapshot
+     * @param startTime             start time of the snapshot
+     * @param failure               global failure reason or null
+     * @param totalShards           total number of shards
+     * @param shardFailures         list of shard failures
+     * @param repositoryStateId     the unique id identifying the state of the repository when the snapshot began
+     * @param includeGlobalState    include cluster global state
+     * @param clusterMetaData       cluster metadata
+     * @param listener              listener to be called on completion of the snapshot
      */
-    SnapshotInfo finalizeSnapshot(SnapshotId snapshotId,
+    void finalizeSnapshot(SnapshotId snapshotId,
                                   List<IndexId> indices,
                                   long startTime,
                                   String failure,
                                   int totalShards,
                                   List<SnapshotShardFailure> shardFailures,
                                   long repositoryStateId,
-                                  final MetaData clusterMetaData,
-                                  boolean includeGlobalState);
+                                  boolean includeGlobalState,
+                                  MetaData clusterMetaData,
+                                  ActionListener<SnapshotInfo> listener);
 
     /**
      * Deletes snapshot

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -81,8 +82,8 @@ public class FsRepository extends BlobStoreRepository {
      * Constructs a shared file system repository.
      */
     public FsRepository(RepositoryMetaData metadata, Environment environment,
-                        NamedXContentRegistry namedXContentRegistry) {
-        super(metadata, environment.settings(), namedXContentRegistry);
+                        NamedXContentRegistry namedXContentRegistry, ThreadPool threadPool) {
+        super(metadata, environment.settings(), namedXContentRegistry, threadPool);
         this.environment = environment;
         String location = REPOSITORIES_LOCATION_SETTING.get(metadata.settings());
         if (location.isEmpty()) {


### PR DESCRIPTION
This pull request is a backport of https://github.com/elastic/elasticsearch/pull/47283

The purpose of this pull request is to speed up the snapshot
finalization. This is archived by parallelizing the writes of the
metadata in the snapshot finalization step. This will also
 speed up the snapshot process in case of large
number of indices.

This improvement makes sense, because the snapshot finalization
takes much longer since https://github.com/crate/crate/pull/9327 is integrated.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
