### PR TITLE
Ignore free memory for shard request sizing

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -346,20 +346,17 @@ public class ShardingUpsertExecutor
     private static class IsUsedBytesOverThreshold implements Predicate<ShardedRequests<?, ?>> {
 
         private static final double HEAP_PERCENTAGE = 0.30d;
-        private static final double MAX_FREE_MEM_USAGE_PERCENT = 0.70d;
 
-        private final Runtime rt;
         private final long maxBytesUsableByShardedRequests;
 
         IsUsedBytesOverThreshold() {
-            rt = Runtime.getRuntime();
+            var rt = Runtime.getRuntime();
             maxBytesUsableByShardedRequests = (long) (rt.maxMemory() * HEAP_PERCENTAGE);
         }
 
         @Override
         public final boolean test(ShardedRequests<?, ?> shardedRequests) {
-            return shardedRequests.usedMemoryEstimate() > maxBytesUsableByShardedRequests
-                   || shardedRequests.usedMemoryEstimate() > (rt.freeMemory() * MAX_FREE_MEM_USAGE_PERCENT);
+            return shardedRequests.usedMemoryEstimate() > maxBytesUsableByShardedRequests;
         }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To avoid having large individual shard requests that use up too much
memory we added a criteria to down-size the number of records per shard
request based on used & available memory.

The problem of using the available memory is that it can hover within
the threshold without triggering a GC for a long time. This will cause
tiny shard requests and impact performance a lot. This can be especially
noticable on a otherwise empty cluster where somebody is performing an
initial import.

The first criteria should be good enough, and if it isn't we can look
into re-adding a second criteria that uses the circuit breaker totals.



## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)