### PR TITLE
Added a extra tag anchor for tables-need-to-be-upgraded warning

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1545,6 +1545,10 @@ partitioning.
 Tables need to be recreated
 ...........................
 
+.. raw:: html
+
+  <span id="tables-need-to-be-upgraded"></span>
+
 .. WARNING::
 
    Do not attempt to upgrade your cluster to a newer major version if this


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

At the moment, we redirect people, based on the error message, to https://cr8.is/d-cluster-check-3,
which resolves to https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-upgraded

However, this section header no longer exists, so the client no longer jumps to the relevant section. We cannot change the bit.ly
link to point to the new header, so this commit just embeds that header tag into the same section as the actual target.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
