### PR TITLE
Remove noMatch from WhereClause

### DIFF
--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.Objects;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.SubqueryAnalyzer;
@@ -31,6 +33,7 @@ import io.crate.analyze.relations.RelationAnalysisContext;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
@@ -73,7 +76,10 @@ final class DeleteAnalyzer {
             ),
             new SubqueryAnalyzer(relationAnalyzer, new StatementAnalysisContext(typeHints, Operation.READ, txnContext))
         );
-        Symbol query = expressionAnalyzer.generateQuerySymbol(delete.getWhere(), new ExpressionAnalysisContext());
+        Symbol query = Objects.requireNonNullElse(
+            expressionAnalyzer.generateQuerySymbol(delete.getWhere(), new ExpressionAnalysisContext()),
+            Literal.BOOLEAN_TRUE
+        );
         query = maybeAliasedStatement.maybeMapFields(query);
 
         Symbol normalizedQuery = normalizer.normalize(query, txnContext);

--- a/sql/src/main/java/io/crate/analyze/QueryClause.java
+++ b/sql/src/main/java/io/crate/analyze/QueryClause.java
@@ -27,7 +27,6 @@ import io.crate.expression.symbol.Symbol;
 import org.elasticsearch.common.Nullable;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public abstract class QueryClause {
 
@@ -78,20 +77,6 @@ public abstract class QueryClause {
 
     public boolean noMatch() {
         return noMatch;
-    }
-
-    public void replace(Function<? super Symbol, ? extends Symbol> replaceFunction) {
-        if (hasQuery()) {
-            Symbol newQuery = replaceFunction.apply(query);
-            if (query != newQuery) {
-                if (newQuery instanceof Input) {
-                    noMatch = !canMatch(newQuery);
-                    query = null;
-                } else {
-                    query = newQuery;
-                }
-            }
-        }
     }
 
     public void accept(Consumer<? super Symbol> consumer) {

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -36,6 +36,7 @@ import io.crate.analyze.relations.select.SelectAnalysis;
 import io.crate.analyze.relations.select.SelectAnalyzer;
 import io.crate.common.collections.Lists2;
 import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -56,6 +57,7 @@ import io.crate.types.ObjectType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.function.Predicate;
 
@@ -118,7 +120,10 @@ public final class UpdateAnalyzer {
         Map<Reference, Symbol> assignmentByTargetCol = getAssignments(
             update.assignments(), typeHints, txnCtx, table, normalizer, subqueryAnalyzer, sourceExprAnalyzer, exprCtx);
 
-        Symbol query = sourceExprAnalyzer.generateQuerySymbol(update.whereClause(), exprCtx);
+        Symbol query = Objects.requireNonNullElse(
+            sourceExprAnalyzer.generateQuerySymbol(update.whereClause(), exprCtx),
+            Literal.BOOLEAN_TRUE
+        );
         query = maybeAliasedStatement.maybeMapFields(query);
 
         Symbol normalizedQuery = normalizer.normalize(query, txnCtx);

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -221,12 +221,9 @@ public class ExpressionAnalyzer {
         return expression.accept(innerAnalyzer, expressionAnalysisContext);
     }
 
+    @Nullable
     public Symbol generateQuerySymbol(Optional<Expression> whereExpression, ExpressionAnalysisContext context) {
-        if (whereExpression.isPresent()) {
-            return convert(whereExpression.get(), context);
-        } else {
-            return Literal.BOOLEAN_TRUE;
-        }
+        return whereExpression.map(expression -> convert(expression, context)).orElse(null);
     }
 
     private Symbol convertFunctionCall(FunctionCall node, ExpressionAnalysisContext context) {

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -55,10 +55,10 @@ public class WhereClauseAnalyzer {
      * Replace parameters and sub-queries with the related values and analyze the query afterwards.
      */
     public static WhereClause resolvePartitions(WhereClause where,
-                                                AbstractTableRelation tableRelation,
+                                                AbstractTableRelation<?> tableRelation,
                                                 Functions functions,
                                                 CoordinatorTxnCtx coordinatorTxnCtx) {
-        if (!where.hasQuery() || !(tableRelation instanceof DocTableRelation)) {
+        if (!where.hasQuery() || !(tableRelation instanceof DocTableRelation) || where.query().equals(Literal.BOOLEAN_TRUE)) {
             return where;
         }
         DocTableInfo table = ((DocTableRelation) tableRelation).tableInfo();

--- a/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -138,7 +138,7 @@ public class EvaluatingNormalizer {
                 return symbol;
             }
 
-            Input input = referenceResolver.getImplementation(symbol);
+            Input<?> input = referenceResolver.getImplementation(symbol);
             if (input != null) {
                 return Literal.of(symbol.valueType(), input.value());
             }

--- a/sql/src/main/java/io/crate/expression/operator/Operator.java
+++ b/sql/src/main/java/io/crate/expression/operator/Operator.java
@@ -23,14 +23,15 @@
 package io.crate.expression.operator;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.OperatorFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -52,18 +53,14 @@ public abstract class Operator<I> extends Scalar<Boolean, I> implements Operator
         // all operators evaluates to NULL if one argument is NULL
         // let's handle this here to prevent unnecessary collect operations
         for (Symbol symbol : function.arguments()) {
-            if (isNull(symbol)) {
+            if (symbol instanceof Input && ((Input<?>) symbol).value() == null) {
                 return Literal.NULL;
             }
         }
         return super.normalizeSymbol(function, txnCtx);
     }
 
-    private static boolean isNull(Symbol symbol) {
-        return symbol.symbolType().isValueSymbol() && ((Literal) symbol).value() == null;
-    }
-
-    static FunctionInfo generateInfo(String name, DataType type) {
+    static FunctionInfo generateInfo(String name, DataType<?> type) {
         return new FunctionInfo(new FunctionIdent(name, ImmutableList.of(type, type)), RETURN_TYPE);
     }
 }

--- a/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -58,11 +58,9 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
 
         Symbol arg = symbol.arguments().get(0);
         if (arg instanceof Input) {
-            Object value = ((Input) arg).value();
+            Object value = ((Input<?>) arg).value();
             if (value == null) {
-                /**
-                 * WHERE NOT NULL -> WHERE NULL
-                 */
+                // WHERE NOT NULL -> WHERE NULL
                 return Literal.NULL;
             }
             if (value instanceof Boolean) {

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -88,8 +88,8 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
     @Override
     public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         Symbol argument = symbol.arguments().get(0);
-        if (argument.symbolType().isValueSymbol()) {
-            Object value = ((Input) argument).value();
+        if (argument instanceof Input) {
+            Object value = ((Input<?>) argument).value();
             try {
                 return Literal.of(returnType, returnType.value(value));
             } catch (ClassCastException | IllegalArgumentException e) {

--- a/sql/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -250,13 +250,7 @@ public final class CopyToPlan implements Plan {
             throw new UnsupportedFeatureException("Output format not supported without specifying columns.");
         }
 
-        WhereClause whereClause;
-        if (copyTo.whereClause() != null) {
-            whereClause = new WhereClause(copyTo.whereClause(), partitions, Collections.emptySet());
-        } else {
-            whereClause = new WhereClause(null, partitions, Collections.emptySet());
-        }
-
+        WhereClause whereClause = new WhereClause(copyTo.whereClause(), partitions, Collections.emptySet());
         QuerySpec querySpec = new QuerySpec(
             outputs,
             whereClause,

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -358,15 +358,14 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             "select id as name from users group by id, name having name != null;");
 
         HavingClause havingClause = relation.having();
-        assertThat(havingClause.query(), nullValue());
+        assertThat(havingClause.query(), isLiteral(null));
     }
 
     @Test
     public void testGroupByHavingNormalize() throws Exception {
         AnalyzedRelation rel = analyze("select sum(floats) from users group by name having 1 > 4");
         HavingClause having = rel.having();
-        assertThat(having.noMatch(), is(true));
-        assertNull(having.query());
+        assertThat(having.queryOrFallback(), isLiteral(false));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -22,14 +22,15 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.symbol.Symbol;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.SqlExpressions;
-import io.crate.testing.T3;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+import static org.hamcrest.core.Is.is;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
 
 public class WhereClauseTest extends CrateDummyClusterServiceUnitTest {
 
@@ -46,8 +47,7 @@ public class WhereClauseTest extends CrateDummyClusterServiceUnitTest {
         WhereClause where2 = new WhereClause(sqlExpressions.asSymbol("x = 10"));
         WhereClause where1_where2 = where1.add(where2.query);
 
-        assertThat(where1_where2.hasQuery(), is(false));
-        assertThat(where1_where2.noMatch, is(true));
+        assertThat(where1_where2.queryOrFallback(), isLiteral(false));
     }
 
     @Test
@@ -57,18 +57,16 @@ public class WhereClauseTest extends CrateDummyClusterServiceUnitTest {
         WhereClause where1_where2 = where1.add(where2.query);
 
         assertThat(where1_where2.hasQuery(), is(true));
-        assertThat(where1_where2.noMatch, is(false));
         assertThat(where1_where2.query(), is(where2.query()));
     }
 
     @Test
     public void testAddWithNullQuery() {
-        WhereClause where1 = new WhereClause((Symbol) null);
+        WhereClause where1 = new WhereClause(null);
         WhereClause where2 = new WhereClause(sqlExpressions.asSymbol("x = 10"));
         WhereClause where1_where2 = where1.add(where2.query);
 
         assertThat(where1_where2.hasQuery(), is(true));
-        assertThat(where1_where2.noMatch, is(false));
         assertThat(where1_where2.query(), is(where2.query()));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
@@ -39,32 +38,6 @@ public class WhereClauseTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() {
         sqlExpressions = new SqlExpressions(T3.sources(clusterService));
-    }
-
-    @Test
-    public void testReplaceWithLiteralTrueSemantics() throws Exception {
-        Symbol query = sqlExpressions.asSymbol("x = 10");
-
-        WhereClause whereReplaced = new WhereClause(query);
-        whereReplaced.replace(s -> Literal.BOOLEAN_TRUE);
-        WhereClause whereLiteralTrue = new WhereClause(Literal.BOOLEAN_TRUE);
-
-        assertThat(whereLiteralTrue.hasQuery(), is(whereReplaced.hasQuery()));
-        assertThat(whereLiteralTrue.noMatch(), is(whereReplaced.noMatch()));
-        assertThat(whereLiteralTrue.query(), is(whereReplaced.query()));
-    }
-
-    @Test
-    public void testReplaceWithLiteralFalseSemantics() throws Exception {
-        Symbol query = sqlExpressions.asSymbol("x = 10");
-
-        WhereClause whereReplaced = new WhereClause(query);
-        whereReplaced.replace(s -> Literal.BOOLEAN_FALSE);
-        WhereClause whereLiteralFalse = new WhereClause(Literal.BOOLEAN_FALSE);
-
-        assertThat(whereLiteralFalse.hasQuery(), is(whereReplaced.hasQuery()));
-        assertThat(whereLiteralFalse.noMatch(), is(whereReplaced.noMatch()));
-        assertThat(whereLiteralFalse.query(), is(whereReplaced.query()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -70,7 +70,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -757,7 +756,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan(e.functions(),
             "RootBoundary[unnest([1, 2])]\n" +
             "ProjectSet[unnest([1, 2])]\n" +
-            "Collect[.empty_row | [] | All]\n"
+            "Collect[.empty_row | [] | true]\n"
         ));
         Symbol output = plan.outputs().get(0);
         assertThat(output.valueType(), is(DataTypes.LONG));
@@ -770,7 +769,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[(unnest([1, 2]) + 1)]\n" +
             "FetchOrEval[(unnest([1, 2]) + 1)]\n" +
             "ProjectSet[unnest([1, 2])]\n" +
-            "Collect[.empty_row | [] | All]\n"
+            "Collect[.empty_row | [] | true]\n"
         ));
     }
 
@@ -787,7 +786,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[count(*), generate_series(1, 2)]\n" +
             "FetchOrEval[count(*), generate_series(1, 2)]\n" +
             "ProjectSet[generate_series(1, 2) | count(*)]\n" +
-            "Count[doc.users | All]\n"
+            "Count[doc.users | true]\n"
         ));
     }
 
@@ -799,7 +798,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "FetchOrEval[count(name), generate_series(1, count(name))]\n" +
             "ProjectSet[generate_series(1, count(name)) | count(name)]\n" +
             "Aggregate[count(name)]\n" +
-            "Collect[doc.users | [name] | All]\n"
+            "Collect[doc.users | [name] | true]\n"
         ));
     }
 
@@ -810,7 +809,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[unnest([1, 2])]\n" +
             "OrderBy[unnest([1, 2]) ASC]\n" +
             "ProjectSet[unnest([1, 2])]\n" +
-            "Collect[sys.nodes | [] | All]\n"
+            "Collect[sys.nodes | [] | true]\n"
         ));
     }
 
@@ -893,7 +892,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan(e.functions(),
             "RootBoundary[name]\n" +
             "TopNDistinct[1 | [name]\n" +
-            "Collect[doc.users | [name] | All]\n"
+            "Collect[doc.users | [name] | true]\n"
         ));
     }
 
@@ -904,7 +903,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan(e.functions(),
             "RootBoundary[id, name]\n" +
             "TopNDistinct[1 | [id, name]\n" +
-            "Collect[doc.users | [id, name] | All]\n"
+            "Collect[doc.users | [id, name] | true]\n"
         ));
     }
 
@@ -917,7 +916,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "GroupBy[address['postcode'] | ]\n" +
             "Boundary[address]\n" +
             "Boundary[address]\n" +
-            "Collect[doc.users | [address] | All]\n"
+            "Collect[doc.users | [address] | true]\n"
         ));
     }
 
