### PR TITLE
Add missing inner object types to columns index metadata.

### DIFF
--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -285,7 +285,7 @@ public class DocIndexMetaData {
         DataType type;
         String typeName = (String) columnProperties.get("type");
 
-        if (typeName == null) {
+        if (typeName == null || ObjectType.NAME.equals(typeName)) {
             Map<String, Object> innerProperties = (Map<String, Object>) columnProperties.get("properties");
             if (innerProperties != null) {
                 ObjectType.Builder builder = ObjectType.builder();
@@ -294,7 +294,7 @@ public class DocIndexMetaData {
                 }
                 type = builder.build();
             } else {
-                type = DataTypes.NOT_SUPPORTED;
+                type = MoreObjects.firstNonNull(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
             }
         } else if (typeName.equalsIgnoreCase("array")) {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Splitting https://github.com/crate/crate/pull/9513

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
