### PR TITLE
Add encode and decode string functions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,9 @@ None
 Changes
 =======
 
+- Added the :ref:`encode(bytea, format) <scalar-encode>` and :ref:`decode(text,
+  format) <scalar-decode>` string functions.
+
 - Added the :ref:`ascii <scalar_ascii>` scalar function.
 
 - Introduced new optional ``RETURNING`` clause for :ref:`Update <ref-update>` to

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -528,6 +528,51 @@ Example::
    In both cases, the scalar functions lpad and rpad, do now accept a len
    greater than 50000.
 
+.. _scalar-encode:
+
+``encode(bytea, format)``
+-------------------------
+
+Encode takes a binary string in hex format and returns a textual representation
+into the specified format. Supported formats are base64, hex, and escape. The
+escape format represents unprintable characters with an octal sequence `\nnn`.
+
+Synopsis::
+
+    encode(string1, format)
+
+Example::
+
+    cr> select encode(E'123\b\t56', 'base64');
+    +--------------------------------+
+    | encode(E'123\b\t56', 'base64') |
+    +--------------------------------+
+    | MTIzCAk1Ng==                   |
+    +--------------------------------+
+    SELECT 1 row in set (... sec)
+
+.. _scalar-decode:
+
+``decode(text, format)``
+-------------------------
+
+Decodes text encoded in the given format, which are listed in the `encode`
+documentation. Returns a binary string in the hex format.
+
+Synopsis::
+
+    decode(text1, format)
+
+Example::
+
+    cr> select decode('T\214', 'escape');
+    +---------------------------+
+    | decode('T\214', 'escape') |
+    +---------------------------+
+    | \x548c                    |
+    +---------------------------+
+    SELECT 1 row in set (... sec)
+
 Date and time functions
 =======================
 

