### PR TITLE
Add implementation for returning clause for update-by-query usecase to storage engine

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
@@ -29,9 +29,9 @@ import io.crate.data.Row;
 
 public class DMLProjector implements Projector {
 
-    private final ShardDMLExecutor<?, ?> batchAccumulator;
+    private final ShardDMLExecutor<?, ?, ?, ?> batchAccumulator;
 
-    public DMLProjector(ShardDMLExecutor<?, ?> batchAccumulator) {
+    public DMLProjector(ShardDMLExecutor<?, ?, ?, ?> batchAccumulator) {
         this.batchAccumulator = batchAccumulator;
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/Doc.java
+++ b/sql/src/main/java/io/crate/expression/reference/Doc.java
@@ -90,6 +90,18 @@ public final class Doc {
         return index;
     }
 
+    public Doc withVersionAndSeqNo(long version, long seqNo) {
+        return new Doc(
+            docId,
+            index,
+            id,
+            version,
+            seqNo,
+            primaryTerm,
+            source,
+            raw);
+    }
+
     public Doc withUpdatedSource(Map<String, Object> updatedSource) {
         return new Doc(
             docId,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pr provides an implementation for an optional returning clause for the update query including a where clause. e.g. 

`update test set foo='foo' where bar='baz' returning id`




## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
