### PR TITLE
Change HyperLogLogPlusPlus to use a ByteBuf instead of raw byte array

### DIFF
--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -35,6 +35,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.DataTypes;
+import io.netty.buffer.Unpooled;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -71,7 +72,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
 
     @Setup
     public void setUp() throws Exception {
-        hyperLogLogPlusPlus = new HyperLogLogPlusPlus(HyperLogLogPlusPlus.DEFAULT_PRECISION);
+        hyperLogLogPlusPlus = new HyperLogLogPlusPlus(HyperLogLogPlusPlus.DEFAULT_PRECISION, capacity -> Unpooled.wrappedBuffer(new byte[capacity]));
         InputCollectExpression inExpr0 = new InputCollectExpression(0);
         Functions functions = new ModulesBuilder()
             .add(new EnterpriseFunctionsModule())

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -38,7 +38,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlusPlus;
+import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;

--- a/enterprise/functions/src/main/java/io/crate/execution/engine/aggregation/impl/HyperLogLogPlusPlus.java
+++ b/enterprise/functions/src/main/java/io/crate/execution/engine/aggregation/impl/HyperLogLogPlusPlus.java
@@ -1,23 +1,24 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ *
+ * This is based on the ASL 2.0 licensed HyperLogLogPlus implementation found in Elasticsearch.
  */
 
-package org.elasticsearch.search.aggregations.metrics.cardinality;
+package io.crate.execution.engine.aggregation.impl;
 
 import org.apache.lucene.util.packed.PackedInts;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -134,7 +135,8 @@ public final class HyperLogLogPlusPlus {
 
     private boolean algorithm = LINEAR_COUNTING;
     private final Hashset hashSet;
-    private final int p, m;
+    private final int p;
+    private final int m;
     private final double alphaMM;
     private final byte[] runLens;
 
@@ -151,15 +153,15 @@ public final class HyperLogLogPlusPlus {
         hashSet = new Hashset();
         final double alpha;
         switch (p) {
-        case 4:
-            alpha = 0.673;
-            break;
-        case 5:
-            alpha = 0.697;
-            break;
-        default:
-            alpha = 0.7213 / (1 + 1.079 / m);
-            break;
+            case 4:
+                alpha = 0.673;
+                break;
+            case 5:
+                alpha = 0.697;
+                break;
+            default:
+                alpha = 0.7213 / (1 + 1.079 / m);
+                break;
         }
         alphaMM = alpha * m * m;
     }

--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -45,7 +45,7 @@ import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlusPlus;
+import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -24,6 +24,7 @@ import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.module.EnterpriseFunctionsModule;
@@ -39,13 +40,13 @@ import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
+import io.netty.buffer.Unpooled;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -159,7 +160,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         void init(int precision) {
             assert hyperLogLogPlusPlus == null : "hyperLogLog algorithm was already initialized";
             try {
-                hyperLogLogPlusPlus = new HyperLogLogPlusPlus(precision);
+                hyperLogLogPlusPlus = new HyperLogLogPlusPlus(precision, capacity -> Unpooled.wrappedBuffer(new byte[capacity]));
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("precision must be >= 4 and <= 18");
             }

--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -30,7 +30,7 @@ import io.crate.types.IntegerType;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlusPlus;
+import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Will allow us to switch over to using a off-heap ByteBuf.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)