### PR TITLE
Returning clause for Update statement

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,9 @@ None
 Changes
 =======
 
+- Introduced new optional ``RETURNING`` clause for :ref:`Update <ref-update>` to
+  return specified values from each row updated.
+
 - Added the :ref:`obj_description(integer, text) <obj_description>` scalar
   function for improved PostgreSQL compatibility.
 

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -20,7 +20,7 @@ Synopsis
     UPDATE table_ident [ [AS] table_alias ] SET
         { column_ident = expression } [, ...]
       [ WHERE condition ]
-      [ RETURNING * | output_expression [ [ AS ] output_name ] [, ...] ]
+      [ RETURNING { * | output_expression [ [ AS ] output_name ] | relation.* } [, ...] ]
 
 Description
 ===========
@@ -30,10 +30,9 @@ condition. Only the columns to be modified need be mentioned in the SET clause;
 columns not explicitly modified retain their previous values.
 
 The optional RETURNING clause causes UPDATE to compute and return value(s) based
-on each row actually updated. Any expression using the table's columns, and/or
-columns of other tables mentioned in FROM, can be computed. The new (post-update)
-values of the table's columns are used. The syntax of the RETURNING list is
-identical to that of the output list of SELECT.
+on each row actually updated. Any expression using the table's columns can be
+computed. The new (post-update) values of the table's columns are used. The
+syntax of the RETURNING list is identical to that of the output list of SELECT.
 
 Parameters
 ==========
@@ -60,3 +59,13 @@ Parameters
 :condition:
   An expression that returns a value of type boolean. Only rows for
   which this expression returns true will be updated.
+
+:output_expression:
+
+	An expression to be computed and returned by the UPDATE command after each
+	row is updated. The expression can use any column names of the table or * to
+	return all columns.
+
+:output_name:
+
+	A name to use for the result of an output expression.

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -25,47 +25,45 @@ Synopsis
 Description
 ===========
 
-UPDATE changes the values of the specified columns in all rows that satisfy the
-condition. Only the columns to be modified need be mentioned in the SET clause;
-columns not explicitly modified retain their previous values.
+UPDATE changes the values of the specified columns in all rows that satisfy
+the condition. Only the columns to be modified need be mentioned in the SET
+clause; columns not explicitly modified retain their previous values.
 
-The optional RETURNING clause causes UPDATE to compute and return value(s) based
-on each row actually updated. Any expression using the table's columns can be
-computed. The new (post-update) values of the table's columns are used. The
-syntax of the RETURNING list is identical to that of the output list of SELECT.
+The optional RETURNING clause for UPDATE causes the query to return the
+specified values from each row that was updated. Any expression using the
+table's columns can be computed. The new (post-update) values of the table's
+columns are used. The syntax of the RETURNING list is identical to that of
+the output list of SELECT.
 
 Parameters
 ==========
 
 :table_ident:
-  The identifier (optionally schema-qualified) of an existing table.
+    The identifier (optionally schema-qualified) of an existing table.
 
 :table_alias:
-  A substitute name for the target table.
+    A substitute name for the target table.
 
-  When an alias is provided, it completely hides the actual name of the
-  table. For example, given ``UPDATE foo AS f``, the remainder of the
-  ``UPDATE`` statement must refer to this table as ``f`` not ``foo``.
+    When an alias is provided, it completely hides the actual name of the
+    table. For example, given ``UPDATE foo AS f``, the remainder of the
+    ``UPDATE`` statement must refer to this table as ``f`` not ``foo``.
 
 :column_ident:
-
-  The name of a column in the table identified by *table_ident*. Subfields
-  can also be defined by using the subscript notation with square
-  brackets.
+    The name of a column in the table identified by *table_ident*. Subfields
+    can also be defined by using the subscript notation with square
+    brackets.
 
 :expression:
-  An expression to assign to the column.
+    An expression to assign to the column.
 
 :condition:
-  An expression that returns a value of type boolean. Only rows for
-  which this expression returns true will be updated.
+    An expression that returns a value of type boolean. Only rows for
+    which this expression returns true will be updated.
 
 :output_expression:
-
-	An expression to be computed and returned by the UPDATE command after each
-	row is updated. The expression can use any column names of the table or * to
-	return all columns.
+    An expression to be computed and returned by the UPDATE command after each
+    row is updated. The expression can use any column names of the table or
+    ``*`` to return all columns.
 
 :output_name:
-
-	A name to use for the result of an output expression.
+    A name to use for the result of the output expression.

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -20,6 +20,7 @@ Synopsis
     UPDATE table_ident [ [AS] table_alias ] SET
         { column_ident = expression } [, ...]
       [ WHERE condition ]
+      [ RETURNING * | output_expression [ [ AS ] output_name ] [, ...] ]
 
 Description
 ===========
@@ -27,6 +28,12 @@ Description
 UPDATE changes the values of the specified columns in all rows that satisfy the
 condition. Only the columns to be modified need be mentioned in the SET clause;
 columns not explicitly modified retain their previous values.
+
+The optional RETURNING clause causes UPDATE to compute and return value(s) based
+on each row actually updated. Any expression using the table's columns, and/or
+columns of other tables mentioned in FROM, can be computed. The new (post-update)
+values of the table's columns are used. The syntax of the RETURNING list is
+identical to that of the output list of SELECT.
 
 Parameters
 ==========

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -37,7 +37,10 @@ statement
     | EXPLAIN (ANALYZE)? statement                                                   #explain
     | OPTIMIZE TABLE tableWithPartitions withProperties?                             #optimize
     | REFRESH TABLE tableWithPartitions                                              #refreshTable
-    | UPDATE aliasedRelation SET assignment (',' assignment)* where?                 #update
+    | UPDATE aliasedRelation
+        SET assignment (',' assignment)*
+        where?
+        (RETURNING selectItem (',' selectItem)*)?      													 	   #update
     | DELETE FROM aliasedRelation where?                                             #delete
     | SHOW (TRANSACTION ISOLATION LEVEL | TRANSACTION_ISOLATION)                     #showTransaction
     | SHOW CREATE TABLE table                                                        #showCreateTable
@@ -652,8 +655,8 @@ nonReserved
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | WINDOW | DEFERRABLE
     | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN | PRECISION
-    | REPLACE | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM | CURRENT_SCHEMA
-    | PROMOTE
+    | REPLACE | RETURNING | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM
+    | CURRENT_SCHEMA | PROMOTE
     ;
 
 SELECT: 'SELECT';
@@ -875,6 +878,7 @@ FILTER: 'FILTER';
 PLAIN: 'PLAIN';
 INDEX: 'INDEX';
 STORAGE: 'STORAGE';
+RETURNING: 'RETURNING';
 
 DYNAMIC: 'DYNAMIC';
 STRICT: 'STRICT';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -620,7 +620,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new Update(
             (Relation) visit(context.aliasedRelation()),
             assignments,
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class),
+            visitCollection(context.selectItem(), SelectItem.class)
+            );
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -291,9 +291,12 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
         for (Assignment assignment : node.assignments()) {
             assignment.accept(this, context);
         }
+
         if (node.whereClause().isPresent()) {
             node.whereClause().get().accept(this, context);
         }
+
+        node.returningClause().forEach(x -> x.accept(this, context));
         return null;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/SelectItem.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SelectItem.java
