### PR TITLE
Replaced unnest function for sample tables in the docs with VALUES

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -373,7 +373,7 @@ If all input values are null, null is returned as a result.
 
 ::
 
-   cr> select string_agg(col1, ', ') from unnest(['a', 'b', 'c']);
+   cr> select string_agg(col1, ', ') from (values('a'), ('b'), ('c')) as t;
    +------------------------+
    | string_agg(col1, ', ') |
    +------------------------+


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Replaced a number of instances of unnest with VALUES in order to make the relationship between the SQL syntax and the sample tables in the documentation more transparent.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
