### PR TITLE
Add changelog entry for crate object[] -> pg json[] remapping.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,16 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Remap CrateDB :ref:`object_data_type` array data type from the PostgreSQL
+  JSON to JSON array type. That might effect some drivers that use the
+  PostgreSQL wire protocol to insert data into tables with object array typed
+  columns. For instance,  when using the ``Npgsql`` driver, it is not longer
+  possible to insert an array of objects into a column of the object array
+  data type by using the parameter of a SQL statement that has the JSON data
+  type and an array of CLR as its value. Instead, use a string array with JSON
+  strings that represent the objects. See the ``Npgsql`` documentation for
+  more details.
+
 - Bulk ``INSERT INTO ... VALUES (...)`` statements do not throw an exception
   any longer when one of the bulk operations fails. The result of the
   execution is only available via the ``results`` array represented by a


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/crate/crate/pull/9367

References https://github.com/crate/crate-npgsql/pull/37

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
