### PR TITLE
Make object column size estimation more accurate

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -212,12 +212,13 @@ Changes
 Fixes
 =====
 
+- Improved the memory accounting for values of type ``geo_shape``, ``object``
+  or ``undefined``. Previously an arbitrary fixed value was used for memory
+  accounting. If the actual payloads are large, this could have led to out of
+  memory errors as the memory usage was under-estimated.
+
 - Fixed an issue that may cause a ``SELECT`` query to hang on multiple nodes
   cluster if a resource error like a ``CircuitBreakingException`` occurs.
-
-- Fixed the memory accounting of the circuit breaker for values which
-  types cannot be defined. Previously, the memory for such data types
-  was not accounted which could potentially lead to out of memory errors.
 
 - Fixed an issue that caused a ``INSERT INTO ... (SELECT ... FROM ..)``
   statement to fail if not all columns of a ``PARTITIONED BY`` clause

--- a/sql/src/main/java/io/crate/breaker/MapSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/MapSizeEstimator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public final class MapSizeEstimator extends SizeEstimator<Map<?, ?>> {
+
+    public static final MapSizeEstimator INSTANCE = new MapSizeEstimator();
+
+    @Override
+    public long estimateSize(@Nullable Map<?, ?> value) {
+        if (value == null) {
+            return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        }
+        return RamUsageEstimator.sizeOfMap(value);
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/SamplingSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/SamplingSizeEstimator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import javax.annotation.Nullable;
+
+/**
+ * A SizeEstimator implementation which only does a real size estimation `everyNth` `estimateSize` calls.
+ *
+ * This can be used to reduce the cost of size estimation if the inner SizeEstimator
+ * is expensive and it is assumed that the data records have mostly the same size.
+ */
+public final class SamplingSizeEstimator<T> extends SizeEstimator<T> {
+
+    private final int everyNth;
+    private final SizeEstimator<T> estimator;
+
+    private long i = 0;
+    private long lastMeasurement = -1L;
+
+    public SamplingSizeEstimator(int everyNth, SizeEstimator<T> estimator) {
+        this.everyNth = everyNth;
+        this.estimator = estimator;
+    }
+
+    @Override
+    public long estimateSize(@Nullable T value) {
+        if ((i % everyNth) == 0 || lastMeasurement == -1) {
+            lastMeasurement = estimator.estimateSize(value);
+        }
+        i++;
+        return lastMeasurement;
+    }
+}

--- a/sql/src/test/java/io/crate/breaker/MapSizeEstimatorTest.java
+++ b/sql/src/test/java/io/crate/breaker/MapSizeEstimatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class MapSizeEstimatorTest {
+
+    @Test
+    public void test_map_size_estimate_depends_on_actual_instance_size() {
+        Map<String, Integer> map = Map.of("x", 10, "y", 20);
+        assertThat(
+            MapSizeEstimator.INSTANCE.estimateSize(map),
+            is(RamUsageEstimator.sizeOfMap(map))
+        );
+    }
+}

--- a/sql/src/test/java/io/crate/breaker/SamplingSizeEstimatorTest.java
+++ b/sql/src/test/java/io/crate/breaker/SamplingSizeEstimatorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class SamplingSizeEstimatorTest {
+
+
+    @Test
+    public void test_sampling_size_estimator_takes_sample_on_first_estimation() {
+        var estimator = new SamplingSizeEstimator<>(10, new ConstSizeEstimator(10));
+        assertThat(estimator.estimateSize(20), is(10L));
+    }
+
+    @Test
+    public void test_sampling_size_estimator_updates_estimate_after_nth_calls() {
+        var estimator = new SamplingSizeEstimator<>(4, StringSizeEstimator.INSTANCE);
+        assertThat(estimator.estimateSize("foobar"), is(56L));
+        assertThat(estimator.estimateSize("a"), is(56L));
+        assertThat(estimator.estimateSize("a"), is(56L));
+        assertThat(estimator.estimateSize("a"), is(56L));
+        assertThat(estimator.estimateSize("a"), is(48L));
+        assertThat(estimator.estimateSize("a"), is(48L));
+    }
+}

--- a/sql/src/test/java/io/crate/breaker/SizeEstimatorFactoryTest.java
+++ b/sql/src/test/java/io/crate/breaker/SizeEstimatorFactoryTest.java
@@ -45,7 +45,7 @@ public class SizeEstimatorFactoryTest {
     @Test
     public void testSizeEstimationForObjects() throws Exception {
         SizeEstimator<Object> estimator = SizeEstimatorFactory.create(ObjectType.untyped());
-        assertThat(estimator.estimateSize(Collections.emptyMap()), is(60L));
+        assertThat(estimator.estimateSize(Collections.emptyMap()), is(24L));
     }
 
     @Test
@@ -57,6 +57,6 @@ public class SizeEstimatorFactoryTest {
     @Test
     public void testSizeEstimationForGeoShape() throws Exception {
         SizeEstimator<Object> estimator = SizeEstimatorFactory.create(DataTypes.GEO_SHAPE);
-        assertThat(estimator.estimateSize(Collections.emptyMap()), is(120L));
+        assertThat(estimator.estimateSize(Collections.emptyMap()), is(24L));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`object` columns can grow very large, our constant estimate of 60 could
have been way too low in many cases.

In an `INSERT INTO .. (SELECT ..)` case that could lead to out of memory
errors, as we created very large shard requests due to the
under-estimation of the size of those.

Follow up to https://github.com/crate/crate/pull/9452


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)