@@ -931,7 +930,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "Boundary[address, subscript_obj(address, 'postcode')]\n" +
             "Boundary[address, address['postcode']]\n" +
             "OrderBy[address['postcode'] ASC]\n" +
-            "Collect[doc.users | [address] | All]\n"
+            "Collect[doc.users | [address] | true]\n"
         ));
 
         Merge merge = e.plan(stmt);
@@ -957,11 +956,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "NestedLoopJoin[\n" +
             "    Boundary[nspacl, nspname, nspowner, oid]\n" +
             "    Boundary[nspacl, nspname, nspowner, oid]\n" +
-            "    Collect[pg_catalog.pg_namespace | [nspacl, nspname, nspowner, oid] | None]\n" +
+            "    Collect[pg_catalog.pg_namespace | [nspacl, nspname, nspowner, oid] | false]\n" +
             "    --- CROSS ---\n" +
             "    Boundary[oid, relacl, relallvisible, relam, relchecks, relfilenode, relforcerowsecurity, relfrozenxid, relhasindex, relhasoids, relhaspkey, relhasrules, relhassubclass, relhastriggers, relispartition, relispopulated, relisshared, relkind, relminmxid, relname, relnamespace, relnatts, reloftype, reloptions, relowner, relpages, relpartbound, relpersistence, relreplident, relrowsecurity, reltablespace, reltoastrelid, reltuples, reltype]\n" +
             "    Boundary[oid, relacl, relallvisible, relam, relchecks, relfilenode, relforcerowsecurity, relfrozenxid, relhasindex, relhasoids, relhaspkey, relhasrules, relhassubclass, relhastriggers, relispartition, relispopulated, relisshared, relkind, relminmxid, relname, relnamespace, relnatts, reloftype, reloptions, relowner, relpages, relpartbound, relpersistence, relreplident, relrowsecurity, reltablespace, reltoastrelid, reltuples, reltype]\n" +
