### PR TITLE
Add returning for insert to storage engine

### DIFF
--- a/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -257,6 +257,7 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
         private final BitSet successfulWrites = new BitSet();
         private final BitSet failureLocations = new BitSet();
+        private final ArrayList<Object[]> resultRows = new ArrayList<>();
 
         public void update(ShardResponse response) {
             IntArrayList itemIndices = response.itemIndices();
@@ -270,6 +271,10 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
                     failureLocations.set(location, true);
                 }
             }
+            List<Object[]> resultRows = response.getResultRows();
+            if (resultRows != null) {
+                this.resultRows.addAll(resultRows);
+            }
         }
 
         public boolean successfulWrites(int location) {
@@ -278,6 +283,10 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
 
         public boolean failed(int location) {
             return failureLocations.get(location);
+        }
+
+        public List<Object[]> resultRows() {
+            return resultRows;
         }
 
         public int numSuccessfulWrites() {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/FromRawInsertSource.java
@@ -24,13 +24,25 @@ package io.crate.execution.dml.upsert;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class FromRawInsertSource implements InsertSourceGen {
 
-    @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public BytesReference generateSourceAndCheckConstraintsAsBytesReference(Object[] values) throws IOException {
         return new BytesArray(((String) values[0]));
+    }
+
+    @Override
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
+        return JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            new BytesArray(((String) values[0])).array()
+        ).map();
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
@@ -33,8 +33,6 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -63,7 +61,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
     }
 
     @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
         String rawSource = (String) values[0];
         Map<String, Object> source = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
         mixinDefaults(source, defaults);
@@ -73,7 +71,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
         for (Map.Entry<ColumnIdent, Input<?>> entry : generatedCols.entrySet()) {
             source.putIfAbsent(entry.getKey().fqn(), entry.getValue().value());
         }
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        return source;
     }
 
     private Map<Reference, Object> buildDefaults(List<Reference> defaults,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -39,9 +39,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.xcontent.XContentFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -97,7 +95,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     }
 
     @Override
-    public BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
         row.firstCells(values);
         row.secondCells(defaultValues);
 
@@ -125,8 +123,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
             Maps.mergeInto(source, column.name(), column.path(), entry.getValue().value());
         }
         checks.validate(source);
