### PR TITLE
Returning clause for insert

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ None
 Changes
 =======
 
+- Introduced new optional ``RETURNING`` clause for :ref:`Insert <ref-insert>` to
+  return specified values from each row inserted.
+
 - Added a ``mod`` alias for the :ref:`modulus <scalar-modulus>` function for
   improved PostgreSQL compatibility.
 

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -24,17 +24,18 @@ Synopsis
       { VALUES ( expression [, ...] ) [, ...] | ( query ) | query }
       [ ON CONFLICT (column_ident [, ...]) DO UPDATE SET { column_ident = expression [, ...] } |
         ON CONFLICT [ ( column_ident [, ...] ) ] DO NOTHING ]
+      [ RETURNING { * | output_expression [ [ AS ] output_name ] | relation.* } [, ...] ]
 
 Description
 ===========
 
-INSERT creates one or more rows specified by value expressions.
+``INSERT`` creates one or more rows specified by value expressions.
 
 The target column names can be listed in any order. If no list of column names
 is given at all, the default is all the columns of the table in lexical order;
-or the first N column names, if there are only N columns supplied by the VALUES
-clause. The values supplied by the VALUES clause are associated with the
-explicit or implicit column list left-to-right.
+or the first N column names, if there are only N columns supplied by the
+``VALUES`` clause. The values supplied by the ``VALUES`` clause are associated
+with the explicit or implicit column list left-to-right.
 
 Each column not present in the explicit or implicit column list will not be
 filled.
@@ -42,6 +43,12 @@ filled.
 If the expression for any column is not of the correct data type, automatic
 type conversion will be attempted.
 
+The optional ``RETURNING`` clause causes ``INSERT`` to compute and return
+values based from each row actually inserted (or updated, if an ``ON
+CONFLICT DO UPDATE`` clause was used). This is primarily useful for obtaining
+values that were supplied by defaults, such as a :ref:`_id
+<sql_administration_system_column_id>`, also any expression using the table's
+columns is allowed.
 
 ``ON CONFLICT DO UPDATE SET``
 -----------------------------
@@ -119,14 +126,22 @@ Parameters
 ==========
 
 :table_ident:
-  The identifier (optionally schema-qualified) of an existing table.
+    The identifier (optionally schema-qualified) of an existing table.
 
 :column_ident:
-  The name of a column or field in the table pointed to by *table_ident*.
+    The name of a column or field in the table pointed to by *table_ident*.
 
 :expression:
-  An expression or value to assign to the corresponding column.
+    An expression or value to assign to the corresponding column.
 
 :query:
-  A query (SELECT statement) that supplies the rows to be inserted.
-  Refer to the ``SELECT`` statement for a description of the syntax.
+    A query (``SELECT`` statement) that supplies the rows to be inserted.
+    Refer to the ``SELECT`` statement for a description of the syntax.
+
+:output_expression:
+    An expression to be computed and returned by the ``INSERT`` command
+    after each row is updated. The expression can use any column names
+    of the table or use ``*`` to return all columns.
+
+:output_name:
+    A name to use for the result of the output expression.

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -141,7 +141,8 @@ Parameters
 :output_expression:
     An expression to be computed and returned by the ``INSERT`` command
     after each row is updated. The expression can use any column names
-    of the table or use ``*`` to return all columns.
+    of the table or use ``*`` to return all columns. :ref:`System columns
+    <sql_administration_system_columns>` can also be returned.
 
 :output_name:
     A name to use for the result of the output expression.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -40,7 +40,7 @@ statement
     | UPDATE aliasedRelation
         SET assignment (',' assignment)*
         where?
-        (RETURNING selectItem (',' selectItem)*)?      													 	   #update
+        returning?                                                                   #update
     | DELETE FROM aliasedRelation where?                                             #delete
     | SHOW (TRANSACTION ISOLATION LEVEL | TRANSACTION_ISOLATION)                     #showTransaction
     | SHOW CREATE TABLE table                                                        #showCreateTable
@@ -71,7 +71,8 @@ statement
     | SET LICENSE stringLiteral                                                      #setLicense
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
-        onConflict?                                                                  #insert
+        onConflict?
+        returning?                                                                   #insert
     | RESTORE SNAPSHOT qname (ALL | TABLE tableWithPartitions) withProperties?       #restore
     | COPY tableWithPartition FROM path=expr withProperties? (RETURN SUMMARY)?       #copyFrom
     | COPY tableWithPartition columns? where?
@@ -137,6 +138,10 @@ selectItem
 
 where
     : WHERE condition=booleanExpression
+    ;
+
+returning
+    : RETURNING selectItem (',' selectItem)*
     ;
 
 filter

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -561,11 +561,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             }
             throw e;
         }
