### PR TITLE
Fix the type of fs.disks and fs.data in sys.nodes

### DIFF
--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -48,9 +48,9 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     public static class Builder {
 
-        ImmutableMap.Builder<String, DataType> innerTypesBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, DataType<?>> innerTypesBuilder = ImmutableMap.builder();
 
-        public Builder setInnerType(String key, DataType innerType) {
+        public Builder setInnerType(String key, DataType<?> innerType) {
             innerTypesBuilder.put(key, innerType);
             return this;
         }
@@ -64,7 +64,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         return new Builder();
     }
 
-    private ImmutableMap<String, DataType> innerTypes;
+    private ImmutableMap<String, DataType<?>> innerTypes;
 
     /**
      * Constructor used for the {@link org.elasticsearch.common.io.stream.Streamable}
@@ -74,15 +74,15 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         this(ImmutableMap.of());
     }
 
-    private ObjectType(ImmutableMap<String, DataType> innerTypes) {
+    private ObjectType(ImmutableMap<String, DataType<?>> innerTypes) {
         this.innerTypes = innerTypes;
     }
 
-    public Map<String, DataType> innerTypes() {
+    public Map<String, DataType<?>> innerTypes() {
         return innerTypes;
     }
 
-    public DataType innerType(String key) {
+    public DataType<?> innerType(String key) {
         return innerTypes.getOrDefault(key, UndefinedType.INSTANCE);
     }
 
@@ -198,10 +198,10 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     public ObjectType(StreamInput in) throws IOException {
         int typesSize = in.readVInt();
-        ImmutableMap.Builder<String, DataType> builder = ImmutableMap.builderWithExpectedSize(typesSize);
+        ImmutableMap.Builder<String, DataType<?>> builder = ImmutableMap.builderWithExpectedSize(typesSize);
         for (int i = 0; i < typesSize; i++) {
             String key = in.readString();
-            DataType type = DataTypes.fromStream(in);
+            DataType<?> type = DataTypes.fromStream(in);
             builder.put(key, type);
         }
         innerTypes = builder.build();
@@ -210,7 +210,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(innerTypes.size());
-        for (Map.Entry<String, DataType> entry : innerTypes.entrySet()) {
+        for (Map.Entry<String, DataType<?>> entry : innerTypes.entrySet()) {
             out.writeString(entry.getKey());
             DataTypes.toStream(entry.getValue(), out);
         }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -212,6 +212,10 @@ Changes
 Fixes
 =====
 
+- Fixed the type information of the ``fs['data']`` and ``fs['disks']`` column
+  in the ``sys.nodes`` table. Querying those columns could have resulted in
+  serialization errors.
+
 - Fixed the support for the ``readonly`` property in ``CREATE REPOSITORY``.
 
 - Improved the memory accounting for values of type ``geo_shape``, ``object``

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -173,10 +173,10 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
             );
     }
 
-    private static DataType makeArray(DataType valueType, int numArrayDimensions) {
-        DataType arrayType = valueType;
+    private static DataType<?> makeArray(DataType<?> valueType, int numArrayDimensions) {
+        DataType<?> arrayType = valueType;
         for (int i = 0; i < numArrayDimensions; i++) {
-            arrayType = new ArrayType(arrayType);
+            arrayType = new ArrayType<>(arrayType);
         }
         return arrayType;
     }

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -66,12 +66,12 @@ import org.elasticsearch.threadpool.ThreadPoolStats;
 import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.DOUBLE;
-import static io.crate.types.DataTypes.SHORT;
-import static io.crate.types.DataTypes.TIMESTAMPZ;
 import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.LONG;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.TIMESTAMPZ;
 
 public class SysNodesTableInfo extends StaticTableInfo<NodeStatsContext> {
 
@@ -230,7 +230,7 @@ public class SysNodesTableInfo extends StaticTableInfo<NodeStatsContext> {
                 }
             })
 
-            .register("thread_pools", new ArrayType(ObjectType.untyped()), NodeThreadPoolsExpression::new)
+            .register("thread_pools", new ArrayType<>(ObjectType.untyped()), NodeThreadPoolsExpression::new)
 
             .register("thread_pools", "active", INTEGER, () -> new NodeStatsThreadPoolExpression<Integer>() {
                 @Override
@@ -363,13 +363,13 @@ public class SysNodesTableInfo extends StaticTableInfo<NodeStatsContext> {
                     .setInnerType("writes", LONG)
                     .setInnerType("bytes_written", LONG)
                     .build())
-                .setInnerType("disks", new ArrayType(ObjectType.builder()
+                .setInnerType("disks", new ArrayType<>(ObjectType.builder()
                                                          .setInnerType("dev", STRING)
                                                          .setInnerType("size", LONG)
                                                          .setInnerType("used", LONG)
                                                          .setInnerType("available", LONG)
                                                          .build()))
-                .setInnerType("data", new ArrayType(ObjectType.builder()
+                .setInnerType("data", new ArrayType<>(ObjectType.builder()
                                                         .setInnerType("dev", STRING)
                                                         .setInnerType("path", STRING)
                                                         .build()))
@@ -390,39 +390,39 @@ public class SysNodesTableInfo extends StaticTableInfo<NodeStatsContext> {
                 () -> forFunction((NodeStatsContext r) -> r.isComplete() ? FsInfoHelpers.Stats.writeOperations(r.fsInfo().getIoStats()) : null))
             .register("fs", ImmutableList.of("total", "bytes_written"), LONG,
                 () -> forFunction((NodeStatsContext r) -> r.isComplete() ? FsInfoHelpers.Stats.bytesWritten(r.fsInfo().getIoStats()) : null))
-            .register("fs", ImmutableList.of("disks"), ObjectType.untyped(), NodeStatsFsDisksExpression::new)
-            .register("fs", ImmutableList.of("disks", "dev"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<String>() {
+            .register("fs", ImmutableList.of("disks"), new ArrayType<>(ObjectType.untyped()), NodeStatsFsDisksExpression::new)
+            .register("fs", ImmutableList.of("disks", "dev"), DataTypes.STRING, () -> new NodeStatsFsArrayExpression<String>() {
                 @Override
                 protected String valueForItem(FsInfo.Path input) {
                     return FsInfoHelpers.Path.dev(input);
                 }
             })
-            .register("fs", ImmutableList.of("disks", "size"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<Long>() {
+            .register("fs", ImmutableList.of("disks", "size"), LONG, () -> new NodeStatsFsArrayExpression<Long>() {
                 @Override
                 protected Long valueForItem(FsInfo.Path input) {
                     return FsInfoHelpers.Path.size(input);
                 }
             })
-            .register("fs", ImmutableList.of("disks", "used"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<Long>() {
+            .register("fs", ImmutableList.of("disks", "used"), LONG, () -> new NodeStatsFsArrayExpression<Long>() {
                 @Override
                 protected Long valueForItem(FsInfo.Path input) {
                     return FsInfoHelpers.Path.used(input);
                 }
             })
-            .register("fs", ImmutableList.of("disks", "available"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<Long>() {
+            .register("fs", ImmutableList.of("disks", "available"), LONG, () -> new NodeStatsFsArrayExpression<Long>() {
                 @Override
                 protected Long valueForItem(FsInfo.Path input) {
                     return FsInfoHelpers.Path.available(input);
                 }
             })
-            .register("fs","data", ObjectType.untyped(), NodeStatsFsDataExpression::new)
-            .register("fs", ImmutableList.of("data", "dev"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<String>() {
+            .register("fs","data", new ArrayType<>(ObjectType.untyped()), NodeStatsFsDataExpression::new)
+            .register("fs", ImmutableList.of("data", "dev"), DataTypes.STRING, () -> new NodeStatsFsArrayExpression<String>() {
                 @Override
                 protected String valueForItem(FsInfo.Path input) {
                     return FsInfoHelpers.Path.dev(input);
                 }
             })
-            .register("fs", ImmutableList.of("data", "path"), ObjectType.untyped(), () -> new NodeStatsFsArrayExpression<String>() {
+            .register("fs", ImmutableList.of("data", "path"), DataTypes.STRING, () -> new NodeStatsFsArrayExpression<String>() {
                 @Override
                 protected String valueForItem(FsInfo.Path input) {
                     return input.getPath();

--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -149,7 +149,7 @@ public class ColumnRegistrar<T> {
     }
 
     public ColumnRegistrar<T> register(ColumnIdent column,
-                                       DataType type,
+                                       DataType<?> type,
                                        boolean nullable,
                                        @Nullable RowCollectExpressionFactory<T> expression) {
         Reference ref = new Reference(
@@ -182,13 +182,13 @@ public class ColumnRegistrar<T> {
         if (dataType.id() != ObjectType.ID) {
             return;
         }
-        Map<String, DataType> innerTypes = ((ObjectType) dataType).innerTypes();
+        Map<String, DataType<?>> innerTypes = ((ObjectType) dataType).innerTypes();
         int pos = 0;
-        for (Map.Entry<String, DataType> entry : innerTypes.entrySet()) {
+        for (Map.Entry<String, DataType<?>> entry : innerTypes.entrySet()) {
             List<String> subPath = new ArrayList<>(path);
             subPath.add(entry.getKey());
             ColumnIdent ci = new ColumnIdent(topLevelName, subPath);
-            DataType innerType = entry.getValue();
+            DataType<?> innerType = entry.getValue();
             Reference ref = new Reference(
                 new ReferenceIdent(relationName, ci),
                 rowGranularity,

--- a/sql/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
@@ -22,20 +22,27 @@
 
 package io.crate.metadata;
 
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.StaticTableReferenceResolver;
 import io.crate.expression.reference.sys.node.NodeStatsContext;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.test.integration.CrateUnitTest;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 import org.elasticsearch.Version;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Iterator;
+import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 
-public class SysNodesTableInfoTest extends CrateUnitTest {
+public class SysNodesTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     /**
      * Ensures that all columns registered in SysNodesTableInfo can actually be resolved
@@ -60,5 +67,23 @@ public class SysNodesTableInfoTest extends CrateUnitTest {
 
         assertThat(sysNodeTableStatws.create().getChild("minimum_wire_compatibility_version").value(),
                    is(Version.CURRENT.minimumCompatibilityVersion().externalNumber()));
+    }
+
+    @Test
+    public void test_column_that_is_a_child_of_an_array_has_array_type_on_select() {
+        SysNodesTableInfo table = new SysNodesTableInfo();
+        Reference ref = table.getReference(new ColumnIdent("fs", List.of("data", "path")));
+        assertThat(ref.valueType(), is(DataTypes.STRING));
+
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        AnalyzedRelation statement = e.analyze("select fs['data']['path'] from sys.nodes");
+        assertThat(statement.fields().get(0).valueType(), is(new ArrayType<>(DataTypes.STRING)));
+    }
+
+    @Test
+    public void test_fs_data_is_a_object_array() {
+        SysNodesTableInfo table = new SysNodesTableInfo();
+        Reference ref = table.getReference(new ColumnIdent("fs", "data"));
+        assertThat(ref.valueType(), Matchers.is(new ArrayType<>(ObjectType.untyped())));
     }
 }

--- a/sql/src/test/java/io/crate/metadata/table/ColumnRegistrarTest.java
+++ b/sql/src/test/java/io/crate/metadata/table/ColumnRegistrarTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.table;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static io.crate.types.DataTypes.LONG;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ColumnRegistrarTest {
+
+    @Test
+    public void test_array_within_object_has_array_type() {
+        var columns = new ColumnRegistrar<>(new RelationName("doc", "dummy"), RowGranularity.DOC);
+        columns.register(
+            "fs",
+            ObjectType.builder()
+                .setInnerType("total", ObjectType.builder().setInnerType("size", LONG).build())
+                .setInnerType("data", new ArrayType<>(ObjectType.builder().setInnerType("path", DataTypes.STRING).build()))
+                .build(),
+            () -> null
+        );
+        Reference reference = columns.infos().get(new ColumnIdent("fs", "data"));
+        assertThat(reference.valueType(), Matchers.is(new ArrayType<>(ObjectType.untyped())));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The columns were registered as `object` but are actually an array.

That caused a `ClassCastException` after the merge of
https://github.com/crate/crate/pull/9456 and potentially could also have
led to serialization errors using the PostgreSQL protocol.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)