-
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        return source;
     }
 
     private static Tuple<List<Reference>, Object[]> addDefaults(List<Reference> targets,

--- a/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -28,13 +28,19 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public interface InsertSourceGen {
 
-    BytesReference generateSourceAndCheckConstraints(Object[] values) throws IOException;
+    default BytesReference generateSourceAndCheckConstraintsAsBytesReference(Object[] values) throws IOException {
+        return BytesReference.bytes(XContentFactory.jsonBuilder().map(generateSourceAndCheckConstraints(values)));
+    }
+
+    Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException;
 
     static InsertSourceGen of(TransactionContext txnCtx,
                               Functions functions,
@@ -51,4 +57,5 @@ public interface InsertSourceGen {
         }
         return new InsertSourceFromCells(txnCtx, functions, table, indexName, validation, targets);
     }
+
 }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public abstract class AbstractIndexWriterProjection extends Projection {
 
-    public static final List<Symbol> OUTPUTS = ImmutableList.of(new InputColumn(0, DataTypes.LONG));  // number of rows imported
+    public static final List<? extends Symbol> OUTPUTS = ImmutableList.of(new InputColumn(0, DataTypes.LONG));  // number of rows imported
 
     private static final String BULK_SIZE = "bulk_size";
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -78,7 +78,9 @@ public class ColumnIndexWriterProjector implements Projector {
                                       @Nullable Map<Reference, Symbol> updateAssignments,
                                       int bulkActions,
                                       boolean autoCreateIndices,
-                                      UUID jobId) {
+                                      List<Symbol> returnValues,
+                                      UUID jobId
+                                      ) {
         RowShardResolver rowShardResolver = new RowShardResolver(
             txnCtx, functions, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
         assert columnReferences.size() == insertInputs.size()
@@ -94,6 +96,9 @@ public class ColumnIndexWriterProjector implements Projector {
             updateColumnNames = convert.targetNames();
             assignments = convert.sources();
         }
+
+        Symbol[] returnValueOrNull = returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[]{});
+
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
@@ -101,13 +106,21 @@ public class ColumnIndexWriterProjector implements Projector {
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
-            null,
+            returnValueOrNull,
             jobId,
             true);
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, assignments, insertValues.materialize(), null, null, null, null);
+            id -> new ShardUpsertRequest.Item(id,
+                                              assignments,
+                                              insertValues.materialize(),
+                                              null,
+                                              null,
+                                              null,
+                                              returnValueOrNull);
+
+        var upsertResultContext = returnValues.isEmpty() ? UpsertResultContext.forRowCount() : UpsertResultContext.forResultValues();
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
@@ -126,7 +139,7 @@ public class ColumnIndexWriterProjector implements Projector {
             transportActionProvider.transportBulkCreateIndicesAction(),
             targetTableNumShards,
             targetTableNumReplicas,
-            UpsertResultContext.forRowCount()
+            upsertResultContext
         );
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
@@ -53,6 +53,22 @@ public class UpsertResultContext {
         };
     }
 
+    public static UpsertResultContext forResultValues() {
+        return new UpsertResultContext(
+            () -> null, () -> null, () -> null, Collections.emptyList(), UpsertResultCollectors.newResultValueCollector()) {
+
+            @Override
+            BiConsumer<ShardedRequests, String> getItemFailureRecorder() {
+                return (s, f) -> { };
+            }
+
+            @Override
+            Predicate<ShardedRequests> getHasSourceUriFailureChecker() {
+                return (ignored) -> false;
+            }
+        };
+    }
+
     public static UpsertResultContext forReturnSummary(TransactionContext txnCtx,
                                                        SourceIndexWriterReturnSummaryProjection projection,
                                                        DiscoveryNode discoveryNode,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
@@ -53,6 +53,11 @@ class UpsertResults {
         result.successRowCount += successRowCount;
     }
 
+    void addResultValues(List<Object[]> resultValues) {
+        Result result = getResultSafe(null);
+        result.resultValues.addAll(resultValues);
+    }
+
     void addResult(String uri, @Nullable String failureMessage, long lineNumber) {
         Result result = getResultSafe(uri);
         if (failureMessage == null) {
@@ -83,6 +88,10 @@ class UpsertResults {
         return getResultSafe(null).successRowCount;
     }
 
+    List<Object[]> getResultValuesForNoUri() {
+        return getResultSafe(null).resultValues;
+    }
+
     void merge(UpsertResults other) {
         for (Map.Entry<String, Result> entry : other.resultsByUri.entrySet()) {
             Result result = resultsByUri.get(entry.getKey());
@@ -91,7 +100,6 @@ class UpsertResults {
             } else {
                 result.merge(entry.getValue());
             }
-
         }
     }
 
@@ -118,6 +126,8 @@ class UpsertResults {
         private long errorRowCount = 0;
         private final Map<String, Map<String, Object>> errors = new HashMap<>();
         private boolean sourceUriFailure = false;
+        private final List<Object[]> resultValues = new ArrayList<>();
+
 
         void merge(Result upsertResult) {
             successRowCount += upsertResult.successRowCount;
@@ -132,6 +142,7 @@ class UpsertResults {
                 Long errorCnt = (Long) val.get(ERROR_COUNT_KEY);
                 updateErrorCount(entry.getKey(), lineNumbers, errorCnt);
             }
+            resultValues.addAll(upsertResult.resultValues);
         }
 
         private void updateErrorCount(String msg, List<Long> lineNumbers, Long increaseBy) {

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -494,6 +494,7 @@ public class ProjectionToProjectorVisitor
             projection.onDuplicateKeyAssignments(),
             projection.bulkActions(),
             projection.autoCreateIndices(),
+            projection.returnValues(),
             context.jobId
         );
     }

--- a/sql/src/main/java/io/crate/expression/reference/Doc.java
+++ b/sql/src/main/java/io/crate/expression/reference/Doc.java
@@ -90,18 +90,6 @@ public final class Doc {
         return index;
     }
 
-    public Doc withVersionAndSeqNo(long version, long seqNo) {
-        return new Doc(
-            docId,
-            index,
-            id,
-            version,
-            seqNo,
-            primaryTerm,
-            source,
-            raw);
-    }
-
     public Doc withUpdatedSource(Map<String, Object> updatedSource) {
         return new Doc(
             docId,

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -95,7 +95,7 @@ public class Insert implements LogicalPlan {
 
     @Override
     public List<Symbol> outputs() {
-        return MergeCountProjection.OUTPUTS;
+        return (List<Symbol>) writeToTable.outputs();
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
@@ -56,9 +56,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
     }
@@ -68,9 +66,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
             txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
-        BytesReference source = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
         assertThat(Maps.getByPath(map, "x"), is(2));
         assertThat(Maps.getByPath(map, "y"), is(3));
     }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -90,8 +90,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":2,\"z\":3}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
+        assertThat(source, is(Map.of("x", 1, "y", 2, "z", 3)));
     }
 
     @Test
@@ -109,9 +109,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
+        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
         assertThat(map.get("b"), is(11));
         assertThat(Maps.getByPath(map, "obj.a"), is(10));
         assertThat(Maps.getByPath(map, "obj.c"), is(13));
@@ -153,8 +151,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x));
 
         Object[] input = new Object[]{1};
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"crate\"}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        assertThat(source, is(Map.of("x", 1, "y", "crate")));
     }
 
     @Test
@@ -168,8 +166,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
 
         Object[] input = {1, "cr8"};
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(input);
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":\"cr8\"}"));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        assertThat(source, is(Map.of("x", 1, "y", "cr8")));
     }
 
     @Test
