### PR TITLE
Replace RamAccountingContext usages with RamAccounting interface

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
@@ -46,7 +46,7 @@ import java.util.stream.Collector;
 public class AggregateCollector implements Collector<Row, Object[], Iterable<Row>> {
 
     private final List<? extends CollectExpression<Row, ?>> expressions;
-    private final RamAccountingContext ramAccounting;
+    private final RamAccounting ramAccounting;
     private final AggregationFunction[] aggregations;
     private final Version indexVersionCreated;
     private final Input<Boolean>[] filters;
@@ -55,7 +55,7 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
     private final Function<Object[], Iterable<Row>> finisher;
 
     public AggregateCollector(List<? extends CollectExpression<Row, ?>> expressions,
-                              RamAccountingContext ramAccounting,
+                              RamAccounting ramAccounting,
                               AggregateMode mode,
                               AggregationFunction[] aggregations,
                               Version indexVersionCreated,

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
@@ -41,7 +41,7 @@ public class AggregationPipe implements Projector {
     public AggregationPipe(List<CollectExpression<Row, ?>> expressions,
                            AggregateMode aggregateMode,
                            AggregationContext[] aggregations,
-                           RamAccountingContext ramAccountingContext,
+                           RamAccounting ramAccounting,
                            Version indexVersionCreated) {
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
         Input[][] inputs = new Input[aggregations.length][];
@@ -55,7 +55,7 @@ public class AggregationPipe implements Projector {
 
         collector = new AggregateCollector(
             expressions,
-            ramAccountingContext,
+            ramAccounting,
             aggregateMode,
             functions,
             indexVersionCreated,

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
@@ -51,7 +51,7 @@ public class GroupingProjector implements Projector {
                              CollectExpression<Row, ?>[] collectExpressions,
                              AggregateMode mode,
                              AggregationContext[] aggregations,
-                             RamAccountingContext ramAccountingContext,
+                             RamAccounting ramAccounting,
                              Version indexVersionCreated) {
         assert keys.size() == keyInputs.size() : "number of key types must match with number of key inputs";
         ensureAllTypesSupported(keys);
@@ -73,7 +73,7 @@ public class GroupingProjector implements Projector {
                 functions,
                 inputs,
                 filters,
-                ramAccountingContext,
+                ramAccounting,
                 keyInputs.get(0),
                 key.valueType(),
                 indexVersionCreated
@@ -86,7 +86,7 @@ public class GroupingProjector implements Projector {
                 functions,
                 inputs,
                 filters,
-                ramAccountingContext,
+                ramAccounting,
                 keyInputs,
                 typeView(keys),
                 indexVersionCreated

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.data.Input;
@@ -67,22 +67,22 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
     @Nullable
     @Override
-    public Object newState(RamAccountingContext ramAccountingContext,
+    public Object newState(RamAccounting ramAccounting,
                            Version indexVersionCreated) {
         return null;
     }
 
     @Override
-    public Object iterate(RamAccountingContext ramAccountingContext, Object state, Input... args) {
-        return reduce(ramAccountingContext, state, args[0].value());
+    public Object iterate(RamAccounting ramAccounting, Object state, Input... args) {
+        return reduce(ramAccounting, state, args[0].value());
     }
 
     @Override
-    public Object reduce(RamAccountingContext ramAccountingContext, Object state1, Object state2) {
+    public Object reduce(RamAccounting ramAccounting, Object state1, Object state2) {
         if (state1 == null) {
             if (state2 != null) {
                 // this case happens only once per aggregation so ram usage is only estimated once
-                ramAccountingContext.addBytes(partialEstimator.estimateSize(state2));
+                ramAccounting.addBytes(partialEstimator.estimateSize(state2));
             }
             return state2;
         }
@@ -90,7 +90,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     }
 
     @Override
-    public Object terminatePartial(RamAccountingContext ramAccountingContext, Object state) {
+    public Object terminatePartial(RamAccounting ramAccounting, Object state) {
         return state;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.metadata.FunctionIdent;
@@ -161,7 +161,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     @Override
-    public AverageState iterate(RamAccountingContext ramAccountingContext, AverageState state, Input... args) {
+    public AverageState iterate(RamAccounting ramAccounting, AverageState state, Input... args) {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -178,7 +178,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     @Override
-    public AverageState removeFromAggregatedState(RamAccountingContext ramAccountingContext,
+    public AverageState removeFromAggregatedState(RamAccounting ramAccounting,
                                                   AverageState previousAggState,
                                                   Input[] stateToRemove) {
         if (previousAggState != null) {
@@ -192,7 +192,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     @Override
-    public AverageState reduce(RamAccountingContext ramAccountingContext, AverageState state1, AverageState state2) {
+    public AverageState reduce(RamAccounting ramAccounting, AverageState state1, AverageState state2) {
         if (state1 == null) {
             return state2;
         }
@@ -205,15 +205,15 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     @Override
-    public Double terminatePartial(RamAccountingContext ramAccountingContext, AverageState state) {
+    public Double terminatePartial(RamAccounting ramAccounting, AverageState state) {
         return state.value();
     }
 
     @Nullable
     @Override
-    public AverageState newState(RamAccountingContext ramAccountingContext,
+    public AverageState newState(RamAccounting ramAccounting,
                                  Version indexVersionCreated) {
-        ramAccountingContext.addBytes(AverageStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
         return new AverageState();
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Function;
@@ -109,7 +109,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public LongState iterate(RamAccountingContext ramAccountingContext, LongState state, Input... args) {
+    public LongState iterate(RamAccounting ramAccounting, LongState state, Input... args) {
         if (!hasArgs || args[0].value() != null) {
             return state.add(1L);
         }
@@ -118,9 +118,9 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
 
     @Nullable
     @Override
-    public LongState newState(RamAccountingContext ramAccountingContext,
+    public LongState newState(RamAccounting ramAccounting,
                               Version indexVersionCreated) {
-        ramAccountingContext.addBytes(LongStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
         return new LongState();
     }
 
@@ -152,12 +152,12 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public LongState reduce(RamAccountingContext ramAccountingContext, LongState state1, LongState state2) {
+    public LongState reduce(RamAccounting ramAccounting, LongState state1, LongState state2) {
         return state1.merge(state2);
     }
 
     @Override
-    public Long terminatePartial(RamAccountingContext ramAccountingContext, LongState state) {
+    public Long terminatePartial(RamAccounting ramAccounting, LongState state) {
         return state.value;
     }
 
@@ -264,7 +264,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public LongState removeFromAggregatedState(RamAccountingContext ramAccountingContext,
+    public LongState removeFromAggregatedState(RamAccounting ramAccounting,
                                                LongState previousAggState,
                                                Input[] stateToRemove) {
         if (!hasArgs || stateToRemove[0].value() != null) {

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ComparisonChain;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.metadata.FunctionIdent;
@@ -180,14 +180,14 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
     @Nullable
     @Override
-    public GeometricMeanState newState(RamAccountingContext ramAccountingContext,
+    public GeometricMeanState newState(RamAccounting ramAccounting,
                                        Version indexVersionCreated) {
-        ramAccountingContext.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
         return new GeometricMeanState();
     }
 
     @Override
-    public GeometricMeanState iterate(RamAccountingContext ramAccountingContext, GeometricMeanState state, Input... args) throws CircuitBreakingException {
+    public GeometricMeanState iterate(RamAccounting ramAccounting, GeometricMeanState state, Input... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -198,7 +198,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     @Override
-    public GeometricMeanState reduce(RamAccountingContext ramAccountingContext, GeometricMeanState state1, GeometricMeanState state2) {
+    public GeometricMeanState reduce(RamAccounting ramAccounting, GeometricMeanState state1, GeometricMeanState state2) {
         if (state1 == null) {
             return state2;
         }
@@ -210,7 +210,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     @Override
-    public Double terminatePartial(RamAccountingContext ramAccountingContext, GeometricMeanState state) {
+    public Double terminatePartial(RamAccounting ramAccounting, GeometricMeanState state) {
         return state.value();
     }
 
@@ -220,7 +220,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     @Override
-    public GeometricMeanState removeFromAggregatedState(RamAccountingContext ramAccountingContext,
+    public GeometricMeanState removeFromAggregatedState(RamAccounting ramAccounting,
                                                         GeometricMeanState previousAggState,
                                                         Input[] stateToRemove) {
         if (previousAggState != null) {

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.data.Input;
@@ -67,14 +67,14 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public Comparable newState(RamAccountingContext ramAccountingContext,
+        public Comparable newState(RamAccounting ramAccounting,
                                    Version indexVersionCreated) {
-            ramAccountingContext.addBytes(size);
+            ramAccounting.addBytes(size);
             return null;
         }
 
         @Override
-        public Comparable reduce(RamAccountingContext ramAccountingContext, Comparable state1, Comparable state2) {
+        public Comparable reduce(RamAccounting ramAccounting, Comparable state1, Comparable state2) {
             if (state1 == null) {
                 return state2;
             }
@@ -99,16 +99,16 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public Comparable newState(RamAccountingContext ramAccountingContext,
+        public Comparable newState(RamAccounting ramAccounting,
                                    Version indexVersionCreated) {
             return null;
         }
 
         @Override
-        public Comparable reduce(RamAccountingContext ramAccountingContext, Comparable state1, Comparable state2) {
+        public Comparable reduce(RamAccounting ramAccounting, Comparable state1, Comparable state2) {
             if (state1 == null) {
                 if (state2 != null) {
-                    ramAccountingContext.addBytes(estimator.estimateSize(state2));
+                    ramAccounting.addBytes(estimator.estimateSize(state2));
                 }
                 return state2;
             }
@@ -116,7 +116,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
                 return state1;
             }
             if (state1.compareTo(state2) < 0) {
-                ramAccountingContext.addBytes(estimator.estimateSizeDelta(state1, state2));
+                ramAccounting.addBytes(estimator.estimateSizeDelta(state1, state2));
                 return state2;
             }
             return state1;
@@ -138,13 +138,13 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
     }
 
     @Override
-    public Comparable iterate(RamAccountingContext ramAccountingContext, Comparable state, Input... args) throws CircuitBreakingException {
+    public Comparable iterate(RamAccounting ramAccounting, Comparable state, Input... args) throws CircuitBreakingException {
         Object value = args[0].value();
-        return reduce(ramAccountingContext, state, (Comparable) value);
+        return reduce(ramAccounting, state, (Comparable) value);
     }
 
     @Override
-    public Comparable terminatePartial(RamAccountingContext ramAccountingContext, Comparable state) {
+    public Comparable terminatePartial(RamAccounting ramAccounting, Comparable state) {
         return state;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.data.Input;
@@ -67,16 +67,16 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public Comparable newState(RamAccountingContext ramAccountingContext,
+        public Comparable newState(RamAccounting ramAccounting,
                                    Version indexVersionCreated) {
             return null;
         }
 
         @Override
-        public Comparable reduce(RamAccountingContext ramAccountingContext, Comparable state1, Comparable state2) {
+        public Comparable reduce(RamAccounting ramAccounting, Comparable state1, Comparable state2) {
             if (state1 == null) {
                 if (state2 != null) {
-                    ramAccountingContext.addBytes(estimator.estimateSize(state2));
+                    ramAccounting.addBytes(estimator.estimateSize(state2));
                 }
                 return state2;
             }
@@ -84,7 +84,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
                 return state1;
             }
             if (state1.compareTo(state2) > 0) {
-                ramAccountingContext.addBytes(estimator.estimateSizeDelta(state1, state2));
+                ramAccounting.addBytes(estimator.estimateSizeDelta(state1, state2));
                 return state2;
             }
             return state1;
@@ -102,14 +102,14 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public Comparable newState(RamAccountingContext ramAccountingContext,
+        public Comparable newState(RamAccounting ramAccounting,
                                    Version indexVersionCreated) {
-            ramAccountingContext.addBytes(size);
+            ramAccounting.addBytes(size);
             return null;
         }
 
         @Override
-        public Comparable reduce(RamAccountingContext ramAccountingContext, Comparable state1, Comparable state2) {
+        public Comparable reduce(RamAccounting ramAccounting, Comparable state1, Comparable state2) {
             if (state1 == null) {
                 return state2;
             }
@@ -138,12 +138,12 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
     }
 
     @Override
-    public Comparable terminatePartial(RamAccountingContext ramAccountingContext, Comparable state) {
+    public Comparable terminatePartial(RamAccounting ramAccounting, Comparable state) {
         return state;
     }
 
     @Override
-    public Comparable iterate(RamAccountingContext ramAccountingContext, Comparable state, Input... args) throws CircuitBreakingException {
-        return reduce(ramAccountingContext, state, (Comparable) args[0].value());
+    public Comparable iterate(RamAccounting ramAccounting, Comparable state, Input... args) throws CircuitBreakingException {
+        return reduce(ramAccounting, state, (Comparable) args[0].value());
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.exceptions.CircuitBreakingException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -69,13 +69,13 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
 
     @Nullable
     @Override
-    public TDigestState newState(RamAccountingContext ramAccountingContext,
+    public TDigestState newState(RamAccounting ramAccounting,
                                  Version indexVersionCreated) {
         return TDigestState.createEmptyState();
     }
 
     @Override
-    public TDigestState iterate(RamAccountingContext ramAccountingContext, TDigestState state, Input... args) throws CircuitBreakingException {
+    public TDigestState iterate(RamAccounting ramAccounting, TDigestState state, Input... args) throws CircuitBreakingException {
         if (state.isEmpty()) {
             Object fractionValue = args[1].value();
             initState(state, fractionValue);
@@ -110,7 +110,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     }
 
     @Override
-    public TDigestState reduce(RamAccountingContext ramAccountingContext, TDigestState state1, TDigestState state2) {
+    public TDigestState reduce(RamAccounting ramAccounting, TDigestState state1, TDigestState state2) {
         if (state1.isEmpty()) {
             return state2;
         }
@@ -123,7 +123,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
 
     @Override
     @Nullable
-    public Object terminatePartial(RamAccountingContext ramAccountingContext, TDigestState state) {
+    public Object terminatePartial(RamAccounting ramAccounting, TDigestState state) {
         if (state.isEmpty()) {
             return null;
         }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.statistics.StandardDeviation;
@@ -119,14 +119,14 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
     @Nullable
     @Override
-    public StandardDeviation newState(RamAccountingContext ramAccountingContext,
+    public StandardDeviation newState(RamAccounting ramAccounting,
                                       Version indexVersionCreated) {
-        ramAccountingContext.addBytes(StdDevStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
         return new StandardDeviation();
     }
 
     @Override
-    public StandardDeviation iterate(RamAccountingContext ramAccountingContext, StandardDeviation state, Input... args) throws CircuitBreakingException {
+    public StandardDeviation iterate(RamAccounting ramAccounting, StandardDeviation state, Input... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -137,7 +137,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     }
 
     @Override
-    public StandardDeviation reduce(RamAccountingContext ramAccountingContext, StandardDeviation state1, StandardDeviation state2) {
+    public StandardDeviation reduce(RamAccounting ramAccounting, StandardDeviation state1, StandardDeviation state2) {
         if (state1 == null) {
             return state2;
         }
@@ -154,7 +154,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     }
 
     @Override
-    public StandardDeviation removeFromAggregatedState(RamAccountingContext ramAccountingContext,
+    public StandardDeviation removeFromAggregatedState(RamAccounting ramAccounting,
                                                        StandardDeviation previousAggState,
                                                        Input[] stateToRemove) {
         if (previousAggState != null) {
@@ -167,7 +167,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     }
 
     @Override
-    public Double terminatePartial(RamAccountingContext ramAccountingContext, StandardDeviation state) {
+    public Double terminatePartial(RamAccounting ramAccounting, StandardDeviation state) {
         double result = state.result();
         return Double.isNaN(result) ? null : result;
     }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.metadata.FunctionIdent;
@@ -85,18 +85,18 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
     @Nullable
     @Override
-    public T newState(RamAccountingContext ramAccountingContext, Version indexVersionCreated) {
-        ramAccountingContext.addBytes(bytesSize);
+    public T newState(RamAccounting ramAccounting, Version indexVersionCreated) {
+        ramAccounting.addBytes(bytesSize);
         return null;
     }
 
     @Override
-    public T iterate(RamAccountingContext ramAccountingContext, T state, Input[] args) throws CircuitBreakingException {
-        return reduce(ramAccountingContext, state, returnType.value(args[0].value()));
+    public T iterate(RamAccounting ramAccounting, T state, Input[] args) throws CircuitBreakingException {
+        return reduce(ramAccounting, state, returnType.value(args[0].value()));
     }
 
     @Override
-    public T reduce(RamAccountingContext ramAccountingContext, T state1, T state2) {
+    public T reduce(RamAccounting ramAccounting, T state1, T state2) {
         if (state1 == null) {
             return state2;
         }
@@ -107,7 +107,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     }
 
     @Override
-    public T terminatePartial(RamAccountingContext ramAccountingContext, T state) {
+    public T terminatePartial(RamAccounting ramAccounting, T state) {
         return state;
     }
 
@@ -127,7 +127,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     }
 
     @Override
-    public T removeFromAggregatedState(RamAccountingContext ramAccountingContext, T previousAggState, Input[] stateToRemove) {
+    public T removeFromAggregatedState(RamAccounting ramAccounting, T previousAggState, Input[] stateToRemove) {
         return subtraction.apply(previousAggState, returnType.value(stateToRemove[0].value()));
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.statistics.Variance;
@@ -121,14 +121,14 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
     @Nullable
     @Override
-    public Variance newState(RamAccountingContext ramAccountingContext,
+    public Variance newState(RamAccounting ramAccounting,
                              Version indexVersionCreated) {
-        ramAccountingContext.addBytes(VarianceStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
         return new Variance();
     }
 
     @Override
-    public Variance iterate(RamAccountingContext ramAccountingContext, Variance state, Input... args) throws CircuitBreakingException {
+    public Variance iterate(RamAccounting ramAccounting, Variance state, Input... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -139,7 +139,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     @Override
-    public Variance reduce(RamAccountingContext ramAccountingContext, Variance state1, Variance state2) {
+    public Variance reduce(RamAccounting ramAccounting, Variance state1, Variance state2) {
         if (state1 == null) {
             return state2;
         }
@@ -156,7 +156,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     @Override
-    public Variance removeFromAggregatedState(RamAccountingContext ramAccountingContext,
+    public Variance removeFromAggregatedState(RamAccounting ramAccounting,
                                               Variance previousAggState,
                                               Input[] stateToRemove) {
         if (previousAggState != null) {
@@ -169,7 +169,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     @Override
-    public Double terminatePartial(RamAccountingContext ramAccountingContext, Variance state) {
+    public Double terminatePartial(RamAccounting ramAccounting, Variance state) {
         double result = state.result();
         return Double.isNaN(result) ? null : result;
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.collect;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
@@ -154,7 +155,7 @@ public class CollectTask extends AbstractTask {
         return txnCtx;
     }
 
-    public RamAccountingContext queryPhaseRamAccountingContext() {
+    public RamAccounting getRamAccounting() {
         return queryPhaseRamAccountingContext;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.collect;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.StringSizeEstimator;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -161,7 +161,7 @@ final class GroupByOptimizedIterator {
             List<AggregationContext> aggregations = ctxForAggregations.aggregations();
             List<? extends LuceneCollectorExpression<?>> expressions = docCtx.expressions();
 
-            RamAccountingContext ramAccounting = collectTask.queryPhaseRamAccountingContext();
+            RamAccounting ramAccounting = collectTask.getRamAccounting();
 
             CollectorContext collectorContext = getCollectorContext(
                 sharedShardContext.readerId(), queryShardContext::getForField);
@@ -202,7 +202,7 @@ final class GroupByOptimizedIterator {
                                           List<AggregationContext> aggregations,
                                           List<? extends LuceneCollectorExpression<?>> expressions,
                                           List<CollectExpression<Row, ?>> aggExpressions,
-                                          RamAccountingContext ramAccounting,
+                                          RamAccounting ramAccounting,
                                           InputRow inputRow,
                                           Query query,
                                           CollectorContext collectorContext,
@@ -249,7 +249,7 @@ final class GroupByOptimizedIterator {
     }
 
     private static Iterable<Row> getRows(Map<BytesRef, Object[]> groupedStates,
-                                         RamAccountingContext ramAccounting,
+                                         RamAccounting ramAccounting,
                                          List<AggregationContext> aggregations,
                                          AggregateMode mode) {
         return () -> groupedStates.entrySet().stream()
@@ -279,7 +279,7 @@ final class GroupByOptimizedIterator {
                                                                        List<AggregationContext> aggregations,
                                                                        List<? extends LuceneCollectorExpression<?>> expressions,
                                                                        List<CollectExpression<Row, ?>> aggExpressions,
-                                                                       RamAccountingContext ramAccounting,
+                                                                       RamAccounting ramAccounting,
                                                                        InputRow inputRow,
                                                                        Query query,
                                                                        AtomicReference<Throwable> killed,
@@ -388,7 +388,7 @@ final class GroupByOptimizedIterator {
     }
 
     private static void aggregateValues(List<AggregationContext> aggregations,
-                                        RamAccountingContext ramAccounting,
+                                        RamAccounting ramAccounting,
                                         Object[] states) {
         for (int i = 0; i < aggregations.size(); i++) {
             AggregationContext aggregation = aggregations.get(i);
@@ -404,7 +404,7 @@ final class GroupByOptimizedIterator {
         }
     }
 
-    private static Object[] initStates(List<AggregationContext> aggregations, RamAccountingContext ramAccounting) {
+    private static Object[] initStates(List<AggregationContext> aggregations, RamAccounting ramAccounting) {
         Object[] states = new Object[aggregations.size()];
         for (int i = 0; i < aggregations.size(); i++) {
             AggregationContext aggregation = aggregations.get(i);

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -199,7 +199,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             queryContext.minScore(),
             Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
             batchSize,
-            collectTask.queryPhaseRamAccountingContext(),
+            collectTask.getRamAccounting(),
             collectorContext,
             optimizeQueryForSearchAfter,
             LuceneSortGenerator.generateLuceneSort(collectTask.txnCtx(), collectorContext, collectPhase.orderBy(), docInputFactory, fieldTypeLookup),

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -145,7 +145,7 @@ public class RemoteCollectorFactory {
                 transportActionProvider.transportKillJobsNodeAction(),
                 searchTp,
                 tasksService,
-                collectTask.queryPhaseRamAccountingContext(),
+                collectTask.getRamAccounting(),
                 consumer,
                 createRemoteCollectPhase(childJobId, collectPhase, activePrimaryRouting.shardId(), nodeId)
             );

--- a/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -118,7 +118,7 @@ public abstract class ShardCollectorProvider {
             Projections.shardProjections(collectPhase.projections()),
             collectPhase.jobId(),
             collectTask.txnCtx(),
-            collectTask.queryPhaseRamAccountingContext(),
+            collectTask.getRamAccounting(),
             projectorFactory,
             iterator
         );

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -23,7 +23,7 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.phases.NodeOperation;
@@ -64,7 +64,7 @@ public class RemoteCollector {
     private final TransportJobAction transportJobAction;
     private final TransportKillJobsNodeAction transportKillJobsNodeAction;
     private final TasksService tasksService;
-    private final RamAccountingContext ramAccountingContext;
+    private final RamAccounting ramAccounting;
     private final RowConsumer consumer;
     private final RoutedCollectPhase collectPhase;
 
@@ -82,7 +82,7 @@ public class RemoteCollector {
                            TransportKillJobsNodeAction transportKillJobsNodeAction,
                            Executor executor,
                            TasksService tasksService,
-                           RamAccountingContext ramAccountingContext,
+                           RamAccounting ramAccounting,
                            RowConsumer consumer,
                            RoutedCollectPhase collectPhase) {
         this.jobId = jobId;
@@ -101,7 +101,7 @@ public class RemoteCollector {
         this.transportJobAction = transportJobAction;
         this.transportKillJobsNodeAction = transportKillJobsNodeAction;
         this.tasksService = tasksService;
-        this.ramAccountingContext = ramAccountingContext;
+        this.ramAccounting = ramAccounting;
         this.consumer = consumer;
         this.collectPhase = collectPhase;
     }
@@ -194,7 +194,7 @@ public class RemoteCollector {
             RECEIVER_PHASE_ID,
             "RemoteCollectPhase",
             pageBucketReceiver,
-            ramAccountingContext,
+            ramAccounting,
             1
         ));
         return builder;

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ProjectorSetupCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ProjectorSetupCollectSource.java
@@ -48,7 +48,7 @@ public class ProjectorSetupCollectSource implements CollectSource {
             collectPhase.projections(),
             collectPhase.jobId(),
             collectTask.txnCtx(),
-            collectTask.queryPhaseRamAccountingContext(),
+            collectTask.getRamAccounting(),
             projectorFactory,
             sourceDelegate.getIterator(txnCtx, collectPhase, collectTask, supportMoveToStart)
         );

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -271,7 +271,7 @@ public class ShardCollectSource implements CollectSource {
             collectPhase.projections(),
             collectPhase.jobId(),
             collectTask.txnCtx(),
-            collectTask.queryPhaseRamAccountingContext(),
+            collectTask.getRamAccounting(),
             sharedProjectorFactory
         );
         boolean requireMoveToStartSupport = supportMoveToStart && !projectors.providesIndependentScroll();
@@ -376,7 +376,7 @@ public class ShardCollectSource implements CollectSource {
                 orderBy.reverseFlags(),
                 orderBy.nullsFirst()
             ),
-            new RowAccountingWithEstimators(columnTypes, collectTask.queryPhaseRamAccountingContext()),
+            new RowAccountingWithEstimators(columnTypes, collectTask.getRamAccounting()),
             executor,
             availableThreads,
             supportMoveToStart

--- a/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchResponse.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchResponse.java
@@ -26,7 +26,7 @@ import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import io.crate.Streamer;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Bucket;
 import io.crate.execution.engine.distribution.StreamBucket;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,7 +50,7 @@ public class NodeFetchResponse extends TransportResponse {
         return fetched;
     }
 
-    public NodeFetchResponse(StreamInput in, IntObjectMap<Streamer[]> streamers, RamAccountingContext ramAccounting) throws IOException {
+    public NodeFetchResponse(StreamInput in, IntObjectMap<Streamer[]> streamers, RamAccounting ramAccounting) throws IOException {
         ramAccounting.addBytes(in.available());
         int numReaders = in.readVInt();
         if (numReaders > 0) {

--- a/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
@@ -25,7 +25,7 @@ package io.crate.execution.engine.fetch;
 import com.carrotsearch.hppc.IntObjectMap;
 import io.crate.Streamer;
 import io.crate.breaker.CrateCircuitBreakerService;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.engine.distribution.StreamBucket;
 import io.crate.execution.jobs.TasksService;
@@ -87,10 +87,10 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
     public void execute(String targetNode,
                         final IntObjectMap<Streamer[]> streamers,
                         final NodeFetchRequest request,
-                        RamAccountingContext ramAccountingContext,
+                        RamAccounting ramAccounting,
                         ActionListener<NodeFetchResponse> listener) {
         transports.sendRequest(TRANSPORT_ACTION, targetNode, request, listener,
-            new ActionListenerResponseHandler<>(listener, in -> new NodeFetchResponse(in, streamers, ramAccountingContext)));
+            new ActionListenerResponseHandler<>(listener, in -> new NodeFetchResponse(in, streamers, ramAccounting)));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
@@ -26,7 +26,7 @@ import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.IntObjectMap;
 import io.crate.Streamer;
 import io.crate.action.FutureActionListener;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Bucket;
 
 import java.util.Map;
@@ -41,18 +41,18 @@ public class TransportFetchOperation implements FetchOperation {
     private final Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers;
     private final UUID jobId;
     private final int fetchPhaseId;
-    private final RamAccountingContext ramAccountingContext;
+    private final RamAccounting ramAccounting;
 
     public TransportFetchOperation(TransportFetchNodeAction transportFetchNodeAction,
                                    Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers,
                                    UUID jobId,
                                    int fetchPhaseId,
-                                   RamAccountingContext ramAccountingContext) {
+                                   RamAccounting ramAccounting) {
         this.transportFetchNodeAction = transportFetchNodeAction;
         this.nodeIdToReaderIdToStreamers = nodeIdToReaderIdToStreamers;
         this.jobId = jobId;
         this.fetchPhaseId = fetchPhaseId;
-        this.ramAccountingContext = ramAccountingContext;
+        this.ramAccounting = ramAccounting;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class TransportFetchOperation implements FetchOperation {
             nodeId,
             nodeIdToReaderIdToStreamers.get(nodeId),
             new NodeFetchRequest(jobId, fetchPhaseId, closeContext, toFetch),
-            ramAccountingContext,
+            ramAccounting,
             listener);
         return listener;
     }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
@@ -22,11 +22,11 @@
 
 package io.crate.execution.engine.pipeline;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.Projector;
 import io.crate.execution.dsl.projection.Projection;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 
 import java.util.UUID;
 
@@ -34,7 +34,7 @@ public interface ProjectorFactory {
 
     Projector create(Projection projection,
                      TransactionContext txnCtx,
-                     RamAccountingContext ramAccountingContext,
+                     RamAccounting ramAccounting,
                      UUID jobId);
 
     RowGranularity supportedGranularity();

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/Projectors.java
@@ -23,7 +23,7 @@
 package io.crate.execution.engine.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Projector;
 import io.crate.data.Row;
@@ -47,7 +47,7 @@ public final class Projectors {
     public Projectors(Collection<? extends Projection> projections,
                       UUID jobId,
                       TransactionContext txnCtx,
-                      RamAccountingContext ramAccountingContext,
+                      RamAccounting ramAccounting,
                       ProjectorFactory projectorFactory) {
         boolean independentScroll = false;
         this.projectors = new ArrayList<>(projections.size());
@@ -55,7 +55,7 @@ public final class Projectors {
             if (projection.requiredGranularity().ordinal() > projectorFactory.supportedGranularity().ordinal()) {
                 continue;
             }
-            Projector projector = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId);
+            Projector projector = projectorFactory.create(projection, txnCtx, ramAccounting, jobId);
             projectors.add(projector);
             independentScroll = independentScroll || projector.providesIndependentScroll();
         }
@@ -69,7 +69,7 @@ public final class Projectors {
     public static BatchIterator<Row> wrap(Collection<? extends Projection> projections,
                                           UUID jobId,
                                           TransactionContext txnCtx,
-                                          RamAccountingContext ramAccountingContext,
+                                          RamAccounting ramAccounting,
                                           ProjectorFactory projectorFactory,
                                           BatchIterator<Row> source) {
         BatchIterator<Row> result = source;
@@ -77,7 +77,7 @@ public final class Projectors {
             if (projection.requiredGranularity().ordinal() > projectorFactory.supportedGranularity().ordinal()) {
                 continue;
             }
-            result = projectorFactory.create(projection, txnCtx, ramAccountingContext, jobId).apply(result);
+            result = projectorFactory.create(projection, txnCtx, ramAccounting, jobId).apply(result);
         }
         return result;
     }

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.window;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.Input;
 import io.crate.data.Projector;
@@ -65,7 +65,7 @@ public class WindowProjector {
                                            Functions functions,
                                            InputFactory inputFactory,
                                            TransactionContext txnCtx,
-                                           RamAccountingContext ramAccountingContext,
+                                           RamAccounting ramAccounting,
                                            Version indexVersionCreated,
                                            IntSupplier numThreads,
                                            Executor executor) {
@@ -100,7 +100,7 @@ public class WindowProjector {
                         (AggregationFunction) impl,
                         filter,
                         indexVersionCreated,
-                        ramAccountingContext)
+                        ramAccounting)
                 );
             } else if (impl instanceof WindowFunction) {
                 windowFunctions.add((WindowFunction) impl);
@@ -116,7 +116,7 @@ public class WindowProjector {
             () -> inputFactory.ctxForInputColumns(txnCtx);
         int arrayListElementOverHead = 32;
         RowAccountingWithEstimators accounting = new RowAccountingWithEstimators(
-            Symbols.typeView(projection.standalone()), ramAccountingContext, arrayListElementOverHead);
+            Symbols.typeView(projection.standalone()), ramAccounting, arrayListElementOverHead);
         Comparator<Object[]> cmpPartitionBy = partitions.isEmpty()
             ? null
             : createComparator(createInputFactoryContext, new OrderBy(windowDefinition.partitions()));

--- a/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.jobs;
 
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,23 +38,23 @@ public class DistResultRXTask implements Task, DownstreamRXTask {
     private final int numBuckets;
     private final PageBucketReceiver pageBucketReceiver;
     private final CompletableFuture<Void> completionFuture;
-    private final RamAccountingContext ramAccounting;
+    private final RamAccounting ramAccounting;
 
     private long totalBytesUsed = -1;
 
     public DistResultRXTask(int id,
                             String name,
                             PageBucketReceiver pageBucketReceiver,
-                            RamAccountingContext ramAccountingContext,
+                            RamAccounting ramAccounting,
                             int numBuckets) {
         this.id = id;
         this.name = name;
         this.numBuckets = numBuckets;
         this.pageBucketReceiver = pageBucketReceiver;
-        this.ramAccounting = ramAccountingContext;
+        this.ramAccounting = ramAccounting;
         this.completionFuture = pageBucketReceiver.completionFuture().handle((result, ex) -> {
-            totalBytesUsed = ramAccountingContext.totalBytes();
-            ramAccountingContext.close();
+            totalBytesUsed = ramAccounting.totalBytes();
+            ramAccounting.close();
             if (ex instanceof IllegalStateException) {
                 kill(ex);
             }

--- a/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -23,7 +23,7 @@
 package io.crate.expression.symbol;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,7 +40,7 @@ public enum AggregateMode {
         }
 
         @Override
-        public <TP, TF> TF finishCollect(RamAccountingContext ramAccounting, AggregationFunction<TP, TF> function, TP state) {
+        public <TP, TF> TF finishCollect(RamAccounting ramAccounting, AggregationFunction<TP, TF> function, TP state) {
             return (TF) state;
         }
     },
@@ -53,7 +53,7 @@ public enum AggregateMode {
         return function.info().returnType();
     }
 
-    public <TP, TF> TF finishCollect(RamAccountingContext ramAccounting, AggregationFunction<TP, TF> function, TP state) {
+    public <TP, TF> TF finishCollect(RamAccounting ramAccounting, AggregationFunction<TP, TF> function, TP state) {
         return function.terminatePartial(ramAccounting, state);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will allow us to use different implementations.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)