### PR TITLE
Add returning clause on update in grammar, parser and analyzer

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ Deprecations
 Changes
 =======
 
+- Introduced new optional ```RETURNING`` clause for :ref:`Update <ref-update>` to
+  return values based on each row actually updated.
+
 - Optimized ``SELECT DISTINCT .. LIMIT n`` queries. On high cardinality
   columns this type of queries can now execute up to 200% faster and use
   less memory.

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -20,7 +20,7 @@ Synopsis
     UPDATE table_ident [ [AS] table_alias ] SET
         { column_ident = expression } [, ...]
       [ WHERE condition ]
-      [ RETURNING * | output_expression [ [ AS ] output_name ] [, ...] ]
+      [ RETURNING { * | output_expression [ [ AS ] output_name ] | relation.* } [, ...] ]
 
 Description
 ===========
@@ -30,10 +30,9 @@ condition. Only the columns to be modified need be mentioned in the SET clause;
 columns not explicitly modified retain their previous values.
 
 The optional RETURNING clause causes UPDATE to compute and return value(s) based
-on each row actually updated. Any expression using the table's columns, and/or
-columns of other tables mentioned in FROM, can be computed. The new (post-update)
-values of the table's columns are used. The syntax of the RETURNING list is
-identical to that of the output list of SELECT.
+on each row actually updated. Any expression using the table's columns can be
+computed. The new (post-update) values of the table's columns are used. The
+syntax of the RETURNING list is identical to that of the output list of SELECT.
 
 Parameters
 ==========
@@ -60,3 +59,13 @@ Parameters
 :condition:
   An expression that returns a value of type boolean. Only rows for
   which this expression returns true will be updated.
+
+:output_expression:
+
+	An expression to be computed and returned by the UPDATE command after each
+	row is updated. The expression can use any column names of the table or * to
+	return all columns.
+
+:output_name:
+
+	A name to use for the result of an output expression.

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -20,6 +20,7 @@ Synopsis
     UPDATE table_ident [ [AS] table_alias ] SET
         { column_ident = expression } [, ...]
       [ WHERE condition ]
+      [ RETURNING * | output_expression [ [ AS ] output_name ] [, ...] ]
 
 Description
 ===========
@@ -27,6 +28,12 @@ Description
 UPDATE changes the values of the specified columns in all rows that satisfy the
 condition. Only the columns to be modified need be mentioned in the SET clause;
 columns not explicitly modified retain their previous values.
+
+The optional RETURNING clause causes UPDATE to compute and return value(s) based
+on each row actually updated. Any expression using the table's columns, and/or
+columns of other tables mentioned in FROM, can be computed. The new (post-update)
+values of the table's columns are used. The syntax of the RETURNING list is
+identical to that of the output list of SELECT.
 
 Parameters
 ==========

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -37,7 +37,10 @@ statement
     | EXPLAIN (ANALYZE)? statement                                                   #explain
     | OPTIMIZE TABLE tableWithPartitions withProperties?                             #optimize
     | REFRESH TABLE tableWithPartitions                                              #refreshTable
-    | UPDATE aliasedRelation SET assignment (',' assignment)* where?                 #update
+    | UPDATE aliasedRelation
+        SET assignment (',' assignment)*
+        where?
+        (RETURNING selectItem (',' selectItem)*)?      													 	   #update
     | DELETE FROM aliasedRelation where?                                             #delete
     | SHOW (TRANSACTION ISOLATION LEVEL | TRANSACTION_ISOLATION)                     #showTransaction
     | SHOW CREATE TABLE table                                                        #showCreateTable
@@ -663,8 +666,8 @@ nonReserved
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | WINDOW | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN | PRECISION
-    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM | CURRENT_SCHEMA
-    | PROMOTE
+    | REPLACE | RETURNING | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM
+    | CURRENT_SCHEMA | PROMOTE
     ;
 
 SELECT: 'SELECT';
@@ -886,6 +889,7 @@ FILTER: 'FILTER';
 PLAIN: 'PLAIN';
 INDEX: 'INDEX';
 STORAGE: 'STORAGE';
+RETURNING: 'RETURNING';
 
 DYNAMIC: 'DYNAMIC';
 STRICT: 'STRICT';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -629,7 +629,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new Update(
             (Relation) visit(context.aliasedRelation()),
             assignments,
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class),
+            visitCollection(context.selectItem(), SelectItem.class)
+            );
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -300,9 +300,12 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
         for (Assignment assignment : node.assignments()) {
             assignment.accept(this, context);
         }
+
         if (node.whereClause().isPresent()) {
             node.whereClause().get().accept(this, context);
         }
+
+        node.returningClause().forEach(x -> x.accept(this, context));
         return null;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/SelectItem.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SelectItem.java
@@ -23,4 +23,9 @@ package io.crate.sql.tree;
 
 public abstract class SelectItem
     extends Node {
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSelectItem(this, context);
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Update.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Update.java
@@ -33,13 +33,18 @@ public class Update extends Statement {
     private final Relation relation;
     private final List<Assignment<Expression>> assignments;
     private final Optional<Expression> where;
+    private final List<SelectItem> returning;
 
-    public Update(Relation relation, List<Assignment<Expression>> assignments, Optional<Expression> where) {
+    public Update(Relation relation,
+                  List<Assignment<Expression>> assignments,
+                  Optional<Expression> where,
+                  List<SelectItem> returning) {
         Preconditions.checkNotNull(relation, "relation is null");
         Preconditions.checkNotNull(assignments, "assignments are null");
         this.relation = relation;
         this.assignments = assignments;
         this.where = where;
+        this.returning = returning;
     }
 
     public Relation relation() {
@@ -54,9 +59,13 @@ public class Update extends Statement {
         return where;
     }
 
+    public List<SelectItem> returningClause() {
+        return returning;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hashCode(relation, assignments, where);
+        return Objects.hashCode(relation, assignments, where, returning);
     }
 
     @Override
@@ -65,6 +74,7 @@ public class Update extends Statement {
             .add("relation", relation)
             .add("assignments", assignments)
             .add("where", where)
+            .add("returning", returning)
             .toString();
     }
 
@@ -77,7 +87,8 @@ public class Update extends Statement {
 
         if (!assignments.equals(update.assignments)) return false;
         if (!relation.equals(update.relation)) return false;
-        if (where != null ? !where.equals(update.where) : update.where != null) return false;
+        if (!java.util.Objects.equals(where, update.where)) return false;
+        if (!java.util.Objects.equals(returning, update.returning)) return false;
 
         return true;
     }
@@ -86,4 +97,5 @@ public class Update extends Statement {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitUpdate(this, context);
     }
+
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -68,6 +68,7 @@ import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.SubqueryExpression;
 import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.SwapTable;
+import io.crate.sql.tree.Update;
 import io.crate.sql.tree.Window;
 import org.junit.Rule;
 import org.junit.Test;
@@ -304,6 +305,17 @@ public class TestStatementBuilder {
         printStatement("update foo set col['x'] = 3 where foo['x'] = 2");
         printStatement("update schemah.foo set foo.a='b', foo.b=foo.a");
         printStatement("update schemah.foo set foo.a=abs(-6.3334), x=true where x=false");
+    }
+
+    @Test
+    public void test_update_returning_clause() {
+        printStatement("update foo set foo='a' returning id");
+        printStatement("update foo set foo='a' where x=false returning id");
+        printStatement("update foo set foo='a' returning id AS foo");
+        printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
+        printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
+        printStatement("update foo set foo='a' returning \"column['nested']\" AS bar");
+        printStatement("update foo set foo='a' returning foo.bar - 1 AS foo");
     }
 
     @Test
@@ -1613,6 +1625,7 @@ public class TestStatementBuilder {
             statement instanceof DropView ||
             statement instanceof DropRepository ||
             statement instanceof DropSnapshot ||
+            statement instanceof Update ||
             statement instanceof Window) {
                 println(SqlFormatter.formatSql(statement));
                 println("");

--- a/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -22,6 +22,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.Multimap;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
@@ -34,11 +35,16 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
     private final AbstractTableRelation table;
     private final Map<Reference, Symbol> assignmentByTargetCol;
     private final Symbol query;
+    private final Multimap<String, Symbol> returningClause;
 
-    public AnalyzedUpdateStatement(AbstractTableRelation table, Map<Reference, Symbol> assignmentByTargetCol, Symbol query) {
+    public AnalyzedUpdateStatement(AbstractTableRelation table,
+                                   Map<Reference, Symbol> assignmentByTargetCol,
+                                   Symbol query,
+                                   Multimap<String, Symbol> returningClause) {
         this.table = table;
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.query = query;
+        this.returningClause = returningClause;
     }
 
     public AbstractTableRelation table() {
@@ -51,6 +57,10 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
 
     public Symbol query() {
         return query;
+    }
+
+    public Multimap<String, Symbol> returningClause() {
+        return returningClause;
     }
 
     @Override
@@ -68,6 +78,9 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
         consumer.accept(query);
         for (Symbol sourceExpr : assignmentByTargetCol.values()) {
             consumer.accept(sourceExpr);
+        }
+        for (Symbol returningSymbol : returningClause.values()) {
+            consumer.accept(returningSymbol);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -32,6 +32,8 @@ import io.crate.analyze.relations.NameFieldProvider;
 import io.crate.analyze.relations.RelationAnalysisContext;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
+import io.crate.analyze.relations.select.SelectAnalysis;
+import io.crate.analyze.relations.select.SelectAnalyzer;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -118,7 +120,13 @@ public final class UpdateAnalyzer {
         query = maybeAliasedStatement.maybeMapFields(query);
 
         Symbol normalizedQuery = normalizer.normalize(query, txnCtx);
-        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery);
+
+        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(update.returningClause(),
+                                                                          relCtx.sources(),
+                                                                          sourceExprAnalyzer,
+                                                                          exprCtx);
+
+        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery, selectAnalysis.outputMultiMap());
     }
 
     private HashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -319,8 +319,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         ExpressionAnalysisContext expressionAnalysisContext = context.expressionAnalysisContext();
         expressionAnalysisContext.windows(node.getWindows());
 
-        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelect(
-            node.getSelect(),
+        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(
+            node.getSelect().getSelectItems(),
             context.sources(),
             expressionAnalyzer,
             expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -32,7 +32,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.QualifiedName;
-import io.crate.sql.tree.Select;
+import io.crate.sql.tree.SelectItem;
 import io.crate.sql.tree.SingleColumn;
 
 import java.util.List;
@@ -41,15 +41,15 @@ import java.util.Map;
 
 public class SelectAnalyzer {
 
-    private static final InnerVisitor INSTANCE = new InnerVisitor();
+    public static final InnerVisitor INSTANCE = new InnerVisitor();
 
-    public static SelectAnalysis analyzeSelect(Select select,
-                                               Map<QualifiedName, AnalyzedRelation> sources,
-                                               ExpressionAnalyzer expressionAnalyzer,
-                                               ExpressionAnalysisContext expressionAnalysisContext) {
+    public static SelectAnalysis analyzeSelectItems(List<SelectItem> selectItems,
+                                                    Map<QualifiedName, AnalyzedRelation> sources,
+                                                    ExpressionAnalyzer expressionAnalyzer,
+                                                    ExpressionAnalysisContext expressionAnalysisContext) {
         SelectAnalysis selectAnalysis = new SelectAnalysis(
-            select.getSelectItems().size(), sources, expressionAnalyzer, expressionAnalysisContext);
-        select.accept(INSTANCE, selectAnalysis);
+            selectItems.size(), sources, expressionAnalyzer, expressionAnalysisContext);
+        selectItems.forEach(x -> x.accept(INSTANCE, selectAnalysis));
         SelectSymbolValidator.validate(selectAnalysis.outputSymbols());
         return selectAnalysis;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pr introduces a new  optional `RETURNING` clause for `UPDATE` to return values based on each row which is updated. The syntax of the `RETURNING` values is the same to that of the output values of `SELECT`, therefore the logic from`SELECT` has been reused.

 The implementation touches the antlr grammar, the relevant parts of the parser and the analyzer but does not cover any further logic yet. This will be part of a separate pr.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