-            "    Collect[pg_catalog.pg_class | [oid, relacl, relallvisible, relam, relchecks, relfilenode, relforcerowsecurity, relfrozenxid, relhasindex, relhasoids, relhaspkey, relhasrules, relhassubclass, relhastriggers, relispartition, relispopulated, relisshared, relkind, relminmxid, relname, relnamespace, relnatts, reloftype, reloptions, relowner, relpages, relpartbound, relpersistence, relreplident, relrowsecurity, reltablespace, reltoastrelid, reltuples, reltype] | None]\n" +
+            "    Collect[pg_catalog.pg_class | [oid, relacl, relallvisible, relam, relchecks, relfilenode, relforcerowsecurity, relfrozenxid, relhasindex, relhasoids, relhaspkey, relhasrules, relhassubclass, relhastriggers, relispartition, relispopulated, relisshared, relkind, relminmxid, relname, relnamespace, relnatts, reloftype, reloptions, relowner, relpages, relpartbound, relpersistence, relreplident, relrowsecurity, reltablespace, reltoastrelid, reltuples, reltype] | false]\n" +
             "]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -460,10 +460,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "Boundary[_fetchid, _fetchid]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[_fetchid]\n" +
-            "    Collect[doc.t1 | [_fetchid] | All]\n" +
+            "    Collect[doc.t1 | [_fetchid] | true]\n" +
             "    --- CROSS ---\n" +
             "    Boundary[_fetchid]\n" +