-        return new Insert(
+        return new Insert<>(
             table,
             (Query) visit(context.insertSource().query()),
             columns,
-            createDuplicateKeyContext(context));
+            getReturningItems(context.returning()),
+            createDuplicateKeyContext(context)
+        );
     }
 
     /**
@@ -621,7 +623,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             (Relation) visit(context.aliasedRelation()),
             assignments,
             visitIfPresent(context.where(), Expression.class),
-            visitCollection(context.selectItem(), SelectItem.class)
+            getReturningItems(context.returning())
             );
     }
 
@@ -1798,6 +1800,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         // single quote escaping is handled at later stage
         // as we require more context on the surrounding characters
         return value.substring(2, value.length() - 1);
+    }
+
+    private List<SelectItem> getReturningItems(@Nullable SqlBaseParser.ReturningContext context) {
+        return context == null ? List.of() : visitCollection(context.selectItem(),
+                                                             SelectItem.class);
     }
 
     private QualifiedName getQualifiedName(SqlBaseParser.QnameContext context) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -328,6 +328,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
     public R visitInsert(Insert<?> node, C context) {
         node.table().accept(this, context);
         node.insertSource().accept(this, context);
+        node.returningClause().forEach(x -> x.accept(this, context));
         return null;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -33,12 +33,18 @@ public final class Insert<T> extends Statement {
     private final DuplicateKeyContext<T> duplicateKeyContext;
     private final List<String> columns;
     private final Query insertSource;
+    private final List<SelectItem> returning;
 
-    public Insert(Table<T> table, Query subQuery, List<String> columns, DuplicateKeyContext<T> duplicateKeyContext) {
+    public Insert(Table<T> table,
+                  Query insertSource,
+                  List<String> columns,
+                  List<SelectItem> returning,
+                  DuplicateKeyContext<T> duplicateKeyContext) {
         this.table = table;
         this.columns = columns;
-        this.insertSource = subQuery;
+        this.insertSource = insertSource;
         this.duplicateKeyContext = duplicateKeyContext;
+        this.returning = returning;
     }
 
     public Table table() {
@@ -57,9 +63,13 @@ public final class Insert<T> extends Statement {
         return duplicateKeyContext;
     }
 
+    public List<SelectItem> returningClause() {
+        return returning;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hashCode(table, columns, insertSource);
+        return Objects.hashCode(table, columns, insertSource, returning);
     }
 
     @Override
@@ -73,7 +83,8 @@ public final class Insert<T> extends Statement {
         Insert<?> insert = (Insert<?>) o;
         return table.equals(insert.table) &&
                columns.equals(insert.columns) &&
-               insertSource.equals(insert.insertSource);
+               insertSource.equals(insert.insertSource) &&
+               returning.equals(insert.returning);
     }
 
     @Override
@@ -82,6 +93,7 @@ public final class Insert<T> extends Statement {
             .add("table", table)
             .add("columns", columns)
             .add("insertSource", insertSource)
+            .add("returning", returning)
             .toString();
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1073,6 +1073,14 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_insert_returning() {
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning id");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning id as foo");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning *");
+        printStatement("insert into foo (id, name) values ('string', 1.2) returning foo.*");
+    }
+
+    @Test
     public void testParameterExpressionLimitOffset() {
         // ORMs like SQLAlchemy generate these kind of queries.
         printStatement("select * from foo limit ? offset ?");
@@ -1639,6 +1647,7 @@ public class TestStatementBuilder {
             statement instanceof DropRepository ||
             statement instanceof DropSnapshot ||
             statement instanceof Update ||
+            statement instanceof Insert ||
             statement instanceof Window) {
                 println(SqlFormatter.formatSql(statement));
                 println("");

--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -61,11 +63,24 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
     @Nullable
     private final Symbol clusteredBySymbol;
 
+    /**
+     * List of columns used for the result set.
+     */
+    @Nullable
+    private final List<Field> fields;
+
+    /**
+     * List of values or expressions used to be retrieved from the updated rows.
+     */
+    private final List<Symbol> returnValues;
+
     AnalyzedInsertStatement(AnalyzedRelation subQueryRelation,
                             DocTableInfo tableInfo,
                             List<Reference> targetColumns,
                             boolean ignoreDuplicateKeys,
-                            Map<Reference, Symbol> onDuplicateKeyAssignments) {
+                            Map<Reference, Symbol> onDuplicateKeyAssignments,
+                            List<ColumnIdent> outputNames,
+                            List<Symbol> returnValues) {
         this.targetTable = tableInfo;
         this.subQueryRelation = subQueryRelation;
         this.ignoreDuplicateKeys = ignoreDuplicateKeys;
@@ -103,6 +118,17 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
             generatedColumns,
             defaultExpressionColumns,
             false);
