### PR TITLE
Do not store partition values, but include on select

### DIFF
--- a/common/src/main/java/io/crate/common/collections/Maps.java
+++ b/common/src/main/java/io/crate/common/collections/Maps.java
@@ -90,6 +90,26 @@ public final class Maps {
         return map;
     }
 
+    @Nullable
+    public static <T> T removeByPath(Map<String, T> map, List<String> path) {
+        assert path instanceof RandomAccess : "`path` must support random access for performance";
+        Map<String, T> m = map;
+        for (int i = 0; i < path.size(); i++) {
+            String key = path.get(i);
+            if (i + 1 == path.size()) {
+                return m.remove(key);
+            } else {
+                T val = map.get(key);
+                if (val instanceof Map) {
+                    m = (Map<String, T>) val;
+                } else {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Inserts a value into source under the given key+path
      */

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,6 +94,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that resulted in the values for nested partitioned columns to
+  be missing from the result.
+
 - Fixed an issue that caused ``SELECT *`` to include nested columns of type
   ``geo_shape`` instead of only selecting top-level columns.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -62,8 +62,18 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
                                       Settings settings,
                                       TransportActionProvider transportActionProvider,
                                       BigArrays bigArrays) {
-        super(clusterService, schemas, nodeJobsCounter, functions, threadPool, settings, transportActionProvider,
-            blobShard.indexShard(), new ShardRowContext(blobShard, clusterService), bigArrays);
+        super(
+            clusterService,
+            schemas,
+            nodeJobsCounter,
+            functions,
+            threadPool,
+            settings,
+            transportActionProvider,
+            blobShard.indexShard(),
+            new ShardRowContext(blobShard, clusterService),
+            bigArrays
+        );
         inputFactory = new InputFactory(functions);
         this.blobShard = blobShard;
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -50,6 +50,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataTypes;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -110,6 +111,7 @@ final class GroupByOptimizedIterator {
 
     @Nullable
     static BatchIterator<Row> tryOptimizeSingleStringKey(IndexShard indexShard,
+                                                         DocTableInfo table,
                                                          LuceneQueryBuilder luceneQueryBuilder,
                                                          FieldTypeLookup fieldTypeLookup,
                                                          BigArrays bigArrays,
@@ -172,7 +174,9 @@ final class GroupByOptimizedIterator {
                 collectPhase.where(),
                 collectTask.txnCtx(),
                 indexShard.mapperService(),
+                indexShard.shardId().getIndexName(),
                 queryShardContext,
+                table,
                 sharedShardContext.indexService().cache()
             );
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -41,8 +41,12 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.Functions;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -72,6 +76,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     private final DocInputFactory docInputFactory;
     private final BigArrays bigArrays;
     private final FieldTypeLookup fieldTypeLookup;
+    private final DocTableInfo table;
 
     public LuceneShardCollectorProvider(Schemas schemas,
                                         LuceneQueryBuilder luceneQueryBuilder,
@@ -83,17 +88,34 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                                         TransportActionProvider transportActionProvider,
                                         IndexShard indexShard,
                                         BigArrays bigArrays) {
-        super(clusterService, schemas, nodeJobsCounter, functions, threadPool, settings, transportActionProvider, indexShard,
-            new ShardRowContext(indexShard, clusterService), bigArrays);
+        super(
+            clusterService,
+            schemas,
+            nodeJobsCounter,
+            functions,
+            threadPool,
+            settings,
+            transportActionProvider,
+            indexShard,
+            new ShardRowContext(indexShard, clusterService),
+            bigArrays
+        );
         this.luceneQueryBuilder = luceneQueryBuilder;
         this.functions = functions;
         this.indexShard = indexShard;
         this.localNodeId = () -> clusterService.localNode().getId();
-        fieldTypeLookup = indexShard.mapperService()::fullName;
+        var mapperService = indexShard.mapperService();
+        fieldTypeLookup = mapperService::fullName;
+        var relationName = RelationName.fromIndexName(indexShard.shardId().getIndexName());
+        this.table = schemas.getTableInfo(relationName, Operation.READ);
         this.docInputFactory = new DocInputFactory(
             functions,
             fieldTypeLookup,
-            new LuceneReferenceResolver(fieldTypeLookup)
+            new LuceneReferenceResolver(
+                indexShard.shardId().getIndexName(),
+                fieldTypeLookup,
+                table.partitionedByColumns()
+            )
         );
         this.bigArrays = bigArrays;
     }
@@ -112,7 +134,9 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 collectPhase.where(),
                 collectTask.txnCtx(),
                 indexShard.mapperService(),
+                indexShard.shardId().getIndexName(),
                 queryShardContext,
+                table,
                 sharedShardContext.indexService().cache()
             );
             collectTask.addSearcher(sharedShardContext.readerId(), searcher);
@@ -139,6 +163,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     protected BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase, CollectTask collectTask) {
         return GroupByOptimizedIterator.tryOptimizeSingleStringKey(
             indexShard,
+            table,
             luceneQueryBuilder,
             fieldTypeLookup,
             bigArrays,
@@ -168,7 +193,9 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 collectPhase.where(),
                 collectTask.txnCtx(),
                 indexService.mapperService(),
+                indexShard.shardId().getIndexName(),
                 queryShardContext,
+                table,
                 indexService.cache()
             );
             collectTask.addSearcher(sharedShardContext.readerId(), searcher);

--- a/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -76,7 +76,12 @@ public class NodeFetchOperation {
 
         FetchCollector createCollector(int readerId, RamAccountingContext ramAccountingContext) {
             IndexService indexService = fetchTask.indexService(readerId);
-            LuceneReferenceResolver resolver = new LuceneReferenceResolver(indexService.mapperService()::fullName);
+            var mapperService = indexService.mapperService();
+            LuceneReferenceResolver resolver = new LuceneReferenceResolver(
+                fetchTask.indexService(readerId).index().getName(),
+                mapperService::fullName,
+                fetchTask.table(readerId).partitionedByColumns()
+            );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());
             for (Reference reference : refs) {
                 exprs.add(resolver.getImplementation(reference));

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -88,8 +88,10 @@ import io.crate.memory.MemoryManager;
 import io.crate.memory.MemoryManagerFactory;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Routing;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.metadata.table.Operation;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.StreamerVisitor;
 import io.crate.types.DataTypes;
@@ -140,9 +142,11 @@ public class JobSetup {
     private final PKLookupOperation pkLookupOperation;
     private final Executor searchTp;
     private final String nodeName;
+    private final Schemas schemas;
 
     @Inject
     public JobSetup(Settings settings,
+                    Schemas schemas,
                     MapSideDataCollectOperation collectOperation,
                     ClusterService clusterService,
                     NodeJobsCounter nodeJobsCounter,
@@ -158,6 +162,7 @@ public class JobSetup {
                     ShardCollectSource shardCollectSource,
                     MemoryManagerFactory memoryManagerFactory) {
         this.nodeName = Node.NODE_NAME_SETTING.get(settings);
+        this.schemas = schemas;
         this.collectOperation = collectOperation;
         this.clusterService = clusterService;
         this.circuitBreakerService = circuitBreakerService;
@@ -791,6 +796,7 @@ public class JobSetup {
                 localNodeId,
                 context.sharedShardContexts,
                 clusterService.state().metaData(),
+                relationName -> schemas.getTableInfo(relationName, Operation.READ),
                 routings));
             return true;
         }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -61,7 +61,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
     public static LuceneCollectorExpression<?> create(final Reference reference) {
         assert reference.column().name().equals(DocSysColumns.DOC.name()) :
             "column name must be " + DocSysColumns.DOC.name();
-        if (reference.column().path().size() == 0) {
+        if (reference.column().isTopLevel()) {
             return new DocCollectorExpression();
         }
         return new ChildDocCollectorExpression(reference.valueType(), reference.column().path());

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -66,8 +66,10 @@ import io.crate.metadata.DocReferences;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataTypes;
 import org.apache.logging.log4j.LogManager;
@@ -107,23 +109,39 @@ public class LuceneQueryBuilder {
     private static final Logger LOGGER = LogManager.getLogger(LuceneQueryBuilder.class);
     private static final Visitor VISITOR = new Visitor();
     private final Functions functions;
-    private final EvaluatingNormalizer normalizer;
 
     @Inject
     public LuceneQueryBuilder(Functions functions) {
         this.functions = functions;
-        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
     }
 
     public Context convert(Symbol query,
                            TransactionContext txnCtx,
                            MapperService mapperService,
+                           String indexName,
                            QueryShardContext queryShardContext,
+                           DocTableInfo table,
                            IndexCache indexCache) throws UnsupportedFeatureException {
-        Context ctx = new Context(txnCtx, functions, mapperService, indexCache, queryShardContext);
+        var refResolver = new LuceneReferenceResolver(
+            indexName,
+            mapperService::fullName,
+            table.partitionedByColumns()
+        );
+        var normalizer = new EvaluatingNormalizer(functions, RowGranularity.PARTITION, refResolver, null);
+        Context ctx = new Context(
+            txnCtx,
+            functions,
+            mapperService,
+            indexCache,
+            queryShardContext,
+            indexName,
+            table.partitionedByColumns()
+        );
         CoordinatorTxnCtx coordinatorTxnCtx = CoordinatorTxnCtx.systemTransactionContext();
         ctx.query = eliminateNullsIfPossible(
-            inverseSourceLookup(query), s -> normalizer.normalize(s, coordinatorTxnCtx)).accept(VISITOR, ctx);
+            inverseSourceLookup(normalizer.normalize(query, coordinatorTxnCtx)),
+            s -> normalizer.normalize(s, coordinatorTxnCtx)
+        ).accept(VISITOR, ctx);
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("WHERE CLAUSE [{}] -> LUCENE QUERY [{}] ", SymbolPrinter.INSTANCE.printUnqualified(query), ctx.query);
         }
@@ -157,14 +175,20 @@ public class LuceneQueryBuilder {
                 Functions functions,
                 MapperService mapperService,
                 IndexCache indexCache,
-                QueryShardContext queryShardContext) {
+                QueryShardContext queryShardContext,
+                String indexName,
+                List<Reference> partitionColumns) {
             this.txnCtx = txnCtx;
             this.queryShardContext = queryShardContext;
             FieldTypeLookup typeLookup = mapperService::fullName;
             this.docInputFactory = new DocInputFactory(
                 functions,
                 typeLookup,
-                new LuceneReferenceResolver(typeLookup)
+                new LuceneReferenceResolver(
+                    indexName,
+                    typeLookup,
+                    partitionColumns
+                )
             );
             this.mapperService = mapperService;
             this.indexCache = indexCache;

--- a/sql/src/main/java/io/crate/metadata/DocReferences.java
+++ b/sql/src/main/java/io/crate/metadata/DocReferences.java
@@ -95,7 +95,7 @@ public final class DocReferences {
         return reference;
     }
 
-    private static Reference docRefToRegularRef(Reference ref) {
+    public static Reference docRefToRegularRef(Reference ref) {
         ColumnIdent column = ref.column();
         if (!column.isTopLevel() && column.name().equals(DocSysColumns.Names.DOC)) {
             return ref.getRelocated(new ReferenceIdent(ref.ident().tableIdent(), column.shiftRight()));

--- a/sql/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/sql/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -157,9 +157,17 @@ public final class ReservoirSampler {
             if (indexService == null) {
                 continue;
             }
-            FieldTypeLookup fieldTypeLookup = indexService.mapperService()::fullName;
+            var mapperService = indexService.mapperService();
+            FieldTypeLookup fieldTypeLookup = mapperService::fullName;
             var ctx = new DocInputFactory(
-                functions, fieldTypeLookup, new LuceneReferenceResolver(fieldTypeLookup)).getCtx(coordinatorTxnCtx);
+                functions,
+                fieldTypeLookup,
+                new LuceneReferenceResolver(
+                    indexService.index().getName(),
+                    fieldTypeLookup,
+                    docTable.partitionedByColumns()
+                )
+            ).getCtx(coordinatorTxnCtx);
             ctx.add(columns);
             List<Input<?>> inputs = ctx.topLevelInputs();
             List<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();

--- a/sql/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -71,6 +71,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
             "dummy",
             new SharedShardContexts(mock(IndicesService.class), UnaryOperator.identity()),
             clusterService.state().getMetaData(),
+            relationName -> null,
             Collections.emptyList());
 
         expectedException.expect(IllegalArgumentException.class);
@@ -110,6 +111,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
             "dummy",
             new SharedShardContexts(mock(IndicesService.class, RETURNS_MOCKS), UnaryOperator.identity()),
             metaData,
+            relationName -> null,
             ImmutableList.of(routing));
 
         context.prepare();

--- a/sql/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.reference.doc;
 
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.IndexEnv;
 import io.crate.testing.SQLExecutor;
@@ -55,15 +56,14 @@ public abstract class DocLevelExpressionsTest extends CrateDummyClusterServiceUn
             .build();
         indexEnv = new IndexEnv(
             THREAD_POOL,
-            StreamSupport.stream(e.schemas().spliterator(), false)
+            (DocTableInfo) StreamSupport.stream(e.schemas().spliterator(), false)
                 .filter(x -> x instanceof DocSchemaInfo)
                 .map(x -> (DocSchemaInfo) x)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No doc schema found"))
                 .getTables()
                 .iterator()
-                .next()
-                .ident(),
+                .next(),
             clusterService.state(),
             Version.CURRENT,
             createTempDir()

--- a/sql/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -40,14 +40,17 @@ import static org.hamcrest.Matchers.instanceOf;
 public class LuceneReferenceResolverTest extends CrateUnitTest {
 
     // just return any fieldType to get passt the null check
+    private RelationName name = new RelationName("s", "t");
     private LuceneReferenceResolver luceneReferenceResolver = new LuceneReferenceResolver(
-        i -> KeywordFieldMapper.Defaults.FIELD_TYPE);
+        name.indexNameOrAlias(),
+        i -> KeywordFieldMapper.Defaults.FIELD_TYPE,
+        List.of()
+    );
 
     @Test
     public void testGetImplementationWithColumnsOfTypeCollection() {
         Reference arrayRef = new Reference(
-            new ReferenceIdent(
-            new RelationName("s", "t"), "a"), RowGranularity.DOC, DataTypes.DOUBLE_ARRAY, null, null
+            new ReferenceIdent(name, "a"), RowGranularity.DOC, DataTypes.DOUBLE_ARRAY, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(arrayRef),
             instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
@@ -56,8 +59,7 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     @Test
     public void testGetImplementationForSequenceNumber() {
         Reference seqNumberRef = new Reference(
-            new ReferenceIdent(
-                new RelationName("s", "t"), "_seq_no"), RowGranularity.DOC, DataTypes.LONG, null, null
+            new ReferenceIdent(name, "_seq_no"), RowGranularity.DOC, DataTypes.LONG, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(seqNumberRef), instanceOf(SeqNoCollectorExpression.class));
     }
@@ -65,8 +67,7 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     @Test
     public void testGetImplementationForPrimaryTerm() {
         Reference primaryTerm = new Reference(
-            new ReferenceIdent(
-                new RelationName("s", "t"), "_primary_term"), RowGranularity.DOC, DataTypes.LONG, null, null
+            new ReferenceIdent(name, "_primary_term"), RowGranularity.DOC, DataTypes.LONG, null, null
         );
         assertThat(luceneReferenceResolver.getImplementation(primaryTerm),
                    instanceOf(PrimaryTermCollectorExpression.class));
@@ -75,8 +76,7 @@ public class LuceneReferenceResolverTest extends CrateUnitTest {
     @Test
     public void test_ignored_dynamic_references_are_resolved_using_sourcelookup() {
         Reference ignored = new DynamicReference(
-            new ReferenceIdent(
-                new RelationName("s", "t"), "a", List.of("b")), RowGranularity.DOC, ColumnPolicy.IGNORED);
+            new ReferenceIdent(name, "a", List.of("b")), RowGranularity.DOC, ColumnPolicy.IGNORED);
 
         assertThat(luceneReferenceResolver.getImplementation(ignored),
                    instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -97,7 +97,7 @@ public final class QueryTester implements AutoCloseable {
 
             indexEnv = new IndexEnv(
                 threadPool,
-                table.ident(),
+                table,
                 clusterService.state(),
                 indexVersion,
                 tempDir
@@ -193,7 +193,9 @@ public final class QueryTester implements AutoCloseable {
                     symbol,
                     systemTxnCtx,
                     indexEnv.mapperService(),
+                    indexEnv.indexService().index().getName(),
                     indexEnv.queryShardContext(),
+                    table,
                     indexEnv.indexCache()
                 ).query(),
                 indexEnv


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We've had two bugs, that to some degree negated each other:

- In 4.0 and 4.1 we stored the partition column value within objects if
using INSERT FROM QUERY.

- We didn't include the value for nested partition columns if the parent
object was selected. (If it was inserted using INSERT FROM QUERY)

With the de-duplication of INSERT FROM VALUES and INSERT FROM QUERY we
then always included the values.

This now changes it to:

- Never include the value
- Always include the value on selects


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
