### PR TITLE
Fix varargs warnings in RamAccountingBatchIteratorTest

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -53,8 +53,8 @@ public class RamAccountingPageIteratorTest extends CrateUnitTest {
 
     private static NoopCircuitBreaker NOOP_CIRCUIT_BREAKER = new NoopCircuitBreaker("dummy");
     private static RowN[] TEST_ROWS = new RowN[]{
-        new RowN(new String[]{"a", "b", "c"}),
-        new RowN(new String[]{"d", "e", "f"})
+        new RowN("a", "b", "c"),
+        new RowN("d", "e", "f")
     };
 
     private long originalBufferSize;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes:

    warning: non-varargs call of varargs method with inexact argument type for last parameter; new RowN(new String[]{"a", "b", "c"}),

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)