### PR TITLE
Fix NPE in verifyIndexIsDeleted on node startup due to stale index file

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -217,6 +217,10 @@ Changes
 Fixes
 =====
 
+- Fixed a ``NullPointerException`` that could prevent a node from starting up.
+  This could occur if the node crashed or disconnected while a user deleted a
+  table.
+
 - Fixed the type information of the ``fs['data']`` and ``fs['disks']`` column
   in the ``sys.nodes`` table. Querying those columns could have resulted in
   serialization errors.

--- a/es/es-server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -674,6 +674,9 @@ public class IndicesService extends AbstractLifecycleComponent
             final IndexMetaData metaData;
             try {
                 metaData = metaStateService.loadIndexState(index);
+                if (metaData == null) {
+                    return null;
+                }
             } catch (Exception e) {
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to load state file from a stale deleted index, folders will be left on disk", index), e);
                 return null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/elastic/elasticsearch/commit/d10fa1ccbbe419919d5736722c621c3566971be4

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)