### PR TITLE
Add returning clause to update-by-id usecase to the storage engine

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
@@ -21,8 +21,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
+import org.elasticsearch.common.Nullable;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public interface AnalyzedStatement {
@@ -55,5 +58,13 @@ public interface AnalyzedStatement {
      */
     default boolean isUnboundPlanningSupported() {
         return false;
+    }
+
+    /**
+     * Defines the columns for the result set or null if not present.
+     */
+    @Nullable
+    default List<Field> fields() {
+        return null;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -34,6 +34,7 @@ import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.analyze.relations.select.SelectAnalysis;
 import io.crate.analyze.relations.select.SelectAnalyzer;
+import io.crate.common.collections.Lists2;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -100,6 +101,7 @@ public final class UpdateAnalyzer {
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, table);
         SubqueryAnalyzer subqueryAnalyzer =
             new SubqueryAnalyzer(relationAnalyzer, new StatementAnalysisContext(typeHints, Operation.READ, txnCtx));
+
         ExpressionAnalyzer sourceExprAnalyzer = new ExpressionAnalyzer(
             functions,
             txnCtx,
@@ -121,12 +123,19 @@ public final class UpdateAnalyzer {
 
         Symbol normalizedQuery = normalizer.normalize(query, txnCtx);
 
-        SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(update.returningClause(),
-                                                                          relCtx.sources(),
-                                                                          sourceExprAnalyzer,
-                                                                          exprCtx);
+        List<Symbol> outputSymbol = null;
+        List<ColumnIdent> outputNames = null;
 
-        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery, selectAnalysis.outputMultiMap());
+        if (!update.returningClause().isEmpty()) {
+            SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(update.returningClause(),
+                                                                              relCtx.sources(),
+                                                                              sourceExprAnalyzer,
+                                                                              exprCtx);
+            outputSymbol = Lists2.map(selectAnalysis.outputSymbols(), x -> normalizer.normalize(x, txnCtx));
+            outputNames = selectAnalysis.outputNames();
+        }
+
+        return new AnalyzedUpdateStatement(table, assignmentByTargetCol, normalizedQuery, outputNames, outputSymbol);
     }
 
     private HashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
@@ -43,8 +43,6 @@ public interface AnalyzedRelation extends AnalyzedStatement {
 
     Field getField(ColumnIdent path, Operation operation) throws UnsupportedOperationException, ColumnUnknownException;
 
-    List<Field> fields();
-
     QualifiedName getQualifiedName();
 
     /** * @return The outputs of the relation */

--- a/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.JobKilledException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -78,7 +79,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     protected WritePrimaryResult<ShardDeleteRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardDeleteRequest request,
                                                                                         AtomicBoolean killed) throws IOException {
-        ShardResponse shardResponse = new ShardResponse();
+        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
         Translog.Location translogLocation = null;
         boolean debugEnabled = logger.isDebugEnabled();
         for (ShardDeleteRequest.Item item : request.items()) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -38,6 +38,7 @@ import io.crate.planner.node.dml.LegacyUpsertById;
 import io.crate.planner.node.dml.UpdateById;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
@@ -114,8 +115,10 @@ public class LegacyUpsertByIdTask {
             upsertById.numBulkResponses() > 0 || items.size() > 1,
             upsertById.updateColumns(),
             upsertById.insertColumns(),
+            null,
             jobId,
-            false
+            false,
+            Version.CURRENT
         );
     }
 
@@ -326,7 +329,9 @@ public class LegacyUpsertByIdTask {
                                                     item.insertValues(),
                                                     item.version(),
                                                     item.seqNo(),
-                                                    item.primaryTerm()));
+                                                    item.primaryTerm(),
+                                                    null
+                        ));
         }
         return requestsByShard;
     }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.Doc;
