### PR TITLE
Fixed support for `readonly` property in CREATE REPOSITORY

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -212,6 +212,8 @@ Changes
 Fixes
 =====
 
+- Fixed the support for the ``readonly`` property in ``CREATE REPOSITORY``.
+
 - Improved the memory accounting for values of type ``geo_shape``, ``object``
   or ``undefined``. Previously an arbitrary fixed value was used for memory
   accounting. If the actual payloads are large, this could have led to out of

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -289,7 +289,7 @@ A repository that stores its snapshot on the Amazon S3 service.
 
   Whether retries should be throttled (ie use backoff).
 
-**read_only**
+**readonly**
   | *Type:*    ``boolean``
   | *Default:* ``false``
 
@@ -423,7 +423,7 @@ A read-only repository that points to the location of a
 
 .. rubric:: Parameters
 
-**read_only**
+**readonly**
   | *Type:*    ``text``
 
   This url must point to the root of the shared

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.repositories.s3.S3RepositorySettings.CHUNK_SIZE_
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.ENDPOINT_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.MAX_RETRIES_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.PROTOCOL_SETTING;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.READONLY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SERVER_SIDE_ENCRYPTION_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.STORAGE_CLASS_SETTING;
@@ -84,7 +85,8 @@ public class S3Repository extends BlobStoreRepository {
                        ENDPOINT_SETTING,
                        PROTOCOL_SETTING,
                        MAX_RETRIES_SETTING,
-                       USE_THROTTLE_RETRIES_SETTING);
+                       USE_THROTTLE_RETRIES_SETTING,
+                       READONLY_SETTING);
     }
 
     private final S3Service service;

--- a/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/es/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -35,6 +35,8 @@ import java.util.Locale;
 
 class S3RepositorySettings {
 
+    static final Setting<Boolean> READONLY_SETTING = Setting.boolSetting("readonly", false);
+
     /**
      * The access key to authenticate with s3.
      */

--- a/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/es/es-server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -64,12 +64,16 @@ public class FsRepository extends BlobStoreRepository {
     public static final Setting<ByteSizeValue> REPOSITORIES_CHUNK_SIZE_SETTING = Setting.byteSizeSetting("repositories.fs.chunk_size",
         new ByteSizeValue(Long.MAX_VALUE), new ByteSizeValue(5), new ByteSizeValue(Long.MAX_VALUE), Property.NodeScope);
 
+
+    static final Setting<Boolean> READONLY_SETTING =
+        Setting.boolSetting("readonly", false, Property.NodeScope);
+
     public static List<Setting<?>> mandatorySettings() {
         return List.of(LOCATION_SETTING);
     }
 
     public static List<Setting<?>> optionalSettings() {
-        return List.of(COMPRESS_SETTING, CHUNK_SIZE_SETTING);
+        return List.of(COMPRESS_SETTING, CHUNK_SIZE_SETTING, READONLY_SETTING);
     }
 
     private final Environment environment;

--- a/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
@@ -43,7 +43,11 @@ public class TypeSettings {
     TypeSettings(Map<String, Setting<?>> required,
                  Map<String, Setting<?>> optional) {
         this.required = required;
-        this.all = ImmutableMap.<String, Setting<?>>builder().putAll(required).putAll(optional).putAll(GENERIC).build();
+        this.all = ImmutableMap.<String, Setting<?>>builder()
+            .putAll(required)
+            .putAll(optional)
+            .putAll(GENERIC)
+            .build();
     }
 
     public Map<String, Setting<?>> required() {

--- a/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -149,6 +149,7 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
             "   buffer_size='5mb'," +
             "   max_retries=2," +
             "   use_throttle_retries=false," +
+            "   readonly=false, " +
             "   canned_acl=false)");
         assertThat(request.name(), is("foo"));
         assertThat(request.type(), is("s3"));
@@ -167,7 +168,9 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
                 hasEntry("use_throttle_retries", "false"),
                 hasEntry("protocol", "http"),
                 hasEntry("secret_key", "0xCAFEE"),
-                hasEntry("server_side_encryption", "false"))
+                hasEntry("server_side_encryption", "false"),
+                hasEntry("readonly", "false")
+            )
         );
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -73,6 +73,10 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         execute("CREATE REPOSITORY " + REPOSITORY_NAME + " TYPE \"fs\" with (location=?, compress=True)",
             new Object[]{defaultRepositoryLocation.getAbsolutePath()});
         assertThat(response.rowCount(), is(1L));
+        execute(
+            "CREATE REPOSITORY my_repo_ro TYPE \"fs\" with (location=?, compress=true, readonly=true)",
+            new Object[]{defaultRepositoryLocation.getAbsolutePath()}
+        );
     }
 
     private void createTableAndSnapshot(String tableName, String snapshotName) {
@@ -146,9 +150,14 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         execute("CREATE SNAPSHOT " + snapshotName() + " TABLE backmeup WITH (wait_for_completion=true)");
         assertThat(response.rowCount(), is(1L));
 
-        execute("select name, \"repository\", concrete_indices, state from sys.snapshots");
+        execute("select name, \"repository\", concrete_indices, state from sys.snapshots order by 2");
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is(String.format("my_snapshot| my_repo| [%s.backmeup]| SUCCESS\n", sqlExecutor.getCurrentSchema())));
+            is(String.format(
+                "my_snapshot| my_repo| [%s.backmeup]| SUCCESS\n" +
+                // shows up twice because both repos have the same data path
+                "my_snapshot| my_repo_ro| [%s.backmeup]| SUCCESS\n",
+                sqlExecutor.getCurrentSchema(),
+                sqlExecutor.getCurrentSchema())));
     }
 
     @Test
@@ -187,9 +196,11 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
                 " TABLE custom.backmeup PARTITION (date='1970-01-01')  WITH (wait_for_completion=true)");
         assertThat(response.rowCount(), is(1L));
 
-        execute("select name, \"repository\", concrete_indices, state from sys.snapshots");
+        execute("select name, \"repository\", concrete_indices, state from sys.snapshots order by 2");
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is("my_snapshot| my_repo| [custom..partitioned.backmeup.04130]| SUCCESS\n"));
+            is("my_snapshot| my_repo| [custom..partitioned.backmeup.04130]| SUCCESS\n" +
+               // shows up twice because the repos have the same fs path.
+               "my_snapshot| my_repo_ro| [custom..partitioned.backmeup.04130]| SUCCESS\n"));
     }
 
     @Test
@@ -483,5 +494,11 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)");
         ensureYellow();
         execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE employees with (wait_for_completion=true)");
+    }
+
+    @Test
+    public void test_cannot_create_snapshot_in_read_only_repo() {
+        expectedException.expectMessage("cannot create snapshot in a readonly repository");
+        execute("create snapshot my_repo_ro.s1 ALL WITH (wait_for_completion=true)");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We documented the property as `read_only` but it is actually `readonly`
and needs to be part of the internal `optionalSettings` properties.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)