@@ -184,13 +182,11 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 13);
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
 
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.a"), is(10));
-        assertThat(Maps.getByPath(map, "b"), is(11));
-        assertThat(Maps.getByPath(map, "obj.c"), is(13));
+        assertThat(Maps.getByPath(source, "obj.a"), is(10));
+        assertThat(Maps.getByPath(source, "b"), is(11));
+        assertThat(Maps.getByPath(source, "obj.c"), is(13));
     }
 
     @Test
@@ -220,11 +216,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("y", 2);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.x"), is(0));
-        assertThat(Maps.getByPath(map, "obj.y"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        assertThat(Maps.getByPath(source, "obj.x"), is(0));
+        assertThat(Maps.getByPath(source, "obj.y"), is(2));
     }
 
     @Test
@@ -238,11 +232,8 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.functions(), t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
-
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "obj.x"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        assertThat(Maps.getByPath(source, "obj.x"), is(2));
     }
 
     @Test
@@ -250,11 +241,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t6 = e.resolveTableInfo("t6");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.functions(), t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
-        Map<String, Object> map = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(source)).map();
-        assertThat(Maps.getByPath(map, "x"), is(1));
-        assertThat(Maps.getByPath(map, "y"), is(2));
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
+        assertThat(Maps.getByPath(source, "x"), is(1));
+        assertThat(Maps.getByPath(source, "y"), is(2));
     }
 
     @Test
@@ -271,9 +260,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             GeneratedColumns.Validation.VALUE_MATCH,
             List.of(Objects.requireNonNull(tableInfo.getReference(new ColumnIdent("x")))));
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
 
-        assertThat(source.utf8ToString(), is("{\"x\":1,\"y\":1}"));
+        assertThat(source, is(Map.of("x", 1, "y", 1)));
     }
 
     @Test
@@ -293,9 +282,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             GeneratedColumns.Validation.VALUE_MATCH,
             List.of());
 
-        BytesReference source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
 
-        assertThat(source.utf8ToString(), is("{\"x\":\"test\"}"));
+        assertThat(source, is(Map.of("x", "test")));
     }
 
     @Test
@@ -314,7 +303,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         );
         var payloads = List.of(Map.of("x", 10), Map.of("x", 20));
         var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { payloads });
-        assertThat(source.utf8ToString(), is("{\"payloads\":[{\"x\":10},{\"x\":20}]}"));
+        assertThat(source, is(Map.of("payloads", List.of(Map.of("x", 10), Map.of("x", 20)))));
     }
 
     @Test
@@ -338,6 +327,6 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         obj.put("x", 10);
         obj.put("p", 1);
         var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { obj });
-        assertThat(source.utf8ToString(), is("{\"obj\":{\"x\":10}}"));
+        assertThat(source, is(Map.of("obj", Map.of("x", 10))));
     }
 }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -115,17 +115,14 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 tasksService, indicesService, shardStateAction, functions, schemas, indexNameExpressionResolver);
         }
 
-        @Nullable
         @Override