-            "    Collect[doc.t2 | [_fetchid] | All]\n" +
+            "    Collect[doc.t2 | [_fetchid] | true]\n" +
             "]\n";
         assertThat(logicalPlan, isPlan(e.functions(), expectedPlan));
 
@@ -502,10 +502,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "FetchOrEval[name]\n" +
             "HashJoin[\n" +
             "    Boundary[_fetchid, address['postcode']]\n" +
-            "    Collect[doc.users | [_fetchid, address['postcode']] | All]\n" +
+            "    Collect[doc.users | [_fetchid, address['postcode']] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[_fetchid, a]\n" +
-            "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+            "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
             "]\n";
         assertThat(logicalPlan, is(isPlan(e.functions(), expectedPlan)));
 
@@ -519,10 +519,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "HashJoin[\n" +
             "    Boundary[_fetchid, address['postcode']]\n" +
             "    Boundary[_fetchid, address['postcode']]\n" +
-            "    Collect[doc.users | [_fetchid, address['postcode']] | All]\n" +
+            "    Collect[doc.users | [_fetchid, address['postcode']] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[_fetchid, a]\n" +
-            "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+            "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
             "]\n";
         assertThat(logicalPlan, is(isPlan(e.functions(), expectedPlan)));
     }

--- a/sql/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -64,7 +64,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(plan, isPlan(e.functions(), "Limit[20;7]\n" +
                                                "Limit[10;5]\n" +
-                                               "Collect[doc.users | [_fetchid] | All]\n"));
+                                               "Collect[doc.users | [_fetchid] | true]\n"));
 
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(

--- a/sql/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -53,7 +53,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "RootBoundary[x, x]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t1 | [x] | All]\n" +
+            "    Collect[doc.t1 | [x] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[x]\n" +
             "    Collect[doc.t2 | [x] | (x = 10)]\n" +
@@ -72,10 +72,10 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "Filter[(coalesce(x, 10) = 10)]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t1 | [x] | All]\n" +
+            "    Collect[doc.t1 | [x] | true]\n" +
             "    --- LEFT ---\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t2 | [x] | All]\n" +
+            "    Collect[doc.t2 | [x] | true]\n" +
             "]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }
@@ -94,7 +94,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "    Collect[doc.t1 | [x] | (x > 5)]\n" +
             "    --- LEFT ---\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t2 | [x] | All]\n" +
+            "    Collect[doc.t2 | [x] | true]\n" +
             "]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }
@@ -110,7 +110,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "Filter[(coalesce(x, 10) = 10)]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t1 | [x] | All]\n" +
+            "    Collect[doc.t1 | [x] | true]\n" +
             "    --- RIGHT ---\n" +
             "    Boundary[x]\n" +
             "    Collect[doc.t2 | [x] | (x > 5)]\n" +
@@ -129,7 +129,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "Filter[((coalesce(x, 10) = 10) AND (x > 5))]\n" +
             "NestedLoopJoin[\n" +
             "    Boundary[x]\n" +
-            "    Collect[doc.t1 | [x] | All]\n" +
+            "    Collect[doc.t1 | [x] | true]\n" +
             "    --- FULL ---\n" +
             "    Boundary[x]\n" +
             "    Collect[doc.t2 | [x] | (x > 5)]\n" +

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -62,10 +62,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, isPlan(sqlExecutor.functions(),
                                                 "Union[\n" +
                                                     "OrderBy[name ASC]\n" +
-                                                    "Collect[doc.users | [name] | All]\n" +
+                                                    "Collect[doc.users | [name] | true]\n" +
                                                 "---\n" +
                                                     "OrderBy[text ASC]\n" +
-                                                    "Collect[doc.users | [text] | All]\n" +
+                                                    "Collect[doc.users | [text] | true]\n" +
                                                 "]\n"));
     }
 
