### PR TITLE
Support pg array value input notation

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -5,6 +5,7 @@ archivesBaseName = 'crate-common'
 
 dependencies {
     compile project(':shared')
+    implementation project(':pgwire')
     implementation project(':es:es-server')
     implementation "com.google.guava:guava:${versions.guava}"
     testImplementation project(':integration-testing')

--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -23,10 +23,12 @@ package io.crate.types;
 
 import com.google.common.base.Preconditions;
 import io.crate.Streamer;
+import io.crate.protocols.postgres.parser.PgArrayParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -110,6 +112,12 @@ public class ArrayType<T> extends DataType<List<T>> {
             for (Object o : values) {
                 result.add(innerType.value(o));
             }
+        } else if (value instanceof String) {
+            //noinspection unchecked
+            return (List<T>) PgArrayParser.parse(
+                ((String) value).getBytes(StandardCharsets.UTF_8),
+                bytes -> innerType.value(new String(bytes, StandardCharsets.UTF_8))
+            );
         } else {
             Object[] values = (Object[]) value;
             result = new ArrayList<>(values.length);

--- a/common/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/common/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -39,6 +39,16 @@ import static org.hamcrest.core.Is.is;
 public class ArrayTypeTest extends CrateUnitTest {
 
     @Test
+    public void test_pg_string_array_literal_can_be_converted_to_values() {
+        ArrayType<String> strArray = new ArrayType<>(DataTypes.STRING);
+        List<String> values = strArray.value("{a,abc,A,ABC,null,\"null\",NULL,\"NULL\"}");
+        assertThat(
+            values,
+            contains("a", "abc", "A", "ABC", null, "null", null, "NULL")
+        );
+    }
+
+    @Test
     public void testArrayTypeSerialization() throws Exception {
         // nested string array: [ ["x"], ["y"] ]
         ArrayType arrayType = new ArrayType<>(new ArrayType<>(StringType.INSTANCE));

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -253,6 +253,8 @@ Others
 - The ``node`` argument of the :ref:`REROUTE <alter_table_reroute>` commands of
   :ref:`ref-alter-table` can now either be the id or the name of a node.
 
+- Added support for the PostgreSQL array string literal notation.
+
 
 Fixes
 =====

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -967,6 +967,33 @@ Some valid arrays are::
     ARRAY[column_a, column_b]
     ARRAY[ARRAY[1, 2, 1 + 2], ARRAY[3, 4, 3 + 4]]
 
+
+An alternative way to define arrays is to use string literals and casts to
+arrays. This requires a string literal that contains the elements separated by
+comma and enclosed with curly braces::
+
+    '{ val1, val2, val3 }'
+
+::
+
+    cr> SELECT '{ab, CD, "CD", null, "null"}'::array(text) AS arr;
+    +----------------------------------+
+    | arr                              |
+    +----------------------------------+
+    | ["ab", "CD", "CD", null, "null"] |
+    +----------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+``null`` elements are interpreted as ``NULL`` (none, absent), if you want the
+literal ``null`` string, it has to be enclosed in double quotes.
+
+
+This variant primarily exists for compatibility with PostgreSQL. The ``Array
+constructor`` syntax explained further above is the preferred way to define
+constant array values.
+
+
 Array representation
 ....................
 

--- a/pgwire/src/main/antlr/PgArray.g4
+++ b/pgwire/src/main/antlr/PgArray.g4
@@ -22,11 +22,11 @@ array
    ;
 
 item
-   : STRING         #value
+   : NULL           #null
+   | string         #value
    | NUMBER         #value
    | bool           #value
    | array          #noop
-   | NULL           #null
    ;
 
 bool
@@ -34,9 +34,20 @@ bool
     | 'false'
     ;
 
+
+string
+    : STRING        #quotedString
+    | CHAR+         #unquotedString
+    ;
+
 STRING
     : '"' (ESC | ~["\\])* '"'
     ;
+
+CHAR
+    : [0-9a-zA-Z]
+    ;
+
 
 NUMBER
     : '-'? DIGIT '.' DIGIT EXP?

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -82,6 +82,11 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void test_str_value_to_text_array() {
+        assertEvaluate("cast('{a,abc}' as array(text))", List.of("a", "abc"));
+    }
+
+    @Test
     public void test_object_cast_to_text_results_in_json_string() {
         assertEvaluate("cast({x=10, y=20} as text)", "{\"x\":10,\"y\":20}");
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT

The PostgreSQL JDBC client uses some queries which makes use of this
notation.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)