+import io.crate.expression.reference.DocRefResolver;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+
+final class ReturnValueGen {
+
+    private final List<CollectExpression<Doc, ?>> expressions;
+    private final List<Input<?>> inputs;
+
+    ReturnValueGen(Functions functions, TransactionContext txnCtx, DocTableInfo table, Symbol[] returnValues) {
+        InputFactory.Context<CollectExpression<Doc, ?>> cntx = new InputFactory(functions).ctxForRefs(
+            txnCtx, new DocRefResolver(table.partitionedBy()));
+        cntx.add(List.of(returnValues));
+        this.expressions = cntx.expressions();
+        this.inputs = cntx.topLevelInputs();
+    }
+
+    @Nullable
+    Object[] generateReturnValues(Doc doc) {
+        if (inputs.isEmpty()) {
+            return null;
+        }
+        expressions.forEach(x -> x.setNextRow(doc));
+        Object[] result = new Object[inputs.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = inputs.get(i).value();
+        }
+        return result;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -29,6 +29,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.settings.SessionSettings;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -73,13 +74,23 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
     @Nullable
     private Streamer[] insertValuesStreamer;
 
+    /**
+     * List of references or expressions to compute values for returning for update.
+     */
+    @Nullable
+    private Symbol[] returnValues;
+
+    private boolean allOn4_1;
+
     ShardUpsertRequest() {
     }
 
     private ShardUpsertRequest(SessionSettings sessionSettings,
                                ShardId shardId,
+                               Version version,
                                @Nullable String[] updateColumns,
                                @Nullable Reference[] insertColumns,
+                               @Nullable Symbol[] returnValues,
                                UUID jobId) {
         super(shardId, jobId);
         assert updateColumns != null || insertColumns != null
@@ -93,10 +104,18 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                 insertValuesStreamer[i] = insertColumns[i].valueType().streamer();
             }
         }
+        this.returnValues = returnValues;
+        this.allOn4_1 = version.onOrAfter(Version.V_4_1_0);
     }
 
     public SessionSettings sessionSettings() {
         return sessionSettings;
+    }
+
+
+    @Nullable
+    public Symbol[] getReturnValues() {
+        return returnValues;
     }
 
     String[] updateColumns() {
@@ -137,6 +156,11 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
 
     public ShardUpsertRequest(StreamInput in) throws IOException {
         super(in);
+        if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
+            this.allOn4_1 = in.readBoolean();
+        } else {
+            this.allOn4_1 = false;
+        }
         int assignmentsColumnsSize = in.readVInt();
         if (assignmentsColumnsSize > 0) {
             updateColumns = new String[assignmentsColumnsSize];
@@ -161,11 +185,23 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
 
         int numItems = in.readVInt();
         readItems(in, numItems);
+        if (allOn4_1) {
+            int returnValuesSize = in.readVInt();
+            if (returnValuesSize > 0) {
+                returnValues = new Symbol[returnValuesSize];
+                for (int i = 0; i < returnValuesSize; i++) {
+                    returnValues[i] = Symbols.fromStream(in);
+                }
+            }
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
+            out.writeBoolean(allOn4_1);
+        }
         // Stream References
         if (updateColumns != null) {
             out.writeVInt(updateColumns.length);
@@ -191,7 +227,17 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
 
         out.writeVInt(items.size());
         for (Item item : items) {
-            item.writeTo(out, insertValuesStreamer);
+            item.writeTo(out, insertValuesStreamer, allOn4_1);
+        }
+        if (allOn4_1) {
+            if (returnValues != null) {
+                out.writeVInt(returnValues.length);
+                for (Symbol returnValue : returnValues) {
+                    Symbols.toStream(returnValue, out);
+                }
+            } else {
+                out.writeVInt(0);
+            }
         }
     }
 
@@ -211,12 +257,13 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                validateConstraints == items.validateConstraints &&
                Arrays.equals(updateColumns, items.updateColumns) &&
                Arrays.equals(insertColumns, items.insertColumns) &&
-               Arrays.equals(insertValuesStreamer, items.insertValuesStreamer);
+               Arrays.equals(insertValuesStreamer, items.insertValuesStreamer) &&
+               Arrays.equals(returnValues, items.returnValues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(super.hashCode(), continueOnError, duplicateKeyAction, validateConstraints, updateColumns, insertColumns, insertValuesStreamer);
+        return Objects.hashCode(super.hashCode(), continueOnError, duplicateKeyAction, validateConstraints, updateColumns, insertColumns, insertValuesStreamer, returnValues);
     }
 
     /**
@@ -239,12 +286,20 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
         @Nullable
         private Object[] insertValues;
 
+        /**
+         * List of references or expressions to compute values for returning for update.
+         */
+        @Nullable
+        private Symbol[] returnValues;
+
         public Item(String id,
                     @Nullable Symbol[] updateAssignments,
                     @Nullable Object[] insertValues,
                     @Nullable Long version,
                     @Nullable Long seqNo,
-                    @Nullable Long primaryTerm) {
+                    @Nullable Long primaryTerm,
+                    @Nullable Symbol[] returnValues
+                    ) {
             super(id);
             this.updateAssignments = updateAssignments;
             if (version != null) {
@@ -257,6 +312,7 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                 this.primaryTerm = primaryTerm;
             }
             this.insertValues = insertValues;
+            this.returnValues = returnValues;
         }
 
         @Nullable
@@ -282,8 +338,17 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             return insertValues;
         }
 
+        @Nullable
+        public Symbol[] returnValues() {
+            return returnValues;
+        }
+
         public Item(StreamInput in, @Nullable Streamer[] insertValueStreamers) throws IOException {
             super(in);
+            boolean allOn4_1 = false;
+            if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
+                allOn4_1 = in.readBoolean();
+            }
             if (in.readBoolean()) {
                 int assignmentsSize = in.readVInt();
                 updateAssignments = new Symbol[assignmentsSize];
@@ -302,10 +367,22 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             if (in.readBoolean()) {
                 source = in.readBytesReference();
             }
+            if (allOn4_1) {
+                int returnValueSize = in.readVInt();
+                if (returnValueSize > 0) {
+                    returnValues = new Symbol[returnValueSize];
+                    for (int i = 0; i < returnValueSize; i++) {
+                        returnValues[i] = Symbols.fromStream(in);
+                    }
+                }
+            }
         }
 
-        public void writeTo(StreamOutput out, @Nullable Streamer[] insertValueStreamers) throws IOException {
+        public void writeTo(StreamOutput out, @Nullable Streamer[] insertValueStreamers, boolean allOn4_1) throws IOException {
             super.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
+                out.writeBoolean(allOn4_1);
+            }
             if (updateAssignments != null) {
                 out.writeBoolean(true);
                 out.writeVInt(updateAssignments.length);
@@ -331,6 +408,17 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             if (sourceAvailable) {
                 out.writeBytesReference(source);
             }
+
+            if (allOn4_1) {
+                if (returnValues != null) {
+                    out.writeVInt(returnValues.length);
+                    for (Symbol returnValue : returnValues) {
+                        Symbols.toStream(returnValue, out);
+                    }
+                } else {
+                    out.writeVInt(0);
+                }
+            }
         }
     }
 
@@ -346,6 +434,10 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
         private final Reference[] missingAssignmentsColumns;
         private final UUID jobId;
         private boolean validateGeneratedColumns;
+        @Nullable
+        private final Symbol[] returnValues;
+
+        private final Version version;
 
         public Builder(SessionSettings sessionSettings,
                        TimeValue timeout,
@@ -353,8 +445,10 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                        boolean continueOnError,
                        @Nullable String[] assignmentsColumns,
                        @Nullable Reference[] missingAssignmentsColumns,
+                       @Nullable Symbol[] returnValue,
                        UUID jobId,
-                       boolean validateGeneratedColumns) {
+                       boolean validateGeneratedColumns,
+                       Version version) {
             this.sessionSettings = sessionSettings;
             this.timeout = timeout;
             this.duplicateKeyAction = duplicateKeyAction;
@@ -363,14 +457,18 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             this.missingAssignmentsColumns = missingAssignmentsColumns;
             this.jobId = jobId;
             this.validateGeneratedColumns = validateGeneratedColumns;
+            this.returnValues = returnValue;
+            this.version = version;
         }
 
         public ShardUpsertRequest newRequest(ShardId shardId) {
             return new ShardUpsertRequest(
                 sessionSettings,
                 shardId,
+                version,
                 assignmentsColumns,
                 missingAssignmentsColumns,
+                returnValues,
                 jobId)
                 .timeout(timeout)
                 .continueOnError(continueOnError)

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -42,6 +42,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -50,6 +51,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
@@ -70,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -118,10 +121,12 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     protected WritePrimaryResult<ShardUpsertRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardUpsertRequest request,
                                                                                         AtomicBoolean killed) {
-        ShardResponse shardResponse = new ShardResponse();
+        ShardResponse shardResponse = new ShardResponse(Version.CURRENT, request.getReturnValues());
+        
         String indexName = request.index();
         DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);
         Reference[] insertColumns = request.insertColumns();
+
         GeneratedColumns.Validation valueValidation = request.validateConstraints()
             ? GeneratedColumns.Validation.VALUE_MATCH
             : GeneratedColumns.Validation.NONE;
@@ -133,7 +138,14 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
 
         UpdateSourceGen updateSourceGen = request.updateColumns() == null
             ? null
-            : new UpdateSourceGen(functions, txnCtx, tableInfo, request.updateColumns());
+            : new UpdateSourceGen(functions,
+                                  txnCtx,
+                                  tableInfo,
+                                  request.updateColumns());
+
+        ReturnValueGen returnValueGen = request.getReturnValues() == null
+            ? null
+            : new ReturnValueGen(functions, txnCtx, tableInfo, request.getReturnValues());
 
         Translog.Location translogLocation = null;
         for (ShardUpsertRequest.Item item : request.items()) {
@@ -146,16 +158,23 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 break;
             }
             try {
-                translogLocation = indexItem(
+                IndexItemResponse indexItemResponse = indexItem(
                     request,
                     item,
                     indexShard,
                     item.insertValues() != null, // try insert first
                     updateSourceGen,
-                    insertSourceGen
+                    insertSourceGen,
+                    returnValueGen
                 );
-                if (translogLocation != null) {
-                    shardResponse.add(location);
+                if (indexItemResponse != null) {
+                    if (indexItemResponse.translog != null) {
+                        shardResponse.add(location);
+                        translogLocation = indexItemResponse.translog;
+                    }
+                    if (indexItemResponse.returnValues != null) {
+                        shardResponse.addResultRows(indexItemResponse.returnValues);
+                    }
                 }
             } catch (Exception e) {
                 if (retryPrimaryException(e)) {
@@ -229,12 +248,13 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     }
 
     @Nullable
-    private Translog.Location indexItem(ShardUpsertRequest request,
+    private IndexItemResponse indexItem(ShardUpsertRequest request,
                                         ShardUpsertRequest.Item item,
                                         IndexShard indexShard,
                                         boolean tryInsertFirst,
                                         @Nullable UpdateSourceGen updateSourceGen,
-                                        @Nullable InsertSourceGen insertSourceGen) throws Exception {
+                                        @Nullable InsertSourceGen insertSourceGen,
+                                        @Nullable ReturnValueGen returnValueGen) throws Exception {
         VersionConflictEngineException lastException = null;
         for (int retryCount = 0; retryCount < MAX_RETRY_LIMIT; retryCount++) {
             try {
@@ -245,6 +265,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                     tryInsertFirst,
                     updateSourceGen,
                     insertSourceGen,
+                    returnValueGen,
                     retryCount > 0
                 );
             } catch (VersionConflictEngineException e) {
@@ -276,17 +297,31 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         throw lastException;
     }
 
+    static class IndexItemResponse {
+        @Nullable
+        final Translog.Location translog;
+        @Nullable
+        final Object[] returnValues;
+
+        IndexItemResponse(@Nullable Translog.Location translog, @Nullable Object[] returnValues) {
+            this.translog = translog;
+            this.returnValues = returnValues;
+        }
+    }
+
     @VisibleForTesting
-    protected Translog.Location indexItem(ShardUpsertRequest request,
+    protected IndexItemResponse indexItem(ShardUpsertRequest request,
                                           ShardUpsertRequest.Item item,
                                           IndexShard indexShard,
                                           boolean tryInsertFirst,
                                           UpdateSourceGen updateSourceGen,
                                           InsertSourceGen insertSourceGen,
+                                          ReturnValueGen returnGen,
                                           boolean isRetry) throws Exception {
         final long seqNo;
         final long primaryTerm;
         final long version;
+        Object[] returnValues = null;
         if (tryInsertFirst) {
             version = request.duplicateKeyAction() == DuplicateKeyAction.OVERWRITE
                 ? Versions.MATCH_ANY
@@ -301,12 +336,18 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             }
         } else {
             Doc currentDoc = getDocument(indexShard, item.id(), item.version(), item.seqNo(), item.primaryTerm());
-            BytesReference updatedSource = updateSourceGen.generateSource(
+
+            Map<String, Object> updatedSource = updateSourceGen.generateSource(
                 currentDoc,
                 item.updateAssignments(),
                 item.insertValues()
             );
-            item.source(updatedSource);
+
+            if (item.returnValues() != null) {
+                returnValues = returnGen.generateReturnValues(currentDoc.withUpdatedSource(updatedSource));
+            }
+
+            item.source(BytesReference.bytes(XContentFactory.jsonBuilder().map(updatedSource)));
             seqNo = item.seqNo();
             primaryTerm = item.primaryTerm();
             version = Versions.MATCH_ANY;
@@ -335,7 +376,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 // update the seqNo and version on request for the replicas
                 item.seqNo(indexResult.getSeqNo());
                 item.version(indexResult.getVersion());
-                return indexResult.getTranslogLocation();
+                return new IndexItemResponse(indexResult.getTranslogLocation(), returnValues);
 
             case FAILURE:
                 Exception failure = indexResult.getFailure();

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -38,10 +38,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +105,7 @@ final class UpdateSourceGen {
         }
     }
 
-    BytesReference generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) throws IOException {
+    Map<String, Object> generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) {
         /* We require a new HashMap because all evaluations of the updateAssignments need to be based on the
          * values *before* the update. For example:
          *
@@ -130,7 +127,7 @@ final class UpdateSourceGen {
         generatedColumns.validateValues(updatedSource);
         injectGeneratedColumns(updatedSource);
         checks.validate(updatedDoc);
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(updatedSource));
+        return updatedSource;
     }
 
     private void injectGeneratedColumns(HashMap<String, Object> updatedSource) {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -40,6 +40,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 
@@ -101,13 +102,15 @@ public class ColumnIndexWriterProjector implements Projector {
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
+            null,
             jobId,
-            true
+            true,
+            Version.CURRENT
         );
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, assignments, insertValues.materialize(), null, null, null);
+            id -> new ShardUpsertRequest.Item(id, assignments, insertValues.materialize(), null, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -39,6 +39,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -107,11 +108,13 @@ public class IndexWriterProjector implements Projector {
             true,
             null,
             new Reference[]{rawSourceReference},
+            null,
             jobId,
-            false);
+            false,
+            Version.CURRENT);
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
+            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -503,8 +503,10 @@ public class ProjectionToProjectorVisitor
             false,
             projection.assignmentsColumns(),
             null,
+            projection.returnValues(),
             context.jobId,
-            true
+            true,
+            Version.CURRENT
         );
         ShardDMLExecutor<ShardUpsertRequest, ShardUpsertRequest.Item> shardDMLExecutor = new ShardDMLExecutor<>(
             ShardDMLExecutor.DEFAULT_BULK_SIZE,
@@ -514,7 +516,13 @@ public class ProjectionToProjectorVisitor
             clusterService,
             nodeJobsCounter,
             () -> builder.newRequest(shardId),
-            id -> new ShardUpsertRequest.Item(id, projection.assignments(), null, projection.requiredVersion(), null, null),
+            id -> new ShardUpsertRequest.Item(id,
+                                              projection.assignments(),
+                                              null,
+                                              projection.requiredVersion(),
+                                              null,
+                                              null,
+                                              projection.returnValues()),
             transportActionProvider.transportShardUpsertAction()::execute
         );
 

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -53,6 +53,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.ObjectType;
+import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -566,7 +567,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             stmt.assignmentByTargetCol().keySet(),
             contains(isReference("name", DataTypes.STRING)));
-        assertThat(stmt.returningClause().size(), is(17));
+        assertThat(stmt.returnValues().size(), is(17));
     }
 
     @Test
@@ -576,8 +577,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             stmt.assignmentByTargetCol().keySet(),
             contains(isReference("name", DataTypes.STRING)));
-        assertThat(stmt.returningClause().size(), is(1));
-        assertThat(stmt.returningClause().get("foo"), contains(isField("id")));
+        assertThat(stmt.fields(), contains(isField("foo")));
+        assertThat(stmt.returnValues(), contains(isReference("id")));
     }
 
     @Test
@@ -587,17 +588,15 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             stmt.assignmentByTargetCol().keySet(),
             contains(isReference("name", DataTypes.STRING)));
-        assertThat(stmt.returningClause().size(), is(2));
-        assertThat(stmt.returningClause().get("foo"), contains(isField("id")));
-        assertThat(stmt.returningClause().get("bar"), contains(isField("name")));
+        assertThat(stmt.fields(), is(contains(isField("foo"), isField("bar"))));
+        assertThat(stmt.returnValues(), contains(isReference("id"), isReference("name")));
     }
 
     @Test
     public void test_updat_returning_with_invalid_column_returning_error() {
         expectedException.expect(ColumnUnknownException.class);
         expectedException.expectMessage("Column invalid unknown");
-        AnalyzedUpdateStatement stmt = e.analyze(
-            "UPDATE users SET name='noam' RETURNING invalid");
+        e.analyze("UPDATE users SET name='noam' RETURNING invalid");
     }
 
     @Test
@@ -607,8 +606,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             stmt.assignmentByTargetCol().keySet(),
             contains(isReference("name", DataTypes.STRING)));
-        assertThat(stmt.returningClause().size(), is(1));
-        assertThat(stmt.returningClause().get("foo"), contains(isFunction("add")));
+        assertThat(stmt.fields(), is(contains(isField("foo"))));
+        assertThat(stmt.returnValues(), contains(isFunction("add")));
     }
 
     @Test
@@ -618,9 +617,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             stmt.assignmentByTargetCol().keySet(),
             contains(isReference("name", DataTypes.STRING)));
-        assertThat(stmt.returningClause().size(), is(2));
-        assertThat(stmt.returningClause().get("foo"), contains(isFunction("add")));
-        assertThat(stmt.returningClause().get("bar"), contains(isFunction("subtract")));
+        assertThat(stmt.fields(), is(contains(isField("foo"), isField("bar"))));
+        assertThat(stmt.returnValues(), contains(isFunction("add"), isFunction("subtract")));
     }
 
     private List<Object[]> execute(Plan plan, Row params) throws Exception {

--- a/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.dml;
 
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.Version;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -31,7 +32,7 @@ public class ShardResponseTest extends CrateUnitTest {
 
     @Test
     public void testMarkResponseItemsAndFailures() {
-        ShardResponse shardResponse = new ShardResponse();
+        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
         shardResponse.add(0);
         shardResponse.add(1);
         shardResponse.add(2, new ShardResponse.Failure("dummyId", "dummyMessage", false));

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.analyze.AnalyzedUpdateStatement;
+import io.crate.expression.reference.Doc;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+
+public class ReturnValueGenTest extends CrateDummyClusterServiceUnitTest {
+
+    private final String CREATE_TEST_TABLE = "create table test (id int primary key, message string)";
+
+    @Test
+    public void test_update_returning_id() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid");
+        Object[] objects = returnValues("1", Map.of());
+        assertThat(objects[0], is(1));
+    }
+
+    @Test
+    public void test_update_by_id_returning_multiple_fields() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid, message");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(1));
+        assertThat(objects[1], is("updated"));
+    }
+
+    @Test
+    public void test_update_returning_with_system_columns() throws Exception {
+        setupStatement("update test set message='update' returning _seq_no");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(1L));
+    }
+
+    @Test
+    public void test_update_by_id_returning_functions() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid + 1, UPPER(message)");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(2));
+        assertThat(objects[1], is("UPDATED"));
+    }
+
+    @Test
+    public void test_update_by_id_returning_functions_multiple_inputs() throws Exception {
+        setupStatement("update test set message='updated' where id = 1 returning _docid + _seq_no + 1");
+        Object[] objects = returnValues("1", Map.of("message", "updated"));
+        assertThat(objects[0], is(3L));
+    }
+
+    private Object[] returnValues(String id, Map<String, Object> content) {
+        return returnValueGen.generateReturnValues(doc(id, content));
+    }
+
+    private void setupStatement(String stmt) throws IOException {
+        SQLExecutor executor = SQLExecutor.builder(clusterService).addTable(CREATE_TEST_TABLE).build();
+        AnalyzedUpdateStatement update = executor.analyze(stmt);
+        tableInfo = (DocTableInfo) update.table().tableInfo();
+        returnValueGen = new ReturnValueGen(executor.functions(),
+                                            txnCtx,
+                                            tableInfo,
+                                            update.returnValues().toArray(new Symbol[]{}));
+    }
+
+    private Doc doc(String id, Map<String, Object> content) {
+        return new Doc(1, tableInfo.concreteIndices()[0], id, 1, 1, 1, content, () -> "");
+    }
+
+    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    private DocTableInfo tableInfo;
+    private ReturnValueGen returnValueGen;
+}
+

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -119,12 +118,13 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         @Nullable
         @Override
-        protected Translog.Location indexItem(ShardUpsertRequest request,
+        protected IndexItemResponse indexItem(ShardUpsertRequest request,
                                               ShardUpsertRequest.Item item,
                                               IndexShard indexShard,
                                               boolean tryInsertFirst,
                                               UpdateSourceGen updateSourceGen,
                                               InsertSourceGen insertSourceGen,
+                                              ReturnValueGen returnValueGen,
                                               boolean isRetry) throws Exception {
              throw new VersionConflictEngineException(
                 indexShard.shardId(),
@@ -183,10 +183,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -204,10 +206,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             true,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -245,10 +249,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -266,10 +272,12 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             null,
             new Reference[]{ID_REF},
+            null,
             UUID.randomUUID(),
-            false
+            false,
+            Version.CURRENT
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -73,7 +73,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
         );
 
         Map<String, Object> source = singletonMap("x", 1);
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -93,7 +93,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"x\":2}"));
+        assertThat(updatedSource, is(Map.of("x", 2)));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .startObject()
             .field("y", 100)
             .endObject());
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -129,7 +129,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"y\":8}"));
+        assertThat(updatedSource, is(Map.of("y", 8)));
     }
 
     @Test
@@ -146,7 +146,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -160,7 +160,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"y\":5},\"x\":4}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("y", 5), "x", 4)));
     }
 
 
@@ -179,13 +179,13 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.targetNames()
         );
 
-        BytesReference source = sourceGen.generateSource(
+        Map<String, Object> source = sourceGen.generateSource(
             new Doc(1, table.concreteIndices()[0], "1", 1, 1, 1, emptyMap(), () -> "{}"),
             assignments.sources(),
             new Object[0]
         );
 
-        assertThat(source.utf8ToString(), is("{\"gen\":\"dummySchema\",\"x\":1}"));
+        assertThat(source, is(Map.of("gen","dummySchema","x", 1)));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -249,7 +249,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"y\":\"foo\"},\"x\":4}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("y", "foo"), "x", 4)));
     }
 
     @Test
@@ -266,7 +266,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             table,
             assignments.targetNames()
         );
-        BytesReference updatedSource = updateSourceGen.generateSource(
+        Map<String, Object> updatedSource = updateSourceGen.generateSource(
             new Doc(
                 1,
                 table.concreteIndices()[0],
@@ -280,6 +280,6 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             assignments.sources(),
             new Object[0]
         );
-        assertThat(updatedSource.utf8ToString(), is("{\"obj\":{\"x\":10}}"));
+        assertThat(updatedSource, is(Map.of("obj", Map.of("x", 10))));
     }
 }

--- a/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.dsl.projection;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import org.elasticsearch.Version;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,10 +34,10 @@ public class UpdateProjectionTest {
     @Test
     public void testEquals() throws Exception {
         UpdateProjection u1 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT, null, null);
 
         UpdateProjection u2 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT,null, null);
 
         assertThat(u2.equals(u1), is(true));
         assertThat(u1.equals(u2), is(true));

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -892,4 +892,55 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is("1| Slartibartfast\n" +
                                                      "2| Trillian\n"));
     }
+
+    @Test
+    public void test_update_by_id_returning_id() throws Exception {
+        execute("create table test (id int primary key, message string) clustered into 2 shards");
+        execute("insert into test values(1, 'msg');");
+        assertEquals(1, response.rowCount());
+        refresh();
+
+        execute("update test set message='msg' where id = 1 returning id");
+
+        assertThat((response.cols()[0]), is("id" ));
+        assertThat(printedTable(response.rows()), is("1\n" ));
+    }
+
+    @Test
+    public void test_update_by_id_returning_id_with_outputname() throws Exception {
+        execute("create table test (id int primary key, message string) clustered into 2 shards");
+        execute("insert into test values(1, 'msg');");
+        assertEquals(1, response.rowCount());
+        refresh();
+
+        execute("update test set message='msg' where id = 1 returning id as renamed");
+
+        assertThat((response.cols()[0]), is("renamed" ));
+        assertThat(printedTable(response.rows()), is("1\n" ));
+    }
+
+    @Test
+    public void test_update_by_id_with_subquery_returning_id() throws Exception {
+        execute("create table test (id int primary key, message string) clustered into 2 shards");
+        execute("insert into test values(1, 'msg');");
+        assertEquals(1, response.rowCount());
+        refresh();
+
+        execute("update test set message='updated' where id = (select 1) returning id");
+
+        assertThat(printedTable(response.rows()), is("1\n" ));
+    }
+
+    @Test
+    public void test_update_by_id_where_no_row_is_matching() throws Exception {
+        execute("create table test (id int primary key, message string) clustered into 2 shards");
+        execute("insert into test values(1, 'msg');");
+        assertEquals(1, response.rowCount());
+        refresh();
+
+        execute("update test set message='updated' where id = 99 returning id");
+
+        assertThat(response.cols()[0], is("id"));
+        assertThat(response.rowCount(), is(0L));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pull request implements an optional `RETURNING` clause to cause `UPDATE` to compute and return values based on each row updated, in the case where the update of the row happens by id. The following example should make this more clear:

`update test set foo='bar' where id = 1 returning id` 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