@@ -81,10 +81,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                              "Boundary[name]\n" +
                                                              "FetchOrEval[name]\n" +
                                                              "OrderBy[name ASC]\n" +
-                                                             "Collect[doc.users | [name, text] | All]\n" +
+                                                             "Collect[doc.users | [name, text] | true]\n" +
                                                          "---\n" +
                                                              "OrderBy[text ASC]\n" +
-                                                             "Collect[doc.users | [text] | All]\n" +
+                                                             "Collect[doc.users | [text] | true]\n" +
                                                          "]\n"));
     }
 
@@ -95,10 +95,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                          "NestedLoopJoin[\n" +
                                                          "    Boundary[_fetchid, a]\n" +
                                                          "    OrderBy[a ASC]\n" +
-                                                         "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "    --- INNER ---\n" +
                                                          "    Boundary[_fetchid, b]\n" +
-                                                         "    Collect[doc.t2 | [_fetchid, b] | All]\n" +
+                                                         "    Collect[doc.t2 | [_fetchid, b] | true]\n" +
                                                          "]\n"));
     }
 
@@ -113,15 +113,15 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                          "    NestedLoopJoin[\n" +
                                                          "        Boundary[_fetchid, b]\n" +
                                                          "        OrderBy[b ASC]\n" +
-                                                         "        Collect[doc.t2 | [_fetchid, b] | All]\n" +
+                                                         "        Collect[doc.t2 | [_fetchid, b] | true]\n" +
                                                          "        --- INNER ---\n" +
                                                          "        Boundary[_fetchid, a]\n" +
