### PR TITLE
Using SortingProjector instead of SortingTopNProjector for testUsedMemoryIsAccountedFor test case

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -124,7 +124,7 @@ public class SortingProjectorTest extends CrateUnitTest {
     public void testUsedMemoryIsAccountedFor() throws Exception {
         MemoryCircuitBreaker circuitBreaker = new MemoryCircuitBreaker(new ByteSizeValue(30, ByteSizeUnit.BYTES),
                                                                        1,
-                                                                       LogManager.getLogger(SortingTopNProjectorTest.class)
+                                                                       LogManager.getLogger(SortingProjectorTest.class)
         );
         RowCellsAccountingWithEstimators rowAccounting =
             new RowCellsAccountingWithEstimators(List.of(DataTypes.LONG, DataTypes.BOOLEAN),


### PR DESCRIPTION
# Summary of the changes / Why this improves CrateDB

Using `SortingProjector` instead of `SortingTopNProjector` for `testUsedMemoryIsAccountedFor` test case

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
