### PR TITLE
Add toString implementations to Transport.Connection

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/es/es-server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -370,6 +370,16 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             TcpChannel channel = channel(options.type());
             sendRequestToChannel(this.node, channel, requestId, action, request, options, getVersion(), (byte) 0);
         }
+
+        @Override
+        public String toString() {
+            return "NodeChannels{" +
+                   "channels=" + channels +
+                   ", node=" + node +
+                   ", version=" + version +
+                   ", isClosing=" + isClosing +
+                   '}';
+        }
     }
 
     // This allows transport implementations to potentially override specific connection profiles. This

--- a/es/es-testing/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
@@ -99,6 +99,11 @@ public abstract class DisruptableMockTransport extends MockTransport {
                     throws TransportException {
                     onSendRequest(requestId, action, request, matchingTransport.get());
                 }
+
+                @Override
+                public String toString() {
+                    return "DisruptableMockTransportConnection{node=" + node + '}';
+                }
             };
         } else {
             throw new ConnectTransportException(node, "node " + node + " does not exist");

--- a/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -175,6 +175,11 @@ public class MockTransport implements Transport, LifecycleComponent {
                 requests.put(requestId, Tuple.tuple(node, action));
                 onSendRequest(requestId, action, request, node);
             }
+
+            @Override
+            public String toString() {
+                return "MockTransportConnection{node=" + node + ", requests=" + requests + '}';
+            }
         };
     }
 

--- a/es/es-testing/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -247,6 +247,11 @@ public final class StubbableTransport implements Transport {
         public Transport.Connection getConnection() {
             return connection;
         }
+
+        @Override
+        public String toString() {
+            return "WrappedConnection{" + connection + '}';
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We've an assertion in the test layer that prints any open connections in
the teardown. This increases the amount of information that will be
printed to make it easier to reason about what is still open.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)