-        protected IndexItemResponse indexItem(ShardUpsertRequest request,
-                                              ShardUpsertRequest.Item item,
-                                              IndexShard indexShard,
-                                              boolean tryInsertFirst,
-                                              UpdateSourceGen updateSourceGen,
-                                              InsertSourceGen insertSourceGen,
-                                              ReturnValueGen returnValueGen,
-                                              boolean isRetry) throws Exception {
-             throw new VersionConflictEngineException(
+        protected IndexItemResponse insert(ShardUpsertRequest request,
+                                           ShardUpsertRequest.Item item,
+                                           IndexShard indexShard,
+                                           boolean isRetry,
+                                           @Nullable ReturnValueGen returnGen,
+                                           @Nullable InsertSourceGen insertSourceGen) throws Exception {
+            throw new VersionConflictEngineException(
                 indexShard.shardId(),
                 item.id(),
                 "document with id: " + item.id() + " already exists in '" + request.shardId().getIndexName() + '\'');

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -92,7 +92,9 @@ public class ColumnIndexWriterProjectionTest {
             null,
             null,
             Settings.EMPTY,
-            true
+            true,
+            List.of(),
+            null
         );
 
         assertThat(projection.columnReferencesExclPartition(), Matchers.is(Arrays.asList(

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1458,4 +1458,133 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
                "5| cr8\n")
         );
     }
+
+    @Test
+    public void test_insert_with_id_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id) values (?) returning id",
+                new Object[]{1});
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("id"));
+        assertThat(response.rows()[0][0], is(1));
+
+    }
+
+    @Test
+    public void test_insert_with_multiple_values_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id) values (?) returning id, owner",
+                new Object[]{1});
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("id"));
+        assertThat(response.cols()[1], is("owner"));
+        assertThat(response.rows()[0][0], is(1));
+        assertThat(response.rows()[0][1], is("crate"));
+
+    }
+
+    @Test
+    public void test_insert_with_function_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id) values (?) returning id + 1 as bar",
+                new Object[]{1});
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("bar"));
+        assertThat(response.rows()[0][0], is(2));
+
+    }
+
+
+    @Test
+    public void test_insert_with_seq_no_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id) values (?) returning _seq_no as seq",
+                new Object[]{1});
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("seq"));
+        assertThat(response.rows()[0][0], is(0L));
+
+    }
+
+    @Test
+    public void test_insert_with_owner_renamed_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id) values (?) returning owner as name",
+                new Object[]{1});
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("name"));
+        assertThat(response.rows()[0][0], is("crate"));
+
+    }
+
+        public void test_insert_from_subquery_with_id_field_in_returning_clause() {
+        execute("create table t (" +
+                " id int," +
+                " owner text default 'crate'" +
+                ") with (number_of_replicas=0)");
+
+        execute("insert into t (id)  select '1' as id returning id as foo, owner as name");
+
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.cols()[0], is("foo"));
+        assertThat(response.rows()[0][0], is(1));
+        assertThat(response.cols()[1], is("name"));
+        assertThat(response.rows()[0][1], is("crate"));
+
+    }
+
+    @Test
+    public void test_insert_from_values_on_duplicate_key_with_id_in_returning_clause() {
+        execute("create table t1 (id integer primary key, other string) clustered into 1 shards");
+        execute("insert into t1 (id, other) values (1, 'test'), (2, 'test2')");
+
+        execute("insert into t1 (id, other) values (1, 'updated') ON CONFLICT (id) DO UPDATE SET other = 'updated' returning id, other");
+        assertThat(response.rowCount(), is(1L));
+        refresh();
+
+        assertThat(response.cols()[0], is("id"));
+        assertThat(response.rows()[0][0], is(1));
+
+        assertThat(response.cols()[1], is("other"));
+        assertThat(response.rows()[0][1], is("updated"));
+
+        execute("insert into t1 (id, other) values (1, 'updated_again'), (3, 'new') ON CONFLICT (id) DO UPDATE SET other = excluded.other returning id, other");
+        assertThat(response.rowCount(), is(2L));
+        refresh();
+
+        assertThat(response.cols()[0], is("id"));
+        assertThat(response.cols()[1], is("other"));
+
+        assertThat(response.rows()[0][0], is(1));
+        assertThat(response.rows()[0][1], is("updated_again"));
+
+        assertThat(response.rows()[1][0], is(3));
+        assertThat(response.rows()[1][1], is("new"));
+
+    }
 }

--- a/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import io.crate.analyze.TableDefinitions;
+import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class InsertFromSubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws IOException {
+        e = buildExecutor(clusterService);
+    }
+
+    private static SQLExecutor buildExecutor(ClusterService clusterService) throws IOException {
+        return SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
+    }
+
+    @Test
+    public void test_returning_for_insert_from_values_throw_error_with_4_1_nodes() throws Exception {
+        // Make sure the former initialized cluster service is shutdown
+        cleanup();
+        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        e = buildExecutor(clusterService);
+        expectedException.expect(UnsupportedFeatureException.class);
+        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
+        e.plan("insert into users (id, name) values (1, 'bob') returning id");
+
+    }
+
+    @Test
+    public void test_returning_for_insert_from_subquery_throw_error_with_4_1_nodes() throws Exception {
+        // Make sure the former initialized cluster service is shutdown
+        cleanup();
+        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        e = buildExecutor(clusterService);
+        expectedException.expect(UnsupportedFeatureException.class);
+        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
+        e.plan("insert into users (id, name) select '1' as id, 'b' as name returning id");
+    }
+
+}

--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -137,7 +137,7 @@ public final class QueryTester implements AutoCloseable {
                 GeneratedColumns.Validation.NONE,
                 Collections.singletonList(table.getReference(ColumnIdent.fromPath(column)))
             );
-            BytesReference source = sourceGen.generateSourceAndCheckConstraints(new Object[]{value});
+            BytesReference source = sourceGen.generateSourceAndCheckConstraintsAsBytesReference(new Object[]{value});
             SourceToParse sourceToParse = new SourceToParse(
                 table.concreteIndices()[0],
                 UUIDs.randomBase64UUID(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds support for the returning clause for the insert-from-values as well as the insert-from-subqueries usecase e.g.:

`insert into t (id) values (1) returning id as foo`

`insert into t (id)  select '1' as id returning id as foo`



 

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