--- a/shared/src/main/java/io/crate/common/Hex.java
+++ b/shared/src/main/java/io/crate/common/Hex.java
@@ -24,6 +24,11 @@ package io.crate.common;
 public class Hex {
 
     /**
+     * Hex leading flag for string representations.
+     */
+    public static final String HEX_FLAG = "\\x";
+
+    /**
      * Used to build output as Hex
      */
     private static final char[] DIGITS_LOWER = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
@@ -32,6 +37,41 @@ public class Hex {
      * Used to build output as Hex
      */
     private static final char[] DIGITS_UPPER = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+    /**
+     * Returns true if the argument is in the "bytea" hex format.
+     */
+    public static boolean isHexFormat(String data) {
+        return data.startsWith(HEX_FLAG);
+    }
+
+    /**
+     * Returns a string with the leading hexadecimal flag removed.
+     * This validates the hexadecimal portion of the hex-formatted data.
+     */
+    public static String stripHexFormatFlag(String data) {
+        if (data.length() < 2) {
+            throw new IllegalArgumentException("Invalid hex formatted string");
+        }
+        return validateHex(data.substring(2), 2);
+    }
+
+    /**
+     * Throws an exception if the given hex string contains other characters than hexadecimals,
+     * or returns it verbatim otherwise.
+     * @param data a string that should contain only hexadecimal characters
+     * @param offset for error reporting, the index at which the data starts in order to account for possibly stripped
+     *               HEX_FLAG
+     */
+    public static String validateHex(String data, int offset) {
+        if ((data.length() & 0x01) != 0) {
+            throw new IllegalStateException("Odd number of characters");
+        }
+        for (int i = 0; i < data.length(); i++) {
+            toDigit(data.charAt(i), offset + i);
+        }
+        return data;
+    }
 
     /**
      * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.

--- a/shared/src/main/java/io/crate/common/Octal.java
+++ b/shared/src/main/java/io/crate/common/Octal.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.common;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * Encodes and decodes binary strings into the "bytea" escape format.
+ * Unprintable bytes, outside of the 32..126 range are represented with an octal number "\nnn", and backslashes
+ * are doubled.
+ */
+public class Octal {
+
+    private Octal() {}
+
+    /**
+     * Converts an array of bytes into a String where unprintable characters are represented as octal numbers.
+     */
+    public static String encode(byte[] data) {
+        final StringBuilder sb = new StringBuilder(data.length);
+
+        for (byte b: data) {
+            if (b == 92) {
+                sb.append("\\\\");
+            } else if (b < 32 || b > 126) {
+                // unprintable character
+                sb.append('\\');
+                sb.append((b >> 6) & 0x3);
+                sb.append((b >> 3) & 0x7);
+                sb.append(b & 0x7);
+            } else {
+                sb.append((char) b);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static byte[] decode(String octalData) {
+        final byte[] decodedBytes = new byte[octalData.length()];
+        final char[] encodedChars = octalData.toCharArray();
+        int decIndex = 0;
+
+        for (int encIndex = 0; encIndex < encodedChars.length; encIndex++) {
+            final char c = encodedChars[encIndex];
+            if (c == '\\') {
+                if (encIndex + 1 >= encodedChars.length) {
+                    throwOnTruncatedOctalSequence(encIndex);
+                }
+                if (encodedChars[encIndex + 1] == '\\') {
+                    decodedBytes[decIndex++] = '\\';
+                    encIndex++;
+                    continue;
+                }
+                if (encIndex + 3 >= encodedChars.length) {
+                    throwOnTruncatedOctalSequence(encIndex);
+                }
+                decodedBytes[decIndex++] = (byte) (64 * ensureOctalCharacter(encodedChars, encIndex + 1) +
+                                                   8 * ensureOctalCharacter(encodedChars, encIndex + 2) +
+                                                   ensureOctalCharacter(encodedChars, encIndex + 3));
+                encIndex += 3;
+            } else {
+                decodedBytes[decIndex++] = (byte) c;
+            }
+        }
+        if (decIndex == decodedBytes.length) {
+            return decodedBytes;
+        }
+        return Arrays.copyOf(decodedBytes, decIndex);
+    }
+
+    /**
+     * Checks the given character is a number in base 8.
+     */
+    private static int ensureOctalCharacter(char[] chars, int index) {
+        final int o = Character.digit(chars[index], 8);
+        if (o > 7 || o < 0) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ENGLISH, "Illegal octal character %s at index %d", chars[index], index)
+            );
+        }
+        return o;
+    }
+
+    private static void throwOnTruncatedOctalSequence(int index) {
+        throw new IllegalArgumentException(
+            String.format(Locale.ENGLISH, "Invalid escape sequence at index %d:" +
+                                          " expected 1 or 3 more characters but the end of the string got reached", index)
+        );
+    }
+
+}

--- a/shared/src/test/java/io/crate/common/OctalTest.java
+++ b/shared/src/test/java/io/crate/common/OctalTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class OctalTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testOnlyPrintableCharacters() {
+        final byte[] expected = {97, 98, 99, 100};
+        assertThat(Octal.decode("abcd"), is(expected));
+    }
+
+    @Test
+    public void testValidEncodedString() {
+        final byte[] expected = {48, 49, 50, 92, 51, 52, 53, 0, 1};
+        assertThat(Octal.decode("012\\\\345\\000\\001"), is(expected));
+    }
+
+    @Test
+    public void testIncompleteEscapeSequence() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("Invalid escape sequence at index 3"));
+        Octal.decode("abc\\");
+    }
+
+    /**
+     * Octal number should span 3 characters
+     */
+    @Test
+    public void testInvalidOctalNumber1() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("Invalid escape sequence at index 0"));
+        Octal.decode("\\00");
+    }
+
+    @Test
+    public void testInvalidOctalNumber2() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Illegal octal character 8 at index 3");
+        Octal.decode("\\008");
+    }
+
+    @Test
+    public void testEscapes() {
+        // backslashes
+        assertThat(Octal.decode("\\\\ \\134"), is(new byte[]{92, 32, 92}));
+        // single quotes
+        assertThat(Octal.decode("' \\047"), is(new byte[]{39, 32, 39}));
+    }
+
+    @Test
+    public void testEncode() {
+        assertThat(Octal.encode("a\bb\\c".getBytes(StandardCharsets.UTF_8)), is("a\\010b\\\\c"));
+    }
+
+}

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -50,6 +50,7 @@ import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
 import io.crate.expression.scalar.regex.MatchesFunction;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
 import io.crate.expression.scalar.string.AsciiFunction;
