### PR TITLE
Rename InsertFromSubQueryAnalyzer → InsertAnalyzer

### DIFF
--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -108,7 +108,7 @@ public class Analyzer {
     private final OptimizeTableAnalyzer optimizeTableAnalyzer;
     private final AlterTableAnalyzer alterTableAnalyzer;
     private final AlterTableAddColumnAnalyzer alterTableAddColumnAnalyzer;
-    private final InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer;
+    private final InsertAnalyzer insertAnalyzer;
     private final CopyAnalyzer copyAnalyzer;
     private final UpdateAnalyzer updateAnalyzer;
     private final DeleteAnalyzer deleteAnalyzer;
@@ -154,7 +154,7 @@ public class Analyzer {
         this.showStatementAnalyzer = new ShowStatementAnalyzer(this, schemas);
         this.updateAnalyzer = new UpdateAnalyzer(functions, relationAnalyzer);
         this.deleteAnalyzer = new DeleteAnalyzer(functions, relationAnalyzer);
-        this.insertFromSubQueryAnalyzer = new InsertFromSubQueryAnalyzer(functions, schemas, relationAnalyzer);
+        this.insertAnalyzer = new InsertAnalyzer(functions, schemas, relationAnalyzer);
         this.optimizeTableAnalyzer = new OptimizeTableAnalyzer(schemas, functions);
         this.createRepositoryAnalyzer = new CreateRepositoryAnalyzer(repositoryService, functions);
         this.dropRepositoryAnalyzer = new DropRepositoryAnalyzer(repositoryService);
@@ -445,7 +445,7 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitInsertFromSubquery(InsertFromSubquery node, Analysis analysis) {
-            return insertFromSubQueryAnalyzer.analyze(
+            return insertAnalyzer.analyze(
                 node,
                 analysis.paramTypeHints(),
                 analysis.transactionContext());

--- a/sql/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
-class InsertFromSubQueryAnalyzer {
+class InsertAnalyzer {
 
     private final Functions functions;
     private final Schemas schemas;
@@ -102,7 +102,7 @@ class InsertFromSubQueryAnalyzer {
         }
     }
 
-    InsertFromSubQueryAnalyzer(Functions functions, Schemas schemas, RelationAnalyzer relationAnalyzer) {
+    InsertAnalyzer(Functions functions, Schemas schemas, RelationAnalyzer relationAnalyzer) {
         this.functions = functions;
         this.schemas = schemas;
         this.relationAnalyzer = relationAnalyzer;

--- a/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We no longer have the values / sub-query distinction, so we can trim the
name.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)