### PR TITLE
Replace object arrays with lists in SQL args parsers.

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/parser/SQLArgsParseElement.java
+++ b/sql/src/main/java/io/crate/action/sql/parser/SQLArgsParseElement.java
@@ -25,41 +25,35 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 class SQLArgsParseElement implements SQLParseElement {
 
     @Override
     public void parse(XContentParser parser, SQLRequestParseContext context) throws Exception {
         XContentParser.Token token = parser.currentToken();
-
         if (token != XContentParser.Token.START_ARRAY) {
             throw new SQLParseSourceException("Field [" + parser.currentName() + "] has an invalid value");
         }
-
-        Object[] params = parseSubArray(parser);
-        context.args(params);
+        context.args(parseSubArray(parser));
     }
 
-    Object[] parseSubArray(XContentParser parser)
-        throws IOException {
+    ArrayList<Object> parseSubArray(XContentParser parser) throws IOException {
         XContentParser.Token token;
-        List<Object> subList = new ArrayList<>();
-
+        ArrayList<Object> args = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token.isValue()) {
-                subList.add(parser.objectText());
+                args.add(parser.objectText());
             } else if (token == XContentParser.Token.START_ARRAY) {
-                subList.add(parseSubArray(parser));
+                args.add(parseSubArray(parser));
             } else if (token == XContentParser.Token.START_OBJECT) {
-                subList.add(parser.map());
+                args.add(parser.map());
             } else if (token == XContentParser.Token.VALUE_NULL) {
-                subList.add(null);
+                args.add(null);
             } else {
                 throw new SQLParseSourceException("Field [" + parser.currentName() + "] has an invalid value");
             }
         }
-
-        return subList.toArray(new Object[subList.size()]);
+        return args;
     }
 }
+

--- a/sql/src/main/java/io/crate/action/sql/parser/SQLBulkArgsParseElement.java
+++ b/sql/src/main/java/io/crate/action/sql/parser/SQLBulkArgsParseElement.java
@@ -33,25 +33,22 @@ class SQLBulkArgsParseElement extends SQLArgsParseElement implements SQLParseEle
     @Override
     public void parse(XContentParser parser, SQLRequestParseContext context) throws Exception {
         XContentParser.Token token = parser.currentToken();
-
         if (token != XContentParser.Token.START_ARRAY) {
             throw new SQLParseSourceException("Field [" + parser.currentName() + "] has an invalid value");
         }
-
-        Object[][] params = parseSubArrays(parser);
-        context.bulkArgs(params);
+        context.bulkArgs(parseSubArrays(parser));
     }
 
-    private Object[][] parseSubArrays(XContentParser parser) throws IOException {
+    private List<List<Object>> parseSubArrays(XContentParser parser) throws IOException {
         XContentParser.Token token;
-        List<Object[]> list = new ArrayList<>();
+        ArrayList<List<Object>> bulkArgs = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token == XContentParser.Token.START_ARRAY) {
-                list.add(parseSubArray(parser));
+                bulkArgs.add(parseSubArray(parser));
             } else {
                 throw new SQLParseSourceException("Field [" + parser.currentName() + "] has an invalid value");
             }
         }
-        return list.toArray(new Object[list.size()][]);
+        return bulkArgs;
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParseContext.java
+++ b/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParseContext.java
@@ -21,14 +21,16 @@
 
 package io.crate.action.sql.parser;
 
+import java.util.List;
+
 /**
  * Context for information gathered by parsing an XContent based sql request
  */
 public final class SQLRequestParseContext {
 
     private String stmt;
-    private Object[] args;
-    private Object[][] bulkArgs;
+    private List<Object> args;
+    private List<List<Object>> bulkArgs;
 
     public String stmt() {
         return stmt;
@@ -38,19 +40,19 @@ public final class SQLRequestParseContext {
         this.stmt = stmt;
     }
 
-    public Object[] args() {
+    public List<Object> args() {
         return args;
     }
 
-    public void args(Object[] args) {
+    public void args(List<Object> args) {
         this.args = args;
     }
 
-    public Object[][] bulkArgs() {
+    public List<List<Object>> bulkArgs() {
         return bulkArgs;
     }
 
-    public void bulkArgs(Object[][] bulkArgs) {
+    public void bulkArgs(List<List<Object>> bulkArgs) {
         this.bulkArgs = bulkArgs;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change removes unnecessary list -> object -> list conversions
when parsing parameters of SQL requests.

It also prevents the class cast exception in the insert
from subquery statements with the unnest table function
when using the HTTP protocol to execute statements. E.g.
statements like

    `INSERT INTO t (id) (SELECT col1 FROM unnest(?))`

previously would have failed with the class cast exception.

A changelog entry is not required such as the issue was exposed
due to recent changes and has not been released yet.
 
## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
