### PR TITLE
Fix subscript handling on top of other relations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that caused subscript expressions on top of child relations in
+  which an object column is selected to fail.
+
 - Fixed an issue in :ref:`ref-values` that would not allow combining expressions
   that can be explicitly casted or `NULL` literals in the same column.
 

--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -26,6 +26,7 @@ import io.crate.expression.scalar.SubscriptObjectFunction;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.FetchReference;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
@@ -219,25 +220,39 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         }
         InputColumn inputColumn = sourceSymbols.inputs.get(ref);
         if (inputColumn == null) {
-            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref, sourceSymbols.inputs);
+            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref, ref.column(), sourceSymbols.inputs);
             return subscriptOnRoot == null ? ref : subscriptOnRoot;
         }
         return visitSymbol(ref, sourceSymbols);
     }
 
+    @Override
+    public Symbol visitField(Field field, SourceSymbols sourceSymbols) {
+        InputColumn inputColumn = sourceSymbols.inputs.get(field);
+        if (inputColumn == null) {
+            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(field, field.path(), sourceSymbols.inputs);
+            if (subscriptOnRoot == null) {
+                throw new IllegalArgumentException("Couldn't find " + field + " in " + sourceSymbols);
+            } else {
+                return subscriptOnRoot;
+            }
+        }
+        return inputColumn;
+    }
+
     @Nullable
