### PR TITLE
Improve BwC for returning clause for update

### DIFF
--- a/integration-testing/src/main/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
+++ b/integration-testing/src/main/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
@@ -76,7 +76,7 @@ public class CrateDummyClusterServiceUnitTest extends CrateUnitTest {
 
     @Before
     public void setupDummyClusterService() {
-        clusterService = createClusterService(additionalClusterSettings());
+        clusterService = createClusterService(additionalClusterSettings(), Version.CURRENT);
     }
 
     @After
@@ -99,7 +99,7 @@ public class CrateDummyClusterServiceUnitTest extends CrateUnitTest {
         return EMPTY_CLUSTER_SETTINGS;
     }
 
-    private ClusterService createClusterService(Collection<Setting<?>> additionalClusterSettings) {
+    protected ClusterService createClusterService(Collection<Setting<?>> additionalClusterSettings, Version version) {
         Set<Setting<?>> clusterSettingsSet = Sets.newHashSet(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterSettingsSet.addAll(additionalClusterSettings);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsSet);
@@ -118,7 +118,7 @@ public class CrateDummyClusterServiceUnitTest extends CrateUnitTest {
             buildNewFakeTransportAddress(),
             Collections.emptyMap(),
             new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())),
-            Version.CURRENT
+            version
         );
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(discoveryNode)

--- a/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -27,7 +27,6 @@ import io.crate.exceptions.JobKilledException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -79,7 +78,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     protected WritePrimaryResult<ShardDeleteRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardDeleteRequest request,
                                                                                         AtomicBoolean killed) throws IOException {
-        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
+        ShardResponse shardResponse = new ShardResponse();
         Translog.Location translogLocation = null;
         boolean debugEnabled = logger.isDebugEnabled();
         for (ShardDeleteRequest.Item item : request.items()) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -42,7 +42,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -121,7 +120,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     protected WritePrimaryResult<ShardUpsertRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardUpsertRequest request,
                                                                                         AtomicBoolean killed) {
-        ShardResponse shardResponse = new ShardResponse(Version.CURRENT, request.getReturnValues());
+        ShardResponse shardResponse = new ShardResponse(request.getReturnValues());
         
         String indexName = request.index();
         DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -40,7 +40,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 
@@ -104,9 +103,7 @@ public class ColumnIndexWriterProjector implements Projector {
             columnReferences.toArray(new Reference[columnReferences.size()]),
             null,
             jobId,
-            true,
-            Version.CURRENT
-        );
+            true);
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory =

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -39,7 +39,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -110,8 +109,7 @@ public class IndexWriterProjector implements Projector {
             new Reference[]{rawSourceReference},
             null,
             jobId,
-            false,
-            Version.CURRENT);
+            false);
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
             id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -529,8 +529,7 @@ public class ProjectionToProjectorVisitor
             null,
             projection.returnValues(),
             context.jobId,
-            true,
-            Version.CURRENT
+            true
         );
 
         return new ShardDMLExecutor<>(

--- a/sql/src/main/java/io/crate/planner/PlannerContext.java
+++ b/sql/src/main/java/io/crate/planner/PlannerContext.java
@@ -134,4 +134,8 @@ public class PlannerContext {
     public Functions functions() {
         return functions;
     }
+
+    public ClusterState clusterState() {
+        return clusterState;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -38,7 +38,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -119,8 +118,7 @@ public final class UpdateById implements Plan {
             null, // missing assignments are for INSERT .. ON DUPLICATE KEY UPDATE
             returnValues,
             plannerContext.jobId(),
-            false,
-            Version.CURRENT
+            false
         );
         UpdateRequests updateRequests = new UpdateRequests(requestBuilder, table, assignments);
         return new ShardRequestExecutor<>(

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -69,7 +69,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.types.DataType;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
@@ -237,8 +236,7 @@ public class InsertFromValues implements LogicalPlan {
             writerProjection.allTargetColumns().toArray(new Reference[0]),
             null,
             plannerContext.jobId(),
-            false,
-            Version.CURRENT);
+            false);
 
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
@@ -349,8 +347,7 @@ public class InsertFromValues implements LogicalPlan {
             writerProjection.allTargetColumns().toArray(new Reference[0]),
             null,
             plannerContext.jobId(),
-            true,
-            Version.CURRENT);
+            true);
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
         HashMap<String, InsertSourceFromCells> validatorsCache = new HashMap<>();

--- a/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/ShardResponseTest.java
@@ -23,7 +23,6 @@
 package io.crate.execution.dml;
 
 import io.crate.test.integration.CrateUnitTest;
-import org.elasticsearch.Version;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -32,7 +31,7 @@ public class ShardResponseTest extends CrateUnitTest {
 
     @Test
     public void testMarkResponseItemsAndFailures() {
-        ShardResponse shardResponse = new ShardResponse(Version.CURRENT);
+        ShardResponse shardResponse = new ShardResponse();
         shardResponse.add(0);
         shardResponse.add(1);
         shardResponse.add(2, new ShardResponse.Failure("dummyId", "dummyMessage", false));

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -34,7 +34,6 @@ import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -78,8 +77,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             missingAssignmentColumns,
             null,
             jobId,
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.validateConstraints(false);
 
@@ -132,8 +130,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             missingAssignmentColumns,
             null,
             jobId,
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.validateConstraints(false);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -98,7 +98,6 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     private String charactersIndexUUID;
     private String partitionIndexUUID;
 
-
     static class TestingTransportShardUpsertAction extends TransportShardUpsertAction {
 
 
@@ -185,8 +184,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
@@ -208,8 +206,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
@@ -251,8 +248,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
@@ -274,8 +270,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false,
-            Version.CURRENT
+            false
         ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 

--- a/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
@@ -42,10 +42,10 @@ public class UpdateProjectionTest {
     @Test
     public void testEquals() throws Exception {
         UpdateProjection u1 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT, new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
 
         UpdateProjection u2 = new UpdateProjection(
-            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)}, Version.CURRENT,new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
+            Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)},new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
 
         assertThat(u2.equals(u1), is(true));
         assertThat(u1.equals(u2), is(true));
@@ -60,7 +60,6 @@ public class UpdateProjectionTest {
             Literal.of(1),
             new String[]{"foo"},
             new Symbol[]{Literal.of(1)},
-            Version.CURRENT,
             new Symbol[]{new InputColumn(0, DataTypes.STRING)},
             new Symbol[]{Literal.of(1)},
             null);
@@ -81,7 +80,6 @@ public class UpdateProjectionTest {
             Literal.of(1),
             new String[]{"foo"},
             new Symbol[]{Literal.of(1)},
-            Version.CURRENT,
             new Symbol[]{},
             new Symbol[]{Literal.of(1)},
             null);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This introduces a version check for the returning clause for update in the planner. It also removes all `allOn4_2` version flags from upsert related classes and uses the version from the stream directly as @seut suggested https://github.com/crate/crate/pull/9434#discussion_r371270034. This pr will also  fixes the flaky RollingUpgradeTest in crate-qa against current master.

Related BwC test can be found here https://github.com/crate/crate-qa/pull/131/

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