-                                                         "        Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "        Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "]\n" +
                                                          "    --- INNER ---\n" +
                                                          "    Boundary[_fetchid, a]\n" +    // Aliased relation boundary
                                                          "    Boundary[_fetchid, a]\n" +
-                                                         "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "]\n"));
     }
 
@@ -132,10 +132,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                          "NestedLoopJoin[\n" +
                                                          "    Boundary[_fetchid, a, x]\n" +
                                                          "    OrderBy[x DESC]\n" +
-                                                         "    Collect[doc.t1 | [_fetchid, a, x] | All]\n" +
+                                                         "    Collect[doc.t1 | [_fetchid, a, x] | true]\n" +
                                                          "    --- INNER ---\n" +
                                                          "    Boundary[_fetchid, b]\n" +
-                                                         "    Collect[doc.t2 | [_fetchid, b] | All]\n]" +
+                                                         "    Collect[doc.t2 | [_fetchid, b] | true]\n]" +
                                                          "\n"));
     }
 
@@ -146,10 +146,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                          "OrderBy[b ASC]\n" +
                                                          "NestedLoopJoin[\n" +
                                                          "    Boundary[_fetchid, a]\n" +
-                                                         "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "    --- INNER ---\n" +
                                                          "    Boundary[_fetchid, b]\n" +
