### PR TITLE
Add returning for insert to analyzer

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -328,6 +328,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
     public R visitInsert(Insert<?> node, C context) {
         node.table().accept(this, context);
         node.insertSource().accept(this, context);
+        node.returningClause().forEach(x -> x.accept(this, context));
         return null;
     }
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -61,11 +63,24 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
     @Nullable
     private final Symbol clusteredBySymbol;
 
+    /**
+     * List of columns used for the result set.
+     */
+    @Nullable
+    private final List<Field> fields;
+
+    /**
+     * List of values or expressions used to be retrieved from the updated rows.
+     */
+    private final List<Symbol> returnValues;
+
     AnalyzedInsertStatement(AnalyzedRelation subQueryRelation,
                             DocTableInfo tableInfo,
                             List<Reference> targetColumns,
                             boolean ignoreDuplicateKeys,
-                            Map<Reference, Symbol> onDuplicateKeyAssignments) {
+                            Map<Reference, Symbol> onDuplicateKeyAssignments,
+                            List<ColumnIdent> outputNames,
+                            List<Symbol> returnValues) {
         this.targetTable = tableInfo;
         this.subQueryRelation = subQueryRelation;
         this.ignoreDuplicateKeys = ignoreDuplicateKeys;
@@ -103,6 +118,17 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
             generatedColumns,
             defaultExpressionColumns,
             false);
+        this.returnValues = returnValues;
+        if (!outputNames.isEmpty() && !returnValues.isEmpty()) {
+            this.fields = new ArrayList<>(outputNames.size());
+            Iterator<Symbol> outputsIterator = returnValues.iterator();
+            for (ColumnIdent path : outputNames) {
+                //TODO The relation in the field should be point semantically correctly to this
+                fields.add(new Field(this.subQueryRelation, path, outputsIterator.next()));
+            }
+        } else {
+            fields = null;
+        }
     }
 
     private static Map<ColumnIdent, Integer> toPositionMap(List<Reference> targetColumns) {
@@ -169,6 +195,16 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
             }
         }
         return symbols;
+    }
+
+    @Override
+    @Nullable
+    public List<Field> fields() {
+        return fields;
+    }
+
+    public List<Symbol> returnValues() {
+        return returnValues;
     }
 
     public List<Reference> columns() {

--- a/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -32,6 +32,7 @@ import io.crate.metadata.Reference;
 import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
 import io.crate.types.StringType;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
@@ -42,10 +43,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isInputColumn;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -358,4 +361,45 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             "is not convertible to the type 'object' of target column 'details'");
         e.analyze("insert into users (id, name, details) (select id, name, id from users)");
     }
+
+    @Test
+    public void test_insert_with_id_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id");
+        assertThat(stmt.fields(), contains(isField("id")));
+        assertThat(stmt.returnValues(), contains(isReference("id")));
+    }
+
+    @Test
+    public void test_insert_with_docid_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning _doc");
+        assertThat(stmt.fields(), contains(isField("_doc")));
+        assertThat(stmt.returnValues(), contains(isReference("_doc")));
+    }
+
+    @Test
+    public void test_insert_with_id_renamed_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id as foo");
+        assertThat(stmt.fields(), contains(isField("foo")));
+        assertThat(stmt.returnValues(), contains(isReference("id")));
+    }
+
+    @Test
+    public void test_insert_with_function_in_returning_clause() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning id + 1 as foo");
+        assertThat(stmt.fields(), contains(isField("foo")));
+        assertThat(stmt.returnValues(), contains(isFunction("add")));
+    }
+
+    @Test
+    public void test_insert_with_returning_all_columns() throws Exception {
+        AnalyzedInsertStatement stmt =
+            e.analyze("insert into users(id, name) values(1, 'max') returning *");
+        assertThat(stmt.fields().size(), is(17));
+        assertThat(stmt.returnValues().size(), is(17));
+    }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds return values and output fields to the `AnalyzedInsertStatement` and the `InsertAnalyzer`. 


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
