### PR TITLE
Add translate scalar function, unit tests, and docs

### DIFF
--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -311,6 +311,39 @@ Replaces all occurrences of ``from`` in ``text`` with ``to``.
    +---------------------------------------------+
    SELECT 1 row in set (... sec)
 
+.. _scalar-translate:
+
+``translate(string, from, to)``
+-------------------------------
+
+Performs single-character, one-to-one translations of ``string``.
+It translates one-to-one positionally ``from`` array of characters (string) ``to`` array of characters.
+If ``from`` is longer then ``to`` unmatched symbols in ``from`` are meant to be removed from ``string``.
+
+Synopsis::
+
+    translate(string, from, to)
+
+Examples::
+
+   cr> select translate('Crate', 'Ct', 'Dk');
+   +--------------------------------+
+   | translate('Crate', 'Ct', 'Dk') |
+   +--------------------------------+
+   | Drake                          |
+   +--------------------------------+
+   SELECT 1 row in set (... sec)
+
+::
+
+   cr> select translate('Crate', 'rCe', 'c');
+   +--------------------------------+
+   | translate('Crate', 'rCe', 'c') |
+   +--------------------------------+
+   | cat                            |
+   +--------------------------------+
+   SELECT 1 row in set (... sec)
+
 .. _scalar-trim:
 
 ``trim({LEADING | TRAILING | BOTH} 'str_arg_1' FROM 'str_arg_2')``

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -59,6 +59,7 @@ import io.crate.expression.scalar.string.ReplaceFunction;
 import io.crate.expression.scalar.string.StringCaseFunction;
 import io.crate.expression.scalar.string.StringLeftRightFunction;
 import io.crate.expression.scalar.string.StringPaddingFunction;
+import io.crate.expression.scalar.string.TranslateFunction;
 import io.crate.expression.scalar.string.TrimFunctions;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
