### PR TITLE
Fix error handling while consuming a next batch

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -118,7 +118,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
     }
 
     @Benchmark
-    public void measureLoadAndConsumeOrderedLuceneBatchIterator(Blackhole blackhole) {
+    public void measureLoadAndConsumeOrderedLuceneBatchIterator(Blackhole blackhole) throws Exception {
         BatchIterator<Row> it = OrderedLuceneBatchIteratorFactory.newInstance(
             Collections.singletonList(createOrderedCollector(indexSearcher, columnName)),
             OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),

--- a/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/sort/SortingTopNCollectorBenchmark.java
@@ -91,14 +91,14 @@ public class SortingTopNCollectorBenchmark {
     }
 
     @Benchmark
-    public Object measureBoundedSortingCollector() {
+    public Object measureBoundedSortingCollector() throws Exception {
         BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, boundedSortingCollector);
         return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();
     }
 
     @Benchmark
-    public Object measureUnboundedSortingCollector() {
+    public Object measureUnboundedSortingCollector() throws Exception {
         BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL, false);
         BatchIterator<Row> sortingBatchIterator = CollectingBatchIterator.newInstance(it, unboundedSortingCollector);
         return sortingBatchIterator.loadNextBatch().toCompletableFuture().join();

--- a/dex/src/main/java/io/crate/data/BatchIterator.java
+++ b/dex/src/main/java/io/crate/data/BatchIterator.java
@@ -121,7 +121,7 @@ public interface BatchIterator<T> extends Killable {
      *         Once the future completes the iterator is still in an "off-row" state, but {@link #moveNext()}
      *         can be called again if the next batch contains more data.
      */
-    CompletionStage<?> loadNextBatch();
+    CompletionStage<?> loadNextBatch() throws Exception;
 
     /**
      * @return true if no more batches can be loaded

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -25,7 +25,6 @@ package io.crate.data;
 import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
@@ -62,9 +61,9 @@ public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (closed) {
-            return CompletableFuture.failedFuture(new IllegalStateException("Iterator is closed"));
+            throw new IllegalStateException("Iterator is closed");
         }
         return delegate.loadNextBatch();
     }

--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -135,7 +135,7 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (resultFuture == null) {
             resultFuture = loadItems.get()
                 .whenComplete((r, t) -> {
@@ -149,7 +149,7 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
                 });
             return resultFuture;
         }
-        return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already loaded"));
+        throw new IllegalStateException("BatchIterator already loaded");
     }
 
     @Override

--- a/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
@@ -84,7 +84,7 @@ public final class FlatMapBatchIterator<TIn, TOut> implements BatchIterator<TOut
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         return source.loadNextBatch();
     }
 

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -28,7 +28,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -95,8 +94,8 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
-        return CompletableFuture.failedFuture(new IllegalStateException("All batches already loaded"));
+    public CompletionStage<?> loadNextBatch() throws Exception {
+        throw new IllegalStateException("All batches already loaded");
     }
 
     @Override

--- a/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
@@ -22,7 +22,6 @@
 
 package io.crate.data;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public final class LimitingBatchIterator<T> extends ForwardingBatchIterator<T> {
@@ -64,9 +63,9 @@ public final class LimitingBatchIterator<T> extends ForwardingBatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (allLoaded()) {
-            return CompletableFuture.failedFuture(new IllegalStateException("Iterator already fully loaded"));
+            throw new IllegalStateException("Iterator already fully loaded");
         }
         return super.loadNextBatch();
     }

--- a/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
@@ -48,7 +48,7 @@ public abstract class MappedForwardingBatchIterator<I, O> implements BatchIterat
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         return delegate().loadNextBatch();
     }
 

--- a/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
@@ -80,7 +80,7 @@ public final class TopNDistinctBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         return source.loadNextBatch();
     }
 

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
@@ -96,7 +96,7 @@ public abstract class JoinBatchIterator<L, R, C> implements BatchIterator<C> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         return activeIt.loadNextBatch();
     }
 

--- a/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
@@ -92,7 +92,7 @@ class SemiJoinNLBatchIterator<L, R, C> implements BatchIterator<L> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         return activeIt.loadNextBatch();
     }
 

--- a/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
@@ -74,7 +74,7 @@ public class CollectingBatchIteratorTest {
     }
 
     @Test
-    public void testCollectingBatchIteratorPropagatesExceptionOnLoadNextBatch() {
+    public void testCollectingBatchIteratorPropagatesExceptionOnLoadNextBatch() throws Exception {
         CompletableFuture<Iterable<Row>> loadItemsFuture = new CompletableFuture<>();
         BatchIterator<Row> collectingBatchIterator = CollectingBatchIterator.newInstance(
             () -> {},

--- a/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
+++ b/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
@@ -114,15 +114,15 @@ public class BatchSimulatingIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (!currentlyLoading.compareAndSet(false, true)) {
-            return CompletableFuture.failedFuture(new IllegalStateException("loadNextBatch call during load operation"));
+            throw new IllegalStateException("loadNextBatch call during load operation");
         }
         if (delegate.allLoaded()) {
             currentBatch++;
             if (currentBatch > numBatches) {
                 currentlyLoading.compareAndSet(true, false);
-                return CompletableFuture.failedFuture(new IllegalStateException("Iterator already fully loaded"));
+                throw new IllegalStateException("Iterator already fully loaded");
             }
             return CompletableFuture.runAsync(() -> {
                 try {

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -96,6 +96,10 @@ Changes
 Fixes
 =====
 
+- Fixed a bug which could lead to stuck queries when an error happens inside
+  distributed execution plans, e.g. a ``CircuitBreakingException`` due to
+  exceeded memory usage.
+
 - Fixed an issue that resulted in the values for nested partitioned columns to
   be missing from the result.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -177,11 +176,11 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (closed) {
-            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator is closed"));
+            throw new IllegalStateException("BatchIterator is closed");
         }
-        return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already fully loaded"));
+        throw new IllegalStateException("BatchIterator already fully loaded");
     }
 
     private Weight createWeight() throws IOException {

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -260,7 +260,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
 
     @Override
     public CompletableFuture<?> loadNextBatch() {
-        return CompletableFuture.failedFuture(new IllegalStateException("All batches already loaded"));
+        throw new IllegalStateException("All batches already loaded");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -102,12 +102,12 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (closed) {
-            return CompletableFuture.failedFuture(new IllegalStateException("BatchIterator already closed"));
+            throw new IllegalStateException("BatchIterator already closed");
         }
         if (allLoaded()) {
-            return CompletableFuture.failedFuture(new IllegalStateException("All data already loaded"));
+            throw new IllegalStateException("All data already loaded");
         }
         Throwable err;
         CompletableFuture<? extends Iterable<? extends KeyIterable<Key, Row>>> future;

--- a/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
@@ -132,7 +132,7 @@ public class HashInnerJoinBatchIterator extends JoinBatchIterator<Row, Row, Row>
     }
 
     @Override
-    public CompletionStage<?> loadNextBatch() {
+    public CompletionStage<?> loadNextBatch() throws Exception {
         if (activeIt == left) {
             numberOfLeftBatchesLoadedForBlock++;
         }

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -51,8 +51,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
 import static io.crate.testing.TestingHelpers.getFunctions;
@@ -105,7 +103,7 @@ public class NodeStatsTest extends CrateUnitTest {
     }
 
     @Test
-    public void testNoRequestIfNotRequired() throws InterruptedException, ExecutionException, TimeoutException {
+    public void testNoRequestIfNotRequired() throws Exception {
         List<Symbol> toCollect = new ArrayList<>();
         toCollect.add(idRef);
 
@@ -125,7 +123,7 @@ public class NodeStatsTest extends CrateUnitTest {
     }
 
     @Test
-    public void testRequestsAreIssued() throws InterruptedException, ExecutionException, TimeoutException {
+    public void testRequestsAreIssued() throws Exception {
         List<Symbol> toCollect = new ArrayList<>();
         toCollect.add(idRef);
         toCollect.add(nameRef);
@@ -143,7 +141,7 @@ public class NodeStatsTest extends CrateUnitTest {
     }
 
     @Test
-    public void testRequestsIfRequired() throws InterruptedException, ExecutionException, TimeoutException {
+    public void testRequestsIfRequired() throws Exception {
         List<Symbol> toCollect = new ArrayList<>();
         toCollect.add(idRef);
         toCollect.add(hostnameRef);

--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
@@ -102,12 +102,16 @@ public class BatchPagingIteratorTest {
                 }
                 // this is intentionally not recursive to not consume the whole source in the first `fetchMore` call
                 // but to simulate multiple pages and fetchMore calls
-                return source.loadNextBatch().toCompletableFuture().thenApply(ignored -> {
-                    while (source.moveNext()) {
-                        rows.add(new RowN(source.currentElement().materialize()));
-                    }
-                    return singleton(new KeyIterable<>(1, rows));
-                });
+                try {
+                    return source.loadNextBatch().toCompletableFuture().thenApply(ignored -> {
+                        while (source.moveNext()) {
+                            rows.add(new RowN(source.currentElement().materialize()));
+                        }
+                        return singleton(new KeyIterable<>(1, rows));
+                    });
+                } catch (Exception e) {
+                    return CompletableFuture.failedFuture(e);
+                }
             };
             return new BatchPagingIterator<>(
                 PassThroughPagingIterator.repeatable(),


### PR DESCRIPTION
Changes the signature of `BatchIterator.loadNextBatch` to throw an exception in order to force all callers/consumers to handle it properly.
Swallowed exceptions would otherwise lead to stuck queries.

Another option would be to adjust all `loadNextBatch` implementations to never throw any exception but return a failing future instead.
As this could not be enforced, we decided to go the other way around.