### PR TITLE
Fix NOT NULL constraint validation for children of object arrays

### DIFF
--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -51,6 +51,14 @@ public class ArrayType<T> extends DataType<List<T>> {
             "Inner type must not be null.");
     }
 
+    public static DataType<?> makeArray(DataType<?> valueType, int numArrayDimensions) {
+        DataType<?> arrayType = valueType;
+        for (int i = 0; i < numArrayDimensions; i++) {
+            arrayType = new ArrayType<>(arrayType);
+        }
+        return arrayType;
+    }
+
     /**
      * Defaults to the {@link ArrayStreamer} but subclasses may override this method.
      */

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -217,6 +217,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused a type cast error in ``INSERT`` statements if the
+  target table contained a ``array(object() as (...)`` column where a child of
+  the object array contained a ``NOT NULL`` constraint.
+
 - Fixed a ``NullPointerException`` that could prevent a node from starting up.
   This could occur if the node crashed or disconnected while a user deleted a
   table.

--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -57,7 +57,7 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
         if (operation == Operation.UPDATE) {
             ensureColumnCanBeUpdated(path);
         }
-        Reference reference = tableInfo.getReference(path);
+        Reference reference = tableInfo.getReadReference(path);
         if (reference == null) {
             reference = tableInfo.indexColumn(path);
             if (reference == null) {
@@ -70,7 +70,7 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
                 }
             }
         }
-        return allocate(path, makeArrayIfContainedInObjectArray(reference));
+        return allocate(path, reference);
     }
 
     /**

--- a/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -34,11 +34,11 @@ public interface FieldProvider<T extends Symbol> {
 
     T resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation);
 
-    FieldProvider UNSUPPORTED = (qualifiedName, path, operation) -> {
+    FieldProvider<?> UNSUPPORTED = (qualifiedName, path, operation) -> {
         throw new UnsupportedOperationException(
             "Columns cannot be used in this context. " +
             "Maybe you wanted to use a string literal which requires single quotes: '" + qualifiedName + "'");
     };
 
-    FieldProvider<Literal> FIELDS_AS_LITERAL = ((qualifiedName, path, operation) -> Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
+    FieldProvider<Literal<?>> FIELDS_AS_LITERAL = ((qualifiedName, path, operation) -> Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/CheckConstraints.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/CheckConstraints.java
@@ -28,8 +28,8 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.ValueExtractors;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Reference;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 
 import java.util.ArrayList;
@@ -49,7 +49,10 @@ public final class CheckConstraints<T, E extends CollectExpression<T, ?>> {
         InputFactory.Context<E> ctx = inputFactory.ctxForRefs(txnCtx, refResolver);
         notNullColumns = new ArrayList<>(table.notNullColumns());
         for (int i = 0; i < notNullColumns.size(); i++) {
-            Reference notNullRef = table.getReference(notNullColumns.get(i));
+            ColumnIdent columnIdent = notNullColumns.get(i);
+            Reference notNullRef = table.getReadReference(columnIdent);
+            assert notNullRef != null
+                : "ColumnIdent retrieved via `table.notNullColumns` must be available via `table.getReadReference`";
             inputs.add(ctx.add(notNullRef));
         }
         expressions = ctx.expressions();

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -106,8 +106,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
             if (target.granularity() == RowGranularity.DOC) {
                 ColumnIdent column = target.column();
                 Maps.mergeInto(source, column.name(), column.path(), value, Map::putIfAbsent);
-            } else if (target.granularity() == RowGranularity.PARTITION &&
-                       !(target instanceof GeneratedReference)) {
+            } else if (target.granularity() == RowGranularity.PARTITION && !(target instanceof GeneratedReference)) {
                 // values for columns used as partitioning criteria are not part of the source map;
                 // separate validation is necessary.
                 checks.validate(target.column(), value);
@@ -126,10 +125,10 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         return BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
     }
 
-    private Tuple<List<Reference>, Object[]> addDefaults(List<Reference> targets,
-                                                         DocTableInfo table,
-                                                         TransactionContext txnCtx,
-                                                         Functions functions) {
+    private static Tuple<List<Reference>, Object[]> addDefaults(List<Reference> targets,
+                                                                DocTableInfo table,
+                                                                TransactionContext txnCtx,
+                                                                Functions functions) {
         ArrayList<Reference> defaultColumns = new ArrayList<>(table.defaultExpressionColumns().size());
         ArrayList<Object> defaultValues = new ArrayList<>();
         for (Reference ref : table.defaultExpressionColumns()) {

--- a/sql/src/main/java/io/crate/expression/ValueExtractors.java
+++ b/sql/src/main/java/io/crate/expression/ValueExtractors.java
@@ -26,6 +26,7 @@ import io.crate.data.Row;
 import io.crate.metadata.ColumnIdent;
 import io.crate.types.DataType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -43,6 +44,18 @@ public final class ValueExtractors {
         if (o instanceof Map) {
             //noinspection unchecked
             return getByPath((Map) o, column.path());
+        }
+        if (o instanceof List) {
+            List<?> values = (List<?>) o;
+            ArrayList<Object> extractedValues = new ArrayList<>(values.size());
+            for (Object value : values) {
+                if (value instanceof Map) {
+                    extractedValues.add(getByPath((Map) value, column.path()));
+                } else {
+                    extractedValues.add(value);
+                }
+            }
+            return extractedValues;
         }
         return o;
     }

--- a/sql/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -28,11 +28,21 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 import org.elasticsearch.cluster.ClusterState;
 
 import javax.annotation.Nullable;
+import java.util.function.Predicate;
+
+import static io.crate.types.ArrayType.makeArray;
 
 public interface TableInfo extends RelationInfo {
+
+    Predicate<DataType<?>> IS_OBJECT_ARRAY =
+        type -> type instanceof ArrayType && ((ArrayType<?>) type).innerType().id() == ObjectType.ID;
 
     /**
      * returns information about a column with the given ident.
@@ -40,6 +50,73 @@ public interface TableInfo extends RelationInfo {
      */
     @Nullable
     Reference getReference(ColumnIdent columnIdent);
