### PR TITLE
WIP: Fix select of partitioned by value it is nested object column.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,9 @@ Changes
 Fixes
 =====
 
+- Fixed a bug that would not allow a user to select nested object's column
+  values if it is used in the :ref:`partitioned_by_clause` clause.
+
 - Fixed a bug that would lead to insertion of records via ``INSERT INTO ...
   (SELECT ... FROM ..)`` and ``INSERT INTO ... VALUES (...)`` into different
   partitions while using the same partition by value. This occurs only when

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -59,7 +59,6 @@ import io.crate.sql.tree.InsertFromValues;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.ValuesList;
 import io.crate.types.DataType;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 
 import javax.annotation.Nullable;
@@ -507,20 +506,16 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
 
             for (ColumnIdent partitionIdent : context.tableInfo().partitionedBy()) {
                 if (partitionIdent.getRoot().equals(columnIdent)) {
-                    Object nestedValue = mapValue.remove(String.join(".", partitionIdent.path()));
-                    if (nestedValue instanceof BytesRef) {
-                        nestedValue = ((BytesRef) nestedValue).utf8ToString();
-                    }
+                    Object nestedValue = mapValue.get(String.join(".", partitionIdent.path()));
                     if (partitionMap != null) {
-                        partitionMap.put(partitionIdent.fqn(), BytesRefs.toString(nestedValue));
+                        partitionMap.put(partitionIdent.fqn(), String.valueOf(nestedValue));
                     }
                 }
             }
-
-            // put the rest into source
-            return mapValue;
+            // put into source
+            return columnValue;
         } else if (partitionMap != null) {
-            partitionMap.put(columnIdent.name(), BytesRefs.toString(columnValue));
+            partitionMap.put(columnIdent.name(), String.valueOf(columnValue));
             return columnValue;
         }
         return null;

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -2307,6 +2307,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(
             printedTable(response.rows()),
             is("test| 04732d1g64p36d9i60o30c1g| {metadata['date']=1401235200000}\n"));
-        assertThat(printedTable(execute("SELECT count(*) FROM test").rows()), is("2\n"));
+        assertThat(
+            printedTable(execute("SELECT * FROM test").rows()),
+            is("1| {date=1401235200000}\n" +
+               "2| {date=1401235200000}\n"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

WIP ...

The partition values should not be a part of the `ShardUpsertRequest#Items` insertValues,
such as it should be resolved later on from the partition ident. 

But It is not the case for:
- Insert from values.
- Insert from subquery when a nested object column is used as the partition by key. 


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
