### PR TITLE
Fix sphinx dev command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
           agent { label 'medium' }
           steps {
             sh 'cd ./blackbox/ && ./bootstrap.sh'
-            sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b html -E blackbox/docs/ docs/out/html'
+            sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b html -E docs/ docs/out/html'
             sh 'find ./blackbox/*/src/ -type f -name "*.py" | xargs ./blackbox/.venv/bin/pycodestyle'
           }
         }

--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+DOCS_DIR=$DIR/../docs
 PATH=$DIR/.venv/bin:$PATH
 if test "$1" == "dev"; then
-    sphinx-autobuild -W $DIR/docs $DIR/docs/_out/html
+    sphinx-autobuild -n -W -E $DOCS_DIR $DOCS_DIR/_out/html
 else
     declare -i RESULT=0
     printf "\033[1mCleaning output folder ...\033[0m\n"
     rm -rf $DIR/docs/_out
     RESULT+=$?
     printf "\033[1;44mBuilding server docs ...\033[0m\n"
-    sphinx-build -n -W -b html -E $DIR/docs $DIR/docs/_out/html
+    sphinx-build -n -W -b html -E $DOCS_DIR $DOCS_DIR/_out/html
     RESULT+=$?
     exit $RESULT
 fi

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -12,7 +12,7 @@ zc.customdoctests==1.0.1
 
 # packages for local dev
 
-sphinx-autobuild==0.6.0
+sphinx-autobuild==0.7.1
 
 # the next section should mirror the RTD environment
 

--- a/devs/docs/write_docs.rst
+++ b/devs/docs/write_docs.rst
@@ -16,7 +16,7 @@ Java_ (needed for the doctests_). Make sure that ``python3`` is on your
 
 You can run the sphinx build as a development server, like so::
 
-    $ ./gradlew blackbox:developDocs
+    $ ./gradlew :blackbox:developDocs
 
 Once the web server running, you can view your local copy of the docs by
 visiting http://127.0.0.1:8000 in a web browser.
@@ -27,7 +27,7 @@ you.
 
 Alternatively, you can just build the docs without starting the web server::
 
-    $ ./gradlew blackbox:buildDocs
+    $ ./gradlew :blackbox:buildDocs
 
 
 Many of the examples in the documentation are executable and function as
@@ -35,7 +35,7 @@ doctests_.
 
 You can run the doctests like so::
 
-    $ ./gradlew blackbox:itest
+    $ ./gradlew :blackbox:itest
 
 *Note*: Your network connection should be up and running, or some of the tests
 will fail.

--- a/docs/appendices/compliance.rst
+++ b/docs/appendices/compliance.rst
@@ -18,7 +18,7 @@ what CrateDB supports, what they are and how to use them.
    :header: ID,Package,#,Description,Supported,Verified,Comments
    :widths: 80,140,15,250,130
    :delim: U+0009
-   :file: ../../../sql/src/main/resources/sql_features.tsv
+   :file: ../../sql/src/main/resources/sql_features.tsv
    :exclude: {4: '(?i)N\w*'}
    :included_cols: 0,1,2,3,6
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`sphinx dev` failed as it couldn't find the `sql_features.tsv` that is
referenced in `docs/appendices/compliance.rst`.

Changing the path itself in turn broke the `sphinx` command. Possibly
because `sphinx-autobuild` and `sphinx-build` interpret the path
differently.

This changes the `sphinx` command to not rely on the `blackbox/docs`
symlink to `../docs` which solves the issue.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)