### PR TITLE
tests: Make sure disrupted connections timeout eventually

### DIFF
--- a/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
@@ -64,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -281,9 +283,33 @@ public final class MockTransportService extends TransportService {
             throw new ConnectTransportException(discoveryNode, "UNRESPONSIVE: simulated");
         });
 
-        transport().addSendBehavior(transportAddress, (connection, requestId, action, request, options) -> {
-            // don't send anything, the receiving node is unresponsive
-        });
+        transport().addSendBehavior(
+            transportAddress,
+            new StubbableTransport.SendRequestBehavior() {
+                private Set<Transport.Connection> toClose = ConcurrentHashMap.newKeySet();
+
+                @Override
+                public void sendRequest(Transport.Connection connection,
+                                        long requestId,
+                                        String action,
+                                        TransportRequest request,
+                                        TransportRequestOptions options) {
+                    // don't send anything, the receiving node is unresponsive
+                    toClose.add(connection);
+                }
+
+                @Override
+                public void clearCallback() {
+                    // close to simulate that tcp-ip eventually times out and closes connection
+                    // (necessary to ensure transport eventually responds).
+                    try {
+                        IOUtils.close(toClose);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This might prevent `testAckedIndexing` from failing occassionally.

See https://github.com/elastic/elasticsearch/pull/42579


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)