### PR TITLE
Add ceiling alias for ceil scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ None
 Changes
 =======
 
+- Added a ``ceiling`` alias for the :ref:`ceil <scalar-ceil>` function for
+  improved PostgreSQL compatibility.
+
 - Added the :ref:`encode(bytea, format) <scalar-encode>` and :ref:`decode(text,
   format) <scalar-decode>` string functions.
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1166,6 +1166,13 @@ return value will be of type ``bigint``::
     +------------+
     SELECT 1 row in set (... sec)
 
+
+``ceiling(number)``
+-------------------
+
+This is an alias for :ref:`ceil <scalar-ceil>`.
+
+
 .. _scalar-floor:
 
 ``floor(number)``

--- a/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -66,7 +66,7 @@ public final class GeneratedColumnExpander {
     );
 
     private static final Set<String> ROUNDING_FUNCTIONS = ImmutableSet.of(
-        CeilFunction.NAME,
+        CeilFunction.CEIL,
         FloorFunction.NAME,
         RoundFunction.NAME,
         DateTruncFunction.NAME

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -35,29 +35,40 @@ import java.util.List;
 
 public final class CeilFunction {
 
-    public static final String NAME = "ceil";
+    public static final String CEIL = "ceil";
+    public static final String CEILING = "ceiling";
 
     public static void register(ScalarFunctionModule module) {
-        module.register(NAME, new FunctionResolver() {
-            @Nullable
-            @Override
-            public List<DataType> getSignature(List<? extends FuncArg> funcArgs) {
-                return FuncParams.SINGLE_NUMERIC.match(funcArgs);
-            }
+        module.register(CEIL, new CeilFunctionResolver(CEIL));
+        module.register(CEILING, new CeilFunctionResolver(CEILING));
+    }
 
-            @Override
-            public FunctionImplementation getForTypes(List<DataType> types) throws IllegalArgumentException {
-                if (types.size() != 1) {
-                    throw FunctionResolver.noSignatureMatch(NAME, types);
-                }
-                DataType argType = types.get(0);
-                DataType returnType = DataTypes.getIntegralReturnType(argType);
-                if (returnType == null) {
-                    throw FunctionResolver.noSignatureMatch(NAME, types);
-                }
-                return new UnaryScalar<>(
-                    NAME, argType, returnType, x -> returnType.value(Math.ceil(((Number) x).doubleValue())));
+    private static class CeilFunctionResolver implements FunctionResolver {
+
+        private final String name;
+
+        public CeilFunctionResolver(String name) {
+            this.name = name;
+        }
+
+        @Nullable
+        @Override
+        public List<DataType> getSignature(List<? extends FuncArg> funcArgs) {
+            return FuncParams.SINGLE_NUMERIC.match(funcArgs);
+        }
+
+        @Override
+        public FunctionImplementation getForTypes(List<DataType> types) throws IllegalArgumentException {
+            if (types.size() != 1) {
+                throw FunctionResolver.noSignatureMatch(name, types);
             }
-        });
+            DataType<?> argType = types.get(0);
+            DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
+            if (returnType == null) {
+                throw FunctionResolver.noSignatureMatch(name, types);
+            }
+            return new UnaryScalar<>(
+                name, argType, returnType, x -> returnType.value(Math.ceil(((Number) x).doubleValue())));
+        }
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -43,6 +43,11 @@ public class CeilFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void test_ceiling_works_as_alias_for_ceil() {
+        assertEvaluate("ceiling(-95.3)", -95L);
+    }
+
+    @Test
     public void testEvaluateOnIntAndLong() throws Exception {
         assertNormalize("ceil(cast(20 as integer))", isLiteral(20));
         assertNormalize("ceil(cast(null as integer))", isLiteral(null, DataTypes.INTEGER));
@@ -53,6 +58,6 @@ public class CeilFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeReference() throws Exception {
-        assertNormalize("ceil(age)", isFunction(CeilFunction.NAME));
+        assertNormalize("ceil(age)", isFunction(CeilFunction.CEIL));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`ceiling` is listed as numeric function by PostgreSQL JDBC
`getNumericFunctions` implementation.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)