### PR TITLE
Add a default implementation for Row::materialize

### DIFF
--- a/dex/src/main/java/io/crate/data/Buckets.java
+++ b/dex/src/main/java/io/crate/data/Buckets.java
@@ -59,12 +59,4 @@ public class Buckets {
         }
         return res;
     }
-
-    public static Object[] materialize(Row row) {
-        Object[] res = new Object[row.numColumns()];
-        for (int i = 0; i < row.numColumns(); i++) {
-            res[i] = row.get(i);
-        }
-        return res;
-    }
 }

--- a/dex/src/main/java/io/crate/data/Row.java
+++ b/dex/src/main/java/io/crate/data/Row.java
@@ -70,5 +70,11 @@ public interface Row {
     /**
      * Returns a materialized view of this row.
      */
-    Object[] materialize();
+    default Object[] materialize() {
+        Object[] result = new Object[numColumns()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = get(i);
+        }
+        return result;
+    }
 }

--- a/dex/src/main/java/io/crate/data/join/CombinedRow.java
+++ b/dex/src/main/java/io/crate/data/join/CombinedRow.java
@@ -22,7 +22,6 @@
 
 package io.crate.data.join;
 
-import io.crate.data.Buckets;
 import io.crate.data.Row;
 
 public class CombinedRow implements Row, ElementCombiner<Row, Row, Row> {
@@ -55,11 +54,6 @@ public class CombinedRow implements Row, ElementCombiner<Row, Row, Row> {
             return null;
         }
         return right.get(index);
-    }
-
-    @Override
-    public Object[] materialize() {
-        return Buckets.materialize(this);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/InputRow.java
+++ b/sql/src/main/java/io/crate/expression/InputRow.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression;
 
-import io.crate.data.Buckets;
 import io.crate.data.Input;
 import io.crate.data.Row;
 
@@ -45,11 +44,6 @@ public class InputRow implements Row {
     @Override
     public Object get(int index) {
         return inputs.get(index).value();
-    }
-
-    @Override
-    public Object[] materialize() {
-        return Buckets.materialize(this);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/protocols/postgres/MessagesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/MessagesTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.data.Buckets;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.test.integration.CrateUnitTest;
@@ -40,7 +39,6 @@ import java.util.Collections;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,11 +63,6 @@ public class MessagesTest extends CrateUnitTest {
                     @Override
                     public Object get(int index) {
                         throw new IllegalArgumentException("Dummy");
-                    }
-
-                    @Override
-                    public Object[] materialize() {
-                        return Buckets.materialize(this);
                     }
                 },
                 Collections.singletonList(DataTypes.INTEGER),


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)