### PR TITLE
Fix ALTER TABLE .. ADD to work if table contains nested primary keys

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -206,6 +206,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused an error when using ``ALTER TABLE .. ADD`` on a
+  table which contains nested primary key columns.
+
 - Fixed issues that would prevent usage or lead to incorrect behaviour
   of the client that use PostgreSQL Wire Protocol when inserting arrays
   of certain types:

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -280,7 +280,7 @@ public class AnalyzedColumnDefinition<T> {
         this.isIndex = true;
     }
 
-    void addChild(AnalyzedColumnDefinition<T> analyzedColumnDefinition) {
+    public void addChild(AnalyzedColumnDefinition<T> analyzedColumnDefinition) {
         children.add(analyzedColumnDefinition);
     }
 
@@ -533,6 +533,7 @@ public class AnalyzedColumnDefinition<T> {
     public void ident(ColumnIdent ident) {
         assert this.ident == null : "ident must be null";
         this.ident = ident;
+        this.name = ident.leafName();
     }
 
     boolean isArrayOrInArray() {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -574,4 +574,5 @@ public class AnalyzedTableElements<T> {
     public boolean hasGeneratedColumns() {
         return numGeneratedColumns > 0;
     }
+
 }

--- a/sql/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/sql/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -404,4 +404,12 @@ public class ColumnIdent implements Comparable<ColumnIdent> {
         newPath.add(0, this.name);
         return new ColumnIdent(name, newPath);
     }
+
+    public String leafName() {
+        if (path.isEmpty()) {
+            return name;
+        } else {
+            return path.get(path.size() - 1);
+        }
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes #9386

`AnalyzedTableElements.toMapping()` requires the individual table
elements to be connected with their child elements to correctly generate
the mapping for object columns.

Internally when we process a `ALTER TABLE .. ADD` we implicitly re-add
all existing primary keys to the `AnalyzedTableElements` structure, but
if the primary keys were nested columns we didn't build the object
  graph.

Furthermore, we first used the `ident(..)` setter followed by the
`name(..)` setter, the `name(..)` setter implicitly created the `ident`
which meant that all nested primary keys were changed to their top-level
object name.

This caused a `column "xy" specified more than once` error.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)