### PR TITLE
Fix initial merge buckets error handling (bp #9455)

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -46,6 +46,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that may cause a ``SELECT`` query to hang on multiple nodes
+  cluster if a resource error like a ``CircuitBreakingException`` occurs.
+
 - Fixed the memory accounting of the circuit breaker for values which
   types cannot be defined. Previously, the memory for such data types
   was not accounted which could potentially lead to out of memory errors.

--- a/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -165,7 +165,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
                 try {
                     pagingIterator.merge(buckets);
                     executor.execute(this::consumeRows);
-                } catch (RejectedExecutionException e) {
+                } catch (Throwable e) {
                     consumer.accept(null, e);
                     throwable = e;
                 }

--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -244,7 +244,7 @@ public class DistResultRXTaskTest extends CrateUnitTest {
     }
 
     @Test
-    public void testBatchIteratorIsCompletedExceptionallyIfMergeBucketFails() throws Exception {
+    public void test_batch_iterator_is_completed_exceptionally_if_merge_buckets_on_next_page_fails() throws Exception {
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
 
         DistResultRXTask ctx = getPageDownstreamContext(batchConsumer, new FailOnMergePagingIterator<>(2), 2);
@@ -257,6 +257,23 @@ public class DistResultRXTaskTest extends CrateUnitTest {
         bucketReceiver.setBucket(1, bucket, false, pageResultListener);
         bucketReceiver.setBucket(0, bucket, true, pageResultListener);
         bucketReceiver.setBucket(1, bucket, true, pageResultListener);
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("raised on merge");
+        batchConsumer.getResult();
+    }
+
+    @Test
+    public void test_batch_iterator_is_completed_exceptionally_if_first_merge_buckets_fails() throws Exception {
+        TestingRowConsumer batchConsumer = new TestingRowConsumer();
+
+        DistResultRXTask ctx = getPageDownstreamContext(batchConsumer, new FailOnMergePagingIterator<>(1), 1);
+        PageBucketReceiver bucketReceiver = ctx.getBucketReceiver((byte) 0);
+        assertThat(bucketReceiver, notNullValue());
+
+        PageResultListener pageResultListener = mock(PageResultListener.class);
+        Bucket bucket = new CollectionBucket(Collections.singletonList(new Object[] { "foo" }));
+        bucketReceiver.setBucket(0, bucket, true, pageResultListener);
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("raised on merge");


### PR DESCRIPTION
If an error besides `RejectedExecutionException`, e.g. a `CircuitBreakingException`,
is raised  while triggering the consumer initially inside the cumulative bucket
receiver, the error isn’t propagated and thus the query will hang.

Backport of #9455.