### PR TITLE
Fix ClassCastException of unnest if used with multi dimensional arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,3 @@ Fixes
 
 - Improved performance of snapshot finalization as https://github.com/crate/crate/pull/9327
   introduced a performance regression on the snapshot process.
-
-- Fixed a ``ClassCastException`` that could occur when using ``unnest`` on
-  multi dimensional arrays.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,3 +59,6 @@ Fixes
 
 - Improved performance of snapshot finalization as https://github.com/crate/crate/pull/9327
   introduced a performance regression on the snapshot process.
+
+- Fixed a ``ClassCastException`` that could occur when using ``unnest`` on
+  multi dimensional arrays.

--- a/sql/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
@@ -57,28 +57,4 @@ public class UnnestFunctionTest extends AbstractTableFunctionsTest {
             "NULL| 1\n" +
             "NULL| NULL\n");
     }
-
-    @Test
-    public void test_unnest_flattens_multi_dimensional_arrays() {
-        assertExecute(
-            "unnest([[1, 2], [3, 4, 5]])",
-            "1\n" +
-            "2\n" +
-            "3\n" +
-            "4\n" +
-            "5\n"
-        );
-    }
-
-    @Test
-    public void test_unnest_1st_col_multi_dim_array_and_2nd_col_array() {
-        assertExecute(
-            "unnest([[1, 2], [3, 4, 5]], ['a', 'b'])",
-            "1| a\n" +
-            "2| b\n" +
-            "3| NULL\n" +
-            "4| NULL\n" +
-            "5| NULL\n"
-        );
-    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -22,6 +22,8 @@
 
 package io.crate.integrationtests;
 
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
@@ -142,5 +144,16 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
         execute("select * from substr('foo',1,2), array_cat([1], [2, 3])");
         assertThat(printedTable(response.rows()),
             is("fo| [1, 2, 3]\n"));
+    }
+
+    @Test
+    public void test_unnest_used_in_select_list_with_multi_dimensional_array_has_correct_return_type() {
+        execute("select unnest([[1, 2, 3], [1, 2]]) as x");
+        assertThat(response.columnTypes()[0], is(new ArrayType(DataTypes.LONG)));
+        assertThat(
+            printedTable(response.rows()),
+            is("[1, 2, 3]\n" +
+               "[1, 2]\n")
+        );
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -99,11 +99,8 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testUnnestUsedInSelectList() {
-        execute("select unnest(col1) * 2, col2 from (select [1, 2, 3, 4], 'foo') tbl (col1, col2) order by 1 desc limit 2");
-        assertThat(
-            printedTable(response.rows()),
-            is("8| foo\n6| foo\n")
-        );
+        execute("select unnest(col1) * 2, col2 from unnest([[1, 2, 3, 4]], ['foo']) order by 1 desc limit 2");
+        assertThat(printedTable(response.rows()), is("8| foo\n6| foo\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts the initial fix which also changed the behavior to fully
unnest multi dimensional arrays.

That can break `insert into ... from unnest` use cases and shouldn't be
done as part of a hotfix.

It instead fixes the return type to avoid a `ClassCastException` later
on.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)