### PR TITLE
Fix ClassCastException / type declaration in sys.allocations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,4 +57,5 @@ None
 Fixes
 =====
 
-None
+- Fixed a regression introduced in ``4.0.11`` which caused a
+  ``ClassCastException`` when querying ``sys.allocations``.

--- a/sql/src/main/java/io/crate/expression/reference/sys/ArrayTypeNestableContextCollectExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/ArrayTypeNestableContextCollectExpression.java
@@ -23,9 +23,9 @@
 package io.crate.expression.reference.sys;
 
 
+import io.crate.common.collections.Lists2;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public abstract class ArrayTypeNestableContextCollectExpression<RowType, IterType, ReturnType>
@@ -39,20 +39,12 @@ public abstract class ArrayTypeNestableContextCollectExpression<RowType, IterTyp
 
     @Override
     public void setNextRow(RowType rowType) {
-        computeValue(items(rowType));
+        List<IterType> items = items(rowType);
+        value = items == null ? null : Lists2.map(items, this::valueForItem);
     }
 
     @Override
     public List<ReturnType> value() {
         return value;
-    }
-
-    protected void computeValue(List<IterType> items) {
-        int size = items.size();
-        ArrayList<ReturnType> result = new ArrayList<>(size);
-        for (int idx = 0; idx < size; idx++) {
-            result.add(valueForItem(items.get(idx)));
-        }
-        value = result;
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocationDecisionsExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocationDecisionsExpression.java
@@ -32,13 +32,4 @@ public abstract class SysAllocationDecisionsExpression<ReturnType> extends Array
     protected List<SysAllocation.SysAllocationNodeDecision> items(SysAllocation row) {
         return row.decisions();
     }
-
-    @Override
-    public void setNextRow(SysAllocation sysAllocation) {
-        value = null;
-        List<SysAllocation.SysAllocationNodeDecision> decisions = items(sysAllocation);
-        if (decisions != null) {
-            computeValue(decisions);
-        }
-    }
 }

--- a/sql/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
@@ -25,6 +25,7 @@ package io.crate.metadata.sys;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import io.crate.types.ArrayType;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,6 +65,8 @@ public class SysAllocationsTest extends SQLTransportIntegrationTest {
                 "FROM sys.allocations " +
                 "WHERE table_name = 't1' " +
                 "ORDER BY primary, shard_id");
+
+        assertThat(response.columnTypes()[0].id(), is(ArrayType.ID));
         assertThat(response.rowCount(), is(2L));
 
         Object[] row;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`decisions` was typed as `object` but is an array.

After the merge of https://github.com/crate/crate/pull/9456 this incorrect
typing started causing a `ClassCastException`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)