### PR TITLE
Remove RamAccounting from LuceneBatchIterator

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class LuceneBatchIteratorBenchmark {
 
-    public static final RamAccountingContext RAM_ACCOUNTING_CONTEXT = new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"));
     private CollectorContext collectorContext;
     private IndexSearcher indexSearcher;
     private List<IntegerColumnReference> columnRefs;
@@ -83,7 +82,6 @@ public class LuceneBatchIteratorBenchmark {
             null,
             false,
             collectorContext,
-            RAM_ACCOUNTING_CONTEXT,
             columnRefs,
             columnRefs
         );

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -125,7 +125,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 queryContext.minScore(),
                 Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
                 getCollectorContext(sharedShardContext.readerId(), queryShardContext::getForField),
-                collectTask.queryPhaseRamAccountingContext(),
                 docCtx.topLevelInputs(),
                 docCtx.expressions()
             );

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
@@ -60,7 +60,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     private final Query query;
     private final Float minScore;
     private final boolean doDocsScores;
-    private RamAccounting ramAccounting;
+    private final RamAccounting ramAccounting;
     private final CollectorContext collectorContext;
     private final Function<FieldDoc, Query> searchAfterQueryOptimize;
     private final Sort sort;

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import io.crate.breaker.RamAccountingContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LongColumnReference;
 import io.crate.test.integration.CrateUnitTest;
@@ -36,7 +35,6 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,7 +74,6 @@ public class LuceneBatchIteratorTest extends CrateUnitTest {
                 null,
                 false,
                 new CollectorContext(mappedFieldType -> null),
-                new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy")),
                 columnRefs,
                 columnRefs
             )

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -24,7 +24,6 @@ package io.crate.testing;
 
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.auth.user.User;
-import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterators;
 import io.crate.data.Input;
 import io.crate.execution.dml.upsert.GeneratedColumns;
@@ -48,7 +47,6 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -168,7 +166,6 @@ public final class QueryTester implements AutoCloseable {
                 null,
                 false,
                 new CollectorContext(indexEnv.queryShardContext()::getForField),
-                new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy")),
                 Collections.singletonList(input),
                 ctx.expressions()
             );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It is not the responsibility of the inner most BatchIterator to trigger
circuit breaking errors.

A component that allocates memory for buffering is responsible to fail
and propagate that failure if it uses up too much memory.

This aligns the `LuceneBatchIterator` with all the other data providing
`BatchIterator` implementations. (ordered collect, collect from system
tables, etc..)


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)