### PR TITLE
Allow more characters in unquoted string elements of pg arrays

### DIFF
--- a/pgwire/src/main/antlr/PgArray.g4
+++ b/pgwire/src/main/antlr/PgArray.g4
@@ -45,7 +45,7 @@ STRING
     ;
 
 CHAR
-    : [0-9a-zA-Z]
+    : [!-z]
     ;
 
 

--- a/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
+++ b/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.fail;
 
 public class PgArrayParserTest {
@@ -50,8 +51,8 @@ public class PgArrayParserTest {
         }
     };
 
-    private static Object parse(String array, Function<byte[], Object> convert) {
-        return PgArrayParser.parse(array.getBytes(UTF_8), convert);
+    private static <T> T parse(String array, Function<byte[], Object> convert) {
+        return (T) PgArrayParser.parse(array.getBytes(UTF_8), convert);
     }
 
     @Test
@@ -67,6 +68,11 @@ public class PgArrayParserTest {
     @Test
     public void test_string_array_with_null_items() {
         assertThat(parse("{\"a\", NULL, NULL}", String::new), is(Arrays.asList("a", null, null)));
+    }
+
+    @Test
+    public void test_dash_and_underline_are_allowed_in_unquoted_strings() {
+        assertThat(parse("{catalog_name,end-exec}", String::new), contains("catalog_name","end-exec"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The JDBC client requires support for unquoted `-` and `_` characters.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)