### PR TITLE
Always normalize the WHERE clause of relations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -217,6 +217,9 @@ Changes
 Fixes
 =====
 
+- Fixed an NPE which occurred when using the ``current_timestamp`` inside the
+  ``WHERE`` clause on a **view** relation.
+
 - Fixed the data type of the ``sys.jobs_metrics.classification['labels']``
   column, should be ``text_array`` instead of an ``undefined`` type.
 

--- a/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -163,4 +163,11 @@ public class ViewsITest extends SQLTransportIntegrationTest {
         execute("select a['b'], c['d']['e'] from v1");
         assertThat(printedTable(response.rows()), is("1| 2\n"));
     }
+
+    @Test
+    public void test_where_clause_on_view_normalized_on_coordinator_node() {
+        execute("create table test (x timestamp, y int)");
+        execute("create view v_test as select * from test");
+        execute("select * from v_test where x > current_timestamp - 1000 * 60 * 60 * 24");
+    }
 }


### PR DESCRIPTION
Even if the relation is not a field-resolver (e.g. when using views), the WHERE clause must be normalized.
Otherwise e.g. a ``current_timestamp`` scalar isn’t normalized on the  coordinator node and runs into an NPE on a data node as no TransactionContext is set/available.

Relates #9476.