### PR TITLE
Fix crate-node cli script for non-release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -305,6 +305,7 @@ jar {
         }
     }
 
+    archiveFileName = 'crate-app.jar'
     from(configurations.compileNotTransitive.collect { it.isDirectory() ? it : zipTree(it) }) {
         exclude 'META-INF/**' // Don't let Gradle merge service files
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

On non-release builds the `bin/crate-node` script resulted in an error
because it couldn't find the `NodeToolCli`. This couldn't be found
because the `crate-app.jar` that was referenced in the `classpath`
didn't exist. It was called something like
`crate-app-4.1.0-SNAPSHOT-b144b29bea.jar` instead.

This sets the `archiveFileName` to `crate-app.jar` so that non-release
builds have the same jar name as release builds do.

Adapting the classpath of the `crate-node` script dynamically didn't
work out. Changing it to something like:

    classpath = sourceSets.main.runtimeClasspath + files("lib/${jar.archiveFileName.get()")

Would require a dependency on the jar task which results in a cyclic
dependency and breaks the build.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)