### PR TITLE
Improve documentation regarding analyzers types

### DIFF
--- a/docs/general/ddl/analyzers.rst
+++ b/docs/general/ddl/analyzers.rst
@@ -110,6 +110,16 @@ This is the same as the `standard-analyzer`_ analyzer.
 
 Uses the :ref:`lowercase-tokenizer` tokenizer.
 
+.. _plain-analyzer:
+
+``plain``
+----------
+
+``type='plain'``
+
+The plain analyzer is an alias for the keyword_ analyzer and cannot be extended.
+You must extend the keyword_ analyzer instead.
+
 .. _whitespace-analyzer:
 
 ``whitespace``
@@ -144,7 +154,7 @@ stopwords_path
 ``keyword``
 -----------
 
-``type=keyword``
+``type='keyword'``
 
 Creates one single token from the field-contents.
 

--- a/docs/general/ddl/column-policy.rst
+++ b/docs/general/ddl/column-policy.rst
@@ -48,8 +48,8 @@ Note that adding new columns to a table with a ``dynamic`` policy will affect
 the schema of the table. Once a column is added, it shows up in the
 ``information_schema.columns`` table and its type and attributes are fixed. It
 will have the type that was guessed by its inserted/updated value and they will
-always be ``not_indexed`` which means they are analyzed with the ``plain``
-analyzer, which means as-is.
+be analyzed as ``plain`` with the :ref:`plain <plain-analyzer>` analyzer,
+which means as-is.
 
 .. NOTE::
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -95,7 +95,8 @@ characters are allowed. Example::
     ... );
     CREATE OK, 1 row affected (... sec)
 
-Columns of type text can also be analyzed. See :ref:`sql_ddl_index_fulltext`.
+Columns of type text can also be analyzed. By default the :ref:`plain
+<plain-analyzer>` analyzer is used. See :ref:`sql_ddl_index_fulltext`.
 
 .. NOTE::
 
@@ -761,7 +762,8 @@ the schema of the table. Once a column is added, it shows up in the
 ``information_schema.columns`` table and its type and attributes are fixed.
 They will have the type that was guessed by their inserted/updated value and
 they will always be ``not_indexed`` which means they are analyzed with the
-``plain`` analyzer, which means as-is.
+:ref:`plain <plain-analyzer>`, which means as-is.
+
 
 If a new column ``a`` was added with type ``integer``, adding strings to this
 column will result in an error.

--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -101,7 +101,7 @@ may not work anymore.  See :ref:`builtin-analyzer` for details about available
 builtin analyzer or :ref:`sql-ddl-custom-analyzer`.
 
 If no analyzer is specified when using a fulltext index, the
-:ref:`standard <standard-analyzer>` analyzer is used::
+:ref:`plain <plain-analyzer>` analyzer is used::
 
     cr> create table table_c (
     ...   first_column text INDEX using fulltext


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pr adds the `plain` analyzer to the analyzer documentation and changes the description for the default analyzer for `text` columns from `standard` to `plain` in the fulltext indices documentation. It also adds missing ticks to the documentation of the `keyword` analyzer. 

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
