### PR TITLE
Add the `values` table function and use it in `values` statements.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -57,7 +57,7 @@ import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.expression.tablefunctions.TableFunctionFactory;
-import io.crate.expression.tablefunctions.UnnestFunction;
+import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -774,7 +774,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
         Function function = new Function(
             new FunctionInfo(
-                new FunctionIdent(UnnestFunction.NAME, Symbols.typeView(arrays)),
+                new FunctionIdent(ValuesFunction.NAME, Symbols.typeView(arrays)),
                 ObjectType.untyped(),
                 FunctionInfo.Type.TABLE
             ),
@@ -784,7 +784,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         TableFunctionImplementation tableFunc = TableFunctionFactory.from(implementation);
         TableInfo tableInfo = tableFunc.createTableInfo();
         Operation.blockedRaiseException(tableInfo, context.currentOperation());
-        QualifiedName qualifiedName = new QualifiedName(UnnestFunction.NAME);
+        QualifiedName qualifiedName = new QualifiedName(ValuesFunction.NAME);
         TableFunctionRelation relation = new TableFunctionRelation(
             tableInfo,
             tableFunc,

--- a/sql/src/main/java/io/crate/expression/tablefunctions/ColumnOrientedRowsIterator.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/ColumnOrientedRowsIterator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.tablefunctions;
+
+import io.crate.data.Row;
+import io.crate.data.RowN;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+class ColumnOrientedRowsIterator implements Iterable<Row> {
+
+    private final Supplier<Iterator<Object>[]> iteratorsPerColumn;
+
+    ColumnOrientedRowsIterator(Supplier<Iterator<Object>[]> iteratorsPerColumn) {
+        this.iteratorsPerColumn = iteratorsPerColumn;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<Row> iterator() {
+        Iterator<Object>[] iterators = iteratorsPerColumn.get();
+        Object[] cells = new Object[iterators.length];
+        RowN row = new RowN(cells);
+
+        return new Iterator<>() {
+
+            @Override
+            public boolean hasNext() {
+                for (Iterator<Object> it : iterators) {
+                    if (it.hasNext()) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public Row next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("No more rows");
+                }
+                for (int i = 0; i < iterators.length; i++) {
+                    Iterator<Object> iterator = iterators[i];
+                    cells[i] = iterator.hasNext() ? iterator.next() : null;
+                }
+                return row;
+            }
+        };
+    }
+}

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionModule.java
@@ -32,5 +32,6 @@ public class TableFunctionModule extends AbstractFunctionModule<TableFunctionImp
         UnnestFunction.register(this);
         EmptyRowTableFunction.register(this);
         GenerateSeries.register(this);
+        ValuesFunction.register(this);
     }
 }

--- a/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -23,6 +23,7 @@
 package io.crate.analyze.relations;
 
 import io.crate.exceptions.ValidationException;
+import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -53,5 +55,12 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedRelation relation = executor.analyze("select 'foo' = any(partitioned_by) " +
                                                      "from information_schema.tables");
         assertThat(relation.fields().get(0).path().sqlFqn(), is("'foo' = ANY(partitioned_by)"));
+    }
+
+    @Test
+    public void test_process_values_result_in_table_function_with_values_name() {
+        AnalyzedRelation relation = executor.analyze("VALUES ([1, 2], 'a')");
+        assertThat(relation, instanceOf(TableFunctionRelation.class));
+        assertThat(relation.getQualifiedName().toString(), is(ValuesFunction.NAME));
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
 
     private SqlExpressions sqlExpressions;
-    private Functions functions;
+    protected Functions functions;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before

--- a/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.tablefunctions;
+
+import io.crate.metadata.FunctionIdent;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class ValuesFunctionTest extends AbstractTableFunctionsTest {
+
+    @Test
+    public void test_one_col_one_row() {
+        assertExecute("_values([1])", "1\n");
+    }
+
+    @Test
+    public void test_two_mixed_cols() {
+        assertExecute("_values([1, 2], ['a', 'b'])",
+                      "1| a\n" +
+                      "2| b\n");
+    }
+
+    @Test
+    public void test_first_array_shorter() {
+        assertExecute("_values([1, 2], [1, 2, 3])",
+                      "1| 1\n" +
+                      "2| 2\n" +
+                      "NULL| 3\n");
+    }
+
+    @Test
+    public void test_second_array_shorter() {
+        assertExecute("_values([1, 2, 3], [1, 2])",
+                      "1| 1\n" +
+                      "2| 2\n" +
+                      "3| NULL\n");
+    }
+
+    @Test
+    public void test_single_null_argument_returns_zero_rows() {
+        assertExecute("_values(null)", "");
+    }
+
+    @Test
+    public void test_null_and_array_with_null() {
+        assertExecute("_values(null, [1, null])",
+                      "NULL| 1\n" +
+                      "NULL| NULL\n");
+    }
+
+    @Test
+    public void test_does_not_flatten_nested_arrays() {
+        assertExecute("_values([[1, 2], [3, 4, 5]])",
+                      "[1, 2]\n" +
+                      "[3, 4, 5]\n"
+        );
+    }
+
+    @Test
+    public void test_does_not_flatten_nested_arrays_with_mixed_depth() {
+        assertExecute("_values([[1, 2], [3, 4, 5]], ['a', 'b'])",
+                      "[1, 2]| a\n" +
+                      "[3, 4, 5]| b\n"
+        );
+    }
+
+    @Test
+    public void test_function_return_type_of_the_next_nested_item() {
+        List<DataType> argumentTypes = List.of(new ArrayType<>(new ArrayType<>(DataTypes.STRING)));
+        var funcImplementation = functions.getQualified(
+            new FunctionIdent(ValuesFunction.NAME, argumentTypes));
+
+        assertThat(funcImplementation.info().returnType(), is(new ArrayType<>(DataTypes.STRING)));
+    }
+
+    @Test
+    public void test_function_arguments_must_have_array_types() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Function argument must have an array data type, but was 'text'");
+        functions.getQualified(new FunctionIdent(ValuesFunction.NAME, List.of(DataTypes.STRING)));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The behaviour of the unnest table function has been
changed to unnest nested arrays as well. The implementation
of the `VALUES` statement uses the `unnest` table function
which leads to the behaviour change of the statement. Therefore,
we introduce the `values` table function that can be used for the
`values` statement's implementation.

`VALUES([[1, 2], [3]], [‘a’, ‘b’])`
will return the following rows:

```
    [1, 2] | a
    [3] | b
```

instead of
```
    1 | a
    2 | b
    3 | NULL
```

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
