### PR TITLE
Implement equals, hashCode and isConvertableTo in ObjectType.

### DIFF
--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.RandomAccess;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -411,6 +412,32 @@ public final class DataTypes {
             idx++;
         }
         return streamer;
+    }
+
+    public static boolean compareTypesById(DataType<?> left, DataType<?> right) {
+        if (left.id() != right.id()) {
+            return false;
+        } else if (isArray(left)) {
+            return compareTypesById(
+                ((ArrayType) left).innerType(),
+                ((ArrayType) right).innerType());
+        } else {
+            return true;
+        }
+    }
+
+    public static boolean compareTypesById(List<DataType> left, List<DataType> right) {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        assert left instanceof RandomAccess && right instanceof RandomAccess
+            : "data type lists should support RandomAccess for fast lookups";
+        for (int i = 0; i < left.size(); i++) {
+            if (!compareTypesById(left.get(i), right.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -35,6 +35,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static io.crate.types.DataTypes.ALLOWED_CONVERSIONS;
+import static io.crate.types.DataTypes.UNDEFINED;
 
 public class ObjectType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
@@ -66,10 +71,6 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     private ImmutableMap<String, DataType<?>> innerTypes;
 
-    /**
-     * Constructor used for the {@link org.elasticsearch.common.io.stream.Streamable}
-     * interface which initializes the fields after object creation.
-     */
     private ObjectType() {
         this(ImmutableMap.of());
     }
@@ -177,6 +178,46 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             return m;
         }
         return null;
+    }
+
+    @Override
+    public boolean isConvertableTo(DataType o) {
+        Set<DataType> conversions = ALLOWED_CONVERSIONS.getOrDefault(id(), Set.of());
+        if (conversions.contains(o)) {
+            return true;
+        }
+
+        if (o.id() != id() || o.id() == UNDEFINED.id()) {
+            return false;
+        }
+        ObjectType that = (ObjectType) o;
+        if (innerTypes.isEmpty() || that.innerTypes().isEmpty()) {
+            return true;
+        } else {
+            for (var thisInnerField : this.innerTypes.entrySet()) {
+                var thisInnerType = thisInnerField.getValue();
+                var thatInnerType = that.innerTypes().get(thisInnerField.getKey());
+                if (thatInnerType == null
+                    || !thisInnerType.isConvertableTo(thatInnerType)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+        ObjectType that = (ObjectType) o;
+        return Objects.equals(innerTypes, that.innerTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), innerTypes);
     }
 
     @Override

--- a/common/src/test/java/io/crate/types/DataTypesTest.java
+++ b/common/src/test/java/io/crate/types/DataTypesTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.crate.types.DataTypes.compareTypesById;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
@@ -290,6 +291,39 @@ public class DataTypesTest extends CrateUnitTest {
     @Test
     public void testInt8IsAliasedToLong() {
         assertThat(DataTypes.ofName("int8"), is(DataTypes.LONG));
+    }
+
+    @Test
+    public void test_compare_by_id_primitive_types() {
+        assertThat(compareTypesById(DataTypes.STRING, DataTypes.STRING), is(true));
+        assertThat(compareTypesById(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
+    }
+
+    @Test
+    public void test_compare_by_id_complex_types() {
+        assertThat(compareTypesById(ObjectType.untyped(), DataTypes.BIGINT_ARRAY), is(false));
+        assertThat(compareTypesById(ObjectType.untyped(), DataTypes.GEO_POINT), is(false));
+    }
+
+    @Test
+    public void test_compare_by_id_primitive_and_complex_types() {
+        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
+        assertThat(compareTypesById(ObjectType.untyped(), DataTypes.DOUBLE), is(false));
+    }
+
+    @Test
+    public void test_compare_by_id_array_types_of_the_same_dimension() {
+        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
+        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
+    }
+
+    @Test
+    public void test_compare_by_id_array_types_of_not_equal_dimension_and_same_inner_type() {
+        assertThat(
+            compareTypesById(
+                new ArrayType<>(DataTypes.STRING_ARRAY),
+                DataTypes.STRING_ARRAY),
+            is(false));
     }
 
     private static void assertCompareValueTo(Object val1, Object val2, int expected) {

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -154,7 +154,7 @@ public class TableElementsAnalyzer {
                     Reference parentRef = context.tableInfo.getReference(parent.ident());
                     if (parentRef != null) {
                         parent.position = parentRef.column().isTopLevel() ? parentRef.position() : null;
-                        if (parentRef.valueType().equals(new ArrayType<>(ObjectType.untyped()))) {
+                        if (parentRef.valueType().id() == ArrayType.ID) {
                             parent.collectionType(ArrayType.NAME);
                         } else {
                             parent.objectType(parentRef.columnPolicy());

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -35,6 +35,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
+import io.crate.protocols.postgres.parser.PgArrayParsingException;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -68,7 +69,7 @@ public final class ValueNormalizer {
         Literal<?> literal;
         try {
             literal = (Literal<?>) valueSymbol.cast(reference.valueType());
-        } catch (ConversionException e) {
+        } catch (PgArrayParsingException | ConversionException e) {
             throw new ColumnValidationException(
                 reference.column().name(),
                 tableInfo.ident(),
@@ -86,7 +87,7 @@ public final class ValueNormalizer {
             } else if (isObjectArray(targetType)) {
                 normalizeObjectArrayValue((List<Map<String, Object>>) value, reference, tableInfo);
             }
-        } catch (ConversionException e) {
+        } catch (PgArrayParsingException | ConversionException e) {
             throw new ColumnValidationException(
                 reference.column().name(),
                 tableInfo.ident(),

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -112,6 +112,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+
 @Singleton
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
@@ -230,9 +231,12 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         List<Symbol> leftOutputs = left.outputs();
         List<Symbol> rightOutputs = right.outputs();
         for (int i = 0; i < leftOutputs.size(); i++) {
-            if (!leftOutputs.get(i).valueType().equals(rightOutputs.get(i).valueType())) {
-                throw new UnsupportedOperationException("Corresponding output columns at position: " + (i + 1) +
-                                                        " must be compatible for all parts of a UNION");
+            var leftType = leftOutputs.get(i).valueType();
+            var rightType = rightOutputs.get(i).valueType();
+            if (!DataTypes.compareTypesById(leftType, rightType)) {
+                throw new UnsupportedOperationException(
+                    "Corresponding output columns at position: " + (i + 1) +
+                    " must be compatible for all parts of a UNION");
             }
         }
     }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.reference.ReferenceResolver;
@@ -35,11 +34,10 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.GeoPointType;
+import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
@@ -56,7 +54,7 @@ import static io.crate.types.ArrayType.unnest;
 
 public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollectorExpression<?>> {
 
-    private static final Set<DataType<?>> NO_FIELD_TYPES = ImmutableSet.of(ObjectType.untyped(), DataTypes.GEO_SHAPE);
+    private static final Set<Integer> NO_FIELD_TYPES_IDS = Set.of(ObjectType.ID, GeoShapeType.ID);
     private final FieldTypeLookup fieldTypeLookup;
 
     public LuceneReferenceResolver(FieldTypeLookup fieldTypeLookup) {
@@ -109,7 +107,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         String fqn = ref.column().fqn();
         MappedFieldType fieldType = fieldTypeLookup.get(fqn);
         if (fieldType == null) {
-            return NO_FIELD_TYPES.contains(unnest(ref.valueType())) || isIgnoredDynamicReference(ref)
+            return NO_FIELD_TYPES_IDS.contains(unnest(ref.valueType()).id()) || isIgnoredDynamicReference(ref)
                 ? DocCollectorExpression.create(toSourceLookup(ref))
                 : new NullValueCollectorExpression();
         }

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -152,8 +152,8 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
     }
 
     public static void register(ScalarFunctionModule module) {
-        for (Map.Entry<DataType, String> function : CastFunctionResolver.CAST_SIGNATURES.entrySet()) {
-            module.register(function.getValue(), new Resolver(function.getKey(), function.getValue()));
+        for (Map.Entry<String, DataType> function : CastFunctionResolver.CAST_SIGNATURES.entrySet()) {
+            module.register(function.getKey(), new Resolver(function.getValue(), function.getKey()));
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -44,7 +44,7 @@ public class CastFunctionResolver {
     static final String TRY_CAST_PREFIX = "try_";
     private static final String TO_PREFIX = "to_";
 
-    static final Map<DataType, String> CAST_SIGNATURES; // data type -> name
+    static final Map<String, DataType> CAST_SIGNATURES; // cast function name -> data type
 
     static {
         List<DataType> CAST_FUNC_TYPES = Lists2.concat(
@@ -53,10 +53,10 @@ public class CastFunctionResolver {
 
         CAST_SIGNATURES = new HashMap<>((CAST_FUNC_TYPES.size()) * 2);
         for (var type : CAST_FUNC_TYPES) {
-            CAST_SIGNATURES.put(type, castFuncName(type));
+            CAST_SIGNATURES.put(castFuncName(type), type);
 
             var arrayType = new ArrayType<>(type);
-            CAST_SIGNATURES.put(arrayType, castFuncName(arrayType));
+            CAST_SIGNATURES.put(castFuncName(arrayType), arrayType);
         }
     }
 
@@ -74,17 +74,17 @@ public class CastFunctionResolver {
      * resolve the needed conversion function info based on the wanted return data type
      */
     private static FunctionInfo functionInfo(DataType dataType, DataType returnType, boolean tryCast) {
-        String functionName = CAST_SIGNATURES.get(returnType);
-        if (functionName == null) {
+        var castFunctionName = castFuncName(returnType);
+        if (CAST_SIGNATURES.get(castFunctionName) == null) {
             throw new IllegalArgumentException(
                 String.format(Locale.ENGLISH, "No cast function found for return type %s",
                     returnType.getName()));
         }
-        functionName = tryCast ? TRY_CAST_PREFIX + functionName : functionName;
-        return new FunctionInfo(new FunctionIdent(functionName, List.of(dataType)), returnType);
+        castFunctionName = tryCast ? TRY_CAST_PREFIX + castFunctionName : castFunctionName;
+        return new FunctionInfo(new FunctionIdent(castFunctionName, List.of(dataType)), returnType);
     }
 
     public static boolean supportsExplicitConversion(DataType returnType) {
-        return CAST_SIGNATURES.containsKey(returnType);
+        return CAST_SIGNATURES.containsKey(castFuncName(returnType));
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/cast/TryCastScalarFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/TryCastScalarFunction.java
@@ -42,9 +42,9 @@ public class TryCastScalarFunction extends CastFunction {
     }
 
     public static void register(ScalarFunctionModule module) {
-        for (Map.Entry<DataType, String> function : CastFunctionResolver.CAST_SIGNATURES.entrySet()) {
-            String name = CastFunctionResolver.TRY_CAST_PREFIX + function.getValue();
-            module.register(name, new Resolver(function.getKey(), name));
+        for (Map.Entry<String, DataType> function : CastFunctionResolver.CAST_SIGNATURES.entrySet()) {
+            String name = CastFunctionResolver.TRY_CAST_PREFIX + function.getKey();
+            module.register(name, new Resolver(function.getValue(), name));
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -45,6 +45,7 @@ import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.UnionExecutionPlan;
 import io.crate.planner.consumer.FetchMode;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -149,7 +150,8 @@ public class Union implements LogicalPlan {
 
         ResultDescription leftResultDesc = left.resultDescription();
         ResultDescription rightResultDesc = right.resultDescription();
-        assert leftResultDesc.streamOutputs().equals(rightResultDesc.streamOutputs())
+
+        assert DataTypes.compareTypesById(leftResultDesc.streamOutputs(), rightResultDesc.streamOutputs())
             : "Left and right must output the same types, got " +
               "lhs=" + leftResultDesc.streamOutputs() + ", rhs=" + rightResultDesc.streamOutputs();
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -418,7 +418,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInsertInvalidObjectArrayInObject() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for details: Invalid value '{\"arguments\"=[1, 2, 3], \"awesome\"=true}' in insert statement");
+        expectedException.expectMessage(
+            "Validation failed for details: " +
+            "Cannot cast {\"arguments\"=[1, 2, 3], \"awesome\"=true} to type object");
         e.analyze("insert into deeply_nested (details) " +
                 "values (" +
                 "  {awesome=true, arguments=[1,2,3]}" +
@@ -428,7 +430,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInsertInvalidObjectArrayFieldInObjectArray() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags['metadata']['id']: Invalid bigint");
+        expectedException.expectMessage(
+            "Validation failed for tags: Cannot cast [{\"metadata\"=[{\"id\"=1}, " +
+            "{\"id\"=2}], \"name\"='right'}, {\"metadata\"=[{\"id\"='foo'}], \"name\"='wrong'}] to type object_array");
         e.analyze("insert into deeply_nested (tags) " +
                 "values (" +
                 "  [" +

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -180,11 +180,12 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInvalidInsertIntoObject() throws Exception {
+        setUpObjectTable();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for object_field['created']: Invalid timestamp");
-
-        setUpObjectTable();
+        expectedException.expectMessage(
+            "Validation failed for object_field:" +
+            " Cannot cast {\"created\"=true, \"size\"=127} to type object");
         execute("insert into test12 (object_field, strict_field) values (?,?)", new Object[]{
             new HashMap<String, Object>() {{
                 put("created", true);
@@ -194,7 +195,6 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
                 put("path", "/dev/null");
                 put("created", 0);
             }}
-
         });
     }
 
@@ -302,8 +302,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         execute("insert into t1 values ({a='abc'})");
         waitForMappingUpdateOnAll("t1", "o.a");
 
-        expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for o['a']: Invalid text");
+        expectedException.expectMessage("Cannot cast {\"a\"=['123', '456']} to type object");
         execute("insert into t1 values ({a=['123', '456']})");
     }
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -1243,8 +1243,15 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
                                                                "    quote string index using fulltext" +
                                                                "  ))" +
                                                                ")");
-        assertThat(md.references().get(ColumnIdent.fromPath("tags")).valueType(),
-            is(new ArrayType(ObjectType.untyped())));
+        assertThat(
+            md.references().get(ColumnIdent.fromPath("tags")).valueType(),
+            is(new ArrayType<>(
+                ObjectType.builder()
+                    .setInnerType("size", DataTypes.DOUBLE)
+                    .setInnerType("numbers", DataTypes.INTEGER_ARRAY)
+                    .setInnerType("quote", DataTypes.STRING)
+                    .build()))
+        );
         assertThat(md.references().get(ColumnIdent.fromPath("tags")).columnPolicy(),
             is(ColumnPolicy.STRICT));
         assertThat(md.references().get(ColumnIdent.fromPath("tags.size")).valueType(),
@@ -1252,7 +1259,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(md.references().get(ColumnIdent.fromPath("tags.size")).indexType(),
             is(Reference.IndexType.NO));
         assertThat(md.references().get(ColumnIdent.fromPath("tags.numbers")).valueType(),
-            is(new ArrayType(DataTypes.INTEGER)));
+            is(new ArrayType<>(DataTypes.INTEGER)));
         assertThat(md.references().get(ColumnIdent.fromPath("tags.quote")).valueType(),
             is(DataTypes.STRING));
         assertThat(md.references().get(ColumnIdent.fromPath("tags.quote")).indexType(),

--- a/sql/src/test/java/io/crate/metadata/table/ColumnRegistrarTest.java
+++ b/sql/src/test/java/io/crate/metadata/table/ColumnRegistrarTest.java
@@ -26,7 +26,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
@@ -40,16 +39,21 @@ public class ColumnRegistrarTest {
 
     @Test
     public void test_array_within_object_has_array_type() {
+        var fsDataDataType = new ArrayType<>(
+            ObjectType.builder()
+                .setInnerType("path", DataTypes.STRING)
+                .build()
+        );
         var columns = new ColumnRegistrar<>(new RelationName("doc", "dummy"), RowGranularity.DOC);
         columns.register(
             "fs",
             ObjectType.builder()
                 .setInnerType("total", ObjectType.builder().setInnerType("size", LONG).build())
-                .setInnerType("data", new ArrayType<>(ObjectType.builder().setInnerType("path", DataTypes.STRING).build()))
+                .setInnerType("data", fsDataDataType)
                 .build(),
             () -> null
         );
         Reference reference = columns.infos().get(new ColumnIdent("fs", "data"));
-        assertThat(reference.valueType(), Matchers.is(new ArrayType<>(ObjectType.untyped())));
+        assertThat(reference.valueType(), Matchers.is(fsDataDataType));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Implements missing `equals`, `hashCode` and `isConvertableTo` in the object data type.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
