### PR TITLE
Switch from deferred to eager memory accounting

### DIFF
--- a/dex/src/main/java/io/crate/breaker/BlockBasedRamAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/BlockBasedRamAccounting.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import java.util.function.LongConsumer;
+
+/**
+ * A RamAccounting implementation that reserves blocks of memory up-front.
+ * This implementation should be used from a single thread only.
+ */
+public final class BlockBasedRamAccounting implements RamAccounting {
+
+    public static final int MAX_BLOCK_SIZE_IN_BYTES = 2 * 1024 * 1024;
+
+    /**
+     * 2 GB × 0.001 ➞ MB
+     *   = 2 MB
+     *
+     * 256 MB × 0.001 ➞ MB
+     *
+     *   = 0.256 MB
+     */
+    private static final double BREAKER_LIMIT_PERCENTAGE = 0.001;
+
+    private final LongConsumer reserveMemory;
+    private final int blockSizeInBytes;
+
+    private long usedBytes = 0;
+    private long reservedBytes = 0;
+
+    /**
+     * Scale the block size that is eagerly allocated depending on the circuit breakers current limit and the shards
+     * on the node.
+     */
+    public static int calculateBlockSizeInBytes(long breakerLimit, int shardsUsedOnNode) {
+        int blockSize = Math.min((int) (breakerLimit * BREAKER_LIMIT_PERCENTAGE), MAX_BLOCK_SIZE_IN_BYTES);
+        return blockSize / Math.max(shardsUsedOnNode, 1);
+    }
+
+    public BlockBasedRamAccounting(LongConsumer reserveMemory, int blockSizeInBytes) {
+        this.reserveMemory = reserveMemory;
+        this.blockSizeInBytes = blockSizeInBytes;
+    }
+
+    @Override
+    public void addBytes(long bytes) {
+        usedBytes += bytes;
+        if ((reservedBytes - usedBytes) < 0) {
+            long reserveBytes = bytes > blockSizeInBytes ? bytes : blockSizeInBytes;
+            try {
+                reserveMemory.accept(reserveBytes);
+            } catch (Exception e) {
+                usedBytes -= bytes;
+                throw e;
+            }
+            reservedBytes += reserveBytes;
+        }
+        assert reservedBytes >= usedBytes : "reservedBytes must be >= usedBytes: " + toString();
+    }
+
+    @Override
+    public long totalBytes() {
+        return usedBytes;
+    }
+
+    @Override
+    public void release() {
+        reserveMemory.accept(- reservedBytes);
+        usedBytes = 0;
+        reservedBytes = 0;
+    }
+
+    @Override
+    public void close() {
+        release();
+    }
+
+    @Override
+    public String toString() {
+        return "RamAccounting{" +
+               "usedBytes=" + usedBytes +
+               ", reservedBytes=" + reservedBytes +
+               '}';
+    }
+}

