### PR TITLE
Add returning clause for insert to grammar and parser

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -40,7 +40,7 @@ statement
     | UPDATE aliasedRelation
         SET assignment (',' assignment)*
         where?
-        (RETURNING selectItem (',' selectItem)*)?      													 	   #update
+        returning?                                                                   #update
     | DELETE FROM aliasedRelation where?                                             #delete
     | SHOW (TRANSACTION ISOLATION LEVEL | TRANSACTION_ISOLATION)                     #showTransaction
     | SHOW CREATE TABLE table                                                        #showCreateTable
@@ -71,7 +71,8 @@ statement
     | SET LICENSE stringLiteral                                                      #setLicense
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
-        onConflict?                                                                  #insert
+        onConflict?
+        returning?                                                                   #insert
     | RESTORE SNAPSHOT qname (ALL | TABLE tableWithPartitions) withProperties?       #restore
     | COPY tableWithPartition FROM path=expr withProperties? (RETURN SUMMARY)?       #copyFrom
     | COPY tableWithPartition columns? where?
@@ -137,6 +138,10 @@ selectItem
 
 where
     : WHERE condition=booleanExpression
+    ;
+
+returning
+    : RETURNING selectItem (',' selectItem)*
     ;
 
 filter

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -560,11 +560,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             }
             throw e;
         }
-        return new Insert(
+        return new Insert<>(
             table,
             (Query) visit(context.insertSource().query()),
             columns,
-            createDuplicateKeyContext(context));
+            getReturningItems(context.returning()),
+            createDuplicateKeyContext(context)
+        );
     }
 
     /**
@@ -620,7 +622,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             (Relation) visit(context.aliasedRelation()),
             assignments,
             visitIfPresent(context.where(), Expression.class),
-            visitCollection(context.selectItem(), SelectItem.class)
+            getReturningItems(context.returning())
             );
     }
 
@@ -1789,6 +1791,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         // single quote escaping is handled at later stage
         // as we require more context on the surrounding characters
         return value.substring(2, value.length() - 1);
+    }
+
+    private List<SelectItem> getReturningItems(@Nullable SqlBaseParser.ReturningContext context) {
+        return context == null ? List.of() : visitCollection(context.selectItem(),
+                                                             SelectItem.class);
     }
 
     private QualifiedName getQualifiedName(SqlBaseParser.QnameContext context) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -33,12 +33,18 @@ public final class Insert<T> extends Statement {
     private final DuplicateKeyContext<T> duplicateKeyContext;
     private final List<String> columns;
     private final Query insertSource;
+    private final List<SelectItem> returning;
 
-    public Insert(Table<T> table, Query subQuery, List<String> columns, DuplicateKeyContext<T> duplicateKeyContext) {
+    public Insert(Table<T> table,
+                  Query insertSource,
+                  List<String> columns,
+                  List<SelectItem> returning,
+                  DuplicateKeyContext<T> duplicateKeyContext) {
         this.table = table;
         this.columns = columns;
-        this.insertSource = subQuery;
+        this.insertSource = insertSource;
         this.duplicateKeyContext = duplicateKeyContext;
+        this.returning = returning;
     }
 
     public Table table() {
@@ -57,9 +63,13 @@ public final class Insert<T> extends Statement {
         return duplicateKeyContext;
     }
 
+    public List<SelectItem> returningClause() {
+        return returning;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hashCode(table, columns, insertSource);
+        return Objects.hashCode(table, columns, insertSource, returning);
     }
 
     @Override
@@ -73,7 +83,8 @@ public final class Insert<T> extends Statement {
         Insert<?> insert = (Insert<?>) o;
         return table.equals(insert.table) &&
                columns.equals(insert.columns) &&
-               insertSource.equals(insert.insertSource);
+               insertSource.equals(insert.insertSource) &&
+               returning.equals(insert.returning);
     }
 
     @Override
@@ -82,6 +93,7 @@ public final class Insert<T> extends Statement {
             .add("table", table)
             .add("columns", columns)
             .add("insertSource", insertSource)
+            .add("returning", returning)
             .toString();
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1073,6 +1073,14 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_insert_returning() {
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning id");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning id as foo");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning *");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning foo.*");
+    }
+
+    @Test
     public void testParameterExpressionLimitOffset() {
         // ORMs like SQLAlchemy generate these kind of queries.
         printStatement("select * from foo limit ? offset ?");
@@ -1633,6 +1641,7 @@ public class TestStatementBuilder {
             statement instanceof DropRepository ||
             statement instanceof DropSnapshot ||
             statement instanceof Update ||
+            statement instanceof Insert ||
             statement instanceof Window) {
                 println(SqlFormatter.formatSql(statement));
                 println("");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds the `RETURNING` clause for `INSERT` to the grammar and the parser.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