+        this.returnValues = returnValues;
+        if (!outputNames.isEmpty() && !returnValues.isEmpty()) {
+            this.fields = new ArrayList<>(outputNames.size());
+            Iterator<Symbol> outputsIterator = returnValues.iterator();
+            for (ColumnIdent path : outputNames) {
+                //TODO The relation in the field should be point semantically correctly to this
+                fields.add(new Field(this.subQueryRelation, path, outputsIterator.next()));
+            }
+        } else {
+            fields = null;
+        }
     }
 
     private static Map<ColumnIdent, Integer> toPositionMap(List<Reference> targetColumns) {
@@ -169,6 +195,16 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
             }
         }
         return symbols;
+    }
+
+    @Override
+    @Nullable
+    public List<Field> fields() {
+        return fields;
+    }
+
+    public List<Symbol> returnValues() {
+        return returnValues;
     }
 
     public List<Reference> columns() {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -123,7 +123,7 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
             this.fields = new ArrayList<>(outputNames.size());
             Iterator<Symbol> outputsIterator = returnValues.iterator();
             for (ColumnIdent path : outputNames) {
-                //TODO The relation in the field should be point semantically correctly to this
+                //TODO The relation in the field should point semantically correctly to `this`
                 fields.add(new Field(this.subQueryRelation, path, outputsIterator.next()));
             }
         } else {

--- a/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -257,6 +257,7 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
         private final BitSet successfulWrites = new BitSet();
         private final BitSet failureLocations = new BitSet();
+        private final ArrayList<Object[]> resultRows = new ArrayList<>();
 
         public void update(ShardResponse response) {
             IntArrayList itemIndices = response.itemIndices();
@@ -270,6 +271,10 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
                     failureLocations.set(location, true);
                 }
             }
+            List<Object[]> resultRows = response.getResultRows();
+            if (resultRows != null) {
+                this.resultRows.addAll(resultRows);
+            }
         }
 
         public boolean successfulWrites(int location) {
@@ -278,6 +283,10 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
         public boolean failed(int location) {
             return failureLocations.get(location);
+        }
+
+        public List<Object[]> resultRows() {
+            return resultRows;
         }
 
         public int numSuccessfulWrites() {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
@@ -24,13 +24,25 @@ package io.crate.execution.dml.upsert;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class FromRawInsertSource implements InsertSourceGen {
 
-    @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public BytesReference generateSourceAndCheckConstraintsAsBytesReference(Object[] values) throws IOException {
         return new BytesArray(((String) values[0]));
+    }
+
+    @Override
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
+        return JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            new BytesArray(((String) values[0])).array()
+        ).map();
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
@@ -33,8 +33,6 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -63,7 +61,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
     }
 
     @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
         String rawSource = (String) values[0];
         Map<String, Object> source = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
         mixinDefaults(source, defaults);
@@ -73,7 +71,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
         for (Map.Entry<ColumnIdent, Input<?>> entry : generatedCols.entrySet()) {
             source.putIfAbsent(entry.getKey().fqn(), entry.getValue().value());
         }
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        return source;
     }
 
     private Map<Reference, Object> buildDefaults(List<Reference> defaults,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -39,9 +39,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.xcontent.XContentFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -97,7 +95,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     }
 
     @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
         row.firstCells(values);
         row.secondCells(defaultValues);
 
@@ -125,8 +123,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
             Maps.mergeInto(source, column.name(), column.path(), entry.getValue().value());
         }
         checks.validate(source);
