### PR TITLE
Allow more lenient column type validation in VALUES.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ None
 Fixes
 =====
 
+- Fixed an issue in :ref:`ref-values` that would not allow combining expressions
+  that can be explicitly casted or `NULL` literals in the same column.
+
 - Fixed a `ClassCastException` that occurred when querying certain columns from
   ``information_schema.tables``, ``sys.jobs_log`` or ``sys.jobs_metrics`` with
   a client connected via PostgreSQL wire protocol.

--- a/docs/sql/statements/values.rst
+++ b/docs/sql/statements/values.rst
@@ -40,4 +40,5 @@ An example::
 It is commonly used in :ref:`ref-insert` to provide values to insert into a
 table.
 
-All expressions within the same column must have the same type.
+All expressions within the same column must have the same type or its types
+can be implicitly converted.

--- a/shared/src/main/java/io/crate/common/collections/Lists2.java
+++ b/shared/src/main/java/io/crate/common/collections/Lists2.java
@@ -66,42 +66,6 @@ public final class Lists2 {
     }
 
     /**
-     * Change the layout from rows to column oriented.
-     *
-     * <pre>
-     *
-     * rows: [
-     *  [a, 1],
-     *  [b, 2]
-     * ]
-     *
-     * to
-     *
-     * columnValues: [
-     *  [a, b],
-     *  [1, 2]
-     * ]
-     * </pre>
-     */
-    public static <T> List<List<T>> toColumnOrientation(List<? extends List<T>> rows) {
-        if (rows.isEmpty()) {
-            return List.of();
-        }
-        List<T> firstRow = rows.get(0);
-        int numColumns = firstRow.size();
-        ArrayList<List<T>> columns = new ArrayList<>();
-        for (int c = 0; c < numColumns; c++) {
-            ArrayList<T> columnValues = new ArrayList<>(rows.size());
-            for (int r = 0; r < rows.size(); r++) {
-                List<T> row = rows.get(r);
-                columnValues.add(row.get(c));
-            }
-            columns.add(columnValues);
-        }
-        return columns;
-    }
-
-    /**
      * Apply the replace function on each item of the list and replaces the item.
      *
      * This is similar to Guava's com.google.common.collect.Lists#transform(List, com.google.common.base.Function),

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -97,6 +97,7 @@ import io.crate.sql.tree.Union;
 import io.crate.sql.tree.Values;
 import io.crate.sql.tree.ValuesList;
 import io.crate.types.ArrayType;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.common.collect.Tuple;
@@ -732,42 +733,55 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             new SubqueryAnalyzer(this, context)
         );
         var expressionAnalysisContext = new ExpressionAnalysisContext();
-        java.util.function.Function<Expression, Symbol> expressionToSymbol = e -> expressionAnalyzer.convert(e, expressionAnalysisContext);
+        java.util.function.Function<Expression, Symbol> expressionToSymbol =
+            e -> expressionAnalyzer.convert(e, expressionAnalysisContext);
 
-        ArrayList<List<Symbol>> rows = new ArrayList<>(values.rows().size());
-        List<Symbol> firstRow = null;
-        for (ValuesList row : values.rows()) {
-            List<Symbol> columns = Lists2.map(row.values(), expressionToSymbol);
-            rows.add(columns);
-            if (firstRow == null) {
-                firstRow = columns;
-            } else {
-                if (firstRow.size() != columns.size()) {
+        // There is a first pass to convert expressions from row oriented format:
+        // `[[1, a], [2, b]]` to columns `[[1, 2], [a, b]]`
+        //
+        // At the same time we determine the column type with the highest precedence,
+        // so that we don't fail with slight type miss-matches (long vs. int)
+        List<ValuesList> rows = values.rows();
+        assert rows.size() > 0 : "Parser grammar enforces at least 1 row";
+        ValuesList firstRow = rows.get(0);
+        int numColumns = firstRow.values().size();
+
+        ArrayList<List<Symbol>> columns = new ArrayList<>();
+        ArrayList<DataType<?>> targetTypes = new ArrayList<>(numColumns);
+        for (int c = 0; c < numColumns; c++) {
+            ArrayList<Symbol> columnValues = new ArrayList<>();
+            DataType<?> targetType = DataTypes.UNDEFINED;
+            for (int r = 0; r < rows.size(); r++) {
+                List<Expression> row = rows.get(r).values();
+                if (row.size() != numColumns) {
                     throw new IllegalArgumentException(
                         "VALUES lists must all be the same length. " +
-                        "Found row with " + firstRow.size() + " items and another with " + columns.size() + " items");
+                        "Found row with " + numColumns + " items and another with " + columns.size() + " items");
                 }
-                for (int i = 0; i < firstRow.size(); i++) {
-                    var typeOfFirstRowAtPos = firstRow.get(i).valueType();
-                    var typeOfCurrentRowAtPos = columns.get(i).valueType();
-                    if (!typeOfCurrentRowAtPos.equals(typeOfFirstRowAtPos)) {
-                        throw new IllegalArgumentException(
-                            "The types of the columns within VALUES lists must match. " +
-                            "Found `" + typeOfFirstRowAtPos + "` and `" + typeOfCurrentRowAtPos + "` at position: " + i);
-                    }
+                Symbol cell = expressionToSymbol.apply(row.get(c));
+                columnValues.add(cell);
+
+                var cellType = cell.valueType();
+                if (r > 0 // skip first cell, we don't have to check for self-conversion
+                    && !cellType.isConvertableTo(targetType)
+                    && targetType.id() != DataTypes.UNDEFINED.id()) {
+                    throw new IllegalArgumentException(
+                        "The types of the columns within VALUES lists must match. " +
+                        "Found `" + targetType + "` and `" + cellType + "` at position: " + c);
+                }
+                if (cellType.precedes(targetType)) {
+                    targetType = cellType;
                 }
             }
+            targetTypes.add(targetType);
+            columns.add(columnValues);
         }
-        assert firstRow != null : "Parser grammar enforces at least 1 row, so firstRow can't be null";
 
-        // We re-write VALUES to a UNNEST table function, so that we can re-use the execution layer logic
-
-        List<List<Symbol>> columns = Lists2.toColumnOrientation(rows);
         ArrayList<Symbol> arrays = new ArrayList<>(columns.size());
-        for (int i = 0; i < firstRow.size(); i++) {
-            Symbol column = firstRow.get(i);
-            ArrayType<?> arrayType = new ArrayType<>(column.valueType());
-            List<Symbol> columnValues = columns.get(i);
+        for (int c = 0; c < numColumns; c++) {
+            DataType<?> targetType = targetTypes.get(c);
+            ArrayType<?> arrayType = new ArrayType<>(targetType);
+            List<Symbol> columnValues = Lists2.map(columns.get(c), s -> s.cast(targetType));
             arrays.add(new Function(
                 new FunctionInfo(new FunctionIdent(ArrayFunction.NAME, Symbols.typeView(columnValues)), arrayType),
                 columnValues


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently, the column types in VALUES have to be an exact
match which prevents using literals that can be implicitly
and `null` literals.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
