### PR TITLE
Make cast error message more verbose

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -302,7 +302,7 @@ exceeded an `ArithmeticException` will be raised.
 ::
 
     cr> select sum(name), kind from locations group by kind order by sum(name) desc;
-    SQLActionException[SQLParseException: Cannot cast name to type [double precision, real, bigint, integer, smallint, char]]
+    SQLActionException[SQLParseException: Cannot cast `name` of type `text` to any of the types: [double precision, real, bigint, integer, smallint, char]]
 
 ``avg`` and ``mean``
 --------------------

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -199,7 +199,7 @@ Example::
 
     cr> insert into my_table_ips (fqdn, ip_addr)
     ... values ('localhost', 'not.a.real.ip');
-    SQLActionException[SQLParseException: Cannot cast 'not.a.real.ip' to type ip]
+    SQLActionException[SQLParseException: Cannot cast `'not.a.real.ip'` of type `text` to type `ip`]
 
 Ip addresses support the binary operator `<<`, which checks for subnet inclusion
 using `CIDR notation`_ [ip address/prefix_length]. The left operand must be of

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -73,8 +73,14 @@ public final class ValueNormalizer {
             throw new ColumnValidationException(
                 reference.column().name(),
                 tableInfo.ident(),
-                String.format(Locale.ENGLISH, "Cannot cast %s to type %s", SymbolPrinter.INSTANCE.printUnqualified(valueSymbol),
-                    reference.valueType().getName()));
+                String.format(
+                    Locale.ENGLISH,
+                    "Cannot cast expression `%s` of type `%s` to `%s`",
+                    SymbolPrinter.INSTANCE.printUnqualified(valueSymbol),
+                    valueSymbol.valueType().getName(),
+                    reference.valueType().getName()
+                )
+            );
         }
         Object value = literal.value();
         if (value == null) {

--- a/sql/src/main/java/io/crate/exceptions/ConversionException.java
+++ b/sql/src/main/java/io/crate/exceptions/ConversionException.java
@@ -31,43 +31,49 @@ import java.util.Locale;
 
 public class ConversionException extends IllegalArgumentException {
 
-    private static final String ERROR_MESSAGE = "Cannot cast %s to type %s";
-
-    public ConversionException(FuncArg symbol, Collection<DataType> dataTypes) {
-        super(generateMessage(symbol, dataTypes));
+    public ConversionException(FuncArg source, Collection<DataType> targetTypeCandidates) {
+        super(String.format(
+            Locale.ENGLISH,
+            "Cannot cast `%s` of type `%s` to %s",
+            formatFuncArg(source),
+            source.valueType(),
+            targetTypeCandidates.size() > 1
+                ? "any of the types: " + targetTypeCandidates.toString()
+                : "type `" + targetTypeCandidates.iterator().next().getName() + "`"
+        ));
     }
 
-    public ConversionException(Symbol symbol, DataType targetType) {
-        super(generateMessage(symbol, targetType));
+    public ConversionException(FuncArg source, DataType<?> targetType) {
+        super(String.format(
+            Locale.ENGLISH,
+            "Cannot cast `%s` of type `%s` to %s",
+            formatFuncArg(source),
+            source.valueType(),
+            "type `" + targetType.getName() + "`"
+        ));
     }
 
-    public ConversionException(Object value, DataType type) {
-        super(generateMessage(value, type));
+    public ConversionException(DataType<?> sourceType, DataType<?> targetType) {
+        super(String.format(
+            Locale.ENGLISH,
+            "Cannot cast expressions from type `%s` to type `%s`",
+            sourceType.getName(),
+            targetType.getName()
+        ));
     }
 
-    private static String generateMessage(FuncArg arg, Collection<DataType> dataTypes) {
-        String dataTypeString = dataTypes.size() > 1 ?
-            dataTypes.toString() :
-            dataTypes.iterator().next().toString();
-        if (arg instanceof Symbol) {
-            return String.format(Locale.ENGLISH, ERROR_MESSAGE,
-                SymbolPrinter.INSTANCE.printUnqualified((Symbol) arg), dataTypeString);
-        }
-        return String.format(Locale.ENGLISH, ERROR_MESSAGE, arg, dataTypeString);
+    public ConversionException(Object sourceValue, DataType<?> targetType) {
+        super(String.format(
+            Locale.ENGLISH,
+            "Cannot cast value `%s` to type `%s`",
+            sourceValue,
+            targetType.getName()
+        ));
     }
 
-    private static String generateMessage(Symbol value, DataType type) {
-        return String.format(Locale.ENGLISH, ERROR_MESSAGE,
-            SymbolPrinter.INSTANCE.printUnqualified(value), type.toString());
-    }
-
-    private static String generateMessage(Object value, DataType type) {
-        if (value instanceof Symbol) {
-            return generateMessage((Symbol) value, type);
-        } else if (value instanceof String) {
-            return String.format(Locale.ENGLISH, ERROR_MESSAGE,
-                String.format(Locale.ENGLISH, "'%s'", value), type.toString());
-        }
-        return String.format(Locale.ENGLISH, ERROR_MESSAGE, value.toString(), type.toString());
+    private static String formatFuncArg(FuncArg source) {
+        return source instanceof Symbol
+            ? SymbolPrinter.INSTANCE.printUnqualified(((Symbol) source))
+            : source.toString();
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/FuncArg.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FuncArg.java
@@ -33,7 +33,7 @@ public interface FuncArg {
      * Returns the {@link DataType} of this {@link Function} argument.
      * @return The DataType of the value.
      */
-    DataType valueType();
+    DataType<?> valueType();
 
     /**
      * Indicates whether a Symbol can be casted or not.

--- a/sql/src/main/java/io/crate/metadata/functions/params/Param.java
+++ b/sql/src/main/java/io/crate/metadata/functions/params/Param.java
@@ -211,15 +211,14 @@ public final class Param {
     }
 
     private FuncArg rebind(FuncArg bound, FuncArg newTarget) {
-        DataType boundType = bound.valueType();
-        DataType dataType = Objects.requireNonNull(newTarget.valueType(),
-            "Provided dataType type must not be null");
-        if (boundType.equals(dataType)) {
+        DataType<?> boundType = bound.valueType();
+        DataType<?> targetType = Objects.requireNonNull(newTarget.valueType(), "Provided dataType type must not be null");
+        if (boundType.equals(targetType)) {
             return bound;
         }
         FuncArg convertedType = convertTypes(newTarget, bound);
         if (convertedType == null) {
-            throw new ConversionException(newTarget, boundType);
+            throw new ConversionException(bound, targetType);
         }
         return convertedType;
     }

--- a/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
@@ -136,7 +136,7 @@ public class CompoundLiteralTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testArrayDifferentTypes() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'string' to type bigint");
+        expectedException.expectMessage("Cannot cast `'string'` of type `text` to type `bigint`");
         analyzeExpression("[1, 'string']");
     }
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -472,7 +472,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testWhereInSelectDifferentDataTypeValueIncompatibleDataTypes() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type bigint");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         analyze("select 'found' from users where 1 in (1, 'foo', 2)");
     }
 
@@ -681,7 +681,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testNotTimestamp() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast date to type boolean");
+        expectedException.expectMessage("Cannot cast `date` of type `timestamp with time zone` to type `boolean`");
         analyze("select id, name from parted where not date");
     }
 
@@ -826,7 +826,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArrayCompareInvalidArray() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast name to type undefined_array");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `undefined_array`");
         analyze("select * from users where 'George' = ANY (name)");
     }
 
@@ -872,7 +872,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast 5 to type bigint_array");
+        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `bigint`");
         analyze("select * from users where 5 = friends['id']");
     }
 
@@ -1012,7 +1012,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAnyLikeInvalidArray() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast name to type undefined_array");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `undefined_array`");
         analyze("select * from users where 'awesome' LIKE ANY (name)");
     }
 
@@ -1139,7 +1139,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchPredicateWithWrongQueryTerm() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [10, 20] to type text");
+        expectedException.expectMessage("Cannot cast `[10, 20]` of type `bigint_array` to type `text`");
         analyze("select name from users order by match(name, [10, 20])");
     }
 
@@ -1345,7 +1345,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRegexpMatchInvalidArg() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast floats to type text");
+        expectedException.expectMessage("Cannot cast `floats` of type `real` to type `text`");
         analyze("select * from users where floats ~ 'foo'");
     }
 
@@ -1511,7 +1511,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testInvalidCastExpression() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast text to type object_array");
+        expectedException.expectMessage("Cannot cast expressions from type `text` to type `object_array`");
         analyze("select cast(name as array(object)) from users");
     }
 
@@ -1766,7 +1766,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 1 to type undefined_array");
+        expectedException.expectMessage("Cannot cast `1` of type `bigint` to type `undefined_array`");
         analyze("select * from unnest(1, 'foo')");
     }
 

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -169,14 +169,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNumericTypeOutOfRange() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for shorts: Cannot cast -100000 to type smallint");
+        expectedException.expectMessage("Validation failed for shorts: Cannot cast expression `-100000` of type `bigint` to `smallint`");
         analyze("update users set shorts=-100000");
     }
 
     @Test
     public void testNumericOutOfRangeFromFunction() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for bytes: Cannot cast 1234 to type char");
+        expectedException.expectMessage("Validation failed for bytes: Cannot cast expression `1234` of type `bigint` to `char`");
         analyze("update users set bytes=abs(-1234)");
     }
 

--- a/sql/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -55,7 +55,7 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_error_is_raised_if_the_types_of_the_rows_are_not_compatible() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type bigint");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         e.analyze("VALUES (1), ('foo')");
     }
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -327,7 +327,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testIncompatibleLiteralThrowsException() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 2147483648 to type integer");
+        expectedException.expectMessage("Cannot cast `2147483648` of type `bigint` to type `integer`");
         executor.asSymbol("doc.t2.i = 1 + " + Integer.MAX_VALUE);
     }
 
@@ -387,7 +387,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("Cannot cast bigint to type integer_array");
+        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `bigint`");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -277,7 +277,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnyInvalidArrayType() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast ['foo', 'bar', 'baz'] to type boolean_array");
+        expectedException.expectMessage("Cannot cast `['foo', 'bar', 'baz']` of type `text_array` to type `boolean_array`");
         analyzeSelectWhere("select * from users_multi_pk where awesome = any(['foo', 'bar', 'baz'])");
     }
 
@@ -295,7 +295,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         WhereClause whereClause = analyzeSelectWhere(s);
         assertThat(whereClause.query(), isFunction(AnyOperators.Names.EQ,
-            ImmutableList.<DataType>of(DataTypes.INTEGER, new ArrayType(DataTypes.INTEGER))));
+            ImmutableList.of(DataTypes.INTEGER, new ArrayType<>(DataTypes.INTEGER))));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayBoundFunctionResolverTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayBoundFunctionResolverTest.java
@@ -50,7 +50,7 @@ public class ArrayBoundFunctionResolverTest extends AbstractScalarFunctionsTest 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [2] to type integer");
+        expectedException.expectMessage("Cannot cast `[2]` of type `bigint_array` to type `integer`");
         assertEvaluate("array_lower([1], [2])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -105,14 +105,14 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testConvertNonNumericStringToNumber() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast ['foo', 'bar'] to type bigint_array");
+        expectedException.expectMessage("Cannot cast `['foo', 'bar']` of type `text_array` to type `bigint_array`");
         assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast [true] to type geo_point_array");
+        expectedException.expectMessage("Cannot cast `_array(geopoint)` of type `geo_point_array` to type `boolean_array`");
         assertEvaluate("array_unique([geopoint], [true])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -40,7 +40,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testArgumentThatHasNoStringRepr() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast [1] to type text");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint_array`");
         assertNormalize("concat('foo', [1])", null);
     }
 
@@ -83,7 +83,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast [1, 2] to type text");
+        expectedException.expectMessage("Cannot cast `[1, 2]` of type `bigint_array` to type `text`");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/SubstrFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/SubstrFunctionTest.java
@@ -85,7 +85,7 @@ public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testInvalidArgs() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'b' to type integer");
+        expectedException.expectMessage("Cannot cast `'b'` of type `text` to type `integer`");
         assertNormalize("substr('foo', 'b')", null);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
@@ -40,7 +40,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("'1' = 1", true);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type bigint");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         assertEvaluate("'foo' = 1", true);
     }
 
@@ -66,7 +66,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("case 1 when 1.0 then 'foo' else 'bar' end", "foo");
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type bigint");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         assertEvaluate("case 1 when 'foo' then 'foo' else 'bar' end", "bar");
     }
 
@@ -78,7 +78,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("1.2 in (null, 1::integer, 2::long, 3.0)", null);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double precision");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertEvaluate("1 in (null, 1::integer, 2::long, 3.0, 'foo')", true);
     }
 
@@ -90,7 +90,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("1.2 = ANY ([null, 1::integer, 2::long, 3.0])", null);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double precision");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertEvaluate("1 = ANY ([null, 1::integer, 2::long, 3.0, 'foo'])", true);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -43,7 +43,7 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWrongType() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertEvaluate("abs('foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
@@ -37,7 +37,7 @@ public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTypeValidation() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type bigint");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         assertEvaluate("ARRAY[1, 'foo']", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
@@ -41,7 +41,7 @@ public class Ignore3vlFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWrongType() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type boolean");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
         assertEvaluate("ignore3vl('foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -85,7 +85,7 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeString() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertNormalize("log('foo')", Matchers.nullValue());
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -44,7 +44,7 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testInvalidType() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertEvaluate("round('foo')", null);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -48,7 +48,7 @@ public class SquareRootFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testInvalidType() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type double precision");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
         assertEvaluate("sqrt('foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -134,7 +134,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCaseConditionNotBooleanThrowsIllegalArgumentException() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type boolean");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
         assertEvaluate("case when 'foo' then x else 1 end", "");
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -43,7 +43,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testResolveWithInvalidType() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast '1' to type geo_point");
+        expectedException.expectMessage("Cannot cast `'1'` of type `text` to type `geo_point`");
         assertNormalize("distance(1, 'POINT (11 21)')", null);
     }
 
@@ -68,7 +68,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeWithInvalidReferences() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [10.04, 28.02] to type text");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `double precision_array`");
         assertNormalize("distance(name, [10.04, 28.02])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
@@ -57,7 +57,7 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeFromInvalidLiteral() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage(stringContainsInOrder(Arrays.asList("Cannot cast", "to type geo_shape")));
+        expectedException.expectMessage(stringContainsInOrder(Arrays.asList("Cannot cast ", "to type `geo_shape`")));
         assertNormalize("intersects({type='LineString', coordinates=[0, 0]}, 'LINESTRING (0 2, 0 -2)')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -73,7 +73,7 @@ public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast [1, 2] to type text");
+        expectedException.expectMessage("Cannot cast `'foobar'` of type `text` to type `bigint_array`");
 
         assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
     }

--- a/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -69,7 +69,7 @@ public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateInvalidTimestamp() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
-            "Cannot cast 'not_a_timestamp' to type timestamp with time zone");
+            "Cannot cast `'not_a_timestamp'` of type `text` to type `timestamp with time zone`");
         assertEvaluate("timezone('Europe/Madrid', 'not_a_timestamp')", null);
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -70,11 +70,4 @@ public class CastIntegrationTest extends SQLTransportIntegrationTest {
         execute("select try_cast(name as integer) from sys.nodes limit 1");
         assertThat(response.rows()[0][0], is(nullValue()));
     }
-
-    @Test
-    public void testInvalidCastExpression() throws Exception {
-        expectedException.expect(Exception.class);
-        expectedException.expectMessage("Cannot cast text to type object_array");
-        execute("select cast(name as array(object)) from sys.cluster");
-    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -186,7 +186,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table t (i ip) with (number_of_replicas=0)");
         ensureYellow();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast '192.168.1.500' to type ip");
+        expectedException.expectMessage("Cannot cast `'192.168.1.500'` of type `text` to type `ip`");
         execute("insert into t (i) values ('192.168.1.2'), ('192.168.1.3'),('192.168.1.500')");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -674,7 +674,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast [10.3, 20.2] to type integer"));
+                assertThat(e.getMessage(), Matchers.containsString("Cannot cast `[10.3, 20.2]` of type `double precision_array` to type `integer`"));
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -201,7 +201,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast 129 to type char");
+        expectedException.expectMessage("Cannot cast `129` of type `bigint` to type `char`");
 
         setUpSimple();
         execute("delete from t1 where byte_field=129");
@@ -210,7 +210,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast ['a'] to type char_array");
+        expectedException.expectMessage("Cannot cast `['a']` of type `text_array` to type `char_array`");
 
         setUpSimple();
         execute("update t1 set byte_field=0 where byte_field in ('a')");
@@ -302,7 +302,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         waitForMappingUpdateOnAll("t1", "o.a");
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast {\"a\"=['123', '456']} to type object");
+        expectedException.expectMessage("Cannot cast `{\"a\"=['123', '456']}` of type `object` to type `object`");
         execute("insert into t1 values ({a=['123', '456']})");
     }
 

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -436,7 +436,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
 
     public void testRangeQueryOnDocThrowsException() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast _doc");
+        expectedException.expectMessage("Cannot cast `_doc` of type `object` to any of the types: [double precision, ");
         convert("_doc > {\"name\"='foo'}");
     }
 

--- a/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
@@ -136,7 +136,7 @@ public class FuncParamsTest extends CrateUnitTest {
 
         FuncParams arrayParams = FuncParams.builder(Param.of(ObjectType.untyped())).build();
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast 1");
+        expectedException.expectMessage("Cannot cast `1` of type `integer` to type `object`");
         arrayParams.match(list(Literal.of(1)));
     }
 
@@ -146,7 +146,7 @@ public class FuncParamsTest extends CrateUnitTest {
         Field field = new Field(Mockito.mock(AnalyzedRelation.class), path, new InputColumn(0, DataTypes.INTEGER));
         FuncParams params = FuncParams.builder(Param.LONG).build();
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast test to type bigint");
+        expectedException.expectMessage("Cannot cast `test` of type `integer` to type `bigint`");
         params.match(list(field));
     }
 
@@ -162,7 +162,7 @@ public class FuncParamsTest extends CrateUnitTest {
         FuncArg castableArg = new Arg(DataTypes.INTEGER, false);
         FuncParams params = FuncParams.builder(Param.LONG).build();
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast testarg to type bigint");
+        expectedException.expectMessage("Cannot cast `testarg` of type `integer` to type `bigint`");
         params.match(list(castableArg));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds the type of the source expression to the error message. This
might seem redundant for literals, but with functions or columns it can
be helpful to understand why a query is failing.

There was also one scenario where the information was wrong (saying the
target cannot be casted to the target - that didn't make sense).


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)