### PR TITLE
Fix memory accounting leak with primary key operations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -209,6 +209,10 @@ Changes
 Fixes
 =====
 
+- Fixed a potential memory accounting leak for queries with ``WHERE`` clauses
+  on primary keys. This could lead to a node eventually rejecting all further
+  queries with a ``CircuitBreakingException``.
+
 - Fixed a regression introduced in ``2.3.2`` which optimizes subqueries when
   used inside multi-value producing functions and operators like ``IN()``,
   ``ANY()`` or ``ARRAY()`` by applying an implicit ordering. When using data

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -600,7 +600,10 @@ public class JobSetup {
             RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(breaker(), pkLookupPhase);
             RowConsumer lastConsumer = context.getRowConsumer(pkLookupPhase, 0);
             MemoryManager memoryManager = memoryManagerFactory.getMemoryManager(ramAccountingContext);
-            lastConsumer.completionFuture().whenComplete((result, error) -> memoryManager.close());
+            lastConsumer.completionFuture().whenComplete((result, error) -> {
+                memoryManager.close();
+                ramAccountingContext.close();
+            });
             RowConsumer nodeRowConsumer = ProjectingRowConsumer.create(
                 lastConsumer,
                 nodeProjections,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The RamAccounting instance wasn't being closed after the primary key
lookup operation finished. This could result in the circuit breaker
eventually tripping all operations.

In practice the flush buffer of 2MB prevented this leak from causing
havoc as most primary key lookup operations stay beneath 2MB and
therefore never increment the circuit breaker count.

This makes writing a test case also difficult.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)