+import io.crate.expression.scalar.string.EncodeDecodeFunction;
 import io.crate.expression.scalar.string.HashFunctions;
 import io.crate.expression.scalar.string.InitCapFunction;
 import io.crate.expression.scalar.string.LengthFunction;
@@ -139,6 +140,7 @@ public class ScalarFunctionModule extends AbstractModule {
         InitCapFunction.register(this);
         TrimFunctions.register(this);
         AsciiFunction.register(this);
+        EncodeDecodeFunction.register(this);
 
         ConcatFunction.register(this);
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.common.Hex;
+import io.crate.common.Octal;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.metadata.FunctionInfo;
+import io.crate.types.DataTypes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+
+public class EncodeDecodeFunction {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new BinaryScalar<>(new Encode(), "encode", DataTypes.STRING, FunctionInfo.DETERMINISTIC_ONLY));
+        module.register(new BinaryScalar<>(new Decode(), "decode", DataTypes.STRING, FunctionInfo.DETERMINISTIC_ONLY));
+    }
+
+    /**
+     * Takes a binary data of "bytea" type and encodes it into the given output format.
+     */
+    private static class Encode implements BinaryOperator<String> {
+
+        @Override
+        public String apply(String bytea, String format) {
+            final Format fmt;
+
+            try {
+                fmt = Format.valueOf(format.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Encoding format '%s' is not supported", format)
+                );
+            }
+            return fmt.encode(bytea);
+        }
+
+    }
+
+    /**
+     * Takes a string encoded into the given format and returns its hexadecimal representation.
+     */
+    private static class Decode implements BinaryOperator<String> {
+
+        @Override
+        public String apply(String text, String format) {
+            final Format fmt;
+
+            try {
+                fmt = Format.valueOf(format.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Encoding format '%s' is not supported", format)
+                );
+            }
+            return fmt.decode(text);
+        }
+
+    }
+
+    /**
+     * Supported encoding formats.
+     */
+    private enum Format {
+        /**
+         * Represent binary data using base64 encoding.
+         */
+        BASE64(bytea -> {
+            final byte[] text;
+            if (Hex.isHexFormat(bytea)) {
+                text = Hex.decodeHex(Hex.stripHexFormatFlag(bytea));
+            } else {
+                text = Octal.decode(bytea);
+            }
+            return Base64.getEncoder().encodeToString(text);
+        }, text -> {
+            final byte[] value = Base64.getDecoder().decode(text.getBytes(StandardCharsets.UTF_8));
+            return Hex.HEX_FLAG + Hex.encodeHexString(value);
+        }),
+        /**
+         * Hexadecimal representation of binary data.
+         */
+        HEX(bytea -> {
+            if (Hex.isHexFormat(bytea)) {
+                // the input is already in hex format
+                return Hex.stripHexFormatFlag(bytea);
+            }
+            return Hex.encodeHexString(Octal.decode(bytea));
+        }, text -> Hex.HEX_FLAG + Hex.validateHex(text, 0)
+        ),
+        /**
+         * Unprintable characters in binary data are written as octal numbers.
+         */
+        ESCAPE(bytea -> {
+            if (Hex.isHexFormat(bytea)) {
+                return Octal.encode(Hex.decodeHex(Hex.stripHexFormatFlag(bytea)));
+            }
+            return Octal.encode(bytea.getBytes(StandardCharsets.UTF_8));
+        }, text -> Hex.HEX_FLAG + Hex.encodeHexString(Octal.decode(text)));
+
+        private final Function<String, String> encode;
+        private final Function<String, String> decode;
+
+        Format(Function<String, String> encode, Function<String, String> decode) {
+            this.encode = encode;
+            this.decode = decode;
+        }
+
+        String encode(String bytea) {
+            return encode.apply(bytea);
+        }
+
+        String decode(String text) {
+            return decode.apply(text);
+        }
+
+    }
+
+}

