### PR TITLE
Replaced 'unnest' function for sample tables in the docs with 'values'

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -373,7 +373,7 @@ If all input values are null, null is returned as a result.
 
 ::
 
-   cr> select string_agg(col1, ', ') from unnest(['a', 'b', 'c']);
+   cr> select string_agg(col1, ', ') from (values('a'), ('b'), ('c')) as t;
    +------------------------+
    | string_agg(col1, ', ') |
    +------------------------+

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -293,7 +293,7 @@ could be used in multiple :ref:`over` clauses. For instance
    ...   x,
    ...   FIRST_VALUE(x) OVER (w) AS "first",
    ...   LAST_VALUE(x) OVER (w) AS "last"
-   ... FROM unnest([1, 2, 3, 4]) as t(x)
+   ... FROM (VALUES (1), (2), (3), (4)) AS t(x)
    ... WINDOW w AS (ORDER BY x)
    +---+-------+------+
    | x | first | last |
@@ -318,9 +318,11 @@ then it can only add clauses from the referenced window, but not overwrite them.
    cr> SELECT
    ...   x,
    ...   LAST_VALUE(x) OVER (w ORDER BY x)
-   ... FROM unnest(
-   ...      [1, 2, 3, 4],
-   ...      [1, 1, 2, 2]) as t(x, y)
+   ... FROM (VALUES
+   ...      (1, 1),
+   ...      (2, 1),
+   ...      (3, 2),
+   ...      (4, 2) ) AS t(x, y)
    ... WINDOW w AS (PARTITION BY y)
    +---+---+
    | x | y |
@@ -339,7 +341,7 @@ by the window definition of the :ref:`OVER` clause will result in failure.
 
    cr> SELECT
    ...   FIRST_VALUE(x) OVER (w ORDER BY x)
-   ... FROM unnest([1, 2, 3, 4]) as t(x)
+   ... FROM (VALUES(1), (2), (3), (4)) as t(x)
    ... WINDOW w AS (ORDER BY x)
    SQLActionException[SQLParseException: Cannot override ORDER BY clause of window w]
 
@@ -362,7 +364,10 @@ in the ``WINDOW`` clause permits only backward references.
    cr> SELECT
    ...   x,
    ...   ROW_NUMBER() OVER (w)
-   ... FROM unnest([1, 2, 3], [1, 1, 2]) as t(x, y)
+   ... FROM (VALUES
+   ...      (1, 1),
+   ...      (3, 2),
+   ...      (2, 1)) AS t(x, y)
    ... WINDOW p AS (PARTITION BY y),
    ...        w AS (p ORDER BY x)
    +---+---+
@@ -386,7 +391,8 @@ Returns the number of the current row within its window.
 
 Example::
 
-   cr> SELECT col1, ROW_NUMBER() OVER(ORDER BY col1) FROM unnest(['x','y','z']);
+   cr> SELECT col1, ROW_NUMBER() OVER(ORDER BY col1)
+   ... FROM (VALUES('x'), ('y'), ('z')) AS t;
    +------+-----------------------------------------+
    | col1 | row_number() OVER (ORDER BY "col1" ASC) |
    +------+-----------------------------------------+
@@ -412,7 +418,8 @@ Its return type is the type of its argument.
 
 Example::
 
-   cr> SELECT col1, FIRST_VALUE(col1) OVER(ORDER BY col1) FROM unnest(['x','y', 'y', 'z']);
+   cr> SELECT col1, FIRST_VALUE(col1) OVER(ORDER BY col1)
+   ... FROM (VALUES('x'), ('y'), ('y'), ('z')) AS t;
    +------+----------------------------------------------+
    | col1 | first_value(col1) OVER (ORDER BY "col1" ASC) |
    +------+----------------------------------------------+
@@ -439,7 +446,8 @@ Its return type is the type of its argument.
 
 Example::
 
-   cr> SELECT col1, LAST_VALUE(col1) OVER(ORDER BY col1) FROM unnest(['x','y', 'y', 'z']);
+   cr> SELECT col1, LAST_VALUE(col1) OVER(ORDER BY col1)
+   ... FROM (VALUES('x'), ('y'), ('y'), ('z')) AS t;
    +------+---------------------------------------------+
    | col1 | last_value(col1) OVER (ORDER BY "col1" ASC) |
    +------+---------------------------------------------+
@@ -467,7 +475,8 @@ Its return type is the type of its first argument.
 
 Example::
 
-   cr> SELECT col1, NTH_VALUE(col1, 3) OVER(ORDER BY col1) FROM unnest(['x','y', 'y', 'z']);
+   cr> SELECT col1, NTH_VALUE(col1, 3) OVER(ORDER BY col1)
+   ... FROM (VALUES('x'), ('y'), ('y'), ('z')) AS t;
    +------+-----------------------------------------------+
    | col1 | nth_value(col1, 3) OVER (ORDER BY "col1" ASC) |
    +------+-----------------------------------------------+
@@ -514,11 +523,13 @@ Example::
    ...   budget,
    ...   LAG(budget) OVER(
    ...      PARTITION BY dept_id) prev_budget
-   ... FROM unnest(
-   ...   [1, 1, 2, 2, 2],
-   ...   [2017, 2018, 2017, 2018, 2019],
-   ...   [45000, 35000, 15000, 65000, 12000]
-   ... ) as t (dept_id, year, budget);
+   ... FROM (VALUES
+   ...      (1, 2017, 45000),
+   ...      (1, 2018, 35000),
+   ...      (2, 2017, 15000),
+   ...      (2, 2018, 65000),
+   ...      (2, 2019, 12000))
+   ... as t (dept_id, year, budget);
    +---------+------+--------+-------------+
    | dept_id | year | budget | prev_budget |
    +---------+------+--------+-------------+
@@ -569,11 +580,13 @@ Example::
    ...   budget,
    ...   LEAD(budget) OVER(
    ...      PARTITION BY dept_id) next_budget
-   ... FROM unnest(
-   ...   [1, 1, 2, 2, 2],
-   ...   [2017, 2018, 2017, 2018, 2019],
-   ...   [45000, 35000, 15000, 65000, 12000]
-   ... ) as t (dept_id, year, budget);
+   ... FROM (VALUES
+   ...      (1, 2017, 45000),
+   ...      (1, 2018, 35000),
+   ...      (2, 2017, 15000),
+   ...      (2, 2018, 65000),
+   ...      (2, 2019, 12000))
+   ... as t (dept_id, year, budget);
    +---------+------+--------+-------------+
    | dept_id | year | budget | next_budget |
    +---------+------+--------+-------------+


### PR DESCRIPTION


## Summary of the changes / Why this improves CrateDB
Replacing the unnests with VALUES creates a more transparent and readable documentation for sample tables

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
