### PR TITLE
Add a ascii scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,8 @@ None
 Changes
 =======
 
+- Added the :ref:`ascii <scalar_ascii>` scalar function.
+
 - Introduced new optional ``RETURNING`` clause for :ref:`Update <ref-update>` to
   return specified values from each row updated.
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -190,6 +190,26 @@ Returns: ``integer``
     +--------------------------+
     SELECT 1 row in set (... sec)
 
+.. _scalar_ascii:
+
+``ascii(string)``
+-----------------
+
+Returns the ASCII code of the first character. For UTF-8 returns the Unicode
+code point of the characters.
+
+Returns: ``int``
+
+::
+
+    cr> SELECT ascii('a') AS a, ascii('🎈') AS b;
+    +----+--------+
+    |  a |      b |
+    +----+--------+
+    | 97 | 127880 |
+    +----+--------+
+    SELECT 1 row in set (... sec)
+
 ``lower('string')``
 -------------------
 

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -49,6 +49,7 @@ import io.crate.expression.scalar.postgres.PgBackendPidFunction;
 import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
 import io.crate.expression.scalar.regex.MatchesFunction;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
+import io.crate.expression.scalar.string.AsciiFunction;
 import io.crate.expression.scalar.string.HashFunctions;
 import io.crate.expression.scalar.string.InitCapFunction;
 import io.crate.expression.scalar.string.LengthFunction;
@@ -137,6 +138,7 @@ public class ScalarFunctionModule extends AbstractModule {
         StringPaddingFunction.register(this);
         InitCapFunction.register(this);
         TrimFunctions.register(this);
+        AsciiFunction.register(this);
 
         ConcatFunction.register(this);
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import java.util.List;
+
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.BaseFunctionResolver;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.functions.params.FuncParams;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+public final class AsciiFunction {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            new FunctionName(null, "ascii"),
+            new BaseFunctionResolver(FuncParams.builder(List.of(DataTypes.STRING)).build()) {
+
+                @Override
+                public FunctionImplementation getForTypes(List<DataType> types) throws IllegalArgumentException {
+                    return new UnaryScalar<>(
+                        "ascii",
+                        types.get(0),
+                        DataTypes.INTEGER,
+                        AsciiFunction::ascii
+                    );
+                }
+            }
+        );
+    }
+
+    private static int ascii(String value) {
+        if (value.length() == 0) {
+            return 0;
+        }
+        return value.codePointAt(0);
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/AsciiFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AsciiFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import org.junit.Test;
+
+public class AsciiFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_ascii_returns_code_of_first_character() throws Exception {
+        assertEvaluate("ascii('a')", 97);
+        assertEvaluate("ascii('ab')", 97);
+    }
+
+    @Test
+    public void test_ascii_returns_0_for_empty_string() throws Exception {
+        assertEvaluate("ascii('')", 0);
+    }
+
+    @Test
+    public void test_ascii_returns_null_for_null_arg() throws Exception {
+        assertEvaluate("ascii(null)", null);
+    }
+
+    @Test
+    public void test_ascii_with_unicode_arg() throws Exception {
+        assertEvaluate("ascii('💩')", 128169);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://www.postgresql.org/docs/current/functions-string.html

The JDBC client has a method which returns string functions. In
PostgreSQL JDBC this method returns a constant which includes `ascii`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)