### PR TITLE
Replace RamAccounting roundUp with alignObjectSize

### DIFF
--- a/sql/src/main/java/io/crate/breaker/JobContextLogSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/JobContextLogSizeEstimator.java
@@ -23,6 +23,7 @@
 package io.crate.breaker;
 
 import io.crate.expression.reference.sys.job.JobContextLog;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +40,6 @@ public class JobContextLogSizeEstimator extends SizeEstimator<JobContextLog> {
         size += 52L; // 24 bytes (ref+headers) + 4 bytes (id) + 8 bytes (started) + 16 bytes (uuid)
         size += value.statement().length();
 
-        return RamAccountingContext.roundUp(size);
+        return RamUsageEstimator.alignObjectSize(size);
     }
 }

--- a/sql/src/main/java/io/crate/breaker/OperationContextLogSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/OperationContextLogSizeEstimator.java
@@ -23,6 +23,7 @@
 package io.crate.breaker;
 
 import io.crate.expression.reference.sys.operation.OperationContextLog;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +40,6 @@ public class OperationContextLogSizeEstimator extends SizeEstimator<OperationCon
         size += 60L; // 24 bytes (headers) + 4 bytes (id) + 16 bytes (uuid) + 8 bytes (started) + 8 bytes (usedBytes)
         size += value.name().length();
 
-        return RamAccountingContext.roundUp(size);
+        return RamUsageEstimator.alignObjectSize(size);
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
@@ -23,7 +23,6 @@
 package io.crate.execution.engine.aggregation;
 
 import io.crate.breaker.RamAccounting;
-import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.SizeEstimator;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -36,6 +35,7 @@ import io.netty.util.collection.ByteObjectHashMap;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.LongObjectHashMap;
 import io.netty.util.collection.ShortObjectHashMap;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -57,7 +57,7 @@ public final class GroupByMaps {
                                                                      @Nullable DataType<K> type) {
         Integer entryOverHead = type == null ? null : ENTRY_OVERHEAD_PER_TYPE.get(type);
         if (entryOverHead == null) {
-            return (map, k) -> ramAccounting.addBytes(RamAccountingContext.roundUp(sizeEstimator.estimateSize(k) + 36));
+            return (map, k) -> ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(sizeEstimator.estimateSize(k) + 36));
         } else {
             return (map, k) -> {
                 int mapSize = map.size();


### PR DESCRIPTION
The idea behind the `roundUp` was to account for object alignment
overhead. We can use `RamUsageEstimator.alignObjectSize` to do that.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)