--- a/dex/src/test/java/io/crate/breaker/BlockBasedRamAccountingTest.java
+++ b/dex/src/test/java/io/crate/breaker/BlockBasedRamAccountingTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BlockBasedRamAccountingTest {
+
+    @Test
+    public void test_block_based_ram_accounting_reserves_2mb_block_on_first_add_byte_call() {
+        var requestedBytes = new AtomicLong(0L);
+        var ramAccounting = new BlockBasedRamAccounting(requestedBytes::addAndGet, 4096);
+
+        ramAccounting.addBytes(40);
+        assertThat(ramAccounting.totalBytes(), is(40L));
+        assertThat(requestedBytes.get(), is((long) 4096));
+    }
+
+    @Test
+    public void test_requested_bytes_are_released_on_release() {
+        var requestedBytes = new AtomicLong(0L);
+        var ramAccounting = new BlockBasedRamAccounting(requestedBytes::addAndGet, 2048);
+
+        ramAccounting.addBytes(40);
+        ramAccounting.addBytes(40);
+        assertThat(requestedBytes.get(), is((long) 2048));
+        ramAccounting.release();
+        assertThat(requestedBytes.get(), is(0L));
+    }
+
+    @Test
+    public void test_bytes_are_exact_accounted_if_block_size_is_smaller_than_requested_bytes() {
+        var accountedBytes = new AtomicLong(0L);
+        var ramAccounting = new BlockBasedRamAccounting(accountedBytes::addAndGet, 200);
+
+        ramAccounting.addBytes(5432);
+        assertThat(accountedBytes.get(), is(5432L));
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
+++ b/sql/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
+
+/**
+ * A RamAccounting implementation that can be used concurrently.
+ * (If the used `reserveBytes`/`releaseBytes` components are thread-safe)
+ */
+@ThreadSafe
+public final class ConcurrentRamAccounting implements RamAccounting {
+
+    private final AtomicLong usedBytes = new AtomicLong(0L);
+    private final LongConsumer reserveBytes;
+    private final LongConsumer releaseBytes;
+
+    public static ConcurrentRamAccounting forCircuitBreaker(String label, CircuitBreaker circuitBreaker) {
+        return new ConcurrentRamAccounting(
+            bytes -> circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, label),
+            bytes -> circuitBreaker.addWithoutBreaking(- bytes)
+        );
+    }
+
+    public ConcurrentRamAccounting(LongConsumer reserveBytes, LongConsumer releaseBytes) {
+        this.reserveBytes = reserveBytes;
+        this.releaseBytes = releaseBytes;
+    }
+
+    @Override
+    public void addBytes(long bytes) {
+        reserveBytes.accept(bytes);
+        usedBytes.addAndGet(bytes);
+    }
+
+    @Override
+    public long totalBytes() {
+        return usedBytes.get();
+    }
+
+    @Override
+    public void release() {
+        long prevUsedBytes = usedBytes.getAndSet(0);
+        releaseBytes.accept(prevUsedBytes);
+    }
+
+    @Override
+    public void close() {
+        release();
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -22,10 +22,10 @@
 package io.crate.breaker;
 
 import io.crate.execution.dsl.phases.ExecutionPhase;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.atomic.AtomicLong;
@@ -47,8 +47,7 @@ public class RamAccountingContext implements RamAccounting {
     private static final Logger LOGGER = LogManager.getLogger(RamAccountingContext.class);
 
     public static RamAccountingContext forExecutionPhase(CircuitBreaker breaker, ExecutionPhase executionPhase) {
-        String ramAccountingContextId = executionPhase.name() + ": " + executionPhase.phaseId();
-        return new RamAccountingContext(ramAccountingContextId, breaker);
+        return new RamAccountingContext(executionPhase.label(), breaker);
     }
 
     public RamAccountingContext(String contextId, CircuitBreaker breaker) {

--- a/sql/src/main/java/io/crate/execution/dsl/phases/ExecutionPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/ExecutionPhase.java
@@ -74,4 +74,8 @@ public interface ExecutionPhase extends Writeable {
     Collection<String> nodeIds();
 
     <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context);
+
+    default String label() {
+        return name() + ": " + phaseId();
+    }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -21,26 +21,7 @@
 
 package io.crate.execution.engine.collect;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-
-import org.elasticsearch.Version;
-import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
@@ -52,6 +33,23 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.testing.TestingRowConsumer;
+import org.elasticsearch.Version;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CollectTaskTest extends RandomizedTest {
 
@@ -77,7 +75,8 @@ public class CollectTaskTest extends RandomizedTest {
             ramAccounting -> new OnHeapMemoryManager(ramAccounting::addBytes),
             new TestingRowConsumer(),
             mock(SharedShardContexts.class),
-            Version.CURRENT
+            Version.CURRENT,
+            4096
         );
     }
 
@@ -124,7 +123,8 @@ public class CollectTaskTest extends RandomizedTest {
             ramAccounting -> new OnHeapMemoryManager(ramAccounting::addBytes),
             new TestingRowConsumer(),
             mock(SharedShardContexts.class),
-            Version.CURRENT
+            Version.CURRENT,
+            4096
         );
 
         jobCtx.addSearcher(1, mock1);

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -143,7 +143,8 @@ public class RootTaskTest extends CrateUnitTest {
             ramAccounting -> new OnHeapMemoryManager(ramAccounting::addBytes),
             new TestingRowConsumer(),
             mock(SharedShardContexts.class),
-            Version.CURRENT
+            Version.CURRENT,
+            4096
         );
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
 

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -39,16 +39,10 @@ public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
 
     @Test
     public void selectGroupByWithBreaking() throws Exception {
-        long origBufferSize = RamAccountingContext.FLUSH_BUFFER_SIZE;
-        RamAccountingContext.FLUSH_BUFFER_SIZE = 24;
-        try {
-            expectedException.expect(SQLActionException.class);
-            expectedException.expectMessage("CircuitBreakingException: [query] Data too large, data for ");
-            // query takes 252 bytes of memory
-            // 252b * 1.09 = 275b => should break with limit 256b
-            execute("select region, count(*) from sys.summits group by 1");
-        } finally {
-            RamAccountingContext.FLUSH_BUFFER_SIZE = origBufferSize;
-        }
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("CircuitBreakingException: [query] Data too large, data for ");
+        // query takes 252 bytes of memory
+        // 252b * 1.09 = 275b => should break with limit 256b
+        execute("select region, count(*) from sys.summits group by 1");
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -831,7 +831,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t2 (x) values (1), (3), (3), (4), (4)");
         execute("refresh table t1, t2");
 
-        configureQueryCircuitBreakerForCluster(20L, 1.0d);
+        configureQueryCircuitBreakerForCluster(6 * 1024 * 1024, 1.0d);
         CircuitBreaker queryCircuitBreaker = internalCluster().getInstance(CrateCircuitBreakerService.class).getBreaker(CrateCircuitBreakerService.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 5L, queryCircuitBreaker);
         randomiseAndConfigureJoinBlockSize("t2", 5L, queryCircuitBreaker);
@@ -845,7 +845,6 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                    "2| 3\n"));
         } finally {
             configureQueryCircuitBreakerForCluster(queryCircuitBreaker.getLimit(), queryCircuitBreaker.getOverhead());
-            Iterable<TableStats> tableStatsOnAllNodes = internalCluster().getInstances(TableStats.class);
             resetTableStats();
         }
     }
@@ -916,7 +915,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t1 (x) values (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)");
         execute("refresh table t1");
 
-        configureQueryCircuitBreakerForCluster(40L, 1.0d);
+        configureQueryCircuitBreakerForCluster(6 * 1024 * 1024, 1.0d);
         CircuitBreaker queryCircuitBreaker = internalCluster().getInstance(CrateCircuitBreakerService.class).getBreaker(CrateCircuitBreakerService.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 10L, queryCircuitBreaker);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously we'd only call the parent circuit breaker after 2MB of memory
have been accounted for in a local `RamAccountingContext` instance.

This adds a new `BlockBasedRamAccounting` instance which reserves memory
in blocks eagerly.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)