@@ -142,7 +143,7 @@ public class ScalarFunctionModule extends AbstractModule {
         TrimFunctions.register(this);
         AsciiFunction.register(this);
         EncodeDecodeFunction.register(this);
-
+        TranslateFunction.register(this);
         ConcatFunction.register(this);
 
         LengthFunction.register(this);

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.TripleScalar;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.types.DataTypes;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+public final class TranslateFunction {
+    public static void register(ScalarFunctionModule module) {
+        var functionInfo = new FunctionInfo(new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)), DataTypes.STRING);
+        module.register(new TripleScalar<>(functionInfo, TranslateFunction::translate));
+    }
+
+    private static String translate(String text, String from, String to) {
+        if (from.isEmpty() || text.isEmpty()) {
+            return text;
+        } else {
+            return applyTranslationsToText(text, createTranslationMap(from, to));
+        }
+    }
+
+    private static HashMap<Character, Consumer<StringBuilder>> createTranslationMap(String from, String to) {
+        var translationMap = new HashMap<Character, Consumer<StringBuilder>>();
+        var fromLength = from.length();
+        var toLength = to.length();
+
+        for (int i = 0; i < fromLength; i++) {
+            Character fromChar = from.charAt(i);
+
+            checkDuplicatesInFromArg(fromChar, translationMap);
+
+            if (i < toLength) {
+                final var toChar = to.charAt(i);
+                translationMap.put(fromChar, (sb) -> sb.append(toChar));
+            } else {
+                translationMap.put(fromChar, (sb) -> {});
+            }
+        }
+        return translationMap;
+    }
+
+    private static String applyTranslationsToText(String text, HashMap<Character, Consumer<StringBuilder>> translationMap) {
+        var outputSb = new StringBuilder();
+
+        for (var ch: text.toCharArray()) {
+            if (translationMap.containsKey(ch)) {
+                translationMap.get(ch).accept(outputSb);
+            } else {
+                outputSb.append(ch);
+            }
+        }
+
+        return outputSb.toString();
+    }
+
+    /**
+     * Repeated occurrence of any char in the 'from' argument creates an ambiguity of resolving a correct translation.
+     * Therefore, such arguments treated as invalid.
+     */
+    private static void checkDuplicatesInFromArg(Character ch, HashMap<Character, Consumer<StringBuilder>> translationMap) {
+        if (translationMap.containsKey(ch)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ENGLISH, "Argument 'from' contains duplicate characters '%s'", ch)
+            );
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -126,22 +126,20 @@ public class TranslateFunction extends Scalar<String, String> {
 
     protected String translate(String text, String from, String to) {
         var resultSb = new StringBuilder();
-        var fromChars = from.toCharArray();
-        var fromLength = fromChars.length;
-        var toChars = to.toCharArray();
-        var toLength = toChars.length;
+        var fromLength = from.length();
+        var toLength = to.length();
 
         for (int textIdx = 0; textIdx < text.length(); textIdx++) {
             var textChar = text.charAt(textIdx);
 
             int lookupIdx = 0;
 
-            for (;lookupIdx < fromLength && textChar != fromChars[lookupIdx]; lookupIdx++);
+            for (;lookupIdx < fromLength && textChar != from.charAt(lookupIdx); lookupIdx++);
 
             if (lookupIdx < fromLength) {
                 // translation found, the char from "to" is appended, or skipped if there is not match in "to".
                 if (lookupIdx < toLength) {
-                    resultSb.append(toChars[lookupIdx]);
+                    resultSb.append(to.charAt(lookupIdx));
                 }
             } else {
                 // translation for the char not found, therefore the current char is appended

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -23,140 +23,26 @@
 package io.crate.expression.scalar.string;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
+import io.crate.expression.scalar.TripleScalar;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
-import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.function.Consumer;
+/**
+ * A simple implementation of Translation map that
+ * - resembles PostgreSQL implementation
+ * - does not use compile()
+ */
 
-public class TranslateFunction extends Scalar<String, String> {
-    private final FunctionInfo functionInfo = new FunctionInfo(
-        new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)),
-        DataTypes.STRING);
-
-    public TranslateFunction() {
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return functionInfo;
-    }
+public class TranslateFunction {
 
     public static void register(ScalarFunctionModule module) {
-        module.register(new TranslateFunction());
+        var functionInfo = new FunctionInfo(new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)), DataTypes.STRING);
+        module.register(new TripleScalar<>(functionInfo, TranslateFunction::translate));
     }
 
-    @Override
-    public Scalar<String, String> compile(List<Symbol> arguments) {
-        assert arguments.size() == 3 : "function's number of arguments must be 3";
-
-        Symbol fromSymbol = arguments.get(1);
-        if (!Literal.isLiteral(fromSymbol, DataTypes.STRING)) {
-            return this;
-        }
-
-        Symbol toSymbol = arguments.get(2);
-        if (!Literal.isLiteral(toSymbol, DataTypes.STRING)) {
-            return this;
-        }
-
-        var fromStr = (String) ((Input) fromSymbol).value();
-        var toStr = (String) ((Input) toSymbol).value();
-        var toLength = toStr.length();
-
-        var sortedFromChars = fromStr.toCharArray();
-        Arrays.sort(sortedFromChars);
-
-        var lookupIndexes = new int [sortedFromChars.length];
-
-        for (int i = 0; i < sortedFromChars.length; i++) {
-            var ch = fromStr.charAt(i);
-            var lookupIdx = Arrays.binarySearch(sortedFromChars, ch);
-            if (i < toLength) {
-                lookupIndexes[lookupIdx] = i;
-            } else {
-                lookupIndexes[lookupIdx] = -1;
-            }
-        }
-
-        return new WithPrecomputedTranslate(sortedFromChars, lookupIndexes);
-    }
-
-    @Override
-    public String evaluate(TransactionContext txnCtx, Input<String>... args) {
-        var text = args[0].value();
-        if (text == null) {
-            return null;
-        }
-
-        var from = args[1].value();
-        if (from == null) {
-            return null;
-        }
-
-        var to = args[2].value();
-        if (to == null) {
-            return null;
-        }
-
-        if (text.isEmpty() || from.isEmpty()) {
-            return text;
-        } else {
-            return translate(text, from, to);
-        }
-    }
-
-    private class WithPrecomputedTranslate extends TranslateFunction {
-        private char[] sortedLookup;
-        private int[] lookupIndexes;
-
-        private WithPrecomputedTranslate(char[] sortedLookup, int[] lookupIndexes) {
-            this.sortedLookup = sortedLookup;
-            this.lookupIndexes = lookupIndexes;
-        }
-
-        @SafeVarargs
-        @Override
-        public final String evaluate(TransactionContext txnCtx, Input<String>... args) {
-            var text = args[0].value();
-            var from = args[1].value();
-            var to = args[2].value();
-
-            if (text == null) {
-                return null;
-            }
-
-            if (text.isEmpty()) {
-                return text;
-            }
-            var sb = new StringBuilder();
-            for (int i = 0; i < text.length(); i++) {
-                var ch = text.charAt(i);
-                var lookupIdx = Arrays.binarySearch(sortedLookup, ch);
-                if (lookupIdx >= 0) {
-                    var valueIdx = lookupIndexes[lookupIdx];
-                    if (valueIdx >= 0) {
-                        sb.append(to.charAt(valueIdx));
-                    }
-                } else {
-                    sb.append(ch);
-                }
-            }
-            return sb.toString();
-        }
-    }
-
-    protected String translate(String text, String from, String to) {
+    private static String translate(String text, String from, String to) {
         var resultSb = new StringBuilder();
         var fromLength = from.length();
         var toLength = to.length();
@@ -179,36 +65,5 @@ public class TranslateFunction extends Scalar<String, String> {
             }
         }
         return resultSb.toString();
-    }
-
-    protected String translate(String text, HashMap<Character, Consumer<StringBuilder>> translationMap) {
-        return applyTranslationsToText(text, translationMap);
-    }
-
-    private String applyTranslationsToText(String text, HashMap<Character, Consumer<StringBuilder>> translationMap) {
-        var outputSb = new StringBuilder();
-
-        for (int i = 0; i < text.length(); i++) {
-            var fromChar = text.charAt(i);
-            var function = translationMap.get(fromChar);
-            if (function != null) {
-                function.accept(outputSb);
-            } else {
-                outputSb.append(fromChar);
-            }
-        }
-        return outputSb.toString();
-    }
-
-    /**
-     * Repeated occurrence of any char in the 'from' argument creates an ambiguity of resolving a correct translation.
-     * Therefore, such arguments treated as invalid.
-     */
-    private void checkDuplicatesInFromArg(Character ch, HashMap<Character, Consumer<StringBuilder>> translationMap) {
-        if (translationMap.containsKey(ch)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "Argument 'from' contains duplicate characters '%s'", ch)
-            );
-        }
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionOptimisedArray.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionOptimisedArray.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.types.DataTypes;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * An option of translate() that
+ * - is based on an ordered char array for a map lookup
+ * - use compile optimisation
+ */
+
+public class TranslateFunctionOptimisedArray extends Scalar<String, String> {
+
+    private final FunctionInfo functionInfo = new FunctionInfo(
+        new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)),
+        DataTypes.STRING);
+
+    public TranslateFunctionOptimisedArray() {
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return functionInfo;
+    }
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new TranslateFunctionOptimisedArray());
+    }
+
+    @Override
+    public Scalar<String, String> compile(List<Symbol> arguments) {
+        assert arguments.size() == 3 : "function's number of arguments must be 3";
+
+        Symbol fromSymbol = arguments.get(1);
+        if (!Literal.isLiteral(fromSymbol, DataTypes.STRING)) {
+            return this;
+        }
+
+        Symbol toSymbol = arguments.get(2);
+        if (!Literal.isLiteral(toSymbol, DataTypes.STRING)) {
+            return this;
+        }
+
+        var fromStr = (String) ((Input) fromSymbol).value();
+        var toStr = (String) ((Input) toSymbol).value();
+
+        var sortedFromArray = getSortedFromArray(fromStr);
+        var lookupIndexes = getLookupIndexes(sortedFromArray, fromStr, toStr);
+
+        return new WithPrecomputedTranslate(sortedFromArray, lookupIndexes);
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, Input<String>... args) {
+        var text = args[0].value();
+        if (text == null) {
+            return null;
+        }
+
+        var from = args[1].value();
+        if (from == null) {
+            return null;
+        }
+
+        var to = args[2].value();
+        if (to == null) {
+            return null;
+        }
+
+        if (text.isEmpty() || from.isEmpty()) {
+            return text;
+        } else {
+            var sortedFromArray = getSortedFromArray(from);
+            var lookupIndexes = getLookupIndexes(sortedFromArray, from, to);
+
+            return translate(text, to, sortedFromArray, lookupIndexes);
+        }
+    }
+
+    private class WithPrecomputedTranslate extends TranslateFunctionOptimisedArray {
+        private final char[] sortedFromArray;
+        private final int[] lookupIndexes;
+
+        private WithPrecomputedTranslate(char[] sortedFromArray, int[] lookupIndexes) {
+            this.sortedFromArray = sortedFromArray;
+            this.lookupIndexes = lookupIndexes;
+        }
+
+        @SafeVarargs
+        @Override
+        public final String evaluate(TransactionContext txnCtx, Input<String>... args) {
+            var text = args[0].value();
+            var to = args[2].value();
+
+            if (text == null) {
+                return null;
+            }
+
+            if (text.isEmpty()) {
+                return text;
+            }
+
+            return translate(text, to, sortedFromArray, lookupIndexes);
+        }
+    }
+
+    private char[] getSortedFromArray(String from) {
+        var charArray = from.toCharArray();
+        Arrays.sort(charArray);
+        return charArray;
+    }
+
+    private int[] getLookupIndexes(char[] sortedFromArray, String from, String to) {
+        var toLength = to.length();
+        var lookupIndexes = new int [sortedFromArray.length];
+
+        for (int i = 0; i < sortedFromArray.length; i++) {
+            var ch = from.charAt(i);
+            var lookupIdx = Arrays.binarySearch(sortedFromArray, ch);
+            if (i < toLength) {
+                lookupIndexes[lookupIdx] = i;
+            } else {
+                lookupIndexes[lookupIdx] = -1;
+            }
+        }
+
+        return lookupIndexes;
+    }
+
+    private String translate(String text, String to, char[] sortedFromArray, int[] lookupIndexes) {
+        var sb = new StringBuilder();
+        for (int i = 0; i < text.length(); i++) {
+            var ch = text.charAt(i);
+            var lookupIdx = Arrays.binarySearch(sortedFromArray, ch);
+            if (lookupIdx >= 0) {
+                var valueIdx = lookupIndexes[lookupIdx];
+                if (valueIdx >= 0) {
+                    sb.append(to.charAt(valueIdx));
+                }
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionOptimisedMap.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionOptimisedMap.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.types.DataTypes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An option of translate() that
+ * - is based on a map for a lookup
+ * - use compile optimisation
+ */
+
+public class TranslateFunctionOptimisedMap extends Scalar<String, String> {
+
+    private final FunctionInfo functionInfo = new FunctionInfo(
+        new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)),
+        DataTypes.STRING);
+
+    public TranslateFunctionOptimisedMap() {
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return functionInfo;
+    }
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new TranslateFunctionOptimisedMap());
+    }
+
+    @Override
+    public Scalar<String, String> compile(List<Symbol> arguments) {
+        assert arguments.size() == 3 : "function's number of arguments must be 3";
+
+        Symbol fromSymbol = arguments.get(1);
+        if (!Literal.isLiteral(fromSymbol, DataTypes.STRING)) {
+            return this;
+        }
+
+        Symbol toSymbol = arguments.get(2);
+        if (!Literal.isLiteral(toSymbol, DataTypes.STRING)) {
+            return this;
+        }
+
+        var fromStr = (String) ((Input) fromSymbol).value();
+        var toStr = (String) ((Input) toSymbol).value();
+        return new WithPrecomputedTranslate(createTranslationMap(fromStr, toStr));
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, Input<String>... args) {
+        var text = args[0].value();
+        if (text == null) {
+            return null;
+        }
+
+        var from = args[1].value();
+        if (from == null) {
+            return null;
+        }
+
+        var to = args[2].value();
+        if (to == null) {
+            return null;
+        }
+
+        if (text.isEmpty() || from.isEmpty()) {
+            return text;
+        } else {
+            return translate(text, from, to);
+        }
+    }
+
+    private class WithPrecomputedTranslate extends TranslateFunctionOptimisedMap {
+        private final HashMap<Character, Optional<Character>> translationMap;
+
+        private WithPrecomputedTranslate(HashMap<Character, Optional<Character>> translationMap) {
+            this.translationMap = translationMap;
+        }
+
+        @SafeVarargs
+        @Override
+        public final String evaluate(TransactionContext txnCtx, Input<String>... args) {
+            var text = args[0].value();
+
+            if (text == null) {
+                return null;
+            }
+
+            if (text.isEmpty()) {
+                return text;
+            } else {
+                return translate(text, translationMap);
+            }
+        }
+    }
+
+    private String translate(String text, String from, String to) {
+        return applyTranslationsToText(text, createTranslationMap(from, to));
+    }
+
+    private String translate(String text, HashMap<Character, Optional<Character>> translationMap) {
+        return applyTranslationsToText(text, translationMap);
+    }
+
+    private HashMap<Character, Optional<Character>> createTranslationMap(String from, String to) {
+        var translationMap = new HashMap<Character, Optional<Character>>();
+        var fromLength = from.length();
+        var toLength = to.length();
+
+        for (int i = 0; i < fromLength; i++) {
+            Character fromChar = from.charAt(i);
+            /*
+             * we handle duplicate 'from' chars by using the first occurrence and dropping the consequent ones,
+             * so that we could preserve the compatibility of behaviour with PostgreSQL implementation
+             */
+            if (i < toLength) {
+                final var toChar = to.charAt(i);
+                translationMap.putIfAbsent(fromChar, Optional.of(toChar));
+            } else {
+                translationMap.putIfAbsent(fromChar, Optional.empty());
+            }
+        }
+        return translationMap;
+    }
+
+    private String applyTranslationsToText(String text, HashMap<Character, Optional<Character>> translationMap) {
+        var outputSb = new StringBuilder();
+
+        for (var ch: text.toCharArray()) {
+            var optToChar = translationMap.get(ch);
+            if (optToChar != null) {
+                optToChar.ifPresent(outputSb::append);
+            } else {
+                outputSb.append(ch);
+            }
+        }
+
+        return outputSb.toString();
+    }
+}

