### PR TITLE
Remove ParameterContext from Analysis and SQLExecutor.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/Analysis.java
+++ b/sql/src/main/java/io/crate/analyze/Analysis.java
@@ -27,17 +27,15 @@ import io.crate.metadata.CoordinatorTxnCtx;
 
 public class Analysis {
 
-    private final ParameterContext parameterContext;
     private final CoordinatorTxnCtx coordinatorTxnCtx;
 
     private final ParamTypeHints paramTypeHints;
     private AnalyzedStatement analyzedStatement;
     private AnalyzedRelation rootRelation;
 
-    public Analysis(CoordinatorTxnCtx coordinatorTxnCtx, ParameterContext parameterContext, ParamTypeHints paramTypeHints) {
+    public Analysis(CoordinatorTxnCtx coordinatorTxnCtx, ParamTypeHints paramTypeHints) {
         this.paramTypeHints = paramTypeHints;
         this.coordinatorTxnCtx = coordinatorTxnCtx;
-        this.parameterContext = parameterContext;
     }
 
     public void analyzedStatement(AnalyzedStatement analyzedStatement) {
@@ -46,10 +44,6 @@ public class Analysis {
 
     public AnalyzedStatement analyzedStatement() {
         return analyzedStatement;
-    }
-
-    public ParameterContext parameterContext() {
-        return parameterContext;
     }
 
     public void rootRelation(AnalyzedRelation rootRelation) {

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -470,7 +470,7 @@ public class Analyzer {
 
         @Override
         protected AnalyzedStatement visitQuery(Query node, Analysis context) {
-            return relationAnalyzer.analyzeUnbound(
+            return relationAnalyzer.analyze(
                 node,
                 context.transactionContext(),
                 context.paramTypeHints());
@@ -521,7 +521,7 @@ public class Analyzer {
             Query query = showStatementAnalyzer.rewriteShowColumns(
                 node,
                 coordinatorTxnCtx.sessionContext().searchPath().currentSchema());
-            return relationAnalyzer.analyzeUnbound(
+            return relationAnalyzer.analyze(
                 query,
                 coordinatorTxnCtx,
                 context.parameterContext().typeHints());
@@ -535,7 +535,7 @@ public class Analyzer {
         @Override
         protected AnalyzedStatement visitShowSchemas(ShowSchemas node, Analysis context) {
             Query query = showStatementAnalyzer.rewriteShowSchemas(node);
-            return relationAnalyzer.analyzeUnbound(
+            return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
                 context.parameterContext().typeHints());
@@ -545,7 +545,7 @@ public class Analyzer {
         public AnalyzedStatement visitShowSessionParameter(ShowSessionParameter node, Analysis context) {
             ShowStatementAnalyzer.validateSessionSetting(node.parameter());
             Query query = ShowStatementAnalyzer.rewriteShowSessionParameter(node);
-            return relationAnalyzer.analyzeUnbound(
+            return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
                 context.parameterContext().typeHints());
@@ -554,7 +554,7 @@ public class Analyzer {
         @Override
         protected AnalyzedStatement visitShowTables(ShowTables node, Analysis context) {
             Query query = showStatementAnalyzer.rewriteShowTables(node);
-            return relationAnalyzer.analyzeUnbound(
+            return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
                 context.parameterContext().typeHints());

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -186,7 +186,6 @@ public class Analyzer {
             dispatcher,
             new Analysis(
                 new CoordinatorTxnCtx(sessionContext),
-                ParameterContext.EMPTY,
                 paramTypeHints));
         userManager.getAccessControl(sessionContext).ensureMayExecute(analyzedStatement);
         return analyzedStatement;
@@ -198,6 +197,7 @@ public class Analyzer {
         return analyzedStatement;
     }
 
+    @SuppressWarnings("unchecked")
     private class AnalyzerDispatcher extends AstVisitor<AnalyzedStatement, Analysis> {
 
         @Override
@@ -524,7 +524,7 @@ public class Analyzer {
             return relationAnalyzer.analyze(
                 query,
                 coordinatorTxnCtx,
-                context.parameterContext().typeHints());
+                context.paramTypeHints());
         }
 
         @Override
@@ -538,7 +538,7 @@ public class Analyzer {
             return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
-                context.parameterContext().typeHints());
+                context.paramTypeHints());
         }
 
         @Override
@@ -548,7 +548,7 @@ public class Analyzer {
             return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
-                context.parameterContext().typeHints());
+                context.paramTypeHints());
         }
 
         @Override
@@ -557,7 +557,7 @@ public class Analyzer {
             return relationAnalyzer.analyze(
                 query,
                 context.transactionContext(),
-                context.parameterContext().typeHints());
+                context.paramTypeHints());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -118,7 +118,7 @@ class InsertAnalyzer {
         List<Reference> targetColumns =
             new ArrayList<>(resolveTargetColumns(insert.columns(), tableInfo));
 
-        AnalyzedRelation subQueryRelation = relationAnalyzer.analyzeUnbound(
+        AnalyzedRelation subQueryRelation = relationAnalyzer.analyze(
             insert.subQuery(),
             new StatementAnalysisContext(typeHints, Operation.READ, txnCtx, targetColumns));
 

--- a/sql/src/main/java/io/crate/analyze/ParamTypeHints.java
+++ b/sql/src/main/java/io/crate/analyze/ParamTypeHints.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 
 public class ParamTypeHints implements Function<ParameterExpression, Symbol> {
 
-    public static final ParamTypeHints EMPTY = new ParamTypeHints(Collections.<DataType>emptyList());
+    public static final ParamTypeHints EMPTY = new ParamTypeHints(Collections.emptyList());
 
     private final List<DataType> types;
 

--- a/sql/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -64,7 +64,10 @@ public final class ViewAnalyzer {
         }
         try {
             // Analyze the formatted Query to make sure the formatting didn't mess it up in any way.
-            query = relationAnalyzer.analyzeUnbound((Query) SqlParser.createStatement(formattedQuery), txnCtx, ParamTypeHints.EMPTY);
+            query = relationAnalyzer.analyze(
+                (Query) SqlParser.createStatement(formattedQuery),
+                txnCtx,
+                ParamTypeHints.EMPTY);
         } catch (Exception e) {
             throw new UnsupportedOperationException("Invalid query used in CREATE VIEW. " + e.getMessage() + ". Query: " + formattedQuery);
         }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -28,7 +28,6 @@ import io.crate.analyze.HavingClause;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.ParamTypeHints;
-import io.crate.analyze.ParameterContext;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
@@ -113,7 +112,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-
 @Singleton
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
@@ -137,20 +135,10 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         return node.accept(this, statementContext);
     }
 
-    public AnalyzedRelation analyzeUnbound(Query query,
-                                           CoordinatorTxnCtx coordinatorTxnCtx,
-                                           ParamTypeHints paramTypeHints) {
-        return analyze(query, new StatementAnalysisContext(paramTypeHints, Operation.READ, coordinatorTxnCtx));
-    }
-
-    public AnalyzedRelation analyzeUnbound(Query query, StatementAnalysisContext analysisContext) {
-        return analyze(query, analysisContext);
-    }
-
-    public AnalyzedRelation analyze(Node node,
+    public AnalyzedRelation analyze(Query query,
                                     CoordinatorTxnCtx coordinatorTxnCtx,
-                                    ParameterContext parameterContext) {
-        return analyze(node, new StatementAnalysisContext(parameterContext, Operation.READ, coordinatorTxnCtx));
+                                    ParamTypeHints paramTypeHints) {
+        return analyze(query, new StatementAnalysisContext(paramTypeHints, Operation.READ, coordinatorTxnCtx));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.view;
 
-import io.crate.analyze.ParameterContext;
+import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.exceptions.ResourceUnknownException;
@@ -32,7 +32,7 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Statement;
+import io.crate.sql.tree.Query;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
@@ -60,11 +60,12 @@ public class InternalViewInfoFactory implements ViewInfoFactory {
         if (view == null) {
             return null;
         }
-        Statement parsedStmt = SqlParser.createStatement(view.stmt());
         List<Reference> columns;
         try {
-            AnalyzedRelation relation = analyzerProvider.get()
-                .analyze(parsedStmt, CoordinatorTxnCtx.systemTransactionContext(), ParameterContext.EMPTY);
+            AnalyzedRelation relation = analyzerProvider.get().analyze(
+                (Query) SqlParser.createStatement(view.stmt()),
+                CoordinatorTxnCtx.systemTransactionContext(),
+                ParamTypeHints.EMPTY);
             final List<Reference> collectedColumns = new ArrayList<>(relation.fields().size());
             relation.fields()
                 .forEach(field -> collectedColumns.add(

--- a/sql/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -92,7 +92,7 @@ public final class CreateViewPlan implements Plan {
                                                                String formattedQuery) {
         RelationAnalyzer analyzer = new RelationAnalyzer(functions, schemas);
         Query query = (Query) SqlParser.createStatement(formattedQuery);
-        analyzer.analyzeUnbound(query, txnCtx, new ParamTypeHints(List.of()) {
+        analyzer.analyze(query, txnCtx, new ParamTypeHints(List.of()) {
 
                 @Override
                 public Symbol apply(@Nullable ParameterExpression input) {

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -30,10 +30,12 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.TableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.SymbolMatchers.isFunction;
@@ -100,12 +102,9 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBulkDelete() throws Exception {
-        AnalyzedDeleteStatement delete = e.analyze("delete from users where id = ?", new Object[][]{
-            new Object[]{1},
-            new Object[]{2},
-            new Object[]{3},
-            new Object[]{4},
-        });
+        AnalyzedDeleteStatement delete = e.analyze(
+            "delete from users where id = ?",
+            new ParamTypeHints(List.of(DataTypes.INTEGER, DataTypes.INTEGER)));
         assertThat(delete.query(), isFunction(EqOperator.NAME, isReference("id"), instanceOf(ParameterSymbol.class)));
     }
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -11,7 +11,6 @@ import io.crate.analyze.BoundCreateTable;
 import io.crate.analyze.CreateTableStatementAnalyzer;
 import io.crate.analyze.NumberOfShards;
 import io.crate.analyze.ParamTypeHints;
-import io.crate.analyze.ParameterContext;
 import io.crate.data.Row;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.ColumnIdent;
@@ -1066,10 +1065,12 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         CreateTableStatementAnalyzer analyzer = new CreateTableStatementAnalyzer(functions);
 
-        Analysis analysis = new Analysis(new CoordinatorTxnCtx(SessionContext.systemSessionContext()), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
+        Analysis analysis = new Analysis(new CoordinatorTxnCtx(SessionContext.systemSessionContext()), ParamTypeHints.EMPTY);
         CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(SessionContext.systemSessionContext());
         AnalyzedCreateTable analyzedCreateTable = analyzer.analyze(
-            (CreateTable<Expression>) statement, analysis.parameterContext(), analysis.transactionContext());
+            (CreateTable<Expression>) statement,
+            analysis.paramTypeHints(),
+            analysis.transactionContext());
         BoundCreateTable analyzedStatement = CreateTablePlan.bind(
             analyzedCreateTable,
             txnCtx,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Removes analyzer dependency on `ParameterContext`.

We can probably remove `ParameterContext`, but it some test infrastructure adjustment.
It can be probably done in a separate PR.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
