### PR TITLE
Add support for casting objects to text

### DIFF
--- a/common/src/main/java/io/crate/types/StringType.java
+++ b/common/src/main/java/io/crate/types/StringType.java
@@ -24,9 +24,11 @@ package io.crate.types;
 import com.google.common.collect.Ordering;
 import io.crate.Streamer;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -82,13 +84,20 @@ public class StringType extends DataType<String> implements Streamer<String> {
                 return F;
             }
         }
-        if (value instanceof Map || value instanceof Collection) {
+        if (value instanceof Map) {
+            try {
+                return Strings.toString(XContentFactory.jsonBuilder().map((Map) value));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot cast `" + value + "` to type TEXT", e);
+            }
+        }
+        if (value instanceof Collection) {
             throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "Cannot cast %s to type string", value));
+                String.format(Locale.ENGLISH, "Cannot cast %s to type TEXT", value));
         }
         if (value.getClass().isArray()) {
             throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "Cannot cast %s to type string", Arrays.toString((Object[]) value)));
+                String.format(Locale.ENGLISH, "Cannot cast %s to type TEXT", Arrays.toString((Object[]) value)));
         }
         if (value instanceof TimeValue) {
             return ((TimeValue) value).getStringRep();

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ Deprecations
 Changes
 =======
 
+- Added support for casting values of type ``object`` to ``text``. This will
+  cause the object to be converted to a JSON string.
+
 - Optimized ``SELECT DISTINCT .. LIMIT n`` queries. On high cardinality
   columns this type of queries can now execute up to 200% faster and use
   less memory.

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1179,8 +1179,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchPredicateWithWrongQueryTerm() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast {} to type text");
-        analyze("select name from users order by match(name, {})");
+        expectedException.expectMessage("Cannot cast [10, 20] to type text");
+        analyze("select name from users order by match(name, [10, 20])");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -292,14 +292,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUpdateWithWrongParameters() throws Exception {
         Object[] params = {
-            new HashMap<String, Object>(),
+            List.of(new HashMap<String, Object>()),
             new Map[0],
             new Long[]{1L, 2L, 3L}};
         AnalyzedUpdateStatement update = analyze("update users set name=?, friends=? where other_id=?");
 
         Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast {} to type string");
+        expectedException.expectMessage("Cannot cast [{}] to type TEXT");
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }
 
@@ -434,7 +434,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedUpdateStatement update = analyze("update users set tags=? where id=1");
 
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [a, b] to type string");
+        expectedException.expectMessage("Cannot cast [a, b] to type TEXT");
         Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -82,6 +82,11 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void test_object_cast_to_text_results_in_json_string() {
+        assertEvaluate("cast({x=10, y=20} as text)", "{\"x\":10,\"y\":20}");
+    }
+
+    @Test
     public void testPrecedenceOfDoubleColonCastIsHigherThanArithmetic() {
         // used to result in 2.0 as the precedence was like this: ((x::double) / a)::double
         assertEvaluate("x::double / a::double", 2.5, Literal.of(5), Literal.of(2L));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Casting an object to text will result in a JSON string:

    cr> select {x=10, y=20}::text;
    +----------------------------------+
    | CAST({"x"= 10, "y"= 20} AS text) |
    +----------------------------------+
    | {"x":10,"y":20}                  |
    +----------------------------------+

    cr> select {x=10, y=20}::text::object;
    +--------------------------------------------------+
    | CAST(CAST({"x"= 10, "y"= 20} AS text) AS object) |
    +--------------------------------------------------+
    | {"x": 10, "y": 20}                               |
    +--------------------------------------------------+


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)