--- a/sql/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+public class EncodeDecodeFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void testInvalidBytea() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Illegal octal character b at index 4");
+        assertEvaluate("encode('123\\b\\t56', 'base64')", null);
+    }
+
+    @Test
+    public void testInvalidBased64() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Illegal base64 character 8");
+        assertEvaluate("decode(E'123\\b\\t56', 'base64')", null);
+    }
+
+    @Test
+    public void testInvalidBinaryEncodeToBase64() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
+        assertEvaluate("encode('\\xfh', 'base64')", null);
+    }
+
+    @Test
+    public void testInvalidBinaryEncodeToHex() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
+        assertEvaluate("encode('\\xfh', 'hex')", null);
+    }
+
+    @Test
+    public void testInvalidBinaryEncodeToEscape() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
+        assertEvaluate("encode('\\xfh', 'escape')", null);
+    }
+
+    @Test
+    public void testInvalidBinaryDecodeFromHex1() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Illegal hexadecimal character \\ at index 0");
+        assertEvaluate("decode('\\xff', 'hex')", null);
+    }
+
+    @Test
+    public void testInvalidBinaryDecodeFromHex2() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Odd number of characters");
+        assertEvaluate("decode('ffa', 'hex')", null);
+    }
+
+    @Test
+    public void testNulls() {
+        // null format
+        assertEvaluate("encode('\\xff', null)", null);
+        assertEvaluate("decode('FA==', null)", null);
+        // null data
+        assertEvaluate("encode(null, 'base64')", null);
+        assertEvaluate("decode(null, 'base64')", null);
+    }
+
+    @Test
+    public void testUnknownEncodeFormat() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Encoding format 'bad' is not supported");
+        assertEvaluate("encode('\\xff', 'bad')", null);
+    }
+
+    @Test
+    public void testUnknownDecodeFormat() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Encoding format 'bad' is not supported");
+        assertEvaluate("decode('FA==', 'bad')", null);
+    }
+
+    @Test
+    public void testEncodeFuncBase64() {
+        // input in hex format
+        final Literal<Object> name = Literal.of(DataTypes.STRING, "\\x3132330001");
+        assertEvaluate("encode('\\x3132330001', 'base64')", "MTIzAAE=");
+        assertEvaluate("encode(name, 'Base64')", "MTIzAAE=", name);
+        // input in escape format
+        assertEvaluate("encode('123\\000\\001', 'base64')", "MTIzAAE=");
+        assertEvaluate("encode('123', 'base64')", "MTIz");
+    }
+
+    @Test
+    public void testDecodeFuncBase64() {
+        final Literal<Object> name = Literal.of(DataTypes.STRING, "MTIzAAE=");
+        assertEvaluate("decode('MTIzAAE=', 'base64')", "\\x3132330001");
+        assertEvaluate("decode('MTIzAAE=', 'BASE64')", "\\x3132330001");
+        assertEvaluate("decode(name, 'base64')", "\\x3132330001", name);
+    }
+
+    @Test
+    public void testEncodeFuncHex() {
+        assertEvaluate("encode('\\x3132330001', 'hex')", "3132330001");
+        assertEvaluate("encode('123\\000\\001', 'hex')", "3132330001");
+    }
+
+    @Test
+    public void testDecodeFuncHex() {
+        assertEvaluate("decode('3132330001', 'hex')", "\\x3132330001");
+    }
+
+    @Test
+    public void testEncodeEmpties() {
+        assertEvaluate("encode('', 'base64')", "");
+        assertEvaluate("encode('', 'hex')", "");
+        assertEvaluate("encode('', 'escape')", "");
+    }
+
+    @Test
+    public void testEncodeFuncEscape() {
+        assertEvaluate("encode('a\bb\\c', 'escape')", "a\\010b\\\\c");
+        assertEvaluate("encode('\\x6108625c63', 'escape')", "a\\010b\\\\c");
+    }
+
+    @Test
+    public void testDecodeFuncEscape() {
+        assertEvaluate("decode('a\\010b\\\\c', 'escape')", "\\x6108625c63");
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Encode takes a binary string in hex format and returns a textual
representation into the specified format.
Decode does the opposit and returns the string into hex format.

Close #9539

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
