### PR TITLE
Replace Nashorn with GraalVM JS engine in UDF.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     runtime project(':enterprise:ssl-impl')
     runtime project(':enterprise:functions')
     runtime project(':enterprise:licensing')
+    runtime project(':enterprise:lang-js')
 
     testCompile project(':integration-testing')
     testCompile project(':http')

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,10 @@ None
 Changes
 =======
 
+- Replaced the ``Nashorn`` JavaScript engine with ``GraalVM`` for JavaScript
+  :ref:`user-defined functions <sql_administration_udf>`. This change upgrades
+  ``ECMAScript`` support from ``5.1`` to ``10.0``.
+
 - Added support for ``JOIN USING``, e.g. ``SELECT * FROM t1 JOIN t2 USING (col)``,
   an alternative to ``JOIN ON``, when the column name(s) are the same in both relations.
 

--- a/enterprise/lang-js/build.gradle
+++ b/enterprise/lang-js/build.gradle
@@ -11,9 +11,9 @@ task writePropertiesFile {
             into "${buildDir}/tmp"
             include "plugin-descriptor.properties"
             expand(version: project.version,
-                   esVersion: versions.internalES,
-                   jmvCompatibility: project.targetCompatibility,
-                   name: project.name)
+                esVersion: versions.internalES,
+                jmvCompatibility: project.targetCompatibility,
+                name: project.name)
         }
     }
 }
@@ -21,6 +21,11 @@ task writePropertiesFile {
 jar.dependsOn('writePropertiesFile')
 dependencies {
     implementation project(':sql')
+
+    implementation "org.graalvm.js:js:${versions.graalvm}"
+    implementation "org.graalvm.sdk:graal-sdk:${versions.graalvm}"
+    implementation "org.graalvm.truffle:truffle-api:${versions.graalvm}"
+
     testImplementation project(':integration-testing')
     testImplementation project(path: ':sql', configuration: 'testOutput')
     testImplementation project(path: ':dex', configuration: 'testOutput')

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/PolyglotValuesConverter.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/PolyglotValuesConverter.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.operation.language;
+
+import io.crate.data.Input;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.GeoPointType;
+import io.crate.types.GeoShapeType;
+import io.crate.types.ObjectType;
+import org.graalvm.polyglot.TypeLiteral;
+import org.graalvm.polyglot.Value;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+class PolyglotValuesConverter {
+
+    private static final TypeLiteral<Number> NUMBER_TYPE_LITERAL = new TypeLiteral<>() {};
+    private static final TypeLiteral<Map> MAP_TYPE_LITERAL = new TypeLiteral<>() {};
+
+    static Object toCrateObject(Value value, DataType<?> type) {
+        if (value == null) {
+            return null;
+        }
+        switch (type.id()) {
+            case ArrayType.ID:
+                ArrayList<Object> items = new ArrayList<>((int) value.getArraySize());
+                for (int idx = 0; idx < value.getArraySize(); idx++) {
+                    var item = toCrateObject(value.getArrayElement(idx), ((ArrayType) type).innerType());
+                    items.add(idx, item);
+                }
+                return type.value(items);
+            case ObjectType.ID:
+                return type.value(value.as(MAP_TYPE_LITERAL));
+            case GeoPointType.ID:
+                if (value.hasArrayElements()) {
+                    return type.value(toCrateObject(value, DataTypes.DOUBLE_ARRAY));
+                } else {
+                    return type.value(value.asString());
+                }
+            case GeoShapeType.ID:
+                if (value.isString()) {
+                    return type.value(value.asString());
+                } else {
+                    return type.value(value.as(MAP_TYPE_LITERAL));
+                }
+            default:
+                final Object polyglotValue;
+                if (value.isNumber()) {
+                    polyglotValue = value.as(NUMBER_TYPE_LITERAL);
+                } else if (value.isString()) {
+                    polyglotValue = value.asString();
+                } else if (value.isBoolean()) {
+                    polyglotValue = value.asBoolean();
+                } else {
+                    polyglotValue = value.asString();
+                }
+                return type.value(polyglotValue);
+        }
+    }
+
+    static Object[] toPolyglotValues(Input<Object>[] inputs) {
+        Object[] args = new Object[inputs.length];
+        for (int i = 0; i < inputs.length; i++) {
+            args[i] = Value.asValue(inputs[i].value());
+        }
+        return args;
+    }
+}

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -54,3 +54,5 @@ commonscodec=1.10
 hamcrest=2.1
 mockito=2.28.2
 carrotsearch_hppc:0.8.1
+
+graalvm=19.3.1


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes replaces the Nashorn with GraalVM JavaScript
engine, such as Nashorn is scheduled for removal in the
future JDK version, see https://openjdk.java.net/jeps/335.

Please note that we do  not use the GraalVM JIT compiler as the
optimizing compile of the GraalVM JavaScript code, but instead
the GraalVM JavaScript engine is used to compile and execute
JavaScript code.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
