### PR TITLE
Make RamAccounting creators responsible for closing

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -228,10 +228,5 @@ public class RowsBatchIteratorBenchmark {
         public void release() {
 
         }
-
-        @Override
-        public void close() {
-
-        }
     }
 }

--- a/dex/src/main/java/io/crate/breaker/RowAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/RowAccounting.java
@@ -40,9 +40,4 @@ public interface RowAccounting<T> {
      * Stops accounting for previously accounted rows.
      */
     void release();
-
-    /**
-     * Closes this accounting and prevents further use.
-     */
-    void close();
 }

--- a/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
@@ -228,27 +228,15 @@ public class CrossJoinBlockNLBatchIteratorTest {
 
         int numRows;
         int numReleaseCalled;
-        boolean closed;
 
         @Override
         public void accountForAndMaybeBreak(Row row) {
-            if (closed) {
-                throw new RuntimeException("Already closed!");
-            }
             numRows++;
         }
 
         @Override
         public void release() {
-            if (closed) {
-                throw new RuntimeException("Already closed!");
-            }
             numReleaseCalled++;
-        }
-
-        @Override
-        public void close() {
-            closed = true;
         }
     }
 }

--- a/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
+++ b/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
@@ -71,10 +71,4 @@ public class RowAccountingWithEstimators implements RowAccounting<Row> {
     public void release() {
         ramAccounting.release();
     }
-
-    @Override
-    public void close() {
-        ramAccounting.close();
-    }
-
 }

--- a/sql/src/main/java/io/crate/breaker/RowCellsAccountingWithEstimators.java
+++ b/sql/src/main/java/io/crate/breaker/RowCellsAccountingWithEstimators.java
@@ -71,10 +71,4 @@ public class RowCellsAccountingWithEstimators implements RowAccounting<Object[]>
     public void release() {
         ramAccounting.release();
     }
-
-    @Override
-    public void close() {
-        ramAccounting.close();
-    }
-
 }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIterator.java
@@ -51,7 +51,6 @@ public class RamAccountingPageIterator<TKey> implements PagingIterator<TKey, Row
 
     @Override
     public void finish() {
-        rowAccounting.close();
         delegatePagingIterator.finish();
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
@@ -27,8 +27,6 @@ import io.crate.data.BatchIterator;
 import io.crate.data.ForwardingBatchIterator;
 import io.crate.data.Row;
 
-import javax.annotation.Nonnull;
-
 /**
  * Wraps a {@link BatchIterator} and uses {@link io.crate.breaker.RamAccountingContext}
  * to apply the circuit breaking logic by calculating memory occupied for all rows of the iterator.
@@ -59,18 +57,6 @@ public class RamAccountingBatchIterator<T extends Row> extends ForwardingBatchIt
             rowAccounting.accountForAndMaybeBreak(delegateBatchIterator.currentElement());
         }
         return result;
-    }
-
-    @Override
-    public void close() {
-        rowAccounting.close();
-        super.close();
-    }
-
-    @Override
-    public void kill(@Nonnull Throwable throwable) {
-        rowAccounting.close();
-        super.kill(throwable);
     }
 
     /**

--- a/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -54,7 +54,6 @@ public class DistResultRXTask implements Task, DownstreamRXTask {
         this.ramAccounting = ramAccounting;
         this.completionFuture = pageBucketReceiver.completionFuture().handle((result, ex) -> {
             totalBytesUsed = ramAccounting.totalBytes();
-            ramAccounting.close();
             if (ex instanceof IllegalStateException) {
                 kill(ex);
             }

--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -81,15 +81,12 @@ class RestResultSetReceiver implements ResultReceiver<XContentBuilder> {
             result.complete(finishBuilder());
         } catch (IOException e) {
             result.completeExceptionally(e);
-        } finally {
-            rowAccounting.close();
         }
     }
 
     @Override
     public void fail(@Nonnull Throwable t) {
         result.completeExceptionally(t);
-        rowAccounting.close();
     }
 
     XContentBuilder finishBuilder() throws IOException {

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -103,7 +103,6 @@ public class CollectTaskTest extends RandomizedTest {
 
         verify(mock1, times(1)).close();
         verify(mock2, times(1)).close();
-        verify(ramAccountingContext, times(1)).close();
     }
 
     @Test
@@ -132,7 +131,9 @@ public class CollectTaskTest extends RandomizedTest {
 
         verify(batchIterator, times(1)).kill(any(JobKilledException.class));
         verify(mock1, times(1)).close();
-        verify(ramAccountingContext, times(1)).close();
+
+        // CollectTask receives the RamAccountingContext from outside and is not responsible for closing it
+        verify(ramAccountingContext, times(0)).close();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/sort/IgnoreRowCellsAccounting.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/IgnoreRowCellsAccounting.java
@@ -28,16 +28,9 @@ public class IgnoreRowCellsAccounting implements RowAccounting<Object[]> {
 
     @Override
     public void accountForAndMaybeBreak(Object[] cells) {
-
     }
 
     @Override
     public void release() {
-
-    }
-
-    @Override
-    public void close() {
-
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
@@ -29,16 +29,9 @@ public class IgnoreRowAccounting implements RowAccounting<Row> {
 
     @Override
     public void accountForAndMaybeBreak(Row row) {
-
     }
 
     @Override
     public void release() {
-
-    }
-
-    @Override
-    public void close() {
-
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This moves the creation of `RamAccounting` instances and closing of
those instances further together, so that it is easier to reason about
whether a instance is properly getting closed or not.

The general idea is that whoever creates an instance must also make sure
that it is closed.

This also removes the `close` method from `RowAccounting` because that
close call was generally leading to a duplicate close of the underlying
`RamAccounting` instance.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)