### PR TITLE
Stop processing ordinals if killed or closed.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -206,6 +206,10 @@ Changes
 Fixes
 =====
 
+- Fixed a possible OutOfMemory issue which may happen on ``GROUP BY`` statement
+  using a group key of type ``TEXT`` on tables containing at least one shard
+  with a low to medium cardinality on the group key.
+
 - Improved snapshot error handling by assuring a snapshot is declared as failed
   when a shard or node failure happens during the snapshot process.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -28,6 +28,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.GroupProjection;
@@ -54,6 +55,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
@@ -78,6 +80,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -140,9 +144,11 @@ final class GroupByOptimizedIterator {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+
         try {
             QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
             collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+            IndexSearcher indexSearcher = searcher.searcher();
 
             InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
             docCtx.add(collectPhase.toCollect().stream()::iterator);
@@ -150,6 +156,7 @@ final class GroupByOptimizedIterator {
 
             InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations(collectTask.txnCtx());
             ctxForAggregations.add(groupProjection.values());
+            final List<CollectExpression<Row, ?>> aggExpressions = ctxForAggregations.expressions();
 
             List<AggregationContext> aggregations = ctxForAggregations.aggregations();
             List<? extends LuceneCollectorExpression<?>> expressions = docCtx.expressions();
@@ -159,9 +166,6 @@ final class GroupByOptimizedIterator {
             CollectorContext collectorContext = getCollectorContext(
                 sharedShardContext.readerId(), queryShardContext::getForField);
 
-            for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
-                expressions.get(i).startCollect(collectorContext);
-            }
             InputRow inputRow = new InputRow(docCtx.topLevelInputs());
 
             LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
@@ -171,59 +175,77 @@ final class GroupByOptimizedIterator {
                 queryShardContext,
                 sharedShardContext.indexService().cache()
             );
-            return CollectingBatchIterator.newInstance(
-                searcher::close,
-                t -> {},
-                () -> {
-                    try {
-                        return CompletableFuture.completedFuture(
-                            getRows(
-                                applyAggregatesGroupedByKey(
-                                    bigArrays,
-                                    searcher,
-                                    keyIndexFieldData,
-                                    ctxForAggregations,
-                                    aggregations,
-                                    expressions,
-                                    ramAccounting,
-                                    inputRow,
-                                    queryContext
-                                ),
-                                ramAccounting,
-                                aggregations,
-                                groupProjection.mode()
-                            )
-                        );
-                    } catch (Throwable t) {
-                        return CompletableFuture.failedFuture(t);
-                    }
-                },
-                true
-            );
+
+            return getIterator(
+                bigArrays,
+                indexSearcher,
+                leaf -> keyIndexFieldData.load(leaf).getOrdinalsValues(),
+                keyIndexFieldData.getFieldName(),
+                aggregations,
+                expressions,
+                aggExpressions,
+                ramAccounting,
+                inputRow,
+                queryContext.query(),
+                collectorContext,
+                groupProjection.mode());
         } catch (Throwable t) {
             searcher.close();
             throw t;
         }
     }
 
-    static boolean hasHighCardinalityRatio(Supplier<Engine.Searcher> acquireSearcher, String fieldName) {
-        // acquire separate searcher:
-        // Can't use sharedShardContexts() yet, if we bail out the "getOrCreateContext" causes issues later on in the fallback logic
-        try (Engine.Searcher searcher = acquireSearcher.get()) {
-            for (LeafReaderContext leaf : searcher.reader().leaves()) {
-                Terms terms = leaf.reader().terms(fieldName);
-                if (terms == null) {
-                    return true;
-                }
-                double cardinalityRatio = terms.size() / (double) leaf.reader().numDocs();
-                if (cardinalityRatio > CARDINALITY_RATIO_THRESHOLD) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            return true;
+    static BatchIterator<Row> getIterator(BigArrays bigArrays,
+                                          IndexSearcher indexSearcher,
+                                          Function<LeafReaderContext, SortedSetDocValues> ordinalsFunction,
+                                          String keyColumnName,
+                                          List<AggregationContext> aggregations,
+                                          List<? extends LuceneCollectorExpression<?>> expressions,
+                                          List<CollectExpression<Row, ?>> aggExpressions,
+                                          RamAccountingContext ramAccounting,
+                                          InputRow inputRow,
+                                          Query query,
+                                          CollectorContext collectorContext,
+                                          AggregateMode aggregateMode) {
+        for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
+            expressions.get(i).startCollect(collectorContext);
         }
-        return false;
+
+        AtomicReference<Throwable> killed = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean();
+        return CollectingBatchIterator.newInstance(
+            () -> closed.set(true),
+            killed::set,
+            () -> {
+                try {
+                    return CompletableFuture.completedFuture(
+                        getRows(
+                            applyAggregatesGroupedByKey(
+                                bigArrays,
+                                indexSearcher,
+                                ordinalsFunction,
+                                keyColumnName,
+                                aggregations,
+                                expressions,
+                                aggExpressions,
+                                ramAccounting,
+                                inputRow,
+                                query,
+                                killed,
+                                closed
+                            ),
+                            ramAccounting,
+                            aggregations,
+                            aggregateMode
+                        )
+                    );
+                } catch (Throwable t) {
+                    return CompletableFuture.failedFuture(t);
+                }
+            },
+            true
+        );
+
     }
 
     private static Iterable<Row> getRows(Map<BytesRef, Object[]> groupedStates,
@@ -251,22 +273,24 @@ final class GroupByOptimizedIterator {
     }
 
     private static Map<BytesRef, Object[]> applyAggregatesGroupedByKey(BigArrays bigArrays,
-                                                                       Engine.Searcher searcher,
-                                                                       IndexOrdinalsFieldData keyIndexFieldData,
-                                                                       InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations,
+                                                                       IndexSearcher indexSearcher,
+                                                                       Function<LeafReaderContext, SortedSetDocValues> ordinalsFunction,
+                                                                       String keyColumnName,
                                                                        List<AggregationContext> aggregations,
                                                                        List<? extends LuceneCollectorExpression<?>> expressions,
+                                                                       List<CollectExpression<Row, ?>> aggExpressions,
                                                                        RamAccountingContext ramAccounting,
                                                                        InputRow inputRow,
-                                                                       LuceneQueryBuilder.Context queryContext) throws IOException {
+                                                                       Query query,
+                                                                       AtomicReference<Throwable> killed,
+                                                                       AtomicBoolean closed) throws IOException {
         final Map<BytesRef, Object[]> statesByKey = new HashMap<>();
-        IndexSearcher indexSearcher = searcher.searcher();
-        final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(queryContext.query()), ScoreMode.COMPLETE, 1f);
+        final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE, 1f);
         final List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
-        final List<CollectExpression<Row, ?>> aggExpressions = ctxForAggregations.expressions();
         Object[] nullStates = null;
 
         for (LeafReaderContext leaf: leaves) {
+            raiseIfClosedOrKilled(killed, closed);
             Scorer scorer = weight.scorer(leaf);
             if (scorer == null) {
                 continue;
@@ -274,11 +298,12 @@ final class GroupByOptimizedIterator {
             for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
                 expressions.get(i).setNextReader(leaf);
             }
-            SortedSetDocValues values = keyIndexFieldData.load(leaf).getOrdinalsValues();
+            SortedSetDocValues values = ordinalsFunction.apply(leaf);
             try (ObjectArray<Object[]> statesByOrd = bigArrays.newObjectArray(values.getValueCount())) {
                 DocIdSetIterator docs = scorer.iterator();
                 Bits liveDocs = leaf.reader().getLiveDocs();
                 for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                    raiseIfClosedOrKilled(killed, closed);
                     if (docDeleted(liveDocs, doc)) {
                         continue;
                     }
@@ -297,7 +322,7 @@ final class GroupByOptimizedIterator {
                             aggregateValues(aggregations, ramAccounting, states);
                         }
                         if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                            throw new GroupByOnArrayUnsupportedException(keyIndexFieldData.getFieldName());
+                            throw new GroupByOnArrayUnsupportedException(keyColumnName);
                         }
                     } else {
                         if (nullStates == null) {
@@ -308,6 +333,7 @@ final class GroupByOptimizedIterator {
                     }
                 }
                 for (long ord = 0; ord < statesByOrd.size(); ord++) {
+                    raiseIfClosedOrKilled(killed, closed);
                     Object[] states = statesByOrd.get(ord);
                     if (states == null) {
                         continue;
@@ -335,6 +361,26 @@ final class GroupByOptimizedIterator {
             statesByKey.put(null, nullStates);
         }
         return statesByKey;
+    }
+
+    static boolean hasHighCardinalityRatio(Supplier<Engine.Searcher> acquireSearcher, String fieldName) {
+        // acquire separate searcher:
+        // Can't use sharedShardContexts() yet, if we bail out the "getOrCreateContext" causes issues later on in the fallback logic
+        try (Engine.Searcher searcher = acquireSearcher.get()) {
+            for (LeafReaderContext leaf : searcher.reader().leaves()) {
+                Terms terms = leaf.reader().terms(fieldName);
+                if (terms == null) {
+                    return true;
+                }
+                double cardinalityRatio = terms.size() / (double) leaf.reader().numDocs();
+                if (cardinalityRatio > CARDINALITY_RATIO_THRESHOLD) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            return true;
+        }
+        return false;
     }
 
     private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {
@@ -404,5 +450,15 @@ final class GroupByOptimizedIterator {
             return null;
         }
         return groupProjection;
+    }
+
+    private static void raiseIfClosedOrKilled(AtomicReference<Throwable> killed, AtomicBoolean closed) {
+        Throwable killedException = killed.get();
+        if (killedException != null) {
+            Exceptions.rethrowUnchecked(killedException);
+        }
+        if (closed.get()) {
+            throw new IllegalStateException("BatchIterator is closed");
+        }
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -22,24 +22,101 @@
 
 package io.crate.execution.engine.collect;
 
+import io.crate.breaker.RamAccountingContext;
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.execution.engine.aggregation.AggregationContext;
+import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.expression.InputRow;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.BatchIteratorTester;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-public class GroupByOptimizedIteratorTest {
+public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTest {
 
+    private IndexSearcher indexSearcher;
+    private ArrayList<Object[]> expectedResult;
+    private String columnName;
+    private InputCollectExpression inExpr;
+    private List<AggregationContext> aggregationContexts;
+
+    @Before
+    public void prepare() throws Exception {
+        IndexWriter iw = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        columnName = "x";
+        expectedResult = new ArrayList<>(20);
+        for (long i = 0; i < 20; i++) {
+            Document doc = new Document();
+            String val = "val_" + i;
+            doc.add(new SortedSetDocValuesField(columnName, new BytesRef(val)));
+            iw.addDocument(doc);
+            expectedResult.add(new Object[] { val, 1L });
+        }
+        iw.commit();
+        indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
+
+        inExpr = new InputCollectExpression(0);
+        CountAggregation aggregation = ((CountAggregation) getFunctions().getQualified(
+            new FunctionIdent(CountAggregation.NAME, Collections.emptyList())));
+        aggregationContexts = Collections.singletonList(new AggregationContext(aggregation, () -> true));
+    }
+
+    private Supplier<BatchIterator<Row>> createBatchIterator(Runnable onOrdinalsValues) {
+        return () -> GroupByOptimizedIterator.getIterator(
+                BigArrays.NON_RECYCLING_INSTANCE,
+                indexSearcher,
+                leaf -> {
+                    try {
+                        onOrdinalsValues.run();
+                        return DocValues.getSortedSet(leaf.reader(), columnName);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                columnName,
+                aggregationContexts,
+                Collections.emptyList(),
+                Collections.singletonList(inExpr),
+                new RamAccountingContext("group", new NoopCircuitBreaker("test")),
+                new InputRow(Collections.singletonList(inExpr)),
+                new MatchAllDocsQuery(),
+                new CollectorContext(mappedFieldType -> null),
+                AggregateMode.ITER_FINAL
+            );
+    }
 
     @Test
     public void testHighCardinalityRatioReturnsTrueForHighCardinality() throws Exception {
@@ -79,5 +156,53 @@ public class GroupByOptimizedIteratorTest {
             GroupByOptimizedIterator.hasHighCardinalityRatio(() -> new Engine.Searcher("dummy", indexSearcher, () -> {}), "x"),
             is(false)
         );
+    }
+
+    @Test
+    public void test_optimized_iterator_behaviour() throws Exception {
+        BatchIteratorTester tester = new BatchIteratorTester(createBatchIterator(() -> {}));
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
+    }
+
+    @Test
+    public void test_optimized_iterator_stop_processing_on_kill() throws Exception {
+        Throwable expectedException = stopOnInterrupting(it -> it.kill(new InterruptedException("killed")));
+        assertThat(expectedException, instanceOf(InterruptedException.class));
+    }
+
+    @Test
+    public void test_optimized_iterator_stop_processing_on_close() throws Exception {
+        Throwable expectedException = stopOnInterrupting(BatchIterator::close);
+        assertThat(expectedException, instanceOf(IllegalStateException.class));
+    }
+
+    private Throwable stopOnInterrupting(Consumer<BatchIterator<Row>> interruptingConsumer) throws Exception {
+        CountDownLatch waitForLoadNextBatch = new CountDownLatch(1);
+        CountDownLatch pauseOnDocumentCollecting = new CountDownLatch(1);
+        CountDownLatch batchLoadingCompleted = new CountDownLatch(1);
+
+        Supplier<BatchIterator<Row>> itSupplier = createBatchIterator(() -> {
+            waitForLoadNextBatch.countDown();
+            try {
+                pauseOnDocumentCollecting.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        BatchIterator<Row> it = itSupplier.get();
+        Thread t = new Thread(() -> it.loadNextBatch().whenComplete((r, e) -> {
+            if (e != null) {
+                exception.set(e.getCause());
+            }
+            batchLoadingCompleted.countDown();
+        }));
+        t.start();
+        waitForLoadNextBatch.await(5, TimeUnit.SECONDS);
+        interruptingConsumer.accept(it);
+        pauseOnDocumentCollecting.countDown();
+        batchLoadingCompleted.await(5, TimeUnit.SECONDS);
+        return exception.get();
     }
 }


### PR DESCRIPTION
Processing grouping keys and aggregation states consumes memory which could lead to an OOM if memory is already exhausted.
It must stop processing once kill or close is called (e.g. when a CircuitBreakerException is already thrown due to missing memory).
