### PR TITLE
Add the pi scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,8 @@ None
 Changes
 =======
 
+- Added the :ref:`pi <scalar-pi>` scalar function.
+
 - Added a ``ceiling`` alias for the :ref:`ceil <scalar-ceil>` function for
   improved PostgreSQL compatibility.
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1430,6 +1430,25 @@ See below for an example::
     +--------------------+
     SELECT 1 row in set (... sec)
 
+.. _scalar-pi:
+
+``pi()``
+--------
+
+Returns the π constant.
+
+Returns: ``double precision``
+
+::
+
+    cr> SELECT pi();
+    +-------------------+
+    |              pi() |
+    +-------------------+
+    | 3.141592653589793 |
+    +-------------------+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-regexp:
 
 Regular expression functions

--- a/sql/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+public final class PiFunction extends Scalar<Double, Object> {
+
+    private static final String NAME = "pi";
+    private final FunctionInfo info;
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new PiFunction());
+    }
+
+    public PiFunction() {
+        info = new FunctionInfo(new FunctionIdent(NAME, List.of()), DataTypes.DOUBLE);
+    }
+
+    @Override
+    @SafeVarargs
+    public final Double evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        return Math.PI;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return info;
+    }
+}

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -126,6 +126,7 @@ public class ScalarFunctionModule extends AbstractModule {
         SquareRootFunction.register(this);
         LogFunction.register(this);
         TrigonometricFunctions.register(this);
+        PiFunction.register(this);
 
         DateTruncFunction.register(this);
         ExtractFunctions.register(this);

--- a/sql/src/test/java/io/crate/expression/scalar/PiFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/PiFunctionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import org.junit.Test;
+
+public class PiFunctionTest extends AbstractScalarFunctionsTest{
+
+    @Test
+    public void test_pi_returns_pi() {
+        assertEvaluate("pi()", Math.PI);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It is one of the functions returned by PostgreSQL JDBC
`getNumericFunctions()`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)