### PR TITLE
Adds `partition_ident` column to sys.segments table.

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1093,6 +1093,9 @@ of shards.
     * - ``table_name``
       - Table name of the shard.
       - ``TEXT``
+    * - ``partition_ident``
+      - The partition ident of a partitioned table. Empty for non-partitioned tables.
+      - ``TEXT``
     * - ``node``
       - Information about the node the shard is located at.
       - ``OBJECT``

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1074,58 +1074,71 @@ The segment information is useful to understand the behaviour of the underlying
 Lucene file structures for troubleshooting and performance optimization
 of shards.
 
-+-------------------+-------------------------------------------+-------------+
-| Column Name       | Description                               | Return Type |
-+===================+===========================================+=============+
-| ``table_schema``  | Schema name of the table of the shard.    | ``TEXT``    |
-+-------------------+-------------------------------------------+-------------+
-| ``table_name``    | Table name of the shard.                  | ``TEXT``    |
-+-------------------+-------------------------------------------+-------------+
-| ``node``          | ID of the node on which the shard resides.| ``OBJECT``  |
-+-------------------+-------------------------------------------+-------------+
-| ``shard_id``      | ID of the effected shard.                 | ``INTEGER`` |
-+-------------------+-------------------------------------------+-------------+
-|``segment_name``   | Name of the segment, derived from the     | ``TEXT``    |
-|                   | segment generation and used internally    |             |
-|                   | to create file names in the directory of  |             |
-|                   | the shard.                                |             |
-+-------------------+-------------------------------------------+-------------+
-| ``generation``    | Generation number of the segment,         | ``LONG``    |
-|                   | increments for each segment written.      |             |
-+-------------------+-------------------------------------------+-------------+
-| ``num_docs``      | Number of non-deleted lucene documents    | ``INTEGER`` |
-|                   | in the segment.                           |             |
-+-------------------+-------------------------------------------+-------------+
-| ``deleted_docs``  | Number of deleted lucene documents in the | ``INTEGER`` |
-|                   | segment.                                  |             |
-+-------------------+-------------------------------------------+-------------+
-| ``size``          | Disk space used by the segment in bytes.  | ``LONG``    |
-+-------------------+-------------------------------------------+-------------+
-| ``memory``        | Segment data stored in memory for         | ``LONG``    |
-|                   | efficient search, -1 if it is unavailable.|             |
-+-------------------+-------------------------------------------+-------------+
-| ``committed``     | Indicates if the segments are synced to   | ``BOOLEAN`` |
-|                   | disk. Segments that are synced can survive|             |
-|                   | a hard reboot.                            |             |
-+-------------------+-------------------------------------------+-------------+
-| ``primary``       | Describes if this segment is part of a    | ``BOOLEAN`` |
-|                   | primary shard.                            |             |
-+-------------------+-------------------------------------------+-------------+
-| ``search``        | Indicates if the segment is searchable.   | ``BOOLEAN`` |
-|                   | If ``false``, the segment has most likely |             |
-|                   | been written to disk but needs a refresh  |             |
-|                   | to be searchable.                         |             |
-+-------------------+-------------------------------------------+-------------+
-| ``version``       | Version of Lucene used to write the       | ``TEXT``    |
-|                   | segment.                                  |             |
-+-------------------+-------------------------------------------+-------------+
-| ``compound``      | If ``true``, Lucene merges all files      | ``BOOLEAN`` |
-|                   | from the segment into a single file to    |             |
-|                   | save file descriptors.                    |             |
-+-------------------+-------------------------------------------+-------------+
-| ``attributes``    | Contains information about whether high   | ``OBJECT``  |
-|                   | compression was enabled.                  |             |
-+-------------------+-------------------------------------------+-------------+
+.. list-table::
+    :header-rows: 1
+
+    * - Column Name
+      - Description
+      - Return Type
+    * - ``segment_name``
+      - Name of the segment, derived from the segment generation and used
+        internally to create file names in the directory of the shard.
+      - ``TEXT``
+    * - ``shard_id``
+      - ID of the effected shard.
+      - ``INTEGER``
+    * - ``table_schema``
+      - Schema name of the table of the shard.
+      - ``TEXT``
+    * - ``table_name``
+      - Table name of the shard.
+      - ``TEXT``
+    * - ``node``
+      - Information about the node the shard is located at.
+      - ``OBJECT``
+    * - ``node['name']``
+      - The name of the node the shard is located at.
+      - ``TEXT``
+    * - ``node['id']``
+      - The id of the node the shard is located at.
+      - ``TEXT``
+    * - ``generation``
+      - Generation number of the segment, increments for each segment written.
+      - ``LONG``
+    * - ``num_docs``
+      - Number of non-deleted lucene documents in this segment.
+      - ``INTEGER``
+    * - ``deleted_docs``
+      - Number of deleted lucene documents in this segment.
+      - ``INTEGER``
+    * - ``size``
+      - Disk space used by the segment in bytes.
+      - ``LONG``
+    * - ``memory``
+      - Segment data stored in memory for efficient search, -1 if it is
+        unavailable.
+      - ``LONG``
+    * - ``committed``
+      - Indicates if the segments are synced to disk. Segments that are synced
+        can survive a hard reboot.
+      - ``BOOLEAN``
+    * - ``primary``
+      - Describes if this segment is part of a primary shard.
+      - ``BOOLEAN``
+    * - ``search``
+      - Indicates if the segment is searchable. If ``false``, the segment has
+        most likely been written to disk but needs a refresh to be searchable.
+      - ``BOOLEAN``
+    * - ``version``
+      - Version of Lucene used to write the segment.
+      - ``TEXT``
+    * - ``compound``
+      - If ``true``, Lucene merges all files from the segment into a single
+        file to save file descriptors.
+      - ``BOOLEAN``
+    * - ``attributes``
+      - Contains information about whether high compression was enabled.
+      - ``OBJECT``
 
 .. NOTE::
 
@@ -2066,7 +2079,7 @@ been analyzed.
       - Always null. Exists for PostgreSQL compatibility.
 
 
-.. note:: 
+.. note::
 
     Not all data types support creating statistics. So some columns may not
     show up in the table.

--- a/sql/src/main/java/io/crate/metadata/sys/SysSegmentsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSegmentsTableInfo.java
@@ -58,6 +58,7 @@ public class SysSegmentsTableInfo extends StaticTableInfo<ShardSegment> {
         return new ColumnRegistrar<ShardSegment>(IDENT, RowGranularity.DOC)
             .register("table_schema", STRING, () -> forFunction(r -> r.getIndexParts().getSchema()))
             .register("table_name", STRING, () -> forFunction(r -> r.getIndexParts().getTable()))
+            .register("partition_ident", STRING, () -> forFunction(r -> r.getIndexParts().getPartitionIdent()))
             .register("shard_id", INTEGER, () -> forFunction(ShardSegment::getShardId))
             .register("node", ObjectType.builder()
                 .setInnerType("id", STRING)

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -589,7 +589,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(718, response.rowCount());
+        assertEquals(719, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
This column is useful to group segments per partition on partitioned
tables.

The second commit reformat the `sys.segment` documentation to use a list table instead, making it easier to add long descriptions and entries.
