### PR TITLE
Fix resource leak as futures were completed too early

### DIFF
--- a/dex/src/main/java/io/crate/data/Killable.java
+++ b/dex/src/main/java/io/crate/data/Killable.java
@@ -36,6 +36,7 @@ public interface Killable {
      *
      *  <li>terminate if they're otherwise waiting for input/data</li>
      *  <li>terminate expensive and long running operations within a reasonable amount of time (&lt; 2sec)</li>
+     *  <li>only terminate/release resources they created themselves</li>
      *
      * </ul>
      *


### PR DESCRIPTION
The BatchPageIterator must NOT complete foreign futures on `kill()`,
otherwise operations/upstreams are treat as completed too early resulting
in resource leaks.
E.g. the RamAccounting would be released while an operation is still
running and accounting bytes on it (which will then never be released).