### PR TITLE
Add returning clause for sys-update usecase to storage engine

### DIFF
--- a/sql/src/main/java/io/crate/execution/dml/SysUpdateResultSetProjector.java
+++ b/sql/src/main/java/io/crate/execution/dml/SysUpdateResultSetProjector.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml;
+
+import io.crate.data.BatchIterator;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.CollectionBucket;
+import io.crate.data.Input;
+import io.crate.data.Projector;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.expression.reference.sys.SysRowUpdater;
+import io.crate.expression.reference.sys.check.node.SysNodeCheck;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collector;
+
+public class SysUpdateResultSetProjector implements Projector {
+
+    private final Consumer<Object> rowWriter;
+    private final List<NestableCollectExpression<SysNodeCheck, ?>> expressions;
+    private final List<Input<?>> inputs;
+    private final SysRowUpdater<?> sysRowUpdater;
+
+    public SysUpdateResultSetProjector(SysRowUpdater<?> sysRowUpdater,
+                                       Consumer<Object> rowWriter,
+                                       List<NestableCollectExpression<SysNodeCheck, ?>> expressions,
+                                       List<Input<?>> inputs) {
+        this.sysRowUpdater = sysRowUpdater;
+        this.rowWriter = rowWriter;
+        this.expressions = expressions;
+        this.inputs = inputs;
+    }
+
+    @Override
+    public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
+        return CollectingBatchIterator
+            .newInstance(batchIterator,
+                         Collector.of(
+                             ArrayList<Object[]>::new,
+                             (acc, row) -> {
+                                 Object[] returnValues = evaluateReturnValues(row);
+                                 acc.add(returnValues);
+                             },
+                             (state1, state2) -> {
+                                 throw new UnsupportedOperationException(
+                                     "Combine not supported");
+                             },
+                             CollectionBucket::new
+                             ));
+    }
+
+    private Object[] evaluateReturnValues(Row row) {
+        Object sysNodeCheckId = row.get(0);
+        //Update sysNodeCheck to the new value
+        rowWriter.accept(sysNodeCheckId);
+        //Retrieve updated sysNodeCheck and evaluate return values
+        SysNodeCheck sysNodeCheck = (SysNodeCheck) sysRowUpdater.getRow(sysNodeCheckId);
+        expressions.forEach(x -> x.setNextRow(sysNodeCheck));
+        Object[] result = new Object[inputs.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = inputs.get(i).value();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean providesIndependentScroll() {
+        return true;
+    }
+
+}

--- a/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
@@ -23,40 +23,96 @@
 package io.crate.execution.dsl.projection;
 
 import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
-import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class SysUpdateProjection extends DMLProjection {
+public class SysUpdateProjection extends Projection {
+
+    private final Symbol uidSymbol;
 
     private Map<Reference, Symbol> assignments;
 
-    public SysUpdateProjection(DataType idType, Map<Reference, Symbol> assignments) {
-        super(new InputColumn(0, idType));
+    private Symbol[] outputs;
+
+    @Nullable
+    private Symbol[] returnValues;
+
+    private boolean allOn4_1;
+
+    public SysUpdateProjection(Symbol uidSymbol,
+                               Map<Reference, Symbol> assignments,
+                               Version version,
+                               Symbol[] outputs,
+                               @Nullable Symbol[] returnValues
+    ) {
+        this.uidSymbol = uidSymbol;
         this.assignments = assignments;
+        this.allOn4_1 = version.onOrAfter(Version.V_4_1_0);
+        this.returnValues = returnValues;
+        assert Arrays.stream(outputs).noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            : "Cannot operate on Reference, Field or SelectSymbol symbols: " + outputs;
+        this.outputs = outputs;
     }
 
     public SysUpdateProjection(StreamInput in) throws IOException {
-        super(in);
+        uidSymbol = Symbols.fromStream(in);
+        if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
+            this.allOn4_1 = in.readBoolean();
+        }
         int numAssignments = in.readVInt();
         assignments = new HashMap<>(numAssignments, 1.0f);
         for (int i = 0; i < numAssignments; i++) {
             assignments.put(Reference.fromStream(in), Symbols.fromStream(in));
+        }
+        if (allOn4_1) {
+            int outputSize = in.readVInt();
+            outputs = new Symbol[outputSize];
+            for (int i = 0; i < outputSize; i++) {
+                outputs[i] = Symbols.fromStream(in);
+            }
+            int returnValuesSize = in.readVInt();
+            if (returnValuesSize > 0) {
+                returnValues = new Symbol[returnValuesSize];
+                for (int i = 0; i < returnValuesSize; i++) {
+                    returnValues[i] = Symbols.fromStream(in);
+                }
+            }
+        } else {
+            //Outputs should never be null and for BwC reasons
+            //the default value in pre 4.1 was a long for a count
+            outputs = new Symbol[]{new InputColumn(0, DataTypes.LONG)};
         }
     }
 
     @Override
     public ProjectionType projectionType() {
         return ProjectionType.SYS_UPDATE;
+    }
+
+    @Nullable
+    public Symbol[] returnValues() {
+        return returnValues;
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return List.of(outputs);
     }
 
     @Override
@@ -70,25 +126,53 @@ public class SysUpdateProjection extends DMLProjection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        Symbols.toStream(uidSymbol, out);
+        if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
+            out.writeBoolean(allOn4_1);
+        }
         out.writeVInt(assignments.size());
         for (Map.Entry<Reference, Symbol> e : assignments.entrySet()) {
             Reference.toStream(e.getKey(), out);
             Symbols.toStream(e.getValue(), out);
         }
+
+        if (allOn4_1) {
+            out.writeVInt(outputs.length);
+            for (int i = 0; i < outputs.length; i++) {
+                Symbols.toStream(outputs[i], out);
+            }
+            if (returnValues != null) {
+                out.writeVInt(returnValues.length);
+                for (int i = 0; i < returnValues.length; i++) {
+                    Symbols.toStream(returnValues[i], out);
+                }
+            } else {
+                out.writeVInt(0);
+            }
+        }
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SysUpdateProjection that = (SysUpdateProjection) o;
-        return Objects.equals(assignments, that.assignments);
+        return Objects.equals(uidSymbol, that.uidSymbol) &&
+               Objects.equals(assignments, that.assignments) &&
+               Arrays.equals(outputs, that.outputs) &&
+               Arrays.equals(returnValues, that.returnValues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assignments);
+        int result = Objects.hash(super.hashCode(), uidSymbol, assignments);
+        result = 31 * result + Arrays.hashCode(outputs);
+        result = 31 * result + Arrays.hashCode(returnValues);
+        return result;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
@@ -58,7 +58,7 @@ public class SysNodeChecksTableInfo extends StaticTableInfo<SysNodeCheck> {
         public static final ColumnIdent ACKNOWLEDGED = new ColumnIdent("acknowledged");
     }
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<SysNodeCheck>> expressions() {
+    public static Map<ColumnIdent, RowCollectExpressionFactory<SysNodeCheck>> expressions() {
         return columnRegistrar().expressions();
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is pr adds an implementation of  a `RETURNING` clause to update system tables. The following statement is working should also explain the use case:

`update sys.node_checks set acknowledged = true where id = 1 returning id, acknowledged as ack`


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