-
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        return source;
     }
 
     private static Tuple<List<Reference>, Object[]> addDefaults(List<Reference> targets,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -28,13 +28,19 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public interface InsertSourceGen {
 
-    BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException;
+    default BytesReference generateSourceAndCheckConstraintsAsBytesReference(Object[] values) throws IOException {
+        return BytesReference.bytes(XContentFactory.jsonBuilder().map(generateSourceAndCheckConstraints(values)));
+    }
+
+    Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException;
 
     static InsertSourceGen of(TransactionContext txnCtx,
                               Functions functions,
@@ -51,4 +57,5 @@ public interface InsertSourceGen {
         }
         return new InsertSourceFromCells(txnCtx, functions, table, indexName, validation, targets);
     }
+
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -50,8 +50,11 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.DocumentSourceMissingException;
@@ -121,11 +124,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                                                                         ShardUpsertRequest request,
                                                                                         AtomicBoolean killed) {
         ShardResponse shardResponse = new ShardResponse(request.getReturnValues());
-        
         String indexName = request.index();
         DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);
         Reference[] insertColumns = request.insertColumns();
-
         GeneratedColumns.Validation valueValidation = request.validateConstraints()
             ? GeneratedColumns.Validation.VALUE_MATCH
             : GeneratedColumns.Validation.NONE;
@@ -161,7 +162,6 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                     request,
                     item,
                     indexShard,
-                    item.insertValues() != null, // try insert first
                     updateSourceGen,
                     insertSourceGen,
                     returnValueGen
@@ -250,23 +250,20 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     private IndexItemResponse indexItem(ShardUpsertRequest request,
                                         ShardUpsertRequest.Item item,
                                         IndexShard indexShard,
-                                        boolean tryInsertFirst,
                                         @Nullable UpdateSourceGen updateSourceGen,
                                         @Nullable InsertSourceGen insertSourceGen,
                                         @Nullable ReturnValueGen returnValueGen) throws Exception {
         VersionConflictEngineException lastException = null;
+        boolean tryInsertFirst = item.insertValues() != null;
+        boolean isRetry;
         for (int retryCount = 0; retryCount < MAX_RETRY_LIMIT; retryCount++) {
             try {
-                return indexItem(
-                    request,
-                    item,
-                    indexShard,
-                    tryInsertFirst,
-                    updateSourceGen,
-                    insertSourceGen,
-                    returnValueGen,
-                    retryCount > 0
-                );
+                isRetry = retryCount > 0;
+                if (tryInsertFirst) {
+                    return insert(request, item, indexShard, isRetry, returnValueGen, insertSourceGen);
+                } else {
+                    return update(item, indexShard, isRetry, returnValueGen, updateSourceGen);
+                }
             } catch (VersionConflictEngineException e) {
                 lastException = e;
                 if (request.duplicateKeyAction() == DuplicateKeyAction.IGNORE) {
@@ -309,53 +306,112 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     }
 
     @VisibleForTesting
-    protected IndexItemResponse indexItem(ShardUpsertRequest request,
-                                          ShardUpsertRequest.Item item,
-                                          IndexShard indexShard,
-                                          boolean tryInsertFirst,
-                                          UpdateSourceGen updateSourceGen,
-                                          InsertSourceGen insertSourceGen,
-                                          @Nullable ReturnValueGen returnGen,
-                                          boolean isRetry) throws Exception {
-        final long seqNo;
-        final long primaryTerm;
-        final long version;
-        Doc updatedDoc = null;
-        if (tryInsertFirst) {
-            version = request.duplicateKeyAction() == DuplicateKeyAction.OVERWRITE
-                ? Versions.MATCH_ANY
-                : Versions.MATCH_DELETED;
-            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
-            try {
-                item.source(insertSourceGen.generateSourceAndCheckConstraints(item.insertValues()));
-            } catch (IOException e) {
-                throw ExceptionsHelper.convertToElastic(e);
+    protected IndexItemResponse insert(ShardUpsertRequest request,
+                                       ShardUpsertRequest.Item item,
+                                       IndexShard indexShard,
+                                       boolean isRetry,
+                                       @Nullable ReturnValueGen returnGen,
+                                       InsertSourceGen insertSourceGen) throws Exception {
+        assert insertSourceGen != null : "InsertSourceGen must not be null";
+        BytesReference rawSource;
+        Map<String, Object> source = null;
+        try {
+            // This optimizes for the case where the insert value is already string-based, so we can take directly
+            // the rawSource
+            if (insertSourceGen instanceof FromRawInsertSource) {
+                rawSource = insertSourceGen.generateSourceAndCheckConstraintsAsBytesReference(item.insertValues());
+            } else {
+                source = insertSourceGen.generateSourceAndCheckConstraints(item.insertValues());
+                rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
             }
-        } else {
-            Doc currentDoc = getDocument(indexShard, item.id(), item.version(), item.seqNo(), item.primaryTerm());
-
-            Map<String, Object> updatedSource = updateSourceGen.generateSource(
-                currentDoc,
-                item.updateAssignments(),
-                item.insertValues()
-            );
-
-            if (item.returnValues() != null) {
-                updatedDoc = currentDoc.withUpdatedSource(updatedSource);
-            }
-
-            item.source(BytesReference.bytes(XContentFactory.jsonBuilder().map(updatedSource)));
-            seqNo = item.seqNo();
-            primaryTerm = item.primaryTerm();
-            version = Versions.MATCH_ANY;
+        } catch (IOException e) {
+            throw ExceptionsHelper.convertToElastic(e);
         }
+        item.source(rawSource);
+
+        long version = request.duplicateKeyAction() == DuplicateKeyAction.OVERWRITE ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
+        long seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        long primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+
+        Engine.IndexResult indexResult = index(item, indexShard, isRetry, seqNo, primaryTerm, version);
+        Object[] returnvalues = null;
+        if (returnGen != null) {
+            // This optimizes for the case where the insert value is already string-based, so only parse the source
+            // when return values are requested
+            if (source == null) {
+                source = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    BytesReference.toBytes(rawSource)).map();
+            }
+            returnvalues = returnGen.generateReturnValues(
+                // return -1 as docId, the docId can only be retrieved by fetching the inserted document again, which
+                // we want to avoid. The docId is anyway just valid with the lifetime of a searcher and can change afterwards.
+                new Doc(
+                    -1,
+                    indexShard.shardId().getIndexName(),
+                    item.id(),
+                    indexResult.getVersion(),
+                    indexResult.getSeqNo(),
+                    indexResult.getTerm(),
+                    source,
+                    rawSource::utf8ToString
+                )
+            );
+        }
+        return new IndexItemResponse(indexResult.getTranslogLocation(), returnvalues);
+    }
+
+    protected IndexItemResponse update(ShardUpsertRequest.Item item,
+                                       IndexShard indexShard,
+                                       boolean isRetry,
+                                       @Nullable ReturnValueGen returnGen,
+                                       UpdateSourceGen updateSourceGen) throws Exception {
+        assert updateSourceGen != null : "UpdateSourceGen must not be null";
+        Doc fetchedDoc = getDocument(indexShard, item.id(), item.version(), item.seqNo(), item.primaryTerm());
+        Map<String, Object> source = updateSourceGen.generateSource(
+            fetchedDoc,
+            item.updateAssignments(),
+            item.insertValues()
+        );
+        BytesReference rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        item.source(rawSource);
+        long seqNo = item.seqNo();
+        long primaryTerm = item.primaryTerm();
+        long version = Versions.MATCH_ANY;
+
+        Engine.IndexResult indexResult = index(item, indexShard, isRetry, seqNo, primaryTerm, version);
+        Object[] returnvalues = null;
+        if (returnGen != null) {
+            returnvalues = returnGen.generateReturnValues(
+                new Doc(
+                    fetchedDoc.docId(),
+                    fetchedDoc.getIndex(),
+                    fetchedDoc.getId(),
+                    indexResult.getVersion(),
+                    indexResult.getSeqNo(),
+                    indexResult.getTerm(),
+                    source,
+                    rawSource::utf8ToString
+                )
+            );
+        }
+        return new IndexItemResponse(indexResult.getTranslogLocation(), returnvalues);
+    }
+
+    private Engine.IndexResult index(ShardUpsertRequest.Item item,
+                                     IndexShard indexShard,
+                                     boolean isRetry,
+                                     long seqNo,
+                                     long primaryTerm,
+                                     long version) throws Exception {
         SourceToParse sourceToParse = new SourceToParse(
             indexShard.shardId().getIndexName(),
             item.id(),
             item.source(),
             XContentType.JSON
         );
+
         Engine.IndexResult indexResult = executeOnPrimaryHandlingMappingUpdate(
             indexShard.shardId(),
             () -> indexShard.applyIndexOperationOnPrimary(
@@ -369,13 +425,13 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             ),
             e -> indexShard.getFailedIndexResult(e, Versions.MATCH_ANY)
         );
+
         switch (indexResult.getResultType()) {
             case SUCCESS:
                 // update the seqNo and version on request for the replicas
                 item.seqNo(indexResult.getSeqNo());
                 item.version(indexResult.getVersion());
-                return new IndexItemResponse(indexResult.getTranslogLocation(),
-                                             getReturnValues(indexResult, returnGen, updatedDoc));
+                return indexResult;
 
             case FAILURE:
                 Exception failure = indexResult.getFailure();
@@ -425,16 +481,5 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             }
         }
         return columnsNotUsed;
-    }
-
-    @Nullable
-    private static Object[] getReturnValues(Engine.IndexResult indexResult,
-                                            @Nullable ReturnValueGen returnGen,
-                                            @Nullable Doc doc) {
-        if (doc != null && returnGen != null) {
-            return returnGen.generateReturnValues(doc.withVersionAndSeqNo(indexResult.getVersion(),
-                                                                          indexResult.getSeqNo()));
-        }
-        return null;
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public abstract class AbstractIndexWriterProjection extends Projection {
 
-    public static final List<Symbol> OUTPUTS = ImmutableList.of(new InputColumn(0, DataTypes.LONG));  // number of rows imported
+    public static final List<? extends Symbol> OUTPUTS = ImmutableList.of(new InputColumn(0, DataTypes.LONG));  // number of rows imported
 
     private static final String BULK_SIZE = "bulk_size";
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultCollectors.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultCollectors.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.indexing;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.google.common.collect.ImmutableMap;
+import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.execution.dml.ShardResponse;
@@ -37,6 +38,10 @@ import java.util.function.Supplier;
 
 final class UpsertResultCollectors {
 
+    static UpsertResultCollector newResultRowCollector() {
+        return new ResultRowCollector();
+    }
+
     static UpsertResultCollector newRowCountCollector() {
         return new RowCountCollector();
     }
@@ -48,6 +53,44 @@ final class UpsertResultCollectors {
         ));
     }
 
+    private static class ResultRowCollector implements UpsertResultCollector {
+
+        private final Object lock = new Object();
+
+        @Override
+        public Supplier<UpsertResults> supplier() {
+            return UpsertResults::new;
+        }
+
+        @Override
+        public Accumulator accumulator() {
+            return this::processShardResponse;
+        }
+
+        @Override
+        public BinaryOperator<UpsertResults> combiner() {
+            return (i, o) -> {
+                synchronized (lock) {
+                    i.addResultRows(o.getResultRowsForNoUri());
+                }
+                return i;
+            };
+        }
+
+        @Override
+        public Function<UpsertResults, Iterable<Row>> finisher() {
+            return r -> new CollectionBucket(r.getResultRowsForNoUri());
+        }
+
+        @SuppressWarnings("unused")
+        void processShardResponse(UpsertResults upsertResults,
+                                  ShardResponse shardResponse,
+                                  List<RowSourceInfo> rowSourceInfosIgnored) {
+            synchronized (lock) {
+                upsertResults.addResultRows(shardResponse.getResultRows());
+            }
+        }
+    }
 
     private static class RowCountCollector implements UpsertResultCollector {
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
@@ -53,6 +53,22 @@ public class UpsertResultContext {
         };
     }
 
+    public static UpsertResultContext forResultRows() {
+        return new UpsertResultContext(
+            () -> null, () -> null, () -> null, Collections.emptyList(), UpsertResultCollectors.newResultRowCollector()) {
+
+            @Override
+            BiConsumer<ShardedRequests, String> getItemFailureRecorder() {
+                return (s, f) -> { };
+            }
+
+            @Override
+            Predicate<ShardedRequests> getHasSourceUriFailureChecker() {
+                return (ignored) -> false;
+            }
+        };
+    }
+
     public static UpsertResultContext forReturnSummary(TransactionContext txnCtx,
                                                        SourceIndexWriterReturnSummaryProjection projection,
                                                        DiscoveryNode discoveryNode,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
@@ -53,6 +53,11 @@ class UpsertResults {
         result.successRowCount += successRowCount;
     }
 
+    void addResultRows(List<Object[]> resultRows) {
+        Result result = getResultSafe(null);
+        result.resultRows.addAll(resultRows);
+    }
+
     void addResult(String uri, @Nullable String failureMessage, long lineNumber) {
         Result result = getResultSafe(uri);
         if (failureMessage == null) {
@@ -83,6 +88,10 @@ class UpsertResults {
         return getResultSafe(null).successRowCount;
     }
 
+    List<Object[]> getResultRowsForNoUri() {
+        return getResultSafe(null).resultRows;
+    }
+
     void merge(UpsertResults other) {
         for (Map.Entry<String, Result> entry : other.resultsByUri.entrySet()) {
             Result result = resultsByUri.get(entry.getKey());
@@ -91,7 +100,6 @@ class UpsertResults {
             } else {
                 result.merge(entry.getValue());
             }
-
         }
     }
 
@@ -118,6 +126,8 @@ class UpsertResults {
         private long errorRowCount = 0;
         private final Map<String, Map<String, Object>> errors = new HashMap<>();
         private boolean sourceUriFailure = false;
+        private final List<Object[]> resultRows = new ArrayList<>();
+
 
         void merge(Result upsertResult) {
             successRowCount += upsertResult.successRowCount;
@@ -132,6 +142,7 @@ class UpsertResults {
                 Long errorCnt = (Long) val.get(ERROR_COUNT_KEY);
                 updateErrorCount(entry.getKey(), lineNumbers, errorCnt);
             }
+            resultRows.addAll(upsertResult.resultRows);
         }
 
         private void updateErrorCount(String msg, List<Long> lineNumbers, Long increaseBy) {

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -494,6 +494,7 @@ public class ProjectionToProjectorVisitor
             projection.onDuplicateKeyAssignments(),
             projection.bulkActions(),
             projection.autoCreateIndices(),
+            projection.returnValues(),
             context.jobId
         );
     }

--- a/sql/src/main/java/io/crate/expression/reference/Doc.java
+++ b/sql/src/main/java/io/crate/expression/reference/Doc.java
@@ -90,18 +90,6 @@ public final class Doc {
         return index;
     }
 
-    public Doc withVersionAndSeqNo(long version, long seqNo) {
-        return new Doc(
-            docId,
-            index,
-            id,
-            version,
-            seqNo,
-            primaryTerm,
-            source,
-            raw);
-    }
-
     public Doc withUpdatedSource(Map<String, Object> updatedSource) {
         return new Doc(
             docId,

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -95,7 +95,7 @@ public class Insert implements LogicalPlan {
 
     @Override
     public List<Symbol> outputs() {
-        return MergeCountProjection.OUTPUTS;
+        return (List<Symbol>) writeToTable.outputs();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -31,6 +31,7 @@ import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.breaker.TypeGuessEstimateRowSize;
+import io.crate.data.CollectionBucket;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -225,6 +226,8 @@ public class InsertFromValues implements LogicalPlan {
                 plannerContext,
                 subQueryResults));
 
+        List<Symbol> returnValues = this.writerProjection.returnValues();
+
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             plannerContext.transactionContext().sessionSettings(),
             BULK_REQUEST_TIMEOUT_SETTING.setting().get(dependencies.settings()),
@@ -234,7 +237,7 @@ public class InsertFromValues implements LogicalPlan {
             rows.size() > 1, // continueOnErrors
             updateColumnNames,
             writerProjection.allTargetColumns().toArray(new Reference[0]),
-            null,
+            returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[0]),
             plannerContext.jobId(),
             false);
 
@@ -275,8 +278,12 @@ public class InsertFromValues implements LogicalPlan {
                 dependencies.scheduler());
         }).whenComplete((response, t) -> {
             if (t == null) {
-                consumer.accept(
-                    InMemoryBatchIterator.of(new Row1((long) response.numSuccessfulWrites()), SENTINEL), null);
+                if (returnValues.isEmpty()) {
+                    consumer.accept(InMemoryBatchIterator.of(new Row1((long) response.numSuccessfulWrites()), SENTINEL),
+                                    null);
+                } else {
+                    consumer.accept(InMemoryBatchIterator.of(new CollectionBucket(response.resultRows()), SENTINEL, false), null);
+                }
             } else {
                 consumer.accept(null, t);
             }
@@ -446,7 +453,7 @@ public class InsertFromValues implements LogicalPlan {
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null, null);
+                null, null, null, this.writerProjection.returnValues().toArray(new Symbol[0]));
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),

--- a/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -371,4 +371,45 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             isField("col2", DataTypes.STRING) // Planner adds a cast projection; text is okay here
         ));
     }
+
+    @Test
+    public void test_insert_with_id_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id");
+        assertThat(stmt.fields(), contains(isField("id")));
+        assertThat(stmt.returnValues(), contains(isReference("id")));
+    }
+
+    @Test
+    public void test_insert_with_docid_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning _doc");
+        assertThat(stmt.fields(), contains(isField("_doc")));
+        assertThat(stmt.returnValues(), contains(isReference("_doc")));
+    }
+
+    @Test
+    public void test_insert_with_id_renamed_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id as foo");
+        assertThat(stmt.fields(), contains(isField("foo")));
+        assertThat(stmt.returnValues(), contains(isReference("id")));
+    }
+
+    @Test
+    public void test_insert_with_function_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id + 1 as foo");
+        assertThat(stmt.fields(), contains(isField("foo")));
+        assertThat(stmt.returnValues(), contains(isFunction("add")));
+    }
+
+    @Test
+    public void test_insert_with_returning_all_columns() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning *");
+        assertThat(stmt.fields().size(), is(17));
+        assertThat(stmt.returnValues().size(), is(17));
+    }
+
 }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