@@ -23,4 +23,9 @@ package io.crate.sql.tree;
 
 public abstract class SelectItem
     extends Node {
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSelectItem(this, context);
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Update.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Update.java
@@ -33,13 +33,18 @@ public class Update extends Statement {
     private final Relation relation;
     private final List<Assignment<Expression>> assignments;
     private final Optional<Expression> where;
+    private final List<SelectItem> returning;
 
-    public Update(Relation relation, List<Assignment<Expression>> assignments, Optional<Expression> where) {
+    public Update(Relation relation,
+                  List<Assignment<Expression>> assignments,
+                  Optional<Expression> where,
+                  List<SelectItem> returning) {
         Preconditions.checkNotNull(relation, "relation is null");
         Preconditions.checkNotNull(assignments, "assignments are null");
         this.relation = relation;
         this.assignments = assignments;
         this.where = where;
+        this.returning = returning;
     }
 
     public Relation relation() {
@@ -54,9 +59,13 @@ public class Update extends Statement {
         return where;
     }
 
+    public List<SelectItem> returningClause() {
+        return returning;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hashCode(relation, assignments, where);
+        return Objects.hashCode(relation, assignments, where, returning);
     }
 
     @Override
@@ -65,6 +74,7 @@ public class Update extends Statement {
             .add("relation", relation)
             .add("assignments", assignments)
             .add("where", where)
+            .add("returning", returning)
             .toString();
     }
 
@@ -77,7 +87,8 @@ public class Update extends Statement {
 
         if (!assignments.equals(update.assignments)) return false;
         if (!relation.equals(update.relation)) return false;
-        if (where != null ? !where.equals(update.where) : update.where != null) return false;
+        if (!java.util.Objects.equals(where, update.where)) return false;
+        if (!java.util.Objects.equals(returning, update.returning)) return false;
 
         return true;
     }
@@ -86,4 +97,5 @@ public class Update extends Statement {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitUpdate(this, context);
     }
+
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -313,9 +313,10 @@ public class TestStatementBuilder {
         printStatement("update foo set foo='a' where x=false returning id");
         printStatement("update foo set foo='a' returning id AS foo");
         printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
-        printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
         printStatement("update foo set foo='a' returning \"column['nested']\" AS bar");
         printStatement("update foo set foo='a' returning foo.bar - 1 AS foo");
+        printStatement("update foo set foo='a' returning *");
+        printStatement("update foo set foo='a' returning foo.*");
     }
 
     @Test

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -68,6 +68,7 @@ import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.SubqueryExpression;
 import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.SwapTable;
+import io.crate.sql.tree.Update;
 import io.crate.sql.tree.Window;
 import org.junit.Rule;
 import org.junit.Test;
@@ -304,6 +305,17 @@ public class TestStatementBuilder {
         printStatement("update foo set col['x'] = 3 where foo['x'] = 2");
         printStatement("update schemah.foo set foo.a='b', foo.b=foo.a");
         printStatement("update schemah.foo set foo.a=abs(-6.3334), x=true where x=false");
+    }
+
+    @Test
+    public void test_update_returning_clause() {
+        printStatement("update foo set foo='a' returning id");
+        printStatement("update foo set foo='a' where x=false returning id");
+        printStatement("update foo set foo='a' returning id AS foo");
+        printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
+        printStatement("update foo set foo='a' returning id + 1 AS foo, id -1 as bar");
+        printStatement("update foo set foo='a' returning \"column['nested']\" AS bar");
+        printStatement("update foo set foo='a' returning foo.bar - 1 AS foo");
     }
 
     @Test
@@ -1619,6 +1631,7 @@ public class TestStatementBuilder {
             statement instanceof DropView ||
             statement instanceof DropRepository ||
             statement instanceof DropSnapshot ||
+            statement instanceof Update ||
             statement instanceof Window) {
                 println(SqlFormatter.formatSql(statement));
                 println("");

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -29,7 +29,6 @@ import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.Analyzer;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.Relations;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.auth.user.AccessControl;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
@@ -39,6 +38,7 @@ import io.crate.data.RowN;
 import io.crate.exceptions.ReadOnlyException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RoutingProvider;
@@ -319,11 +319,7 @@ public class Session implements AutoCloseable {
             case 'P':
                 Portal portal = getSafePortal(portalOrStatement);
                 AnalyzedStatement analyzedStmt = portal.boundOrUnboundStatement();
-                if (analyzedStmt instanceof AnalyzedRelation) {
-                    return new DescribeResult(((AnalyzedRelation) analyzedStmt).fields());
-                } else {
-                    return new DescribeResult(null);
-                }
+                return new DescribeResult(analyzedStmt.fields());
             case 'S':
                 /*
                  * describe might be called without prior bind call.
@@ -371,11 +367,7 @@ public class Session implements AutoCloseable {
                 if (parameterSymbols.length > 0) {
                     preparedStmt.setDescribedParameters(parameterSymbols);
                 }
-                if (analyzedStatement instanceof AnalyzedRelation) {
-                    AnalyzedRelation relation = (AnalyzedRelation) analyzedStatement;
-                    return new DescribeResult(relation.fields(), parameterSymbols);
-                }
-                return new DescribeResult(null, parameterSymbols);
+                return new DescribeResult(analyzedStatement.fields(), parameterSymbols);
             default:
                 throw new AssertionError("Unsupported type: " + type);
         }
@@ -615,11 +607,11 @@ public class Session implements AutoCloseable {
     public List<? extends DataType> getOutputTypes(String portalName) {
         Portal portal = getSafePortal(portalName);
         AnalyzedStatement analyzedStatement = portal.boundOrUnboundStatement();
-        if (analyzedStatement instanceof AnalyzedRelation) {
-            return Symbols.typeView(((AnalyzedRelation) analyzedStatement).fields());
-        } else {
-            return null;
+        List<Field> fields = analyzedStatement.fields();
+        if (fields != null) {
+            return Symbols.typeView(fields);
         }
+        return null;
     }
 
     public String getQuery(String portalName) {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
@@ -37,6 +37,7 @@ import io.crate.sql.tree.Table;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
@@ -76,6 +77,7 @@ public class AnalyzedCopyFromReturnSummary extends AnalyzedCopyFrom implements A
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields;
     }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
@@ -33,6 +33,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +69,7 @@ public class AnalyzedShowCreateTable implements AnalyzedStatement, AnalyzedRelat
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields;
     }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
@@ -21,8 +21,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
+import org.elasticsearch.common.Nullable;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public interface AnalyzedStatement {
@@ -55,5 +58,13 @@ public interface AnalyzedStatement {
      */
     default boolean isUnboundPlanningSupported() {
         return false;
+    }
+
+    /**
+     * Defines the columns for the result set or null if not present.
+     */
+    @Nullable
+    default List<Field> fields() {
+        return null;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -22,6 +22,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.Multimap;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
@@ -34,11 +35,16 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
     private final AbstractTableRelation table;
     private final Map<Reference, Symbol> assignmentByTargetCol;
     private final Symbol query;
+    private final Multimap<String, Symbol> returningClause;
 
-    public AnalyzedUpdateStatement(AbstractTableRelation table, Map<Reference, Symbol> assignmentByTargetCol, Symbol query) {
+    public AnalyzedUpdateStatement(AbstractTableRelation table,
+                                   Map<Reference, Symbol> assignmentByTargetCol,
+                                   Symbol query,
+                                   Multimap<String, Symbol> returningClause) {
         this.table = table;
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.query = query;
+        this.returningClause = returningClause;
     }
 
     public AbstractTableRelation table() {
@@ -51,6 +57,10 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
 
     public Symbol query() {
         return query;
+    }
+
+    public Multimap<String, Symbol> returningClause() {
+        return returningClause;
     }
 
     @Override
@@ -68,6 +78,9 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
         consumer.accept(query);
         for (Symbol sourceExpr : assignmentByTargetCol.values()) {
             consumer.accept(sourceExpr);
+        }
+        for (Symbol returningSymbol : returningClause.values()) {
+            consumer.accept(returningSymbol);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -22,11 +22,16 @@
 
 package io.crate.analyze;
 
-import com.google.common.collect.Multimap;
 import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import org.elasticsearch.common.Nullable;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -35,16 +40,36 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
     private final AbstractTableRelation table;
     private final Map<Reference, Symbol> assignmentByTargetCol;
     private final Symbol query;
-    private final Multimap<String, Symbol> returningClause;
+
+    /**
+     * List of columns used for the result set.
+     */
+    private final List<Field> fields;
+
+    /**
+     * List of values or expressions used to be retrieved from the updated rows.
+     */
+    private final List<Symbol> returnValues;
 
     public AnalyzedUpdateStatement(AbstractTableRelation table,
                                    Map<Reference, Symbol> assignmentByTargetCol,
                                    Symbol query,
-                                   Multimap<String, Symbol> returningClause) {
+                                   List<ColumnIdent> outputNames,
+                                   List<Symbol> returnValues
+                                   ) {
         this.table = table;
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.query = query;
-        this.returningClause = returningClause;
+        this.returnValues = returnValues;
+        if (!outputNames.isEmpty() && !returnValues.isEmpty()) {
+            this.fields = new ArrayList<>(outputNames.size());
+            Iterator<Symbol> outputsIterator = returnValues.iterator();
+            for (ColumnIdent path : outputNames) {
+                fields.add(new Field(table, path, outputsIterator.next()));
+            }
+        } else {
+            fields = null;
+        }
     }
 
     public AbstractTableRelation table() {
@@ -59,8 +84,13 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
         return query;
     }
 
-    public Multimap<String, Symbol> returningClause() {
-        return returningClause;
+    @Nullable
+    public List<Field> fields() {
+        return fields;
+    }
+
+    public List<Symbol> returnValues() {
+        return returnValues;
     }
 
     @Override
@@ -79,8 +109,13 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
         for (Symbol sourceExpr : assignmentByTargetCol.values()) {
             consumer.accept(sourceExpr);
         }
-        for (Symbol returningSymbol : returningClause.values()) {
+        for (Symbol returningSymbol : returnValues) {
             consumer.accept(returningSymbol);
+        }
+        if (fields != null) {
+            for (Field field : fields) {
+                consumer.accept(field);
+            }
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -34,6 +34,7 @@ import io.crate.profile.ProfilingContext;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.ObjectType;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -78,6 +79,7 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields;
     }

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -35,6 +35,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
@@ -132,6 +133,7 @@ public class MultiSourceSelect implements AnalyzedRelation {
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields.asList();
     }

--- a/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -32,6 +32,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -86,6 +87,7 @@ public class QueriedSelectRelation<T extends AnalyzedRelation> implements Analyz
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields.asList();
     }

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -32,6 +32,8 @@ import io.crate.analyze.relations.NameFieldProvider;
 import io.crate.analyze.relations.RelationAnalysisContext;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
+import io.crate.analyze.relations.select.SelectAnalysis;
+import io.crate.analyze.relations.select.SelectAnalyzer;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -118,7 +120,13 @@ public final class UpdateAnalyzer {
         query = maybeAliasedStatement.maybeMapFields(query);
 
         Symbol normalizedQuery = normalizer.normalize(query, txnCtx);
-        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery);
+
+        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(update.returningClause(),
+                                                                          relCtx.sources(),
+                                                                          sourceExprAnalyzer,
+                                                                          exprCtx);
+
+        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery, selectAnalysis.outputMultiMap());
     }
 
     private HashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -32,6 +32,7 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -145,6 +146,7 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -33,6 +33,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
@@ -100,6 +101,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation {
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields.asList();
     }

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
@@ -33,6 +33,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
@@ -43,6 +44,7 @@ public interface AnalyzedRelation extends AnalyzedStatement {
 
     Field getField(ColumnIdent path, Operation operation) throws UnsupportedOperationException, ColumnUnknownException;
 
+    @Nonnull
     List<Field> fields();
 
     QualifiedName getQualifiedName();

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -34,6 +34,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -89,6 +90,7 @@ public final class AnalyzedView implements AnalyzedRelation {
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields.asList();
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -328,8 +328,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         ExpressionAnalysisContext expressionAnalysisContext = context.expressionAnalysisContext();
         expressionAnalysisContext.windows(node.getWindows());
 
-        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelect(
-            node.getSelect(),
+        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(
+            node.getSelect().getSelectItems(),
             context.sources(),
             expressionAnalyzer,
             expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/sql/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -34,6 +34,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -89,6 +90,7 @@ public class UnionSelect implements AnalyzedRelation {
     }
 
     @Override
+    @Nonnull
     public List<Field> fields() {
         return fields.asList();
     }

--- a/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -32,7 +32,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.QualifiedName;
-import io.crate.sql.tree.Select;
+import io.crate.sql.tree.SelectItem;
 import io.crate.sql.tree.SingleColumn;
 
 import java.util.List;
@@ -41,15 +41,15 @@ import java.util.Map;
 
 public class SelectAnalyzer {
 
-    private static final InnerVisitor INSTANCE = new InnerVisitor();
+    public static final InnerVisitor INSTANCE = new InnerVisitor();
 
-    public static SelectAnalysis analyzeSelect(Select select,
-                                               Map<QualifiedName, AnalyzedRelation> sources,
-                                               ExpressionAnalyzer expressionAnalyzer,
-                                               ExpressionAnalysisContext expressionAnalysisContext) {
+    public static SelectAnalysis analyzeSelectItems(List<SelectItem> selectItems,
+                                                    Map<QualifiedName, AnalyzedRelation> sources,
+                                                    ExpressionAnalyzer expressionAnalyzer,
+                                                    ExpressionAnalysisContext expressionAnalysisContext) {
         SelectAnalysis selectAnalysis = new SelectAnalysis(
-            select.getSelectItems().size(), sources, expressionAnalyzer, expressionAnalysisContext);
-        select.accept(INSTANCE, selectAnalysis);
+            selectItems.size(), sources, expressionAnalyzer, expressionAnalysisContext);
+        selectItems.forEach(x -> x.accept(INSTANCE, selectAnalysis));
         SelectSymbolValidator.validate(selectAnalysis.outputSymbols());
         return selectAnalysis;
     }

--- a/sql/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
@@ -24,9 +24,11 @@ package io.crate.execution.dml;
 
 import com.carrotsearch.hppc.IntArrayList;
 import io.crate.analyze.where.DocKeys;
+import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
+import io.crate.data.RowN;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.support.MultiActionListener;
 import io.crate.execution.support.OneRowActionListener;
@@ -44,12 +46,16 @@ import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.shard.ShardId;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import static io.crate.data.SentinelRow.SENTINEL;
 
 /**
  * Utility class to group requests by shardId and execute them.
@@ -98,16 +104,21 @@ public class ShardRequestExecutor<Req> {
     }
 
     public void execute(RowConsumer consumer, Row parameters, SubQueryResults subQueryResults) {
+        execute(consumer, parameters, subQueryResults, this::rowCountListener);
+    }
+
+    public void executeCollectValues(RowConsumer consumer, Row parameters, SubQueryResults subQueryResults) {
+        execute(consumer, parameters, subQueryResults, this::resultSetListener);
+    }
+
+    private void execute(RowConsumer consumer,
+                         Row parameters,
+                         SubQueryResults subQueryResults,
+                         BiFunction<RowConsumer, Integer, ActionListener<ShardResponse>> f) {
         HashMap<ShardId, Req> requestsByShard = new HashMap<>();
         grouper.bind(parameters, subQueryResults);
         addRequests(0, parameters, requestsByShard, subQueryResults);
-        MultiActionListener<ShardResponse, long[], ? super Row> listener = new MultiActionListener<>(
-            requestsByShard.size(),
-            () -> new long[]{0},
-            ShardRequestExecutor::updateRowCountOrFail,
-            rowCount -> new Row1(rowCount[0]),
-            new OneRowActionListener<>(consumer, Function.identity())
-        );
+        ActionListener<ShardResponse> listener = f.apply(consumer, requestsByShard.size());
         for (Req request : requestsByShard.values()) {
             transportAction.accept(request, listener);
         }
@@ -183,7 +194,50 @@ public class ShardRequestExecutor<Req> {
         ).shardId();
     }
 
-    private static void updateRowCountOrFail(long[] rowCount, ShardResponse response) {
+    private ActionListener<ShardResponse> rowCountListener(RowConsumer consumer, int numberResponse) {
+        return new MultiActionListener<>(
+            numberResponse,
+            () -> new long[]{0},
+            this::countRows,
+            rowCount -> new Row1(rowCount[0]),
+            new OneRowActionListener<>(consumer, Function.identity())
+        );
+    }
+
+    private ActionListener<ShardResponse> resultSetListener(RowConsumer consumer, int numberResponse) {
+        return new MultiActionListener<>(
+            numberResponse,
+            ArrayList::new,
+            this::collectResults,
+            Function.identity(),
+            new ActionListener<List<Row>>() {
+                @Override
+                public void onResponse(List<Row> rows) {
+                    consumer.accept(InMemoryBatchIterator.of(rows, SENTINEL, false), null);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    consumer.accept(null, e);
+                }
+            }
+        );
+    }
+
+    private void countRows(long[] rowCount, ShardResponse response) {
+        updateOrFail(rowCount, response, (acc,b) -> acc[0] += 1);
+    }
+
+    private void collectResults(List<Row> values, ShardResponse response) {
+        updateOrFail(values, response, (acc, res) -> {
+            List<Object[]> resultRows = res.getResultRows();
+            if (resultRows != null) {
+                resultRows.forEach(x -> acc.add(new RowN(x)));
+            }
+        });
+    }
+
+    private static <A> void updateOrFail(A acc, ShardResponse response, BiConsumer<A, ShardResponse> f) {
         Exception exception = response.failure();
         if (exception != null) {
             Throwable t = SQLExceptions.unwrap(exception, e -> e instanceof RuntimeException);
@@ -194,7 +248,7 @@ public class ShardRequestExecutor<Req> {
         for (int i = 0; i < response.itemIndices().size(); i++) {
             ShardResponse.Failure failure = response.failures().get(i);
             if (failure == null) {
-                rowCount[0] += 1;
+                f.accept(acc, response);
             } else if (!failure.versionConflict() && !(failure.message().contains("Document not found") || failure.message().contains("document missing"))) {
                 throw new RuntimeException(failure.message());
             }

--- a/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -24,7 +24,11 @@ package io.crate.execution.dml;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.google.common.base.MoreObjects;
+import io.crate.Streamer;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.WriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -91,10 +95,32 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
     private IntArrayList locations = new IntArrayList();
     private List<Failure> failures = new ArrayList<>();
+
+    /**
+     * Result rows are used to return values from updated rows.
+     */
+    @Nullable
+    private List<Object[]> resultRows;
+
+    /**
+     * Result columns describe the types of the result rows.
+     */
+    @Nullable
+    private Symbol[] resultColumns;
+
+
     @Nullable
     private Exception failure;
 
-    public ShardResponse() {
+    private boolean allOn4_2;
+
+    public ShardResponse(Version version) {
+        this.allOn4_2 = version.onOrAfter(Version.V_4_2_0);
+    }
+
+    public ShardResponse(Version version, @Nullable Symbol[] resultColumns) {
+        this.allOn4_2 = version.onOrAfter(Version.V_4_2_0);
+        this.resultColumns = resultColumns;
     }
 
     public void add(int location) {
@@ -105,6 +131,18 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
     public void add(int location, Failure failure) {
         locations.add(location);
         failures.add(failure);
+    }
+
+    public void addResultRows(Object[] rows) {
+        if (resultRows == null) {
+            resultRows = new ArrayList<>();
+        }
+        resultRows.add(rows);
+    }
+
+    @Nullable
+    public List<Object[]> getResultRows() {
+        return resultRows;
     }
 
     public IntArrayList itemIndices() {
@@ -125,6 +163,11 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
     public ShardResponse(StreamInput in) throws IOException {
         super(in);
+        if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
+            this.allOn4_2 = in.readBoolean();
+        } else {
+            this.allOn4_2 = false;
+        }
         int size = in.readVInt();
         locations = new IntArrayList(size);
         failures = new ArrayList<>(size);
@@ -139,11 +182,37 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
         if (in.readBoolean()) {
             failure = in.readException();
         }
+        if (allOn4_2) {
+            int resultColumnsSize = in.readVInt();
+            if (resultColumnsSize > 0) {
+                resultColumns = new Symbol[resultColumnsSize];
+                for (int i = 0; i < resultColumnsSize; i++) {
+                    Symbol symbol = Symbols.fromStream(in);
+                    resultColumns[i] = symbol;
+                }
+                Streamer[] resultRowStreamers = Symbols.streamerArray(List.of(resultColumns));
+                int resultRowsSize = in.readVInt();
+                if (resultRowsSize > 0) {
+                    resultRows = new ArrayList<>(resultRowsSize);
+                    int rowLength = in.readVInt();
+                    for (int i = 0; i < resultRowsSize; i++) {
+                        Object[] row = new Object[rowLength];
+                        for (int j = 0; j < rowLength; j++) {
+                            row[j] = resultRowStreamers[j].readValueFrom(in);
+                        }
+                        resultRows.add(row);
+                    }
+                }
+            }
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_4_2_0)) {
+            out.writeBoolean(allOn4_2);
+        }
         out.writeVInt(locations.size());
         for (int i = 0; i < locations.size(); i++) {
             out.writeVInt(locations.get(i));
@@ -159,6 +228,26 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
             out.writeException(failure);
         } else {
             out.writeBoolean(false);
+        }
+        if (allOn4_2) {
+            if (resultRows != null) {
+                assert resultColumns != null : "Result columns are required when writing result rows";
+                Streamer[] resultRowStreamers = Symbols.streamerArray(List.of(resultColumns));
+                out.writeVInt(resultColumns.length);
+                for (int i = 0; i < resultColumns.length; i++) {
+                    Symbols.toStream(resultColumns[i], out);
+                }
+                out.writeVInt(resultRows.size());
+                int rowLength = resultRows.get(0).length;
+                out.writeVInt(rowLength);
+                for (Object[] row : resultRows) {
+                    for (int j = 0; j < rowLength; j++) {
+                        resultRowStreamers[j].writeValueTo(out, row[j]);
+                    }
+                }
+            } else {
+                out.writeVInt(0);
+            }
         }
     }
 

--- a/sql/src/main/java/io/crate/execution/dml/SysUpdateResultSetProjector.java
+++ b/sql/src/main/java/io/crate/execution/dml/SysUpdateResultSetProjector.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml;
+
+import io.crate.data.BatchIterator;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.CollectionBucket;
+import io.crate.data.Input;
+import io.crate.data.Projector;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.expression.reference.sys.SysRowUpdater;
+import io.crate.expression.reference.sys.check.node.SysNodeCheck;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collector;
+
+public class SysUpdateResultSetProjector implements Projector {
+
+    private final Consumer<Object> rowWriter;
+    private final List<NestableCollectExpression<SysNodeCheck, ?>> expressions;
+    private final List<Input<?>> inputs;
+    private final SysRowUpdater<?> sysRowUpdater;
+
+    public SysUpdateResultSetProjector(SysRowUpdater<?> sysRowUpdater,
+                                       Consumer<Object> rowWriter,
+                                       List<NestableCollectExpression<SysNodeCheck, ?>> expressions,
+                                       List<Input<?>> inputs) {
+        this.sysRowUpdater = sysRowUpdater;
+        this.rowWriter = rowWriter;
+        this.expressions = expressions;
+        this.inputs = inputs;
+    }
+
+    @Override
+    public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
+        return CollectingBatchIterator
+            .newInstance(batchIterator,
+                         Collector.of(
+                             ArrayList<Object[]>::new,
+                             (acc, row) -> {
+                                 Object[] returnValues = evaluateReturnValues(row);
+                                 acc.add(returnValues);
+                             },
+                             (state1, state2) -> {
+                                 throw new UnsupportedOperationException(
+                                     "Combine not supported");
+                             },
+                             CollectionBucket::new
+                             ));
+    }
+
+    private Object[] evaluateReturnValues(Row row) {
+        Object sysNodeCheckId = row.get(0);
+        //Update sysNodeCheck to the new value
+        rowWriter.accept(sysNodeCheckId);
+        //Retrieve updated sysNodeCheck and evaluate return values
+        SysNodeCheck sysNodeCheck = (SysNodeCheck) sysRowUpdater.getRow(sysNodeCheckId);
+        expressions.forEach(x -> x.setNextRow(sysNodeCheck));
+        Object[] result = new Object[inputs.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = inputs.get(i).value();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean providesIndependentScroll() {
+        return true;
+    }
+
+}

--- a/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.JobKilledException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -78,7 +79,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     protected WritePrimaryResult<ShardDeleteRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardDeleteRequest request,
                                                                                         AtomicBoolean killed) throws IOException {
-        ShardResponse shardResponse = new ShardResponse();
+        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
         Translog.Location translogLocation = null;
         boolean debugEnabled = logger.isDebugEnabled();
         for (ShardDeleteRequest.Item item : request.items()) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.Doc;
+import io.crate.expression.reference.DocRefResolver;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+
+final class ReturnValueGen {
+
+    private final List<CollectExpression<Doc, ?>> expressions;
+    private final List<Input<?>> inputs;
+
+    ReturnValueGen(Functions functions, TransactionContext txnCtx, DocTableInfo table, Symbol[] returnValues) {
+        InputFactory.Context<CollectExpression<Doc, ?>> cntx = new InputFactory(functions).ctxForRefs(
+            txnCtx, new DocRefResolver(table.partitionedBy()));
+        cntx.add(List.of(returnValues));
+        this.expressions = cntx.expressions();
+        this.inputs = cntx.topLevelInputs();
+    }
+
+    @Nullable
+    Object[] generateReturnValues(Doc doc) {
+        if (inputs.isEmpty()) {
+            return null;
+        }
+        expressions.forEach(x -> x.setNextRow(doc));
+        Object[] result = new Object[inputs.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = inputs.get(i).value();
+        }
+        return result;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -38,10 +38,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +105,7 @@ final class UpdateSourceGen {
         }
     }
 
-    BytesReference generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) throws IOException {
+    Map<String, Object> generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) {
         /* We require a new HashMap because all evaluations of the updateAssignments need to be based on the
          * values *before* the update. For example:
          *
@@ -130,7 +127,7 @@ final class UpdateSourceGen {
         generatedColumns.validateValues(updatedSource);
         injectGeneratedColumns(updatedSource);
         checks.validate(updatedDoc);
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(updatedSource));
+        return updatedSource;
     }
 
     private void injectGeneratedColumns(HashMap<String, Object> updatedSource) {

--- a/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
@@ -23,40 +23,96 @@
 package io.crate.execution.dsl.projection;
 
 import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
-import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class SysUpdateProjection extends DMLProjection {
+public class SysUpdateProjection extends Projection {
+
+    private final Symbol uidSymbol;
 
     private Map<Reference, Symbol> assignments;
 
-    public SysUpdateProjection(DataType idType, Map<Reference, Symbol> assignments) {
-        super(new InputColumn(0, idType));
+    private Symbol[] outputs;
+
+    @Nullable
+    private Symbol[] returnValues;
+
+    private boolean allOn4_2;
+
+    public SysUpdateProjection(Symbol uidSymbol,
+                               Map<Reference, Symbol> assignments,
+                               Version version,
+                               Symbol[] outputs,
+                               @Nullable Symbol[] returnValues
+    ) {
+        this.uidSymbol = uidSymbol;
         this.assignments = assignments;
+        this.allOn4_2 = version.onOrAfter(Version.V_4_2_0);
+        this.returnValues = returnValues;
+        assert Arrays.stream(outputs).noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            : "Cannot operate on Reference, Field or SelectSymbol symbols: " + outputs;
+        this.outputs = outputs;
     }
 
     public SysUpdateProjection(StreamInput in) throws IOException {
-        super(in);
+        uidSymbol = Symbols.fromStream(in);
+        if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
+            this.allOn4_2 = in.readBoolean();
+        }
         int numAssignments = in.readVInt();
         assignments = new HashMap<>(numAssignments, 1.0f);
         for (int i = 0; i < numAssignments; i++) {
             assignments.put(Reference.fromStream(in), Symbols.fromStream(in));
+        }
+        if (allOn4_2) {
+            int outputSize = in.readVInt();
+            outputs = new Symbol[outputSize];
+            for (int i = 0; i < outputSize; i++) {
+                outputs[i] = Symbols.fromStream(in);
+            }
+            int returnValuesSize = in.readVInt();
+            if (returnValuesSize > 0) {
+                returnValues = new Symbol[returnValuesSize];
+                for (int i = 0; i < returnValuesSize; i++) {
+                    returnValues[i] = Symbols.fromStream(in);
+                }
+            }
+        } else {
+            //Outputs should never be null and for BwC reasons
+            //the default value in pre 4.1 was a long for a count
+            outputs = new Symbol[]{new InputColumn(0, DataTypes.LONG)};
         }
     }
 
     @Override
     public ProjectionType projectionType() {
         return ProjectionType.SYS_UPDATE;
+    }
+
+    @Nullable
+    public Symbol[] returnValues() {
+        return returnValues;
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return List.of(outputs);
     }
 
     @Override
@@ -70,25 +126,53 @@ public class SysUpdateProjection extends DMLProjection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        Symbols.toStream(uidSymbol, out);
+        if (out.getVersion().onOrAfter(Version.V_4_2_0)) {
+            out.writeBoolean(allOn4_2);
+        }
         out.writeVInt(assignments.size());
         for (Map.Entry<Reference, Symbol> e : assignments.entrySet()) {
             Reference.toStream(e.getKey(), out);
             Symbols.toStream(e.getValue(), out);
         }
+
+        if (allOn4_2) {
+            out.writeVInt(outputs.length);
+            for (int i = 0; i < outputs.length; i++) {
+                Symbols.toStream(outputs[i], out);
+            }
+            if (returnValues != null) {
+                out.writeVInt(returnValues.length);
+                for (int i = 0; i < returnValues.length; i++) {
+                    Symbols.toStream(returnValues[i], out);
+                }
+            } else {
+                out.writeVInt(0);
+            }
+        }
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SysUpdateProjection that = (SysUpdateProjection) o;
-        return Objects.equals(assignments, that.assignments);
+        return Objects.equals(uidSymbol, that.uidSymbol) &&
+               Objects.equals(assignments, that.assignments) &&
+               Arrays.equals(outputs, that.outputs) &&
+               Arrays.equals(returnValues, that.returnValues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assignments);
+        int result = Objects.hash(super.hashCode(), uidSymbol, assignments);
+        result = 31 * result + Arrays.hashCode(outputs);
+        result = 31 * result + Arrays.hashCode(returnValues);
+        return result;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -40,6 +40,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 
@@ -101,13 +102,15 @@ public class ColumnIndexWriterProjector implements Projector {
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
+            null,
             jobId,
-            true
+            true,
+            Version.CURRENT
         );
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, assignments, insertValues.materialize(), null, null, null);
+            id -> new ShardUpsertRequest.Item(id, assignments, insertValues.materialize(), null, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
@@ -29,9 +29,9 @@ import io.crate.data.Row;
 
 public class DMLProjector implements Projector {
 
-    private final ShardDMLExecutor<?, ?> batchAccumulator;
+    private final ShardDMLExecutor<?, ?, ?, ?> batchAccumulator;
 
-    public DMLProjector(ShardDMLExecutor<?, ?> batchAccumulator) {
+    public DMLProjector(ShardDMLExecutor<?, ?, ?, ?> batchAccumulator) {
         this.batchAccumulator = batchAccumulator;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -39,6 +39,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -107,11 +108,13 @@ public class IndexWriterProjector implements Projector {
             true,
             null,
             new Reference[]{rawSourceReference},
+            null,
             jobId,
-            false);
+            false,
+            Version.CURRENT);
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
+            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -27,6 +27,7 @@ import io.crate.action.FutureActionListener;
 import io.crate.action.LimitedExponentialBackoff;
 import io.crate.data.BatchIterator;
 import io.crate.data.BatchIterators;
+import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.execution.dml.ShardRequest;
@@ -41,19 +42,23 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collector;
 
 import static io.crate.execution.jobs.NodeJobsCounter.MAX_NODE_CONCURRENT_OPERATIONS;
 
-public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
+public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
+                              TItem extends ShardRequest.Item,
+                              TAcc,
+                              TResult extends Iterable<? extends Row>>
     implements Function<BatchIterator<Row>, CompletableFuture<? extends Iterable<? extends Row>>> {
 
     private static final Logger LOGGER = LogManager.getLogger(ShardDMLExecutor.class);
@@ -70,7 +75,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     private final Function<String, TItem> itemFactory;
     private final BiConsumer<TReq, ActionListener<ShardResponse>> operation;
     private final String localNodeId;
-
+    private final Collector<ShardResponse, TAcc, TResult> collector;
     private int numItems = -1;
 
     public ShardDMLExecutor(int bulkSize,
@@ -81,7 +86,9 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
                             NodeJobsCounter nodeJobsCounter,
                             Supplier<TReq> requestFactory,
                             Function<String, TItem> itemFactory,
-                            BiConsumer<TReq, ActionListener<ShardResponse>> transportAction) {
+                            BiConsumer<TReq, ActionListener<ShardResponse>> transportAction,
+                            Collector<ShardResponse, TAcc, TResult> collector
+                            ) {
         this.bulkSize = bulkSize;
         this.scheduler = scheduler;
         this.executor = executor;
@@ -91,6 +98,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         this.itemFactory = itemFactory;
         this.operation = transportAction;
         this.localNodeId = getLocalNodeId(clusterService);
+        this.collector = collector;
     }
 
     private void addRowToRequest(TReq req, Row row) {
@@ -99,15 +107,20 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         req.add(numItems, itemFactory.apply((String) uidExpression.value()));
     }
 
-    private CompletableFuture<Long> executeBatch(TReq request) {
-        FutureActionListener<ShardResponse, Long> listener = new FutureActionListener<>(ShardDMLExecutor::processShardResponse);
+    private CompletableFuture<TAcc> executeBatch(TReq request) {
+        FutureActionListener<ShardResponse, TAcc> listener = new FutureActionListener<>((a) -> {
+            TAcc acc = collector.supplier().get();
+            collector.accumulator().accept(acc, a);
+            return acc;
+        });
+
         nodeJobsCounter.increment(localNodeId);
-        CompletableFuture<Long> result = listener.whenComplete((r, f) -> nodeJobsCounter.decrement(localNodeId));
+        CompletableFuture<TAcc> result = listener.whenComplete((r, f) -> nodeJobsCounter.decrement(localNodeId));
         operation.accept(request, withRetry(request, listener));
         return result;
     }
 
-    private RetryListener<ShardResponse> withRetry(TReq request, FutureActionListener<ShardResponse, Long> listener) {
+    private RetryListener<ShardResponse> withRetry(TReq request, FutureActionListener<ShardResponse, TAcc> listener) {
         return new RetryListener<>(
             scheduler,
             l -> operation.accept(request, l),
@@ -117,12 +130,9 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     }
 
     @Override
-    public CompletableFuture<? extends Iterable<Row>> apply(BatchIterator<Row> batchIterator) {
+    public CompletableFuture<TResult> apply(BatchIterator<Row> batchIterator) {
         BatchIterator<TReq> reqBatchIterator =
             BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest, r -> false);
-        BinaryOperator<Long> combinePartialResult = (a, b) -> a + b;
-        long initialResult = 0L;
-
         // If the source batch iterator does not involve IO, mostly in-memory structures are used which we want to free
         // as soon as possible. We do not want to throttle based on the targets node counter in such cases.
         Predicate<TReq> shouldPause = ignored -> true;
@@ -136,12 +146,12 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
             executor,
             reqBatchIterator,
             this::executeBatch,
-            combinePartialResult,
-            initialResult,
+            collector.combiner(),
+            collector.supplier().get(),
             shouldPause,
             BACKOFF_POLICY
         ).consumeIteratorAndExecute()
-            .thenApply(rowCount -> Collections.singletonList(new Row1(rowCount == null ? 0L : rowCount)));
+            .thenApply(collector.finisher());
     }
 
     @Nullable
@@ -155,12 +165,41 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         return nodeId;
     }
 
-    private static long processShardResponse(ShardResponse shardResponse) {
+    private static <A> A processResponse(ShardResponse shardResponse, Function<ShardResponse, A> f) {
         Exception failure = shardResponse.failure();
         if (failure != null) {
             Throwables.throwIfUnchecked(failure);
             throw new RuntimeException(failure);
         }
-        return shardResponse.successRowCount();
+        return f.apply(shardResponse);
     }
+
+    private static Long toRowCount(ShardResponse shardResponse) {
+        return Long.valueOf(processResponse(shardResponse, ShardResponse::successRowCount));
+    }
+
+    private static List<Object[]> toResultRows(ShardResponse shardResponse) {
+        List<Object[]> result = processResponse(shardResponse, ShardResponse::getResultRows);
+        return result == null ? List.of() : result;
+    }
+
+    public static final Collector<ShardResponse, long[], Iterable<Row>> ROW_COUNT_COLLECTOR = Collector.of(
+        () -> new long[]{0L},
+        (acc, response) -> acc[0] += toRowCount(response),
+        (acc, response) -> {
+            acc[0] += response[0];
+            return acc;
+        },
+        acc -> List.of(new Row1(acc[0]))
+    );
+
+    public static final Collector<ShardResponse, List<Object[]>, Iterable<Row>> RESULT_ROW_COLLECTOR = Collector.of(
+        ArrayList::new,
+        (acc, response) -> acc.addAll(toResultRows(response)),
+        (acc, response) -> {
+            acc.addAll(response);
+            return acc;
+        },
+        CollectionBucket::new
+    );
 }

--- a/sql/src/main/java/io/crate/expression/reference/Doc.java
+++ b/sql/src/main/java/io/crate/expression/reference/Doc.java
@@ -90,6 +90,18 @@ public final class Doc {
         return index;
     }
 
+    public Doc withVersionAndSeqNo(long version, long seqNo) {
+        return new Doc(
+            docId,
+            index,
+            id,
+            version,
+            seqNo,
+            primaryTerm,
+            source,
+            raw);
+    }
+
     public Doc withUpdatedSource(Map<String, Object> updatedSource) {
         return new Doc(
             docId,

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
@@ -58,7 +58,7 @@ public class SysNodeChecksTableInfo extends StaticTableInfo<SysNodeCheck> {
         public static final ColumnIdent ACKNOWLEDGED = new ColumnIdent("acknowledged");
     }
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<SysNodeCheck>> expressions() {
+    public static Map<ColumnIdent, RowCollectExpressionFactory<SysNodeCheck>> expressions() {
         return columnRegistrar().expressions();
     }
 

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -38,9 +38,11 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.shard.ShardId;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -51,12 +53,18 @@ public final class UpdateById implements Plan {
     private final Map<Reference, Symbol> assignmentByTargetCol;
     private final DocKeys docKeys;
     private final Assignments assignments;
+    @Nullable
+    private final Symbol[] returnValues;
 
-    public UpdateById(DocTableInfo table, Map<Reference, Symbol> assignmentByTargetCol, DocKeys docKeys) {
+    public UpdateById(DocTableInfo table,
+                      Map<Reference, Symbol> assignmentByTargetCol,
+                      DocKeys docKeys,
+                      List<Symbol> returnValues) {
         this.table = table;
         this.assignments = Assignments.convert(assignmentByTargetCol);
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.docKeys = docKeys;
+        this.returnValues = returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[]{});
     }
 
     @VisibleForTesting
@@ -80,10 +88,14 @@ public final class UpdateById implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        createExecutor(dependencies, plannerContext)
-            .execute(consumer, params, subQueryResults);
-    }
+        ShardRequestExecutor<ShardUpsertRequest> executor = createExecutor(dependencies, plannerContext);
 
+        if (returnValues == null) {
+            executor.execute(consumer, params, subQueryResults);
+        } else {
+            executor.executeCollectValues(consumer, params, subQueryResults);
+        }
+    }
 
     @Override
     public List<CompletableFuture<Long>> executeBulk(DependencyCarrier dependencies,
@@ -105,8 +117,10 @@ public final class UpdateById implements Plan {
             true,
             assignments.targetNames(),
             null, // missing assignments are for INSERT .. ON DUPLICATE KEY UPDATE
+            returnValues,
             plannerContext.jobId(),
-            false
+            false,
+            Version.CURRENT
         );
         UpdateRequests updateRequests = new UpdateRequests(requestBuilder, table, assignments);
         return new ShardRequestExecutor<>(
@@ -156,7 +170,8 @@ public final class UpdateById implements Plan {
                                                                        null,
                                                                        version,
                                                                        seqNo,
-                                                                       primaryTerm);
+                                                                       primaryTerm,
+                                                                       request.getReturnValues());
             request.add(location, item);
         }
     }

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -69,6 +69,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.types.DataType;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
@@ -234,8 +235,11 @@ public class InsertFromValues implements LogicalPlan {
             rows.size() > 1, // continueOnErrors
             updateColumnNames,
             writerProjection.allTargetColumns().toArray(new Reference[0]),
+            null,
             plannerContext.jobId(),
-            false);
+            false,
+            Version.CURRENT);
+
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
         HashMap<String, InsertSourceFromCells> validatorsCache = new HashMap<>();
@@ -343,8 +347,10 @@ public class InsertFromValues implements LogicalPlan {
             true, // continueOnErrors
             updateColumnNames,
             writerProjection.allTargetColumns().toArray(new Reference[0]),
+            null,
             plannerContext.jobId(),
-            true);
+            true,
+            Version.CURRENT);
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
         HashMap<String, InsertSourceFromCells> validatorsCache = new HashMap<>();
@@ -443,7 +449,7 @@ public class InsertFromValues implements LogicalPlan {
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null);
+                null, null, null, null);
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),

--- a/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.dml;
 
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.Version;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -31,7 +32,7 @@ public class ShardResponseTest extends CrateUnitTest {
 
     @Test
     public void testMarkResponseItemsAndFailures() {
-        ShardResponse shardResponse = new ShardResponse();
+        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
         shardResponse.add(0);
         shardResponse.add(1);
         shardResponse.add(2, new ShardResponse.Failure("dummyId", "dummyMessage", false));

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.analyze.AnalyzedUpdateStatement;
+import io.crate.expression.reference.Doc;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+
+public class ReturnValueGenTest extends CrateDummyClusterServiceUnitTest {
+
+    private final String CREATE_TEST_TABLE = "create table test (id int primary key, message string)";
+
+    @Test
+    public void test_update_returning_id() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid");
+        Object[] objects = returnValues("1", Map.of());
+        assertThat(objects[0], is(1));
+    }
+
+    @Test
+    public void test_update_by_id_returning_multiple_fields() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid, message");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(1));
+        assertThat(objects[1], is("updated"));
+    }
+
+    @Test
+    public void test_update_returning_with_system_columns() throws Exception {
+        setupStatement("update test set message='update' returning _seq_no");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(1L));
+    }
+
+    @Test
+    public void test_update_by_id_returning_functions() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid + 1, UPPER(message)");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(2));
+        assertThat(objects[1], is("UPDATED"));
+    }
+
+    @Test
+    public void test_update_by_id_returning_functions_multiple_inputs() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid + _seq_no + 1");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(3L));
+    }
+
+    private Object[] returnValues(String id, Map<String, Object> content) {
+        return returnValueGen.generateReturnValues(doc(id, content));
+    }
+
+    private void setupStatement(String stmt) throws IOException {
+        SQLExecutor executor = SQLExecutor.builder(clusterService).addTable(CREATE_TEST_TABLE).build();
+        AnalyzedUpdateStatement update = executor.analyze(stmt);
+        tableInfo = (DocTableInfo) update.table().tableInfo();
+        returnValueGen = new ReturnValueGen(executor.functions(),
+                                            txnCtx,
+                                            tableInfo,
+                                            update.returnValues().toArray(new Symbol[]{}));
+    }
+
+    private Doc doc(String id, Map<String, Object> content) {
+        return new Doc(1, tableInfo.concreteIndices()[0], id, 1, 1, 1, content, () -> "");
+    }
+
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    private DocTableInfo tableInfo;
+    private ReturnValueGen returnValueGen;
+}
+

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -119,12 +118,13 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         @Nullable
         @Override
-        protected Translog.Location indexItem(ShardUpsertRequest request,
+        protected IndexItemResponse indexItem(ShardUpsertRequest request,
                                               ShardUpsertRequest.Item item,
                                               IndexShard indexShard,
                                               boolean tryInsertFirst,
                                               UpdateSourceGen updateSourceGen,
                                               InsertSourceGen insertSourceGen,
+                                              ReturnValueGen returnValueGen,
                                               boolean isRetry) throws Exception {
              throw new VersionConflictEngineException(
                 indexShard.shardId(),
@@ -183,10 +183,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -204,10 +206,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             true,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -245,10 +249,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -266,10 +272,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -73,7 +73,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         );
 
         Map<String, Object> source = singletonMap("x", 1);
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -93,7 +93,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"x\":2}"));
+        assertThat(updatedSource, is(Map.of("x", 2)));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .startObject()
             .field("y", 100)
             .endObject());
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -129,7 +129,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"y\":8}"));
+        assertThat(updatedSource, is(Map.of("y", 8)));
     }
 
     @Test
@@ -146,7 +146,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -160,7 +160,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"y\":5},\"x\":4}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("y", 5), "x", 4)));
     }
 
 
@@ -179,13 +179,13 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.targetNames()
         );
 
-        BytesReference source = sourceGen.generateSource(
+        Map<String, Object> source = sourceGen.generateSource(
             new Doc(1, table.concreteIndices()[0], "1", 1, 1, 1, emptyMap(), () -> "{}"),
             assignments.sources(),
             new Object[0]
         );
 
-        assertThat(source.utf8ToString(), is("{\"gen\":\"dummySchema\",\"x\":1}"));
+        assertThat(source, is(Map.of("gen","dummySchema","x", 1)));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -249,7 +249,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"y\":\"foo\"},\"x\":4}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("y", "foo"), "x", 4)));
     }
 
     @Test
@@ -266,7 +266,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -280,6 +280,6 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"x\":10}}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("x", 10))));
     }
 }

--- a/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
@@ -21,11 +21,20 @@
 
 package io.crate.execution.dsl.projection;
 
+import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class UpdateProjectionTest {
@@ -33,13 +42,66 @@ public class UpdateProjectionTest {
     @Test
     public void testEquals() throws Exception {
         UpdateProjection u1 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT, new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
 
         UpdateProjection u2 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT,new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
 
         assertThat(u2.equals(u1), is(true));
         assertThat(u1.equals(u2), is(true));
         assertThat(u1.hashCode(), is(u2.hashCode()));
+
+    }
+
+    @Test
+    public void test_serialization() throws Exception {
+
+        UpdateProjection expected = new UpdateProjection(
+            Literal.of(1),
+            new String[]{"foo"},
+            new Symbol[]{Literal.of(1)},
+            Version.CURRENT,
+            new Symbol[]{new InputColumn(0, DataTypes.STRING)},
+            new Symbol[]{Literal.of(1)},
+            null);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        expected.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        UpdateProjection result = new UpdateProjection(in);
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    public void test_serialization_backward_compatibility() throws Exception {
+
+        UpdateProjection expected = new UpdateProjection(
+            Literal.of(1),
+            new String[]{"foo"},
+            new Symbol[]{Literal.of(1)},
+            Version.CURRENT,
+            new Symbol[]{},
+            new Symbol[]{Literal.of(1)},
+            null);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_4_0_0);
+        expected.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(Version.V_4_0_0);
+        UpdateProjection result = new UpdateProjection(in);
+
+        assertThat(result.uidSymbol, equalTo(expected.uidSymbol));
+        assertThat(result.assignments(), equalTo(expected.assignments()));
+        assertThat(result.assignmentsColumns(), equalTo(expected.assignmentsColumns()));
+        assertThat(result.requiredVersion(), equalTo(expected.requiredVersion()));
+
+        //Pre 4.1 versions of UpdateProjection have default output fields set to a long representing
+        //a count which need to set when reading from an pre 4.1 node.
+        assertThat(result.outputs(), equalTo(List.of(new InputColumn(0, DataTypes.LONG))));
+        assertThat(result.returnValues(), equalTo(null));
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
@@ -42,7 +42,7 @@ public class PgGetKeywordsFunctionTest extends AbstractTableFunctionsTest {
             rows.add(new RowN(it.next().materialize()));
         }
         rows.sort(Comparator.comparing(x -> ((String) x.get(0))));
-        assertThat(rows.size(), is(234));
+        assertThat(rows.size(), is(235));
         Row row = rows.get(0);
 
         assertThat(row.get(0), is("add"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pull request introduces an optional ``RETURNING`` clause for the update statement which allows to
 return values based on each row actually updated. This feature enables in particular to retrieve ids or system related columns such as `seq_no` for the updated rows. The syntax and behaviour is  modelled after the `RETURNING` clause from the [postgres-update-statement](https://www.postgresql.org/docs/12/sql-update.html). This is a non-breaking change, `RETURNING` will not be handled as a reserved keyword. 

Example:
`update test set foo='updated' where bar='baz' and x > 0 returning id, _seq_no as seq`


The implementation splits into 4 parts: 
- Grammar extension and adaptation of the parser/analyzer part to support the new clause
- Implementation of the storage engine to cover the update-by-id use case 
- Implementation of the storage engine to cover the update-by-query use case 
- Implementation of the storage engine to cover the sys-table use case

Unfortunately I experienced test-failures in the commits between once it was rebased with master. I managed to fix one of them, but some remain and I will therefore squash all commits to a single one once it is reviewed, because then it is all working.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