-                                                         "    Collect[doc.t2 | [_fetchid, b] | All]\n" +
+                                                         "    Collect[doc.t2 | [_fetchid, b] | true]\n" +
                                                          "]\n"));
     }
 
@@ -160,10 +160,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                           "OrderBy[concat(a, b) ASC]\n" +
                                                           "NestedLoopJoin[\n" +
                                                           "    Boundary[_fetchid, a]\n" +
-                                                          "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                          "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                           "    --- INNER ---\n" +
                                                           "    Boundary[_fetchid, b]\n" +
-                                                          "    Collect[doc.t2 | [_fetchid, b] | All]\n" +
+                                                          "    Collect[doc.t2 | [_fetchid, b] | true]\n" +
                                                           "]\n"));
     }
 
@@ -190,15 +190,15 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                          "NestedLoopJoin[\n" +
                                                          "    NestedLoopJoin[\n" +
                                                          "        Boundary[_fetchid, b]\n" +
-                                                         "        Collect[doc.t2 | [_fetchid, b] | All]\n" +
+                                                         "        Collect[doc.t2 | [_fetchid, b] | true]\n" +
                                                          "        --- INNER ---\n" +
                                                          "        Boundary[_fetchid, a]\n" +
-                                                         "        Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "        Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "]\n" +
                                                          "    --- LEFT ---\n" +
                                                          "    Boundary[_fetchid, a]\n" +    // Aliased relation boundary
                                                          "    Boundary[_fetchid, a]\n" +
-                                                         "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+                                                         "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
                                                          "]\n"));
     }
 
@@ -215,10 +215,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "OrderBy[a ASC]\n" +
             "HashJoin[\n" +
             "    Boundary[_fetchid, a]\n" +
-            "    Collect[doc.t1 | [_fetchid, a] | All]\n" +
+            "    Collect[doc.t1 | [_fetchid, a] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[_fetchid, b]\n" +
-            "    Collect[doc.t2 | [_fetchid, b] | All]\n" +
+            "    Collect[doc.t2 | [_fetchid, b] | true]\n" +
             "]\n"));
     }
 
@@ -238,10 +238,10 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                 "    Boundary[_fetchid, b, y]\n" +
                 "    FetchOrEval[_fetchid, b, y]\n" +
                 "    OrderBy[lower(b) ASC]\n" +
-                "    Collect[doc.t2 | [_fetchid, y, b] | All]\n" +
+                "    Collect[doc.t2 | [_fetchid, y, b] | true]\n" +
                 "    --- INNER ---\n" +
                 "    Boundary[_fetchid, x]\n" +
-                "    Collect[doc.t1 | [_fetchid, x] | All]\n" +
+                "    Collect[doc.t1 | [_fetchid, x] | true]\n" +
                 "]\n")
         );
     }
@@ -280,7 +280,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "    Collect[doc.t1 | [_fetchid, x] | (x = 10)]\n" +
             "    --- INNER ---\n" +
             "    Boundary[_fetchid, y]\n" +
-            "    Collect[doc.t2 | [_fetchid, y] | All]\n" +
+            "    Collect[doc.t2 | [_fetchid, y] | true]\n" +
             "]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }
@@ -303,7 +303,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "    Collect[doc.t1 | [_fetchid, x] | (x = 10)]\n" +
             "    --- CROSS ---\n" +
             "    Boundary[_fetchid]\n" +
-            "    Collect[doc.t2 | [_fetchid] | All]\n" +
+            "    Collect[doc.t2 | [_fetchid] | true]\n" +
             "]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }

--- a/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -50,7 +50,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             "FetchOrEval[id]\n" +
             "OrderBy[(id + 10) ASC]\n" +
             "GroupBy[id | ]\n" +
