### PR TITLE
Account memory for undefined and undefined array types.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -209,6 +209,10 @@ Changes
 Fixes
 =====
 
+- Fixed the memory accounting of the circuit breaker for values which
+  types cannot be defined. Previously, the memory for such data types
+  was not accounted which could potentially lead to out of memory errors.
+
 - Fixed an issue that caused a ``INSERT INTO ... (SELECT ... FROM ..)``
   statement to fail if not all columns of a ``PARTITIONED BY`` clause
   appeared in the target list of the ``INSERT INTO`` statement.

--- a/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
+++ b/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
@@ -32,13 +32,15 @@ import io.crate.types.UndefinedType;
 
 import java.util.Locale;
 
+import static org.apache.lucene.util.RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED;
+
 public class SizeEstimatorFactory {
 
     @SuppressWarnings("unchecked")
     public static <T> SizeEstimator<T> create(DataType type) {
         switch (type.id()) {
             case UndefinedType.ID:
-                return (SizeEstimator<T>) new ConstSizeEstimator(0);
+                return (SizeEstimator<T>) new ConstSizeEstimator(UNKNOWN_DEFAULT_RAM_BYTES_USED);
             case StringType.ID:
             case IpType.ID:
                 return (SizeEstimator<T>) StringSizeEstimator.INSTANCE;

--- a/sql/src/test/java/io/crate/breaker/SizeEstimatorFactoryTest.java
+++ b/sql/src/test/java/io/crate/breaker/SizeEstimatorFactoryTest.java
@@ -59,10 +59,4 @@ public class SizeEstimatorFactoryTest {
         SizeEstimator<Object> estimator = SizeEstimatorFactory.create(DataTypes.GEO_SHAPE);
         assertThat(estimator.estimateSize(Collections.emptyMap()), is(120L));
     }
-
-    @Test
-    public void testSizeEstimationForNull() throws Exception {
-        SizeEstimator<Object> estimator = SizeEstimatorFactory.create(DataTypes.UNDEFINED);
-        assertThat(estimator.estimateSize(Collections.emptyMap()), is(0L));
-    }
 }

--- a/sql/src/test/java/io/crate/breaker/SizeEstimatorTest.java
+++ b/sql/src/test/java/io/crate/breaker/SizeEstimatorTest.java
@@ -22,8 +22,12 @@
 package io.crate.breaker;
 
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 
@@ -51,5 +55,30 @@ public class SizeEstimatorTest extends CrateUnitTest {
         assertThat(sizeEstimator.estimateSize(null), is(8L));
         assertThat(sizeEstimator.estimateSize(new Double[]{1.0d, 2.0d}), is(40L));
         assertThat(sizeEstimator.estimateSizeDelta(new Double[]{1.0d, 2.0d}, null), is(-32L));
+    }
+
+    public void test_undefined_type_estimate_size_for_null_value() {
+        var sizeEstimator = SizeEstimatorFactory.create(DataTypes.UNDEFINED);
+        assertThat(sizeEstimator.estimateSize(null), is(8L));
+    }
+
+    public void test_undefined_type_estimate_size_for_object() {
+        var sizeEstimator = SizeEstimatorFactory.create(DataTypes.UNDEFINED);
+        assertThat(
+            sizeEstimator.estimateSize(""),
+            is((long) RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED));
+    }
+
+    public void test_undefined_array_type_estimate_size_for_null_value() {
+        var sizeEstimator = SizeEstimatorFactory.create(new ArrayType<>(DataTypes.UNDEFINED));
+        assertThat(sizeEstimator.estimateSize(null), is(8L));
+    }
+
+    public void test_undefined_array_type_estimate_size_for_object() {
+        var sizeEstimator = SizeEstimatorFactory.create(new ArrayType<>(DataTypes.UNDEFINED));
+        assertThat(
+            sizeEstimator.estimateSize(List.of("", "")),
+            // 16 bytes for the list memory overhead
+            is(RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED * 2L + 16L));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, the memory accounting for values of the
``undefined`` type would result in 0 bytes and 16 bytes
for values of the  ``undefined array`` type, regardless
the size of the array. The null values for both types
would result in 8 bytes.

Now we use ``RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED``
for the memory accounting of the above mentioned data types
and be more precise about memory utilization.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
