### PR TITLE
Terminate ordered lucene collector on cancel/kill

### DIFF
--- a/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
+++ b/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
@@ -70,7 +70,7 @@ public final class CompletableFutures {
         return new ExceptionalInterceptingFuture<>(delegate, beforeExceptional);
     }
 
-
+    @SuppressForbidden
     private static class ExceptionalInterceptingFuture<T> extends CompletableFuture<T> {
 
         private final CompletableFuture<T> delegate;

--- a/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
+++ b/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
@@ -28,7 +28,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class CompletableFutures {
@@ -54,6 +62,347 @@ public final class CompletableFutures {
             return CompletableFuture.supplyAsync(supplier, executor);
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    public static <T> CompletableFuture<T> runBeforeCompleteExceptional(CompletableFuture<T> delegate,
+                                                                        Consumer<Throwable> beforeExceptional) {
+        return new ExceptionalInterceptingFuture<>(delegate, beforeExceptional);
+    }
+
+
+    private static class ExceptionalInterceptingFuture<T> extends CompletableFuture<T> {
+
+        private final CompletableFuture<T> delegate;
+        private final Consumer<Throwable> beforeExceptional;
+
+        private ExceptionalInterceptingFuture(CompletableFuture<T> delegate, Consumer<Throwable> beforeExceptional) {
+            this.delegate = delegate;
+            this.beforeExceptional = beforeExceptional;
+        }
+
+        @Override
+        public boolean completeExceptionally(Throwable ex) {
+            beforeExceptional.accept(ex);
+            return delegate.completeExceptionally(ex);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return delegate.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isDone() {
+            return delegate.isDone();
+        }
+
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            return delegate.get();
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return delegate.get(timeout, unit);
+        }
+
+        @Override
+        public T join() {
+            return delegate.join();
+        }
+
+        @Override
+        public T getNow(T valueIfAbsent) {
+            return delegate.getNow(valueIfAbsent);
+        }
+
+        @Override
+        public boolean complete(T value) {
+            return delegate.complete(value);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+            return delegate.thenApply(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
+            return delegate.thenApplyAsync(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn,
+                                                       Executor executor) {
+            return delegate.thenApplyAsync(fn, executor);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
+            return delegate.thenAccept(action);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
+            return delegate.thenAcceptAsync(action);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
+            return delegate.thenAcceptAsync(action, executor);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenRun(Runnable action) {
+            return delegate.thenRun(action);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenRunAsync(Runnable action) {
+            return delegate.thenRunAsync(action);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
+            return delegate.thenRunAsync(action, executor);
+        }
+
+        @Override
+        public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other,
+                                                       BiFunction<? super T, ? super U, ? extends V> fn) {
+            return delegate.thenCombine(other, fn);
+        }
+
+        @Override
+        public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
+                                                            BiFunction<? super T, ? super U, ? extends V> fn) {
+            return delegate.thenCombineAsync(other, fn);
+        }
+
+        @Override
+        public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
+                                                            BiFunction<? super T, ? super U, ? extends V> fn,
+                                                            Executor executor) {
+            return delegate.thenCombineAsync(other, fn, executor);
+        }
+
+        @Override
+        public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other,
+                                                          BiConsumer<? super T, ? super U> action) {
+            return delegate.thenAcceptBoth(other, action);
+        }
+
+        @Override
+        public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
+                                                               BiConsumer<? super T, ? super U> action) {
+            return delegate.thenAcceptBothAsync(other, action);
+        }
+
+        @Override
+        public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
+                                                               BiConsumer<? super T, ? super U> action,
+                                                               Executor executor) {
+            return delegate.thenAcceptBothAsync(other, action, executor);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
+            return delegate.runAfterBoth(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
+                                                         Runnable action) {
+            return delegate.runAfterBothAsync(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
+                                                         Runnable action, Executor executor) {
+            return delegate.runAfterBothAsync(other, action, executor);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other,
+                                                      Function<? super T, U> fn) {
+            return delegate.applyToEither(other, fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
+                                                           Function<? super T, U> fn) {
+            return delegate.applyToEitherAsync(other, fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
+                                                           Function<? super T, U> fn,
+                                                           Executor executor) {
+            return delegate.applyToEitherAsync(other, fn, executor);
+        }
+
+        @Override
+        public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other,
+                                                    Consumer<? super T> action) {
+            return delegate.acceptEither(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
+                                                         Consumer<? super T> action) {
+            return delegate.acceptEitherAsync(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
+                                                         Consumer<? super T> action, Executor executor) {
+            return delegate.acceptEitherAsync(other, action, executor);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
+            return delegate.runAfterEither(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other,
+                                                           Runnable action) {
+            return delegate.runAfterEitherAsync(other, action);
+        }
+
+        @Override
+        public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other,
+                                                           Runnable action, Executor executor) {
+            return delegate.runAfterEitherAsync(other, action, executor);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
+            return delegate.thenCompose(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
+            return delegate.thenComposeAsync(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn,
+                                                         Executor executor) {
+            return delegate.thenComposeAsync(fn, executor);
+        }
+
+        @Override
+        public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+            return delegate.whenComplete(action);
+        }
+
+        @Override
+        public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
+            return delegate.whenCompleteAsync(action);
+        }
+
+        @Override
+        public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action,
+                                                      Executor executor) {
+            return delegate.whenCompleteAsync(action, executor);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
+            return delegate.handle(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
+            return delegate.handleAsync(fn);
+        }
+
+        @Override
+        public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn,
+                                                    Executor executor) {
+            return delegate.handleAsync(fn, executor);
+        }
+
+        @Override
+        public CompletableFuture<T> toCompletableFuture() {
+            return delegate.toCompletableFuture();
+        }
+
+        @Override
+        public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
+            return delegate.exceptionally(fn);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return delegate.isCancelled();
+        }
+
+        @Override
+        public boolean isCompletedExceptionally() {
+            return delegate.isCompletedExceptionally();
+        }
+
+        @Override
+        public void obtrudeValue(T value) {
+            delegate.obtrudeValue(value);
+        }
+
+        @Override
+        public void obtrudeException(Throwable ex) {
+            delegate.obtrudeException(ex);
+        }
+
+        @Override
+        public int getNumberOfDependents() {
+            return delegate.getNumberOfDependents();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public <U> CompletableFuture<U> newIncompleteFuture() {
+            return delegate.newIncompleteFuture();
+        }
+
+        @Override
+        public Executor defaultExecutor() {
+            return delegate.defaultExecutor();
+        }
+
+        @Override
+        public CompletableFuture<T> copy() {
+            return delegate.copy();
+        }
+
+        @Override
+        public CompletionStage<T> minimalCompletionStage() {
+            return delegate.minimalCompletionStage();
+        }
+
+        @Override
+        public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier, Executor executor) {
+            return delegate.completeAsync(supplier, executor);
+        }
+
+        @Override
+        public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier) {
+            return delegate.completeAsync(supplier);
+        }
+
+        @Override
+        public CompletableFuture<T> orTimeout(long timeout, TimeUnit unit) {
+            return delegate.orTimeout(timeout, unit);
+        }
+
+        @Override
+        public CompletableFuture<T> completeOnTimeout(T value, long timeout, TimeUnit unit) {
+            return delegate.completeOnTimeout(value, timeout, unit);
         }
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
@@ -151,8 +151,9 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     @Override
     public void cancel(Throwable t) {
         cancelled = t;
-        if (currentCollector != null) {
-            currentCollector.cancel(t);
+        var collector = currentCollector;
+        if (collector != null) {
+            collector.cancel(t);
         }
     }
 
@@ -200,8 +201,9 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
         if (minScore != null) {
             collector = new MinimumScoreCollector(collector, minScore);
         }
-        collector = currentCollector = new CancelableCollector(collector, cancelled);
-        searcher.search(query, collector);
+        var cancelableCollector = new CancelableCollector(collector, cancelled);
+        currentCollector = cancelableCollector;
+        searcher.search(query, cancelableCollector);
         ScoreDoc[] scoreDocs = topFieldCollector.topDocs().scoreDocs;
         if (doDocsScores) {
             TopFieldCollector.populateScores(scoreDocs, searcher, query);
@@ -266,8 +268,9 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
                 return;
             }
             cancelled = t;
-            if (currentLeafCollector != null) {
-                currentLeafCollector.cancel(t);
+            var leafCollector = currentLeafCollector;
+            if (leafCollector != null) {
+                leafCollector.cancel(t);
             }
         }
     }

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
@@ -49,6 +49,9 @@ public abstract class OrderedDocCollector implements Supplier<KeyIterable<ShardI
     public void close() {
     }
 
+    public void cancel(Throwable t) {
+    }
+
     /**
      * Returns an iterable for a batch of rows. In order to consume all rows of this collector,
      * {@code #get()} needs to be called while {@linkplain #exhausted()} is {@code false}.

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
@@ -48,15 +48,18 @@ class ScoreDocRowFunction implements Function<ScoreDoc, Row> {
     private final LuceneCollectorExpression[] expressions;
     private final DummyScorer scorer;
     private final InputRow inputRow;
+    private final Runnable onScoreDoc;
 
     ScoreDocRowFunction(IndexReader indexReader,
                         List<? extends Input<?>> inputs,
                         Collection<? extends LuceneCollectorExpression<?>> expressions,
-                        DummyScorer scorer) {
+                        DummyScorer scorer,
+                        Runnable onScoreDoc) {
         this.indexReader = indexReader;
         this.expressions = expressions.toArray(new LuceneCollectorExpression[0]);
         this.scorer = scorer;
         this.inputRow = new InputRow(inputs);
+        this.onScoreDoc = onScoreDoc;
         for (LuceneCollectorExpression<?> expression : this.expressions) {
             if (expression instanceof OrderByCollectorExpression) {
                 orderByCollectorExpressions.add((OrderByCollectorExpression) expression);
@@ -67,6 +70,7 @@ class ScoreDocRowFunction implements Function<ScoreDoc, Row> {
     @Nullable
     @Override
     public Row apply(@Nullable ScoreDoc input) {
+        onScoreDoc.run();
         if (input == null) {
             return null;
         }

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -65,10 +65,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import static io.crate.testing.TestingHelpers.createReference;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -176,6 +180,39 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
         );
 
         consumeIteratorAndVerifyResultIsException(rowBatchIterator, circuitBreakingException);
+    }
+
+    @Test
+    public void test_lucene_ordered_collector_thread_dies_on_kill() throws Exception {
+        LuceneOrderedDocCollector luceneOrderedDocCollector = createOrderedCollector(searcher1, 1);
+        AtomicReference<Thread> collectThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        BatchIterator<Row> rowBatchIterator = OrderedLuceneBatchIteratorFactory.newInstance(
+            Collections.singletonList(luceneOrderedDocCollector),
+            OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+            mock(RowAccounting.class),
+            c -> {
+                var t = new Thread(c);
+                collectThread.set(t);
+                t.start();
+                latch.countDown();
+            },
+            () -> 1,
+            true
+        );
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(rowBatchIterator, null);
+
+        // Ensure that the collect thread is running
+        latch.await(1, TimeUnit.SECONDS);
+        assertThat(collectThread.get().isAlive(), is(true));
+
+        rowBatchIterator.kill(new InterruptedException("killed"));
+
+        // The collect thread must stop "almost" immediately, 10ms should be enough to wait.
+        // Without any cancel logic in-place the thread operation will continue and may not complete in 10ms.
+        assertBusy(() -> assertThat(collectThread.get().isAlive(), is(false)),
+                   10, TimeUnit.MILLISECONDS);
     }
 
     private void consumeIteratorAndVerifyResultIsException(BatchIterator<Row> rowBatchIterator, Exception exception)


### PR DESCRIPTION
If an ordered lucene collector is running inside a child thread, it should stop processing and the thread should terminate if cancelled/killed.
Otherwise it may still occupy resources (e.g. account memory) AFTER the job was killed and shared resources (ram accounting) are released.