### PR TITLE
Add pg array type notation support

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -52,6 +52,9 @@ None
 Changes
 =======
 
+- Added support for the PostgreSQL notation to refer to array types. For
+  example, it is now possible to use ``text[]`` instead of ``array(test)``.
+
 None
 
 Fixes

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -931,6 +931,14 @@ Array types are defined as follows::
     ... );
     CREATE OK, 1 row affected (... sec)
 
+
+An alternative is the following syntax to refer to arrays::
+
+    <typeName>[]
+
+This means ``text[]`` is equivalent to ``array(text)``.
+
+
 .. NOTE::
 
     Currently arrays cannot be nested. Something like array(array(text))

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -239,6 +239,7 @@ primaryExpression
     | ident ('.' ident)*                                                             #dereference
     | primaryExpression CAST_OPERATOR dataType                                       #doubleColonCast
     | timestamp=primaryExpression AT TIME ZONE zone=primaryExpression                #atTimezone
+    | 'ARRAY'? '[]'                                                                  #emptyArray
     ;
 
 explicitFunction
@@ -267,9 +268,9 @@ subqueryExpression
     ;
 
 parameterOrLiteral
-    : parameterOrSimpleLiteral
-    | arrayLiteral
-    | objectLiteral
+    : parameterOrSimpleLiteral                            #simpleLiteral
+    | ARRAY? '[' (expr (',' expr)*)? ']'                  #arrayLiteral
+    | '{' (objectKeyValue (',' objectKeyValue)*)? '}'     #objectLiteral
     ;
 
 parameterOrSimpleLiteral
@@ -429,14 +430,6 @@ integerLiteral
     : INTEGER_VALUE
     ;
 
-arrayLiteral
-    : ARRAY? '[' (expr (',' expr)*)? ']'
-    ;
-
-objectLiteral
-    : '{' (objectKeyValue (',' objectKeyValue)*)? '}'
-    ;
-
 objectKeyValue
     : key=ident EQ value=expr
     ;
@@ -538,7 +531,8 @@ dataType
     : definedDataType           #definedDataTypeDefault
     | ident                     #dataTypeIdent
     | objectTypeDefinition      #objectDataType
-    | arrayTypeDefinition       #arrayDataType
+    | ARRAY '(' dataType ')'    #arrayDataType
+    | dataType '[]'             #arrayDataType
     ;
 
 definedDataType
@@ -550,10 +544,6 @@ definedDataType
 objectTypeDefinition
     : OBJECT ('(' type=(DYNAMIC | STRICT | IGNORED) ')')?
         (AS '(' columnDefinition ( ',' columnDefinition )* ')')?
-    ;
-
-arrayTypeDefinition
-    : ARRAY '(' dataType ')'
     ;
 
 columnConstraint

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1680,6 +1680,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
+    public Node visitEmptyArray(SqlBaseParser.EmptyArrayContext ctx) {
+        return new ArrayLiteral(List.of());
+    }
+
+    @Override
     public Node visitObjectLiteral(SqlBaseParser.ObjectLiteralContext context) {
         Multimap<String, Expression> objAttributes = LinkedListMultimap.create();
         context.objectKeyValue().forEach(attr ->
@@ -1709,8 +1714,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitArrayTypeDefinition(SqlBaseParser.ArrayTypeDefinitionContext context) {
-        return new CollectionColumnType((ColumnType) visit(context.dataType()));
+    public Node visitArrayDataType(SqlBaseParser.ArrayDataTypeContext ctx) {
+        return new CollectionColumnType<>((ColumnType<?>) visit(ctx.dataType()));
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -963,6 +963,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_cast_with_pg_array_type_definition() {
+        printStatement("SELECT '{a,b,c}'::text[]");
+    }
+
+    @Test
     public void testArrayConstructorSubSelectBuilder() {
         printStatement("select array(select foo from f1) from f2");
         printStatement("select array(select * from f1) as array1 from f2");

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -404,13 +404,18 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void testCreateTableWithArray() {
         BoundCreateTable analysis = analyze(
-            "create table foo (id integer primary key, details array(string))");
+            "create table foo (id integer primary key, details array(string), more_details text[])");
         Map<String, Object> mappingProperties = analysis.mappingProperties();
         Map<String, Object> details = (Map<String, Object>) mappingProperties.get("details");
-
         assertThat(details.get("type"), is("array"));
         Map<String, Object> inner = (Map<String, Object>) details.get("inner");
         assertThat(inner.get("type"), is("keyword"));
+
+
+        Map<String, Object> moreDetails = (Map<String, Object>) mappingProperties.get("more_details");
+        assertThat(moreDetails.get("type"), is("array"));
+        Map<String, Object> moreDetailsInner = (Map<String, Object>) details.get("inner");
+        assertThat(moreDetailsInner.get("type"), is("keyword"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -84,6 +84,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_str_value_to_text_array() {
         assertEvaluate("cast('{a,abc}' as array(text))", List.of("a", "abc"));
+        assertEvaluate("'{a,abc}'::text[]", List.of("a", "abc"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To support casts like `...::text[]`, which is used by the PostgreSQL
JDBC client.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)