+
+    /**
+     * This is like {@link #getReference(ColumnIdent)},
+     * except that the type is adjusted via {@link #getReadType(ColumnIdent)}
+     */
+    @Nullable
+    default Reference getReadReference(ColumnIdent columnIdent) {
+        Reference ref = getReference(columnIdent);
+        if (ref == null) {
+            return null;
+        }
+        DataType<?> readType = getReadType(columnIdent);
+        if (readType.equals(ref.valueType())) {
+            return ref;
+        } else {
+            return new Reference(
+                ref.ident(),
+                ref.granularity(),
+                readType,
+                ref.columnPolicy(),
+                ref.indexType(),
+                ref.isNullable(),
+                ref.isColumnStoreDisabled(),
+                ref.position(),
+                ref.defaultExpression()
+            );
+        }
+    }
+
+    /**
+     * Returns the type of the column for reading.
+     * <p>
+     *      Columns can have two different types. Given the schema:
+     * </p>
+     *
+     * <pre>
+     * {@code
+     *  payloads ARRAY(
+     *      OBJECT(STRICT) AS (
+     *          x INTEGER
+     *      )
+     *  )
+     * }
+     * </pre>
+     *
+     * Reads on `payloads['x']` return a `array(integer)`,
+     * but users would insert something like `[{x: 10}, {x: 20}]` where `x` is an integer.
+     *
+     * @return the type of the column; morphed to array if it is the child of an array object.
+     *         UNDEFINED if the column does not exist.
+     */
+    default DataType<?> getReadType(ColumnIdent column) {
+        Reference ref = getReference(column);
+        if (ref == null) {
+            return DataTypes.UNDEFINED;
+        }
+        Reference rootRef = ref;
+        int arrayDimensions = 0;
+        while (!rootRef.column().isTopLevel()) {
+            rootRef = getReference(rootRef.column().getParent());
+            assert rootRef != null : "The parent column of a nested column must exist";
+            if (IS_OBJECT_ARRAY.test(rootRef.valueType())) {
+                arrayDimensions++;
+            }
+        }
+        return makeArray(ref.valueType(), arrayDimensions);
+    }
 
     /**
      * Retrieve the routing for the table
@@ -53,4 +130,5 @@ public interface TableInfo extends RelationInfo {
                        WhereClause whereClause,
                        RoutingProvider.ShardSelection shardSelection,
                        SessionContext sessionContext);
+
 }

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -205,7 +205,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testInSelfJoinCaseFunctionsThatLookTheSameMustNotReuseFunctionAllocation() throws Exception {
         TableInfo tableInfo = mock(TableInfo.class);
-        when(tableInfo.getReference(new ColumnIdent("id"))).thenReturn(
+        when(tableInfo.getReadReference(new ColumnIdent("id"))).thenReturn(
             new Reference(new ReferenceIdent(new RelationName("doc", "t"), "id"),
                           RowGranularity.DOC,
                           DataTypes.INTEGER,

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
@@ -68,13 +68,13 @@ public class NodeStatsCollectSourceTest extends CrateUnitTest {
         // build where clause with id = ?
         SysNodesTableInfo tableInfo = mock(SysNodesTableInfo.class);
         when(tableInfo.ident()).thenReturn(new RelationName("sys", "nodes"));
-        when(tableInfo.getReference(new ColumnIdent("id"))).thenReturn(
+        when(tableInfo.getReadReference(new ColumnIdent("id"))).thenReturn(
             new Reference(new ReferenceIdent(new RelationName("sys", "nodes"), "id"),
                           RowGranularity.DOC,
                           DataTypes.STRING,
                           null,
                           null));
-        when(tableInfo.getReference(SysNodesTableInfo.Columns.NAME)).thenReturn(
+        when(tableInfo.getReadReference(SysNodesTableInfo.Columns.NAME)).thenReturn(
             new Reference(
                 new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.NAME),
                 RowGranularity.DOC,
@@ -83,7 +83,7 @@ public class NodeStatsCollectSourceTest extends CrateUnitTest {
                 null
             )
         );
-        when(tableInfo.getReference(SysNodesTableInfo.Columns.HOSTNAME)).thenReturn(
+        when(tableInfo.getReadReference(SysNodesTableInfo.Columns.HOSTNAME)).thenReturn(
             new Reference(
                 new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.HOSTNAME),
                 RowGranularity.DOC,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Given a schema like:

    payloads ARRAY(
        OBJECT(STRICT) AS (
            x INTEGER
        )
    )

`payloads['x']` was typed as `integer` instead of `array(integer)`. That
caused a cast error (`Cannot convert [10, 20, ..] to type integer`).


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)