### PR TITLE
Drop limitation from some copy integration tests.

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -706,7 +706,6 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response.rowCount(), is(2L));
     }
 
-    @UseJdbc(0) // copy from returning does not support unbound analysis (prepared statements)
     @Test
     public void testCopyFromReturnSummaryWithFailedRows() throws Exception {
         execute("create table t1 (id int primary key, ts timestamp with time zone)");
@@ -745,7 +744,6 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(result, containsString("data4.json| 1| 1| {JSON parser error: "));
     }
 
-    @UseJdbc(0) // copy from returning does not support unbound analysis (prepared statements)
     @Test
     public void testCopyFromReturnSummaryWithFailedURI() throws Exception {
         execute("create table t1 (id int primary key, ts timestamp with time zone)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Such as COPY statements support unbound analysis,
it is fine to execute tests without `UseJdbc(0)`.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
