### PR TITLE
Consider generated values when checking constraints on InsertSourceGen.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -209,6 +209,17 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would lead to incorrect behaviour of the insert from
+  sub query statement for the scenario when the target table contains a
+  :ref:`generated column <sql-ddl-generated-columns>` with the
+  :ref:`not_null_constraint` constraint and a value for the
+  :ref:`generated column <sql-ddl-generated-columns>` is not provided
+  explicitly. For example, the insert statement below failed due to the
+  :ref:`not_null_constraint` constraint violation::
+
+     CREATE TABLE t (x INT, y AS x + 1 NOT NULL)
+     INSERT INTO t (x) (SELECT 1)
+
 - Fixed a potential memory accounting leak for queries with ``WHERE`` clauses
   on primary keys. This could lead to a node eventually rejecting all further
   queries with a ``CircuitBreakingException``.

--- a/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
@@ -30,12 +30,7 @@ import java.io.IOException;
 public class FromRawInsertSource implements InsertSourceGen {
 
     @Override
-    public void checkConstraints(Object[] values) {
-
-    }
-
-    @Override
-    public BytesReference generateSource(Object[] values) throws IOException {
+    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
         return new BytesArray(((String) values[0]));
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
@@ -55,7 +55,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
                                      List<Reference> defaultExpressionColumns) {
         InputFactory inputFactory = new InputFactory(functions);
         InputFactory.Context<CollectExpression<Map<String, Object>, ?>> ctx =
-            inputFactory.ctxForRefs(txnCtx, FromSourceRefResolver.INSTANCE);
+            inputFactory.ctxForRefs(txnCtx, FromSourceRefResolver.WITHOUT_PARTITIONED_BY_REFS);
         this.generatedCols = new HashMap<>(generatedColumns.size());
         generatedColumns.forEach(r -> generatedCols.put(r.column(), ctx.add(r.generatedExpression())));
         expressions = ctx.expressions();
@@ -63,11 +63,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
     }
 
     @Override
-    public void checkConstraints(Object[] values) {
-    }
-
-    @Override
-    public BytesReference generateSource(Object[] values) throws IOException {
+    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
         String rawSource = (String) values[0];
         Map<String, Object> source = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
         mixinDefaults(source, defaults);

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -34,10 +34,7 @@ import java.util.List;
 
 public interface InsertSourceGen {
 
-    void checkConstraints(Object[] values);
-
-    BytesReference generateSource(Object[] values) throws IOException;
-
+    BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException;
 
     static InsertSourceGen of(TransactionContext txnCtx,
                               Functions functions,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -294,8 +294,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
             primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
             try {
-                insertSourceGen.checkConstraints(item.insertValues());
-                item.source(insertSourceGen.generateSource(item.insertValues()));
+                item.source(insertSourceGen.generateSourceAndCheckConstraints(item.insertValues()));
             } catch (IOException e) {
                 throw ExceptionsHelper.convertToElastic(e);
             }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
@@ -56,7 +56,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSource(new Object[]{"{}"});
+        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(Maps.getByPath(map, "x"), is(1));
@@ -68,7 +68,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSource(new Object[]{"{\"x\":2}"});
+        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(Maps.getByPath(map, "x"), is(2));

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -88,7 +89,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
-        BytesReference source = sourceFromCells.generateSource(new Object[]{1, 2});
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
         assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":2,\"z\":3}"));
     }
 
@@ -98,7 +99,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y, z));
 
         expectedException.expectMessage("Given value 8 for generated column z does not match calculation (x + y) = 3");
-        sourceFromCells.generateSource(new Object[]{1, 2, 8});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2, 8});
     }
 
     @Test
@@ -107,7 +108,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
-        BytesReference source = sourceFromCells.generateSource(new Object[]{m});
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(map.get("b"), is(11));
@@ -116,7 +117,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testNullConstraintCheckCausesErrorIfRequiredPartitionedColumnValueIsNull() {
+    public void testNullConstraintCheckCausesErrorIfRequiredPartitionedColumnValueIsNull() throws IOException {
         QueriedSelectRelation<DocTableRelation> relation = e.normalize("select p from t3");
         DocTableInfo t3 = relation.subRelation().tableInfo();
         PartitionName partitionName = new PartitionName(t3.ident(), singletonList(null));
@@ -125,11 +126,11 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
 
         expectedException.expectMessage("\"p\" must not be null");
-        sourceFromCells.checkConstraints(new Object[0]);
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
     }
 
     @Test
-    public void testNullConstraintCheckPassesIfRequiredPartitionedColumnValueIsNotNull() {
+    public void testNullConstraintCheckPassesIfRequiredPartitionedColumnValueIsNotNull() throws IOException {
         QueriedSelectRelation<DocTableRelation> relation = e.normalize("select p from t3");
         DocTableInfo t3 = relation.subRelation().tableInfo();
         PartitionName partitionName = new PartitionName(t3.ident(), singletonList("10"));
@@ -138,7 +139,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
 
         // this must pass without error
-        sourceFromCells.checkConstraints(new Object[0]);
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
     }
 
     @Test
@@ -151,8 +152,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x));
 
         Object[] input = new Object[]{1};