-    private static Symbol tryCreateSubscriptOnRoot(Reference ref, HashMap<Symbol, InputColumn> inputs) {
-        if (ref.column().isTopLevel()) {
+    private static Symbol tryCreateSubscriptOnRoot(Symbol symbol, ColumnIdent column, HashMap<Symbol, InputColumn> inputs) {
+        if (column.isTopLevel()) {
             return null;
         }
-        ColumnIdent root = ref.column().getRoot();
+        ColumnIdent root = column.getRoot();
         InputColumn rootIC = lookupValueByColumn(inputs, root);
         if (rootIC == null) {
-            return ref;
+            return symbol;
         }
 
-        DataType returnType = ref.valueType();
-        List<String> path = ref.column().path();
+        DataType<?> returnType = symbol.valueType();
+        List<String> path = column.path();
 
         List<Symbol> arguments = mapTail(rootIC, path, Literal::of);
         List<DataType> argumentTypes = Symbols.typeView(arguments);

--- a/sql/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -67,6 +67,9 @@ public class Symbols {
             if (key instanceof Reference && ((Reference) key).column().equals(column)) {
                 return entry.getValue();
             }
+            if (key instanceof Field && ((Field) key).path().equals(column)) {
+                return entry.getValue();
+            }
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
+++ b/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
@@ -22,19 +22,28 @@
 
 package io.crate.planner.operators;
 
+import io.crate.common.collections.Lists2;
+import io.crate.expression.scalar.SubscriptObjectFunction;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.FieldsVisitor;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.common.collections.Lists2;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+
+import static io.crate.common.collections.Lists2.mapTail;
 
 public final class OperatorUtils {
 
@@ -108,7 +117,36 @@ public final class OperatorUtils {
             if (mapped != null) {
                 return mapped;
             }
-            mapped = FieldReplacer.replaceFields(s, f -> mapping.getOrDefault(f, f));
+            mapped = FieldReplacer.replaceFields(s, f -> {
+                Symbol mappedSymbol = mapping.get(f);
+                /* We could have a case like `SELECT obj['x'] FROM (SELECT obj ...) AS t`
+                 *
+                 * `obj['x']` cannot be found in `mapping`, because the sub-relation only contains `obj`.
+                 * We implicitly create a subscript function here; It never ends up being used directly, but it causes
+                 * us to propagate `obj` as `usedColumn` when we build the operators which is important to ensure a correct
+                 * detection of used & unused column to guarantee proper fetch-plan building.
+                 */
+                if (mappedSymbol == null && !f.path().isTopLevel()) {
+                    ColumnIdent root = f.path().getRoot();
+                    for (Symbol symbol : mapping.keySet()) {
+                        if (symbol instanceof Field) {
+                            Field field = (Field) symbol;
+                            if (f.relation().getQualifiedName().equals(field.relation().getQualifiedName()) && field.path().equals(root)) {
+                                List<Symbol> arguments = mapTail(symbol, f.path().path(), Literal::of);
+                                return new io.crate.expression.symbol.Function(
+                                    new FunctionInfo(
+                                        new FunctionIdent(SubscriptObjectFunction.NAME, Symbols.typeView(arguments)),
+                                        f.valueType()
+                                    ),
+                                    arguments
+                                );
+                            }
+                        }
+                    }
+                    return f;
+                }
+                return Objects.requireNonNullElse(mappedSymbol, f);
+            });
             if (mapped != s) {
                 return mapped;
             }

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1299,4 +1299,13 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         Object secondId = response.rows()[1][0];
         assertThat(firstId, not(is(secondId)));
     }
+
+    @Test
+    public void test_group_by_on_subscript_on_object_of_sub_relation() {
+        execute("create table tbl (obj object as (x int))");
+        execute("insert into tbl (obj) values ({x=10})");
+        execute("refresh table tbl");
+        execute("select obj['x'] from (select obj from tbl) as t group by obj['x']");
+        assertThat(printedTable(response.rows()), Is.is("10\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -25,7 +25,9 @@ package io.crate.planner;
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.google.common.collect.Iterables;
+import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.TableDefinitions;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.VersioninigValidationException;
 import io.crate.execution.dsl.phases.ExecutionPhase;
@@ -903,6 +905,19 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[id, name]\n" +
             "TopNDistinct[1 | [id, name]\n" +
             "Collect[doc.users | [id, name] | All]\n"
+        ));
+    }
+
+    @Test
+    public void test_group_by_on_subscript_on_obj_output_of_sub_relation() {
+        String stmt = "SELECT address['postcode'] FROM (SELECT address FROM users) AS u GROUP BY 1";
+        LogicalPlan plan = e.logicalPlan(stmt);
+        assertThat(plan, isPlan(e.functions(),
+            "RootBoundary[address['postcode']]\n" +
+            "GroupBy[address['postcode'] | ]\n" +
+            "Boundary[address]\n" +
+            "Boundary[address]\n" +
+            "Collect[doc.users | [address] | All]\n"
         ));
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -64,7 +64,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
 
     @Test
     public void testOrderByOnColumnNotPresentInDistinctOutputsIsNotAllowed() {
-        expectedException.expectMessage("Cannot order by \"id\"");
+        expectedException.expectMessage("Cannot ORDER BY `id`");
         e.plan("select distinct name from users order by id");
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In a query like

    SELECT obj['x'] FROM (SELECT obj ...) AS t GROUP BY obj['x']

a invalid logical plan was created. It looked as follows:

    RootBoundary[address['postcode']]
    GroupBy[address['postcode'] | ]
    Boundary[_fetchid]
    Boundary[_fetchid]
    FetchOrEval[_fetchid]
    Collect[doc.users | [_fetchid, address['postcode']] | All]

Currently the `Collect` operator is trying to detect columns that are
not intermediately used. If it finds any, it substitutes them with a
`_fetchId`. This `_fetchId` is later picked up by the `FetchOrEval`
operator and resolved to the actual columns that have been selected.

In the scenario above, the parent was using `obj['x']` and the child had
`obj`, but several components weren't taking the relationship between
those into consideration.

So the `Collect` operator assumed that `obj` is unused, but it got
`obj['x']` as used column, which it couldn't interpret because the
`RelationBoundary` operator couldn't handle the mapping. There was no
`<PARENT_REL>.obj['x'] -> <CHILD_REL>.obj['x']` entry.

This raises the question why we have a special notation for lookups into
objects in the first place. We could also always build functions. One
reason is that we've index structures for the nested columns for an
object which we want to utilize.

A `lookup obj -> extract key 'x'` execution would fully load `obj` and
then parse it to extract the key. That can be an expensive operation if
`obj` is large. Especially compared to the alternative execution: Using
a column oriented data structure that we have specifically for
`obj['x']`.

Note that this fix doesn't yet utilize this. Instead we've:

    RootBoundary[address['postcode']]
    GroupBy[address['postcode'] | ]
    Boundary[address]
    Boundary[address]
    Collect[doc.users | [address] | All]

We could follow up with optimizer rules to optimize this scenario.

An alternative approach to fix this was in https://github.com/crate/crate/pull/9519

Which changed the `obj['x']` lookup on the sub-relation to change the
sub-relation itself.

    SELECT obj['x'] FROM (SELECT obj ...) AS t GROUP BY obj['x']

    would become

    SELECT obj['x'] FROM (SELECT obj, obj['x'] ...) AS t GROUP BY obj['x']

This approach looks simpler, but also seems to break semantics: It
introduces the notation that a child relation is modifying its outputs
due to the actions of a parent relation.


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
