### PR TITLE
Make unnest also unnest multi-dimensional arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -206,4 +206,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a ``ClassCastException`` that could occur when using ``unnest`` on
+  multi dimensional arrays.

--- a/sql/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
@@ -57,4 +57,28 @@ public class UnnestFunctionTest extends AbstractTableFunctionsTest {
             "NULL| 1\n" +
             "NULL| NULL\n");
     }
+
+    @Test
+    public void test_unnest_flattens_multi_dimensional_arrays() {
+        assertExecute(
+            "unnest([[1, 2], [3, 4, 5]])",
+            "1\n" +
+            "2\n" +
+            "3\n" +
+            "4\n" +
+            "5\n"
+        );
+    }
+
+    @Test
+    public void test_unnest_1st_col_multi_dim_array_and_2nd_col_array() {
+        assertExecute(
+            "unnest([[1, 2], [3, 4, 5]], ['a', 'b'])",
+            "1| a\n" +
+            "2| b\n" +
+            "3| NULL\n" +
+            "4| NULL\n" +
+            "5| NULL\n"
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -99,8 +99,11 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testUnnestUsedInSelectList() {
-        execute("select unnest(col1) * 2, col2 from unnest([[1, 2, 3, 4]], ['foo']) order by 1 desc limit 2");
-        assertThat(printedTable(response.rows()), is("8| foo\n6| foo\n"));
+        execute("select unnest(col1) * 2, col2 from (select [1, 2, 3, 4], 'foo') tbl (col1, col2) order by 1 desc limit 2");
+        assertThat(
+            printedTable(response.rows()),
+            is("8| foo\n6| foo\n")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We had a miss-match between what type we reported as return type for
unnest and what values we actually returned.

For nested arrays we returned the inner-most type as return type:

    unnest([[1, 2], [3, 4]]) -> bigint

But we didn't unnest the nested arrays, instead we then returned:

    [1, 2]
    [3, 4]

This changes the implementation to do the unnesting recursive to be
compatible with PostgreSQL and to fix the `ClassCastException` that
occurred due to the return-type / value miss-match we had before.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)