### PR TITLE
Make sure describe/bind analysis errors result in sys.jobs_log entries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -248,6 +248,9 @@ Others
 Fixes
 =====
 
+- Fixed an issue that prevented statements from showing up in ``sys.jobs_log``
+  if they run into an error.
+
 - Fixed an NPE which occurred when using the ``current_timestamp`` inside the
   ``WHERE`` clause on a **view** relation.
 


### PR DESCRIPTION
## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)