### PR TITLE
gradle: Don't fail if tests filter doesn't match any tests

### DIFF
--- a/es/build.gradle
+++ b/es/build.gradle
@@ -29,6 +29,10 @@ subprojects {
         jacoco {
             enabled = false
         }
+
+        filter {
+            setFailOnNoMatchingTests(false)
+        }
     }
 
 

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -113,6 +113,10 @@ test {
         }
     }
 
+    filter {
+        setFailOnNoMatchingTests(false)
+    }
+
     jacoco {
         enabled = true;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This allows to use `./gradlew test --tests ClassName.functionName`
without it causing a failure because one of the modules doesn't contain
a matching test.

This makes it easier to use `vim-test` which currently has trouble
triggering tests in projects with multi-module setups.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)