@@ -56,9 +56,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
     }
@@ -68,9 +66,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
         assertThat(Maps.getByPath(map, "x"), is(2));
         assertThat(Maps.getByPath(map, "y"), is(3));
     }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -90,8 +90,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":2,\"z\":3}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
+        assertThat(source, is(Map.of("x", 1, "y", 2, "z", 3)));
     }
 
     @Test
@@ -109,9 +109,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
         assertThat(map.get("b"), is(11));
         assertThat(Maps.getByPath(map, "obj.a"), is(10));
         assertThat(Maps.getByPath(map, "obj.c"), is(13));
@@ -153,8 +151,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x));
 
         Object[] input = new Object[]{1};
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"crate\"}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        assertThat(source, is(Map.of("x", 1, "y", "crate")));
     }
 
     @Test
@@ -168,8 +166,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
 
         Object[] input = {1, "cr8"};
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"cr8\"}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        assertThat(source, is(Map.of("x", 1, "y", "cr8")));
     }
 
     @Test
@@ -184,13 +182,11 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 13);
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
 
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.a"), is(10));
-        assertThat(Maps.getByPath(map, "b"), is(11));
-        assertThat(Maps.getByPath(map, "obj.c"), is(13));
+        assertThat(Maps.getByPath(source, "obj.a"), is(10));
+        assertThat(Maps.getByPath(source, "b"), is(11));
+        assertThat(Maps.getByPath(source, "obj.c"), is(13));
     }
 
     @Test
