### PR TITLE
Make sure planner errors don't cause queries to get stuck

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -22,9 +22,9 @@
 
 package io.crate.planner.operators;
 
+import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
-import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueriedSelectRelation;
@@ -411,7 +411,13 @@ public class LogicalPlanner {
                                   Row params,
                                   SubQueryResults subQueryResults,
                                   boolean enableProfiling) {
-        NodeOperationTree nodeOpTree = getNodeOperationTree(logicalPlan, dependencies, plannerContext, params, subQueryResults);
+        NodeOperationTree nodeOpTree;
+        try {
+            nodeOpTree = getNodeOperationTree(logicalPlan, dependencies, plannerContext, params, subQueryResults);
+        } catch (Throwable t) {
+            consumer.accept(null, t);
+            return;
+        }
         executeNodeOpTree(
             dependencies,
             plannerContext.transactionContext(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If there were assertion errors during the execution of a multi-phase
operator (sub-query), the query could get stuck.

This only happened when a programmer mistake happened elsewhere, so isn't
a user facing issue.

This will make it easier to debug such issues as tests don't get stuck
but fail with an exception.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)