### PR TITLE
Make ReadOnlyException error message more verbose

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -375,7 +375,7 @@ public class Session implements AutoCloseable {
         Portal portal = getSafePortal(portalName);
         AnalyzedStatement analyzedStmt = portal.boundOrUnboundStatement();
         if (isReadOnly && analyzedStmt.isWriteOperation()) {
-            throw new ReadOnlyException();
+            throw new ReadOnlyException(portal.preparedStmt().rawStatement());
         }
         if (analyzedStmt instanceof AnalyzedBegin) {
             resultReceiver.allFinished(false);

--- a/sql/src/main/java/io/crate/exceptions/ReadOnlyException.java
+++ b/sql/src/main/java/io/crate/exceptions/ReadOnlyException.java
@@ -24,10 +24,10 @@ package io.crate.exceptions;
 
 public class ReadOnlyException extends RuntimeException implements ClusterScopeException {
 
-    private static final String MESSAGE = "Only read operations are allowed on this node";
-
-    public ReadOnlyException() {
-        super(MESSAGE);
+    public ReadOnlyException(String statement) {
+        super("Only read operations allowed on this node. Statement: `" +
+              statement.substring(0, Math.max(20, statement.length())) +
+              "` is a write-operation");
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -664,7 +664,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
             conn.setAutoCommit(true);
             PreparedStatement stmt = conn.prepareStatement("create table test(a integer)");
             expectedException.expect(PSQLException.class);
-            expectedException.expectMessage("Only read operations are allowed on this node");
+            expectedException.expectMessage("Only read operations allowed on this node");
             stmt.executeQuery();
         }
     }

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -119,7 +119,7 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
     private void assertReadOnly(String stmt, Object[] args) throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Only read operations are allowed on this node");
+        expectedException.expectMessage("Only read operations allowed on this node");
         execute(stmt, args);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So that if you're looking at a log message from a client you've a better
indication why that error happened.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)