@@ -220,11 +216,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("y", 2);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.x"), is(0));
-        assertThat(Maps.getByPath(map, "obj.y"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        assertThat(Maps.getByPath(source, "obj.x"), is(0));
+        assertThat(Maps.getByPath(source, "obj.y"), is(2));
     }
 
     @Test
@@ -238,11 +232,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
-
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.x"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        assertThat(Maps.getByPath(source, "obj.x"), is(2));
     }
 
     @Test
@@ -250,11 +241,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t6 = e.resolveTableInfo("t6");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "x"), is(1));
-        assertThat(Maps.getByPath(map, "y"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
+        assertThat(Maps.getByPath(source, "x"), is(1));
+        assertThat(Maps.getByPath(source, "y"), is(2));
     }
 
     @Test
@@ -271,9 +260,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             GeneratedColumns.Validation.VALUE_MATCH,
             List.of(Objects.requireNonNull(tableInfo.getReference(new ColumnIdent("x")))));
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
 
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":1}"));
+        assertThat(source, is(Map.of("x", 1, "y", 1)));
     }
 
     @Test
@@ -293,9 +282,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             GeneratedColumns.Validation.VALUE_MATCH,
             List.of());
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
 
-        assertThat(source.utf8ToString(), is("{\"x\":\"test\"}"));
+        assertThat(source, is(Map.of("x", "test")));
     }
 
     @Test
