### PR TITLE
Improve error message for CREATE VIEW

### DIFF
--- a/sql/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -56,12 +56,17 @@ public final class ViewAnalyzer {
             throw new UnsupportedOperationException("Creating a view in the \"blob\" schema is not supported");
         }
         AnalyzedRelation query;
+        String formattedQuery;
         try {
-            String formattedQuery = SqlFormatter.formatSql(createView.query());
+            formattedQuery = SqlFormatter.formatSql(createView.query());
+        } catch (Exception e) {
+            throw new UnsupportedOperationException("Invalid query used in CREATE VIEW. Query: " + createView.query());
+        }
+        try {
             // Analyze the formatted Query to make sure the formatting didn't mess it up in any way.
             query = relationAnalyzer.analyzeUnbound((Query) SqlParser.createStatement(formattedQuery), txnCtx, ParamTypeHints.EMPTY);
         } catch (Exception e) {
-            throw new UnsupportedOperationException("Query cannot be used in a VIEW: " + createView.query());
+            throw new UnsupportedOperationException("Invalid query used in CREATE VIEW. " + e.getMessage() + ". Query: " + formattedQuery);
         }
 
         // We do not bother with exists checks here because it wouldn't be "atomic" as it might be based

--- a/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -97,6 +97,12 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_create_view_with_query_with_invalid_column_results_in_userfriendly_error_message() {
+        expectedException.expectMessage("Invalid query used in CREATE VIEW. Column invalid unknown. Query: SELECT \"invalid\"");
+        e.analyze("create view v1 as select invalid from t1");
+    }
+
+    @Test
     public void testAliasCanBeUsedToAvoidDuplicateColumnNamesInQuery() {
         CreateViewStmt createView = e.analyze("create view v1 as select x, x as y from t1");
         assertThat(createView.analyzedQuery().fields(), contains(isField("x"), isField("y")));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If the query cannot be analyzed it now includes the error message from
the analyzer. So people know if e.g. a column is not found.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)