### PR TITLE
Add support for PostgreSQL record access syntax for objects

### DIFF
--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -91,7 +91,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         if (path.isEmpty()) {
             return DataTypes.UNDEFINED;
         }
-        DataType innerType = DataTypes.UNDEFINED;
+        DataType<?> innerType = DataTypes.UNDEFINED;
         ObjectType currentObject = this;
         for (int i = 0; i < path.size(); i++) {
             innerType = currentObject.innerTypes().get(path.get(i));

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,10 @@ None
 Changes
 =======
 
+- Added support for :ref:`record subscript <record-subscript>` syntax as
+  alternative to the existing :ref:`object subscript <object-subscript>`
+  syntax.
+
 - Added the :ref:`pi <scalar-pi>` scalar function.
 
 - Added a ``ceiling`` alias for the :ref:`ceil <scalar-ceil>` function for

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -101,6 +101,8 @@ the array which should be retrieved.
 
     :ref:`sql_dql_object_arrays_select`
 
+.. _object-subscript:
+
 Object subscript
 ----------------
 
@@ -115,6 +117,20 @@ should be retrieved.
 .. SEEALSO::
 
     :ref:`sql_dql_objects`
+
+.. _record-subscript:
+
+Record subscript
+----------------
+
+Record subscript is an alternative syntax for :ref:`object subscripts
+<object-subscript>`::
+
+    (obj_expression).key
+
+``obj_expression`` is an expression of type ``object`` and ``key`` is an
+identifier that refers to a field inside the object.
+
 
 Function call
 =============

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -234,7 +234,7 @@ primaryExpression
     | ident                                                                          #columnReference
     | qname '(' (setQuant? expr (',' expr)*)? ')' filter? over?                      #functionCall
     | subqueryExpression                                                             #subqueryExpressionDefault
-    // This case handles a simple parenthesized expression.
+    | '(' base=primaryExpression ')' '.' fieldName=ident                             #recordSubscript
     | '(' expr ')'                                                                   #nestedExpression
     // This is an extension to ANSI SQL, which considers EXISTS to be a <boolean expression>
     | EXISTS '(' query ')'                                                           #exists

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -39,6 +39,7 @@ import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CurrentTime;
+import io.crate.sql.tree.RecordSubscript;
 import io.crate.sql.tree.DoubleLiteral;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.ExistsPredicate;
@@ -144,6 +145,14 @@ public final class ExpressionFormatter {
         @Override
         public String visitIntervalLiteral(IntervalLiteral node, List<Expression> context) {
             return IntervalLiteral.format(node);
+        }
+
+        @Override
+        public String visitRecordSubscript(RecordSubscript recordSubscript, List<Expression> parameters) {
+            return '('
+                + recordSubscript.base().accept(this, parameters)
+                + ")."
+                + recordSubscript.field();
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -599,4 +599,8 @@ public abstract class AstVisitor<R, C> {
     public R visitAnalyze(AnalyzeStatement analyzeStatement, C context) {
         return visitStatement(analyzeStatement, context);
     }
+
+    public R visitRecordSubscript(RecordSubscript recordSubscript, C context) {
+        return visitExpression(recordSubscript, context);
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/RecordSubscript.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RecordSubscript.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+public final class RecordSubscript extends Expression {
+
+    private final Expression base;
+    private final String field;
+
+    public RecordSubscript(Expression base, String field) {
+        this.base = base;
+        this.field = field;
+    }
+
+    public Expression base() {
+        return base;
+    }
+
+    public String field() {
+        return field;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRecordSubscript(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RecordSubscript that = (RecordSubscript) o;
+
+        if (!base.equals(that.base)) {
+            return false;
+        }
+        return field.equals(that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = base.hashCode();
+        result = 31 * result + field.hashCode();
+        return result;
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1200,6 +1200,12 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_row_type_access() {
+        printStatement("SELECT (obj).col FROM tbl");
+        printStatement("SELECT ((obj).x).y FROM tbl");
+    }
+
+    @Test
     public void testSubscriptExpression() {
         Expression expression = SqlParser.createExpression("a['sub']");
         assertThat(expression, instanceOf(SubscriptExpression.class));

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2009,4 +2009,22 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expectMessage("Relation 'foobar' unknown. Maybe you meant one of: fooobar, \"Foobaarr\"");
         analyze("select * from foobar");
     }
+
+    @Test
+    public void test_nested_column_of_object_can_be_selected_using_composite_type_access_syntax() {
+        AnalyzedRelation relation = analyze("select (address).postcode from users");
+        assertThat(relation.outputs(), contains(isReference("address['postcode']")));
+    }
+
+    @Test
+    public void test_deep_nested_column_of_object_can_be_selected_using_composite_type_access_syntax() {
+        AnalyzedRelation relation = analyze("select ((details).stuff).name from deeply_nested");
+        assertThat(relation.outputs(), contains(isReference("details['stuff']['name']")));
+    }
+
+    @Test
+    public void test_record_subscript_syntax_can_be_used_on_object_literals() {
+        AnalyzedRelation rel = analyze("select ({x=10}).x");
+        assertThat(rel.outputs(), contains(isLiteral(10L)));
+    }
 }


### PR DESCRIPTION
## TODO

 - [x] Add documentation

## Summary of the changes / Why this improves CrateDB

This adds support for `(object_column).child_column` syntax as
alternative to `object_column['child_column']` to access the children of
object columns.

In PostgreSQL this syntax is used to access fields of composite columns:

https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-ACCESSING

CrateDB currently doesn't have composite columns in the same form as
PostgreSQL does, but `object` columns share a lot of similarity.

We can later on still add composite/row types and have them interop
mostly with `object` columns. (Basically treat composite type as an
extension to `object(strict)` in most regards.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)