@@ -314,7 +303,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         );
         var payloads = List.of(Map.of("x", 10), Map.of("x", 20));
         var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { payloads });
-        assertThat(source.utf8ToString(), is("{\"payloads\":[{\"x\":10},{\"x\":20}]}"));
+        assertThat(source, is(Map.of("payloads", List.of(Map.of("x", 10), Map.of("x", 20)))));
     }
 
     @Test
@@ -338,6 +327,6 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         obj.put("x", 10);
         obj.put("p", 1);
         var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { obj });
-        assertThat(source.utf8ToString(), is("{\"obj\":{\"x\":10}}"));
+        assertThat(source, is(Map.of("obj", Map.of("x", 10))));
     }
 }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -115,17 +115,14 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 tasksService, indicesService, shardStateAction, functions, schemas, indexNameExpressionResolver);
         }
 
-        @Nullable
         @Override
-        protected IndexItemResponse indexItem(ShardUpsertRequest request,
-                                              ShardUpsertRequest.Item item,
-                                              IndexShard indexShard,
-                                              boolean tryInsertFirst,
-                                              UpdateSourceGen updateSourceGen,
-                                              InsertSourceGen insertSourceGen,
-                                              ReturnValueGen returnValueGen,
-                                              boolean isRetry) throws Exception {
-             throw new VersionConflictEngineException(
+        protected IndexItemResponse insert(ShardUpsertRequest request,
+                                           ShardUpsertRequest.Item item,
+                                           IndexShard indexShard,
+                                           boolean isRetry,
+                                           @Nullable ReturnValueGen returnGen,
+                                           @Nullable InsertSourceGen insertSourceGen) throws Exception {
+            throw new VersionConflictEngineException(
                 indexShard.shardId(),
                 item.id(),
                 "document with id: " + item.id() + " already exists in '" + request.shardId().getIndexName() + '\'');

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -92,7 +92,9 @@ public class ColumnIndexWriterProjectionTest {
             null,
             null,
             Settings.EMPTY,
-            true
+            true,
+            List.of(),
+            null
         );
 
         assertThat(projection.columnReferencesExclPartition(), Matchers.is(Arrays.asList(

--- a/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import io.crate.analyze.TableDefinitions;
+import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class InsertFromSubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws IOException {
+        e = buildExecutor(clusterService);
+    }
+
+    private static SQLExecutor buildExecutor(ClusterService clusterService) throws IOException {
+        return SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
+    }
+
+    @Test
+    public void test_returning_for_insert_from_values_throw_error_with_4_1_nodes() throws Exception {
+        // Make sure the former initialized cluster service is shutdown
+        cleanup();
+        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        e = buildExecutor(clusterService);
+        expectedException.expect(UnsupportedFeatureException.class);
+        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
+        e.plan("insert into users (id, name) values (1, 'bob') returning id");
+
+    }
+
+    @Test
+    public void test_returning_for_insert_from_subquery_throw_error_with_4_1_nodes() throws Exception {
+        // Make sure the former initialized cluster service is shutdown
+        cleanup();
+        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        e = buildExecutor(clusterService);
+        expectedException.expect(UnsupportedFeatureException.class);
+        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
+        e.plan("insert into users (id, name) select '1' as id, 'b' as name returning id");
+    }
+
+}

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -137,7 +137,7 @@ public final class QueryTester implements AutoCloseable {
                 GeneratedColumns.Validation.NONE,
                 Collections.singletonList(table.getReference(ColumnIdent.fromPath(column)))
             );
-            BytesReference source = sourceGen.generateSourceAndCheckConstraints(new Object[]{value});
+            BytesReference source = sourceGen.generateSourceAndCheckConstraintsAsBytesReference(new Object[]{value});
             SourceToParse sourceToParse = new SourceToParse(
                 table.concreteIndices()[0],
                 UUIDs.randomBase64UUID(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a new optional `RETURNING` clause for `Insert` to return specified values from each row inserted.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
