### PR TITLE
Do not implicit add ordering on unsupported data types.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -206,6 +206,12 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in ``2.3.2`` which optimizes subqueries when
+  used inside multi-value producing functions and operators like ``IN()``,
+  ``ANY()`` or ``ARRAY()`` by applying an implicit ordering. When using data
+  types (e.g. like an object: ``select array(select {a = col} from test)`` which
+  do not support ordering, an NPE was raised.
+
 - Fixed a possible OutOfMemory issue which may happen on ``GROUP BY`` statement
   using a group key of type ``TEXT`` on tables containing at least one shard
   with a low to medium cardinality on the group key.

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -281,6 +281,16 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_optimize_for_in_subquery_only_operates_on_primitive_types() {
+        LogicalPlan plan = plan("select array(select {a = x} from t1)");
+        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
+        assertThat(subPlan, isPlan("RootBoundary[_map('a', x)]\n" +
+                                   "FetchOrEval[_map('a', x)]\n" +
+                                   "Collect[doc.t1 | [_fetchid] | All]\n"));
+    }
+
+    @Test
     public void testParentQueryIsPushedDownAndMergedIntoSubRelationWhereClause() {
         LogicalPlan plan = plan("select * from " +
                                 " (select a, i from t1 order by a limit 5) t1 " +


### PR DESCRIPTION
The plan optimization for subqueries introduced in e6c7b08954a23bc8d2910fdb61196882d46ef74e did not honor unsupported ordering on non-primitive data types.

Fixes #9406.
