### PR TITLE
Fix resolving of dynamic allocated subscript fields

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,4 +57,6 @@ None
 Fixes
 =====
 
-None
+- Fixed support for using subscript expressions on sub-relations as ordering or
+  grouping symbols, an exception was raised before.
+  Example: ``SELECT ... FROM (SELECT a FROM t1) ORDER BY a['b']``

--- a/sql/src/main/java/io/crate/analyze/Fields.java
+++ b/sql/src/main/java/io/crate/analyze/Fields.java
@@ -71,7 +71,9 @@ public class Fields {
             if (childField == null) {
                 return null;
             }
-            return new Field(scope, column, childField);
+            field = new Field(scope, column, childField);
+            // Add this new dynamic allocated field so upper relations can resolve/map it correctly
+            add(field);
         }
         return field;
     }

--- a/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -82,7 +82,14 @@ public class QueriedSelectRelation<T extends AnalyzedRelation> implements Analyz
         if (operation != Operation.READ) {
             throw new UnsupportedOperationException("getField on QueriedSelectRelation is only supported for READ operations");
         }
-        return fields.getWithSubscriptFallback(path, this, subRelation);
+        Field field = fields.getWithSubscriptFallback(path, this, subRelation);
+        // Dynamic allocated subscript fields must be added to the output so upper relations can resolve them correctly
+        if (field != null
+            && field.path().isTopLevel() == false
+            && querySpec.outputs().contains(field) == false) {
+            querySpec.outputs().add(field.pointer());
+        }
+        return field;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -94,6 +94,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation {
             Field originalField = relation.getField(childPath, operation);
             if (originalField != null) {
                 field = new Field(this, path, originalField);
+                fields.add(field);
             }
         }
         return field;

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -717,4 +717,26 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is("3\n" +
                                                      "2\n"));
     }
+
+    @Test
+    public void test_subscript_on_subrelation_supported_in_order_by() {
+        execute("create table t1 (x object as (a int), y text)");
+        execute("insert into t1 (x, y) values ({a = 2}, '2'), ({a = 1}, '1')");
+        execute("refresh table t1");
+        execute("select x['a'], y from (select x, y from t1) t2 order by 1");
+        assertThat(printedTable(response.rows()), is(
+            "1| 1\n" +
+            "2| 2\n"));
+    }
+
+    @Test
+    public void test_subscript_on_subrelation_supported_in_group_by() {
+        execute("create table t1 (x object as (a int))");
+        execute("insert into t1 (x) values ({a = 2}), ({a = 1}), ({a = 1})");
+        execute("refresh table t1");
+        execute("select x['a'], count(*) from (select x from t1) t2 group by 1 order by 2 desc");
+        assertThat(printedTable(response.rows()), is(
+            "1| 2\n" +
+            "2| 1\n"));
+    }
 }


### PR DESCRIPTION
Dynamic allocated subscript fields must be added to the outputs and fields of the
related relations so upper relations can map (and normalize) them correctly.

This fixes usages of subscript expressions on sub-relations (sub-select,
view, aliased relation) inside non-fetch-columns like ordering or grouping.

Relates #9477.