-        sourceFromCells.checkConstraints(input);
-        BytesReference source = sourceFromCells.generateSource(input);
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
         assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"crate\"}"));
     }
 
@@ -167,8 +167,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
 
         Object[] input = {1, "cr8"};
-        sourceFromCells.checkConstraints(input);
-        BytesReference source = sourceFromCells.generateSource(input);
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
         assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"cr8\"}"));
     }
 
@@ -184,7 +183,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 13);
 
-        BytesReference source = sourceFromCells.generateSource(new Object[]{providedValueForObj});
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
 
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
@@ -206,7 +205,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("c", 14);
 
         expectedException.expectMessage("Given value 14 for generated column obj['c'] does not match calculation (obj['a'] + 3) = 13");
-        sourceFromCells.generateSource(new Object[]{providedValueForObj});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
     }
 
     @Test
@@ -220,7 +219,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("y", 2);
-        BytesReference source = sourceFromCells.generateSource(new Object[]{providedValueForObj});
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(Maps.getByPath(map, "obj.x"), is(0));
@@ -238,7 +237,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
-        BytesReference source = sourceFromCells.generateSource(new Object[]{providedValueForObj});
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
 
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
@@ -250,10 +249,51 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t6 = e.resolveTableInfo("t6");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
-        BytesReference source = sourceFromCells.generateSource(new Object[0]);
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
         Map<String, Object> map = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
+    }
+
+    @Test
+    public void test_not_null_constraint_on_generated_column() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (x int, y as x not null)")
+            .build();
+        DocTableInfo tableInfo = e.resolveTableInfo("t");
+        InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
+            txnCtx,
+            e.functions(),
+            tableInfo,
+            "t",
+            GeneratedColumns.Validation.VALUE_MATCH,
+            List.of(Objects.requireNonNull(tableInfo.getReference(new ColumnIdent("x")))));
+
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
+
+        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":1}"));
+    }
+
+    @Test
+    public void test_not_null_constraint_on_generated_column_that_used_in_partition_by_clause() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                "create table t (x as 'test' not null) " +
+                "partitioned by (x)")
+            .build();
+        DocTableInfo tableInfo = e.resolveTableInfo("t");
+        PartitionName partition = new PartitionName(tableInfo.ident(), singletonList(null));
+        InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
+            txnCtx,
+            e.functions(),
+            tableInfo,
+            partition.asIndexName(),
+            GeneratedColumns.Validation.VALUE_MATCH,
+            List.of());
+
+        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
+
+        assertThat(source.utf8ToString(), is("{\"x\":\"test\"}"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -707,7 +707,6 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         );
     }
 
-
     @Test
     public void testInsertFromQueryOnDuplicateKey() throws Exception {
         setup.setUpCharacters();

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -137,7 +137,7 @@ public final class QueryTester implements AutoCloseable {
                 GeneratedColumns.Validation.NONE,
                 Collections.singletonList(table.getReference(ColumnIdent.fromPath(column)))
             );
-            BytesReference source = sourceGen.generateSource(new Object[]{value});
+            BytesReference source = sourceGen.generateSourceAndCheckConstraints(new Object[]{value});
             SourceToParse sourceToParse = new SourceToParse(
                 table.concreteIndices()[0],
                 UUIDs.randomBase64UUID(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, check constraints were applied before the generated values
were injected into sources, that would lead to incorrect insert from subquery
behaviour for the cases a column uses both generated expression and not null
constraint:

```
create table t (x int, y as x not null)
insert into t (x) (select 1)
```
The row count will be 0, such as the insertion will fail due to the not null
check constraint violation.

This change also drops the `InsertSourceGen#checkConstaint` interface method.
Instead, we perform the constraints check in the generateSource method. The same
approach is taken in `UpdateSourceGen`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
