### PR TITLE
Prevent select on multiple relations with WHERE .. AND FALSE from matching rows

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -96,6 +96,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused queries on more than one relation and a literal
+  ``FALSE`` in the ``WHERE`` clause to match all rows instead of no rows.
+
 - Fixed the following issues in the Admin UI:
 
   - Fixed an issue that prevents the value for nested partitioned columns showing

--- a/sql/src/main/java/io/crate/planner/consumer/QualifiedNameCollector.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QualifiedNameCollector.java
@@ -25,13 +25,21 @@ package io.crate.planner.consumer;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.MatchPredicate;
+import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.QualifiedName;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class QualifiedNameCollector extends DefaultTraversalSymbolVisitor<Set<QualifiedName>, Void> {
 
-    public static final QualifiedNameCollector INSTANCE = new QualifiedNameCollector();
+    private static final QualifiedNameCollector INSTANCE = new QualifiedNameCollector();
+
+    public static Set<QualifiedName> collect(Symbol symbol) {
+        var names = new LinkedHashSet<QualifiedName>();
+        symbol.accept(INSTANCE, names);
+        return names;
+    }
 
     @Override
     public Void visitField(Field field, Set<QualifiedName> context) {

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -93,7 +93,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
 
     @Override
     public LogicalPlan build(TableStats tableStats, Set<PlanHint> hints, Set<Symbol> usedBeforeNextFetch, @Nullable Row params) {
-        Map<Set<QualifiedName>, Symbol> queryParts = getQueryParts(where);
+        Map<Set<QualifiedName>, Symbol> queryParts = QuerySplitter.split(where.queryOrFallback());
         LinkedHashMap<Set<QualifiedName>, JoinPair> joinPairs =
             JoinOperations.buildRelationsToJoinPairsMap(
                 JoinOperations.convertImplicitJoinConditionsToJoinPairs(mss.joinPairs(), queryParts));
@@ -181,7 +181,10 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             );
             joinNames.add(nextRel.getQualifiedName());
         }
-        assert queryParts.isEmpty() : "Must've applied all queryParts";
+        if (!queryParts.isEmpty()) {
+            joinPlan = Filter.create(joinPlan, AndOperator.join(queryParts.values()));
+            queryParts.clear();
+        }
         assert joinPairs.isEmpty() : "Must've applied all joinPairs";
 
         return joinPlan;
@@ -328,12 +331,5 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 consumer.accept(f.pointer());
             }
         });
-    }
-
-    private static Map<Set<QualifiedName>, Symbol> getQueryParts(WhereClause where) {
-        if (where.hasQuery()) {
-            return QuerySplitter.split(where.query());
-        }
-        return Collections.emptyMap();
     }
 }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -44,6 +45,12 @@ final class FilterOnJoinsUtil {
     }
 
     static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join) {
+        if (!WhereClause.canMatch(query)) {
+            return join.replaceSources(List.of(
+                getNewSource(query, join.sources().get(0)),
+                getNewSource(query, join.sources().get(1))
+            ));
+        }
         Map<Set<QualifiedName>, Symbol> splitQuery = QuerySplitter.split(query);
         if (splitQuery.size() == 1 && splitQuery.keySet().iterator().next().size() > 1) {
             return null;

--- a/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -65,6 +65,15 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_query_splitter_retains_literals() {
+        Symbol symbol = asSymbol("t1.a = 10 and t1.x = t2.y and (false)");
+        Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);
+        assertThat(split.size(), is(2));
+        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = '10')"));
+        assertThat(split.get(Set.of(tr1, tr2)), isSQL("((doc.t1.x = doc.t2.y) AND false)"));
+    }
+
+    @Test
     public void testSplitDownTo1Relation() throws Exception {
         Symbol symbol = asSymbol("t1.a = 10 and (t2.b = 30 or t2.b = 20)");
         Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1010,4 +1010,18 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             is("1| 1\n")
         );
     }
+
+    @Test
+    public void test_join_with_and_false_in_where_clause_returns_empty_result() {
+        String stmt = "SELECT n.* " +
+                      "FROM " +
+                      "   pg_catalog.pg_namespace n," +
+                      "   pg_catalog.pg_class c " +
+                      "WHERE " +
+                      "   n.nspname LIKE E'sys' " +
+                      "   AND c.relnamespace = n.oid " +
+                      "   AND (false)";
+        execute(stmt);
+        assertThat(response.rowCount(), is(0L));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

That a `WhereClause` can have `noMatch` set was ignored during the
join-tree building.

I'll probably follow up on this and get rid of the `noMatch` altogether. We've had bugs related to that  in the past. We don't need two different ways to indicate if a query can match (literal false & noMatch).

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)