--- a/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionUnoptimisedMap.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TranslateFunctionUnoptimisedMap.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.TripleScalar;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.types.DataTypes;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+/**
+ * An option of translate() that
+ * - is based on a map for a lookup
+ * - does not use compile optimisation
+ */
+
+public final class TranslateFunctionUnoptimisedMap {
+
+    public static void register(ScalarFunctionModule module) {
+        var functionInfo = new FunctionInfo(new FunctionIdent("translate", ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)), DataTypes.STRING);
+        module.register(new TripleScalar<>(functionInfo, TranslateFunctionUnoptimisedMap::translate));
+    }
+
+    private static String translate(String text, String from, String to) {
+        if (from.isEmpty() || text.isEmpty()) {
+            return text;
+        } else {
+            return applyTranslationsToText(text, createTranslationMap(from, to));
+        }
+    }
+
+    private static HashMap<Character, Optional<Character>> createTranslationMap(String from, String to) {
+        var translationMap = new HashMap<Character, Optional<Character>>();
+        var fromLength = from.length();
+        var toLength = to.length();
+
+        for (int i = 0; i < fromLength; i++) {
+            Character fromChar = from.charAt(i);
+            /*
+             * we handle duplicate 'from' chars by using the first occurrence and dropping the consequent ones,
+             * so that we could preserve the compatibility of behaviour with PostgreSQL implementation
+             */
+            if (i < toLength) {
+                final var toChar = to.charAt(i);
+                translationMap.putIfAbsent(fromChar, Optional.of(toChar));
+            } else {
+                translationMap.putIfAbsent(fromChar, Optional.empty());
+            }
+        }
+        return translationMap;
+    }
+
+    private static String applyTranslationsToText(String text, HashMap<Character, Optional<Character>> translationMap) {
+        var outputSb = new StringBuilder();
+
+        for (var ch: text.toCharArray()) {
+            var optToChar = translationMap.get(ch);
+            if (optToChar != null) {
+                optToChar.ifPresent(outputSb::append);
+            } else {
+                outputSb.append(ch);
+            }
+        }
+
+        return outputSb.toString();
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class TranslateFunctionTest extends AbstractScalarFunctionsTest {
+    @Test
+    public void testNormalizeTranslateFunc() throws Exception {
+        assertNormalize("translate('Crate', 'Ct', 'Dk')", isLiteral("Drake"));
+    }
+
+    @Test
+    public void testEvaluateTranslateFunc() throws Exception {
+        assertEvaluate("translate(name, 'Ct', 'Dk')", "Drake", Literal.of(DataTypes.STRING, "Crate"));
+        assertEvaluate("translate('time', name, name)", "Zeit",
+                       Literal.of(DataTypes.STRING, "emit"), Literal.of(DataTypes.STRING, "tieZ"));
+    }
+
+    @Test
+    public void testWithEmptyTextField() throws Exception {
+        assertNormalize("translate('', 'Ct', 'Dk')", isLiteral(""));
+    }
+
+    @Test
+    public void testWithEmptyFromField() throws Exception {
+        // 'C' replaced with 'D', 't' replaced with 'k'
+        assertNormalize("translate('Crate', '', 'Dk')", isLiteral("Crate"));
+    }
+
+    @Test
+    public void testWithEmptyToField() throws Exception {
+        assertNormalize("translate('Crate', 're', '')", isLiteral("Cat"));
+    }
+
+    @Test
+    public void testWithFromFieldLargerThanToField() throws Exception {
+        // As from.length() > to.length(), unmatched chars in 'from' are removed
+        assertNormalize("translate('Crate', 'rCe', 'c')", isLiteral("cat"));
+    }
+
+    @Test
+    public void testWithToFieldLargerThanFromField() throws Exception {
+        // As to.length() > from.length(), unmatched chars in 'to' are ignored
+        assertNormalize("translate('Crate', 'C', 'Dk')", isLiteral("Drate"));
+    }
+
+    @Test
+    public void testWithDuplicateCharsInFromField() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Argument 'from' contains duplicate characters 'C'");
+        assertEvaluate("translate('Create', 'CtC', 'Dk')", null);
+    }
+
+    @Test
+    public void testWithNullArgument() {
+        assertEvaluate("translate(null, 'Ct', 'Dk')", null);
+        assertEvaluate("translate('Crate', null, 'Dk')", null);
+        assertEvaluate("translate('Crate', 'Ct', null)", null);
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
@@ -72,9 +72,7 @@ public class TranslateFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testWithDuplicateCharsInFromField() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Argument 'from' contains duplicate characters 'C'");
-        assertEvaluate("translate('Create', 'CtC', 'Dk')", null);
+        assertNormalize("translate('Crate', 'CtC', 'Dk')", isLiteral("Drake"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds TRANSLATE scalar string function to Crate that works like in PostgreSQL: (https://www.postgresqltutorial.com/postgresql-translate/).

The PR contains: 
- implementation of function
- unit tests
- documentation
