### PR TITLE
Partitioned columns can be omitted in insert from subquery.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -209,4 +209,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that caused a ``INSERT INTO ... (SELECT ... FROM ..)``
+  statement to fail if not all columns of a ``PARTITIONED BY`` clause
+  appeared in the target list of the ``INSERT INTO`` statement.

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -433,31 +433,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     }
 
     @Test
-    public void testInsertPartitionedTableSomePartitionedColumns() {
-        // insert only some partitioned column values
-        execute("create table parted (id integer, name string, date timestamp with time zone)" +
-                "partitioned by (name, date)");
-        ensureYellow();
-
-        execute("insert into parted (id, name) values (?, ?)",
-            new Object[]{1, "Trillian"});
-        assertThat(response.rowCount(), is(1L));
-        ensureYellow();
-        refresh();
-        String partitionName = new PartitionName(
-            new RelationName(sqlExecutor.getCurrentSchema(), "parted"),
-            Arrays.asList("Trillian", null)).asIndexName();
-        assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
-            .getState().metaData().indices().get(partitionName).getAliases().get(getFqn("parted")));
-
-        execute("select id, name, date from parted");
-        assertThat(response.rowCount(), is(1L));
-        assertThat((Integer) response.rows()[0][0], is(1));
-        assertThat((String) response.rows()[0][1], is("Trillian"));
-        assertNull(response.rows()[0][2]);
-    }
-
-    @Test
     public void testInsertPartitionedTableReversedPartitionedColumns() {
         execute(
             "create table parted (" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It should be possible to omit some columns of the partitioned
by clause in the insert from subquery target columns definition.
The insert from values statement allows it as well.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