-            "Collect[doc.users | [id, (id + 10)] | All]\n"));
+            "Collect[doc.users | [id, (id + 10)] | true]\n"));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
         assertThat(plan, isPlan(e.functions(),
             "RootBoundary[[1, 2, 3]]\n" +
             "GroupBy[[1, 2, 3] | ]\n" +
-            "Collect[doc.users | [[1, 2, 3]] | All]\n"));
+            "Collect[doc.users | [[1, 2, 3]] | true]\n"));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             "RootBoundary[generate_series(1, 2), col1]\n" +
             "GroupBy[generate_series(1, 2), col1 | ]\n" +
             "ProjectSet[generate_series(1, 2) | col1]\n" +
-            "Collect[.unnest | [col1] | All]\n"));
+            "Collect[.unnest | [col1] | true]\n"));
     }
 
     @Test
@@ -92,10 +92,10 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             "HashJoin[\n" +
             "    Boundary[_fetchid, id, department_id]\n" +
             "    FetchOrEval[_fetchid, id, department_id]\n" +
-            "    Collect[doc.users | [_fetchid, department_id, id] | All]\n" +
+            "    Collect[doc.users | [_fetchid, department_id, id] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[id, name]\n" +
-            "    Collect[doc.departments | [id, name] | All]\n" +
+            "    Collect[doc.departments | [id, name] | true]\n" +
             "]\n"));
     }
 
@@ -111,10 +111,10 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             "GroupBy[name | ]\n" +
             "HashJoin[\n" +
             "    Boundary[_fetchid, department_id]\n" +
-            "    Collect[doc.users | [_fetchid, department_id] | All]\n" +
+            "    Collect[doc.users | [_fetchid, department_id] | true]\n" +
             "    --- INNER ---\n" +
             "    Boundary[id, name]\n" +
-            "    Collect[doc.departments | [id, name] | All]\n" +
+            "    Collect[doc.departments | [id, name] | true]\n" +
             "]\n"));
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -62,7 +62,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
             "FetchOrEval[avg(x), avg(x)]\n" +
             "WindowAgg[avg(x) | PARTITION BY y]\n" +
             "WindowAgg[avg(x) | PARTITION BY x]\n" +
-            "Collect[doc.t1 | [x, y] | All]\n";
+            "Collect[doc.t1 | [x, y] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }
 
@@ -71,7 +71,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var plan = plan("SELECT y, AVG(x) FILTER (WHERE x > 1) OVER() FROM t1");
         var expectedPlan = "FetchOrEval[y, avg(x) : (x > 1)]\n" +
                            "WindowAgg[avg(x) : (x > 1)]\n" +
-                           "Collect[doc.t1 | [_fetchid, x] | All]\n";
+                           "Collect[doc.t1 | [_fetchid, x] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }
 
@@ -80,7 +80,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var plan = plan("SELECT x, COUNT(*) FILTER (WHERE y > 1) OVER() FROM t1");
         var expectedPlan = "FetchOrEval[x, count(*) : (y > 1)]\n" +
                            "WindowAgg[count(*) : (y > 1)]\n" +
-                           "Collect[doc.t1 | [_fetchid, y] | All]\n";
+                           "Collect[doc.t1 | [_fetchid, y] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }
 

--- a/sql/src/test/java/io/crate/testing/SQLPrinter.java
+++ b/sql/src/test/java/io/crate/testing/SQLPrinter.java
@@ -51,12 +51,9 @@ public class SQLPrinter {
         } else if (o == null) {
             return "null";
         } else if (o instanceof QueryClause) {
-            if (((QueryClause) o).hasQuery()) {
+            QueryClause queryClause = (QueryClause) o;
+            if (queryClause.hasQuery()) {
                 return print(((QueryClause) o).query());
-            } else if (((QueryClause) o).noMatch()){
-                return "false";
-            } else {
-                return "true";
             }
         }
         return o.toString();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We already have the query which can be `false` to indicate that nothing
can match. Having a second dedicated `noMatch` flag made things more
complicated, and led to bugs as call-sites forgot to consider both,
`query()` and `noMatch()`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)