### PR TITLE
Don’t build mapping/setting requests on empty parted tables.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,9 @@ None
 Fixes
 =====
 
+- Fixed an issue which may result in an ``ArrayIndexOutOfBoundsException`` while
+  altering an empty partitioned table.
+
 - Fixed a regression introduced in ``2.3.2`` which optimizes subqueries when
   used inside multi-value producing functions and operators like ``IN()``,
   ``ANY()`` or ``ARRAY()`` by applying an implicit ordering. When using data

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -225,9 +225,12 @@ public class AlterTableOperation {
                         analysis.tableParameter().settings(),
                         supportedSettings);
 
+                    // update possible existing partitions
                     String[] indices = Stream.of(table.concreteIndices()).toArray(String[]::new);
-                    results.add(updateMapping(analysis.tableParameter().mappings(), indices));
-                    results.add(updateSettings(parameterWithFilteredSettings, indices));
+                    if (indices.length > 0) {
+                        results.add(updateMapping(analysis.tableParameter().mappings(), indices));
+                        results.add(updateSettings(parameterWithFilteredSettings, indices));
+                    }
                 }
             }
         } else {
@@ -341,7 +344,7 @@ public class AlterTableOperation {
                                                " Use 'ALTER table ... set (\"blocks.write\"=true)' and retry");
         }
     }
-    
+
     private CompletableFuture<Long> resizeIndex(IndexMetaData sourceIndex,
                                                 @Nullable String sourceIndexAlias,
                                                 String targetIndexName,

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -517,6 +517,21 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into dynamic_table (id, score, new_col) values (2, 4656234.345, 'hello')");
     }
 
+    /**
+     * Ensures that altering an empty partitioned table will succeed.
+     * (We had a bug resulting in an OutOfBoundException as mapping request builder logic
+     * was called with an empty indices list)
+     */
+    @Test
+    public void testAlterEmptyPartitionedTable() {
+        execute("create table t1 (" +
+                "  id integer, " +
+                "  p int" +
+                ") partitioned by (p) with (number_of_replicas=0, column_policy='strict')");
+        // must not throw an exception
+        execute("alter table t1 set (column_policy = 'dynamic')");
+    }
+
     @Test
     public void testResetColumnPolicy() throws Exception {
         execute("create table dynamic_table (" +


### PR DESCRIPTION
Altering an empty partitioned table must only result in updating the template as no indices exists yet.
Fix the ``ArrayIndexOutOfBoundsException`` which is raised otherwise while accessing the empty indices array.
