### PR TITLE
Add a pg_get_keywords table function

### DIFF
--- a/dex/src/main/java/io/crate/data/RowN.java
+++ b/dex/src/main/java/io/crate/data/RowN.java
@@ -33,7 +33,7 @@ public class RowN implements Row {
         this.size = size;
     }
 
-    public RowN(Object[] cells) {
+    public RowN(Object ... cells) {
         this(cells.length);
         this.cells = cells;
     }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -137,8 +137,10 @@ Window function extensions
 
 
 
-Scalar functions and operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Functions and operators
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added a :ref:`PG_GET_KEYWORDS <pg_catalog.pg_get_keywords>` table function.
 
 - Extended :ref:`CONCAT <scalar_concat>` to do implicit casts, so that calls
   like ``SELECT 't' || 5`` are supported.

--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -145,3 +145,40 @@ The return value always matches the ``start`` / ``stop`` types.
     | 1546516800000 | 2019-01-03, 12:00                 |
     +---------------+-----------------------------------+
     SELECT 3 rows in set (... sec)
+
+
+.. _pg_catalog.pg_get_keywords:
+
+
+``pg_catalog.pg_get_keywords()``
+================================
+
+Returns a list of SQL keywords and their categories.
+
+The result rows have three columns:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Column name
+      - Description
+    * - word
+      - The SQL keyword
+    * - catcode
+      - Code for the category (`R` for reserved keywords, `U` for unreserved
+        keywords)
+    * - catdesc
+      - The description of the category
+
+::
+
+    cr> SELECT * FROM pg_catalog.pg_get_keywords() ORDER BY 1 LIMIT 4;
+    +----------+---------+------------+
+    | word     | catcode | catdesc    |
+    +----------+---------+------------+
+    | add      | R       | reserved   |
+    | alias    | U       | unreserved |
+    | all      | R       | reserved   |
+    | allocate | U       | unreserved |
+    +----------+---------+------------+
+    SELECT 4 rows in set (... sec)

--- a/docs/sql/general/lexical-structure.rst
+++ b/docs/sql/general/lexical-structure.rst
@@ -106,39 +106,110 @@ Key words and identifiers
 =========================
 
 The table bellow lists all **reserved key words** in CrateDB. These need to be
-quoted if used as identifiers.
+quoted if used as identifiers::
 
-.. csv-table::
-   :widths: 10, 10, 10, 10
+    cr> SELECT word FROM pg_catalog.pg_get_keywords() WHERE catcode = 'R' ORDER BY 1;
+    +-------------------+
+    | word              |
+    +-------------------+
+    | add               |
+    | all               |
+    | alter             |
+    | and               |
+    | any               |
+    | array             |
+    | as                |
+    | asc               |
+    | between           |
+    | by                |
+    | called            |
+    | case              |
+    | cast              |
+    | column            |
+    | constraint        |
+    | create            |
+    | cross             |
+    | current_date      |
+    | current_schema    |
+    | current_time      |
+    | current_timestamp |
+    | current_user      |
+    | default           |
+    | delete            |
+    | deny              |
+    | desc              |
+    | describe          |
+    | directory         |
+    | distinct          |
+    | drop              |
+    | else              |
+    | end               |
+    | escape            |
+    | except            |
+    | exists            |
+    | extract           |
+    | false             |
+    | first             |
+    | for               |
+    | from              |
+    | full              |
+    | function          |
+    | grant             |
+    | group             |
+    | having            |
+    | if                |
+    | in                |
+    | index             |
+    | inner             |
+    | input             |
+    | insert            |
+    | intersect         |
+    | into              |
+    | is                |
+    | join              |
+    | last              |
+    | left              |
+    | like              |
+    | limit             |
+    | match             |
+    | natural           |
+    | not               |
+    | null              |
+    | nulls             |
+    | object            |
+    | offset            |
+    | on                |
+    | or                |
+    | order             |
+    | outer             |
+    | persistent        |
+    | recursive         |
+    | reset             |
+    | returns           |
+    | revoke            |
+    | right             |
+    | select            |
+    | session_user      |
+    | set               |
+    | some              |
+    | stratify          |
+    | substring         |
+    | table             |
+    | then              |
+    | transient         |
+    | true              |
+    | try_cast          |
+    | unbounded         |
+    | union             |
+    | update            |
+    | user              |
+    | using             |
+    | when              |
+    | where             |
+    | with              |
+    +-------------------+
+    SELECT 95 rows in set (... sec)
 
-    ADD, ALL, ALTER, AND
-    ANY, ARRAY, AS, ASC
-    BETWEEN, BOOLEAN, BOTH, BY
-    BYTE, CALLED, CASE, CAST
-    COLUMN, CONSTRAINT, CREATE, CROSS
-    CURRENT_DATE, CURRENT_SCHEMA, CURRENT_TIME, CURRENT_TIMESTAMP
-    CURRENT_USER, DEFAULT, DELETE, DENY
-    DESC, DESCRIBE, DIRECTORY, DISTINCT
-    DOUBLE, DROP, ELSE, END
-    ESCAPE, EXCEPT, EXISTS, EXTRACT
-    FALSE, FIRST, FLOAT, FOR
-    FROM, FULL, FUNCTION, GRANT
-    GROUP, HAVING, IF, IN
-    INDEX, INNER, INPUT, INSERT
-    INT, INTEGER, INTERSECT, INTO
-    IP, IS, JOIN, LAST
-    LEADING, LICENSE, LIKE, ILIKE
-    LIMIT, LONG, MATCH, NATURAL
-    NOT, NULL, NULLS, OBJECT
-    OFFSET, ON, OR, ORDER
-    OUTER, PERSISTENT, PRIMARY, RECURSIVE
-    REPLACE, RESET, RETURNS, REVOKE
-    SELECT, SESSION_USER, SET, SHORT
-    SOME, STRATIFY, STRING, SUBSTRING
-    TABLE, THEN, TRAILING, TRANSIENT
-    TRIM, TRUE, TRY_CAST, UNBOUNDED
-    UNION, UPDATE, USER, USING
-    WHEN, WHERE, WITH
 
 Tokens such as ``my_table``, ``id``, ``name``, or ``data`` in the example below
 are **identifiers**, which identify names of tables, columns, and other
@@ -179,7 +250,7 @@ lowercase, such as
 
   INSERT INTO foo (id, name) VALUES (1, 'bar');
 
-Quoted identifiers can contain an arbitrary sequence of charactes enclosed by
+Quoted identifiers can contain an arbitrary sequence of characters enclosed by
 double quotes (``"``). Quoted identifiers are never keywords, so you can use
 ``"update"`` as a table or column name.
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -166,7 +166,7 @@ aliasedRelation
     ;
 
 relationPrimary
-    : table                                                                          #tableName
+    : table                                                                          #tableRelation
     | '(' query ')'                                                                  #subqueryRelation
     | '(' relation ')'                                                               #parenthesizedRelation
     ;
@@ -176,8 +176,8 @@ tableWithPartition
     ;
 
 table
-    : qname
-    | ident '(' valueExpression? (',' valueExpression)* ')'
+    : qname                                                                          #tableName
+    | qname '(' valueExpression? (',' valueExpression)* ')'                          #tableFunction
     ;
 
 aliasedColumns

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1149,14 +1149,15 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitTable(SqlBaseParser.TableContext context) {
-        if (context.qname() != null) {
-            var assignments = Lists2.map(context.valueExpression(), x -> (Assignment<Expression>) visit(x));
-            return new Table<>(getQualifiedName(context.qname()), assignments);
-        }
-        FunctionCall fc = new FunctionCall(
-            getQualifiedName(context.ident()), visitCollection(context.valueExpression(), Expression.class));
-        return new TableFunction(fc);
+    public Node visitTableName(SqlBaseParser.TableNameContext ctx) {
+        return new Table<>(getQualifiedName(ctx.qname()), false);
+    }
+
+    @Override
+    public Node visitTableFunction(SqlBaseParser.TableFunctionContext ctx) {
+        QualifiedName qualifiedName = getQualifiedName(ctx.qname());
+        List<Expression> arguments = visitCollection(ctx.valueExpression(), Expression.class);
+        return new TableFunction(new FunctionCall(qualifiedName, arguments));
     }
 
     // Boolean expressions

--- a/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -25,6 +25,8 @@ package io.crate.sql;
 
 import org.junit.Test;
 
+import java.util.stream.Collectors;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -34,7 +36,10 @@ public class IdentifiersTest {
     public void test_number_of_keywords() {
         // If this test is failing you are introducing a new reserved keyword which is a breaking change.
         // Either add the new term to `nonReserved` in `SqlBase.4g` or add a breaking changes entry and adapt this test.
-        assertThat(Identifiers.KEYWORDS.size(), is(95));
+        assertThat(
+            (int) Identifiers.KEYWORDS.stream().filter(Identifiers.Keyword::isReserved).count(),
+            is(95)
+        );
     }
 
     @Test

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -989,6 +989,7 @@ public class TestStatementBuilder {
         printStatement("select * from unnest([1, 2], ['Arthur', 'Marvin'])");
         printStatement("select * from unnest(?, ?)");
         printStatement("select * from open('/tmp/x')");
+        printStatement("select * from x.y()");
     }
 
     @Test

--- a/sql/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.tablefunctions;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.metadata.BaseFunctionResolver;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.params.FuncParams;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.metadata.tablefunctions.TableFunctionImplementation;
+import io.crate.sql.Identifiers;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import org.elasticsearch.cluster.ClusterState;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+public final class PgGetKeywordsFunction extends TableFunctionImplementation<List<Object>> {
+
+    public static final String NAME = "pg_get_keywords";
+    private static final FunctionName FUNCTION_NAME = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+    private static final RelationName REL_NAME = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
+    private static final PgGetKeywordsFunction INSTANCE = new PgGetKeywordsFunction();
+    private final FunctionInfo info;
+
+    public static void register(TableFunctionModule module) {
+        module.register(
+            FUNCTION_NAME,
+            new BaseFunctionResolver(FuncParams.NONE) {
+
+                @Override
+                public FunctionImplementation getForTypes(List<DataType> argTypes) throws IllegalArgumentException {
+                    assert argTypes.isEmpty() : "argument types for pg_get_keywords must be empty due to FuncParams definition";
+                    return PgGetKeywordsFunction.INSTANCE;
+                }
+            }
+        );
+    }
+
+    static class Columns {
+        static final ColumnIdent WORD = new ColumnIdent("word");
+        static final ColumnIdent CATCODE = new ColumnIdent("catcode");
+        static final ColumnIdent CATDESC = new ColumnIdent("catdesc");
+    }
+
+    public PgGetKeywordsFunction() {
+        info = new FunctionInfo(
+            new FunctionIdent(FUNCTION_NAME, List.of()),
+            ObjectType.untyped(),
+            FunctionInfo.Type.TABLE
+        );
+    }
+
+    @Override
+    public TableInfo createTableInfo() {
+        LinkedHashMap<ColumnIdent, Reference> columnMap = new LinkedHashMap<>();
+        columnMap.put(
+            Columns.WORD,
+            new Reference(new ReferenceIdent(REL_NAME, Columns.WORD), RowGranularity.DOC, DataTypes.STRING, 0, null)
+        );
+        columnMap.put(
+            Columns.CATCODE,
+            new Reference(new ReferenceIdent(REL_NAME, Columns.CATCODE), RowGranularity.DOC, DataTypes.STRING, 1, null)
+        );
+        columnMap.put(
+            Columns.CATDESC,
+            new Reference(new ReferenceIdent(REL_NAME, Columns.CATDESC), RowGranularity.DOC, DataTypes.STRING, 2, null)
+        );
+        return new StaticTableInfo<>(REL_NAME, columnMap, columnMap.values(), List.of()) {
+
+            @Override
+            public Routing getRouting(ClusterState state,
+                                      RoutingProvider routingProvider,
+                                      WhereClause whereClause,
+                                      RoutingProvider.ShardSelection shardSelection,
+                                      SessionContext sessionContext) {
+                return Routing.forTableOnSingleNode(REL_NAME, state.getNodes().getLocalNodeId());
+            }
+        };
+    }
+
+    @Override
+    public Iterable<Row> evaluate(TransactionContext txnCtx, Input<List<Object>>... args) {
+        return () -> Identifiers.KEYWORDS.stream()
+            .map(new Function<Identifiers.Keyword, Row>() {
+
+                final Object[] columns = new Object[3];
+                final RowN row = new RowN(columns);
+
+                @Override
+                public Row apply(Identifiers.Keyword keyword) {
+                    columns[0] = keyword.getWord().toLowerCase(Locale.ENGLISH);
+                    if (keyword.isReserved()) {
+                        columns[1] = "R";
+                        columns[2] = "reserved";
+                    } else {
+                        columns[1] = "U";
+                        columns[2] = "unreserved";
+                    }
+                    return row;
+                }
+            }).iterator();
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return info;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -142,7 +142,7 @@ public class Functions {
      */
     @Nullable
     private FunctionImplementation getBuiltin(FunctionName functionName, List<DataType> dataTypes) {
-        FunctionResolver resolver = lookupBuiltinFunctionResolver(functionName);
+        FunctionResolver resolver = functionResolvers.get(functionName);
         if (resolver == null) {
             return null;
         }
@@ -161,7 +161,7 @@ public class Functions {
     private FunctionImplementation getBuiltinByArgs(FunctionName functionName,
                                                     List<? extends FuncArg> argumentsTypes,
                                                     SearchPath searchPath) {
-        FunctionResolver resolver = lookupFunctionResolver(functionName, searchPath, this::lookupBuiltinFunctionResolver);
+        FunctionResolver resolver = lookupFunctionResolver(functionName, searchPath, functionResolvers::get);
         if (resolver == null) {
             return null;
         }
@@ -178,7 +178,7 @@ public class Functions {
     @Nullable
     private FunctionImplementation getUserDefined(FunctionName functionName,
                                                   List<DataType> argTypes) throws UnsupportedOperationException {
-        FunctionResolver resolver = lookupUdfFunctionResolver(functionName);
+        FunctionResolver resolver = udfResolvers.get(functionName);
         if (resolver == null) {
             return null;
         }
@@ -199,21 +199,11 @@ public class Functions {
     private FunctionImplementation resolveUserDefinedByArgs(FunctionName functionName,
                                                             List<? extends FuncArg> arguments,
                                                             SearchPath searchPath) throws UnsupportedOperationException {
-        FunctionResolver resolver = lookupFunctionResolver(functionName, searchPath, this::lookupUdfFunctionResolver);
+        FunctionResolver resolver = lookupFunctionResolver(functionName, searchPath, udfResolvers::get);
         if (resolver == null) {
             return null;
         }
         return resolveFunctionForArgumentTypes(arguments, resolver);
-    }
-
-    @Nullable
-    private FunctionResolver lookupBuiltinFunctionResolver(FunctionName functionName) {
-        return functionResolvers.get(functionName);
-    }
-
-    @Nullable
-    private FunctionResolver lookupUdfFunctionResolver(FunctionName functionName) {
-        return udfResolvers.get(functionName);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
@@ -25,6 +25,7 @@ package io.crate.metadata.table;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -111,5 +112,10 @@ public abstract class StaticTableInfo<T> implements TableInfo {
     @Override
     public RelationType relationType() {
         return RelationType.BASE_TABLE;
+    }
+
+    @Override
+    public RowGranularity rowGranularity() {
+        return RowGranularity.DOC;
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
@@ -22,17 +22,31 @@
 
 package io.crate.expression.tablefunctions;
 
-import io.crate.expression.AbstractFunctionModule;
-import io.crate.metadata.tablefunctions.TableFunctionImplementation;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import org.junit.Test;
 
-public class TableFunctionModule extends AbstractFunctionModule<TableFunctionImplementation> {
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
-    @Override
-    public void configureFunctions() {
-        UnnestFunction.register(this);
-        EmptyRowTableFunction.register(this);
-        GenerateSeries.register(this);
-        ValuesFunction.register(this);
-        PgGetKeywordsFunction.register(this);
+import static org.hamcrest.Matchers.is;
+
+public class PgGetKeywordsFunctionTest extends AbstractTableFunctionsTest {
+
+    @Test
+    public void test_pg_get_keywords() {
+        var it = execute("pg_catalog.pg_get_keywords()").iterator();
+        List<Row> rows = new ArrayList<>();
+        while (it.hasNext()) {
+            rows.add(new RowN(it.next().materialize()));
+        }
+        rows.sort(Comparator.comparing(x -> ((String) x.get(0))));
+        assertThat(rows.size(), is(234));
+        Row row = rows.get(0);
+
+        assertThat(row.get(0), is("add"));
+        assertThat(row.get(1), is("R"));
+        assertThat(row.get(2), is("reserved"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For better compatibility with PostgreSQL.

The function is used in the PostgreSQL JDBC client in a query that is
invoked when `getSQLKeywords` on `DatabaseMetaData` is called.

We could also use the information in `crash` or the admin-ui for keyword
highlighting and completion.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)