### PR TITLE
Remove createTableInfo from SRF in favor of a objectType

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -98,7 +98,6 @@ import io.crate.sql.tree.ValuesList;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -802,15 +801,9 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 columnValues
             ));
         }
-        Function function = new Function(
-            new FunctionInfo(
-                new FunctionIdent(ValuesFunction.NAME, Symbols.typeView(arrays)),
-                ObjectType.untyped(),
-                FunctionInfo.Type.TABLE
-            ),
-            arrays
-        );
-        FunctionImplementation implementation = functions.getQualified(function.info().ident());
+        FunctionIdent functionIdent = new FunctionIdent(ValuesFunction.NAME, Symbols.typeView(arrays));
+        FunctionImplementation implementation = functions.getQualified(functionIdent);
+        Function function = new Function(implementation.info(), arrays);
         TableFunctionImplementation<?> tableFunc = TableFunctionFactory.from(implementation);
         QualifiedName qualifiedName = new QualifiedName(ValuesFunction.NAME);
         TableFunctionRelation relation = new TableFunctionRelation(

--- a/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -22,28 +22,18 @@
 
 package io.crate.expression.tablefunctions;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.data.CollectionBucket;
 import io.crate.data.Input;
+import io.crate.data.Row;
 import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
 import io.crate.metadata.functions.params.FuncParams;
-import io.crate.metadata.table.StaticTableInfo;
-import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.DataType;
 import io.crate.types.ObjectType;
-import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -52,9 +42,8 @@ import java.util.List;
 public class EmptyRowTableFunction {
 
     private static final String NAME = "empty_row";
-    public static final RelationName TABLE_IDENT = new RelationName("", NAME);
 
-    static class EmptyRowTableFunctionImplementation extends TableFunctionImplementation {
+    static class EmptyRowTableFunctionImplementation extends TableFunctionImplementation<Object> {
 
         private final FunctionInfo info;
 
@@ -68,27 +57,14 @@ public class EmptyRowTableFunction {
         }
 
         @Override
-        public Object evaluate(TransactionContext txnCtx, Input[] args) {
-            return new CollectionBucket(Collections.singletonList(new Object[0]));
+        @SafeVarargs
+        public final Iterable<Row> evaluate(TransactionContext txnCtx, Input<Object>... args) {
+            return List.of(Row.EMPTY);
         }
 
         @Override
-        public TableInfo createTableInfo() {
-            return new StaticTableInfo(TABLE_IDENT, Collections.emptyMap(), null, Collections.emptyList()) {
-                @Override
-                public RowGranularity rowGranularity() {
-                    return RowGranularity.DOC;
-                }
-
-                @Override
-                public Routing getRouting(ClusterState clusterState,
-                                          RoutingProvider routingProvider,
-                                          WhereClause whereClause,
-                                          RoutingProvider.ShardSelection shardSelection,
-                                          SessionContext sessionContext) {
-                    return Routing.forTableOnSingleNode(TABLE_IDENT, clusterState.getNodes().getLocalNodeId());
-                }
-            };
+        public ObjectType returnType() {
+            return ObjectType.untyped();
         }
     }
 

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -22,40 +22,26 @@
 
 package io.crate.expression.tablefunctions;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.data.ArrayBucket;
-import io.crate.data.Bucket;
 import io.crate.data.Input;
-import io.crate.metadata.ColumnIdent;
+import io.crate.data.Row;
+import io.crate.data.RowN;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.table.StaticTableInfo;
-import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
-import org.elasticsearch.cluster.ClusterState;
+import io.crate.types.ObjectType;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 public class TableFunctionFactory {
 
-    public static TableFunctionImplementation from(FunctionImplementation functionImplementation) {
-
-        TableFunctionImplementation tableFunction;
+    public static TableFunctionImplementation<?> from(FunctionImplementation functionImplementation) {
+        TableFunctionImplementation<?> tableFunction;
         switch (functionImplementation.info().type()) {
             case TABLE:
-                tableFunction = (TableFunctionImplementation) functionImplementation;
+                tableFunction = (TableFunctionImplementation<?>) functionImplementation;
                 break;
             case SCALAR:
                 tableFunction = new ScalarTableFunctionImplementation<>((Scalar<?, ?>) functionImplementation);
@@ -82,49 +68,34 @@ public class TableFunctionFactory {
      */
     private static class ScalarTableFunctionImplementation<T> extends TableFunctionImplementation<T> {
 
-        private final RelationName TABLE_IDENT = new RelationName("", "scalar_table");
-
         private final Scalar<?, T> functionImplementation;
+        private final ObjectType returnType;
+        private final FunctionInfo info;
 
         private ScalarTableFunctionImplementation(Scalar<?, T> functionImplementation) {
             this.functionImplementation = functionImplementation;
+            FunctionInfo info = functionImplementation.info();
+            returnType = ObjectType.builder().setInnerType(info.ident().name(), info.returnType()).build();
+            this.info = new FunctionInfo(
+                info.ident(),
+                info.returnType(),
+                FunctionInfo.Type.TABLE
+            );
         }
 
         @Override
         public FunctionInfo info() {
-            return functionImplementation.info();
+            return info;
         }
 
         @Override
-        public Bucket evaluate(TransactionContext txnCtx, Input<T>[] args) {
-            return new ArrayBucket(new Object[][] {new Object[] {functionImplementation.evaluate(txnCtx,args)}});
+        public Iterable<Row> evaluate(TransactionContext txnCtx, Input<T>[] args) {
+            return List.of(new RowN(functionImplementation.evaluate(txnCtx, args)));
         }
 
         @Override
-        public TableInfo createTableInfo() {
-            String functionName = info().ident().name();
-            ColumnIdent col = new ColumnIdent(functionName);
-            Reference reference = new Reference(new ReferenceIdent(TABLE_IDENT, col),
-                                                RowGranularity.DOC,
-                                                info().returnType(),
-                                                1,
-                                                null);
-            Map<ColumnIdent, Reference> referenceByColumn = Collections.singletonMap(col, reference);
-            return new StaticTableInfo(TABLE_IDENT, referenceByColumn, List.of(reference), List.of()) {
-                @Override
-                public Routing getRouting(ClusterState state,
-                                          RoutingProvider routingProvider,
-                                          WhereClause whereClause,
-                                          RoutingProvider.ShardSelection shardSelection,
-                                          SessionContext sessionContext) {
-                    return Routing.forTableOnSingleNode(TABLE_IDENT, state.getNodes().getLocalNodeId());
-                }
-
-                @Override
-                public RowGranularity rowGranularity() {
-                    return RowGranularity.DOC;
-                }
-            };
+        public ObjectType returnType() {
+            return returnType;
         }
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -102,7 +102,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_function_arguments_must_have_array_types() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Function argument must have an array data type, but was 'text'");
-        functions.getQualified(new FunctionIdent(ValuesFunction.NAME, List.of(DataTypes.STRING)));
+        expectedException.expectMessage("Cannot cast `200` of type `bigint` to type `undefined_array`");
+        assertExecute("_values(200)", "");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Remove createTableInfo from SRF in favor of a objectType

This removes a bit of duplication between using the TableInfo to describe
the result columns and having a returnType that also describes the result.

It also clarifies the semantics and implicit type change from objectType to
a non-composite type in case a SRF it is used as an expression with a 
single column.

Note that using the objectType is also a bit missleading, because the values won't include keys, but are more like tuples. We should eventually replace objectType with a proper rowType, but I think that is something we can follow up on and doesn't invalidate this change - I see this as an intermediate step to get there.


The first commit has a dedicated PR (https://github.com/crate/crate/pull/9625) which should be merged first.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)