### PR TITLE
Support arguments of type long as index access to arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -52,6 +52,9 @@ None
 Changes
 =======
 
+- Added support for using columns of type ``long`` inside subscript
+  expressions. (``array_expr[column]``).
+
 - Made :ref:`generate_series <table-functions-generate-series>` addressable by
   specifying the ``pg_catalog`` schema explicitly. So both ``generate_series(1,
   2)`` and ``pg_catalog.generate_series(1, 2)`` are valid.
@@ -60,6 +63,7 @@ Changes
 
 - Added support for the PostgreSQL notation to refer to array types. For
   example, it is now possible to use ``text[]`` instead of ``array(test)``.
+
 
 Fixes
 =====

--- a/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -26,16 +26,15 @@ import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.metadata.functions.params.Param;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 import java.util.List;
-
-import static io.crate.metadata.functions.params.Param.INTEGER;
 
 public class SubscriptFunction extends Scalar<Object, Object[]> {
 
@@ -61,16 +60,16 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
         return evaluate(args[0].value(), args[1].value());
     }
 
-    private Object evaluate(Object element, Object index) {
+    private static Object evaluate(Object element, Object index) {
         if (element == null || index == null) {
             return null;
         }
         assert (element instanceof Object[] || element instanceof List)
             : "first argument must be of type array or list";
-        assert index instanceof Integer : "second argument must be of type integer";
+        assert index instanceof Number : "second argument must be of type integer";
 
         // 1 based arrays as SQL standard says
-        int idx = (int) index - 1;
+        int idx = DataTypes.INTEGER.value(index) - 1;
         try {
             if (element instanceof List) {
                 return ((List) element).get(idx);
@@ -88,12 +87,12 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
         }
 
         protected Resolver() {
-            super(FuncParams.builder(Param.ANY_ARRAY, INTEGER).build());
+            super(FuncParams.builder(Param.ANY_ARRAY, Param.of(DataTypes.INTEGER, DataTypes.LONG)).build());
         }
 
         @Override
         public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            DataType returnType = ((ArrayType) dataTypes.get(0)).innerType();
+            DataType<?> returnType = ((ArrayType<?>) dataTypes.get(0)).innerType();
             return new SubscriptFunction(createInfo(dataTypes, returnType));
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -57,24 +57,18 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     @Override
     public Object evaluate(TransactionContext txnCtx, Input[] args) {
         assert args.length == 2 : "invalid number of arguments";
-        return evaluate(args[0].value(), args[1].value());
-    }
-
-    private static Object evaluate(Object element, Object index) {
+        Object element = args[0].value();
+        Object index = args[1].value();
         if (element == null || index == null) {
             return null;
         }
-        assert (element instanceof Object[] || element instanceof List)
-            : "first argument must be of type array or list";
+        assert element instanceof List : "first argument is typed as array and must be a List";
         assert index instanceof Number : "second argument must be of type integer";
 
         // 1 based arrays as SQL standard says
         int idx = DataTypes.INTEGER.value(index) - 1;
         try {
-            if (element instanceof List) {
-                return ((List) element).get(idx);
-            }
-            return ((Object[]) element)[idx];
+            return ((List<?>) element).get(idx);
         } catch (IndexOutOfBoundsException e) {
             return null;
         }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1462,7 +1462,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(arguments.size(), is(2));
 
         assertThat(arguments.get(0), isFunction(MatchesFunction.NAME));
-        assertThat(arguments.get(1), isLiteral(1));
+        assertThat(arguments.get(1), isLiteral(1L));
 
         List<Symbol> scalarArguments = ((Function) arguments.get(0)).arguments();
         assertThat(scalarArguments.size(), is(2));

--- a/sql/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
@@ -28,6 +29,11 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
 public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_long_can_be_used_as_array_index() {
+        assertEvaluate("['Youri', 'Ruben'][x]", "Youri", Literal.of(1L));
+    }
 
     @Test
     public void testEvaluate() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds support for `array_expr[long_column]`.

Previously the subscript function required the argument to be of type
`integer`. That worked well for literals, because there `long` can be
casted to `int`. But our implicit cast logic is more restrictive if
columns are involved.

This therefore extends the function signature to allow both `integer`
and `long` arguments.

PostgreSQL JDBC uses a query that uses this, a subset of the full query
is:

    select
        con.confkey[pos.n]
    from
        generate_series(1, 32) as pos (n),
        pg_catalog.pg_constraint con


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)