### PR TITLE
Add some missing columns to pg_catalog.pg_type.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,11 @@ None
 Changes
 =======
 
+- Added :ref:`postgres_pg_type` columns: ``typbyval``, ``typcategory``,
+  ``typowner``, ``typisdefined``, ``typrelid``, ``typndims``,
+  ``typcollation``, ``typinput``, ``typoutput``, and ``typndefault`` for improved
+  PostgreSQL compatibility.
+
 - Replaced the ``Nashorn`` JavaScript engine with ``GraalVM`` for JavaScript
   :ref:`user-defined functions <sql_administration_udf>`. This change upgrades
   ``ECMAScript`` support from ``5.1`` to ``10.0``.

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -152,41 +152,43 @@ following tables:
 Some clients require the ``pg_catalog.pg_type`` in order to be able to stream
 arrays or other non-primitive types.
 
-For compatibility reasons there is a trimmed down `pg_type <pgsql_pg_type_>`__ table available in
-CrateDB::
+For compatibility reasons, there is a trimmed down `pg_type <pgsql_pg_type_>`__
+table available in CrateDB::
 
-    cr> select oid, typname, typarray, typelem, typlen from pg_catalog.pg_type order by oid;
-    +------+------------------------------+----------+---------+--------+
-    |  oid | typname                      | typarray | typelem | typlen |
-    +------+------------------------------+----------+---------+--------+
-    |   16 | bool                         |     1000 |       0 |      1 |
-    |   18 | char                         |     1002 |       0 |      1 |
-    |   19 | name                         |       -1 |       0 |     64 |
-    |   20 | int8                         |     1016 |       0 |      8 |
-    |   21 | int2                         |     1005 |       0 |      2 |
-    |   23 | int4                         |     1007 |       0 |      4 |
-    |  114 | json                         |      199 |       0 |     -1 |
-    |  199 | _json                        |        0 |     114 |     -1 |
-    |  600 | point                        |     1017 |       0 |     16 |
-    |  700 | float4                       |     1021 |       0 |      4 |
-    |  701 | float8                       |     1022 |       0 |      8 |
-    | 1000 | _bool                        |        0 |      16 |     -1 |
-    | 1002 | _char                        |        0 |      18 |     -1 |
-    | 1005 | _int2                        |        0 |      21 |     -1 |
-    | 1007 | _int4                        |        0 |      23 |     -1 |
-    | 1015 | _varchar                     |        0 |    1043 |     -1 |
-    | 1016 | _int8                        |        0 |      20 |     -1 |
-    | 1017 | _point                       |        0 |     600 |     -1 |
-    | 1021 | _float4                      |        0 |     700 |     -1 |
-    | 1022 | _float8                      |        0 |     701 |     -1 |
-    | 1043 | varchar                      |     1015 |       0 |     -1 |
-    | 1114 | timestamp without time zone  |     1115 |       0 |      8 |
-    | 1115 | _timestamp without time zone |        0 |    1114 |     -1 |
-    | 1184 | timestamptz                  |     1185 |       0 |      8 |
-    | 1185 | _timestamptz                 |        0 |    1184 |     -1 |
-    | 1186 | interval                     |     1187 |       0 |     16 |
-    | 1187 | _interval                    |        0 |    1186 |     -1 |
-    +------+------------------------------+----------+---------+--------+
+    cr> SELECT oid, typname, typarray, typelem, typlen, typcategory
+    ... FROM pg_catalog.pg_type
+    ... ORDER BY oid;
+    +------+------------------------------+----------+---------+--------+-------------+
+    |  oid | typname                      | typarray | typelem | typlen | typcategory |
+    +------+------------------------------+----------+---------+--------+-------------+
+    |   16 | bool                         |     1000 |       0 |      1 | N           |
+    |   18 | char                         |     1002 |       0 |      1 | S           |
+    |   19 | name                         |       -1 |       0 |     64 | S           |
+    |   20 | int8                         |     1016 |       0 |      8 | N           |
+    |   21 | int2                         |     1005 |       0 |      2 | N           |
+    |   23 | int4                         |     1007 |       0 |      4 | N           |
+    |  114 | json                         |      199 |       0 |     -1 | U           |
+    |  199 | _json                        |        0 |     114 |     -1 | A           |
+    |  600 | point                        |     1017 |       0 |     16 | G           |
+    |  700 | float4                       |     1021 |       0 |      4 | N           |
+    |  701 | float8                       |     1022 |       0 |      8 | N           |
+    | 1000 | _bool                        |        0 |      16 |     -1 | A           |
+    | 1002 | _char                        |        0 |      18 |     -1 | A           |
+    | 1005 | _int2                        |        0 |      21 |     -1 | A           |
+    | 1007 | _int4                        |        0 |      23 |     -1 | A           |
+    | 1015 | _varchar                     |        0 |    1043 |     -1 | A           |
+    | 1016 | _int8                        |        0 |      20 |     -1 | A           |
+    | 1017 | _point                       |        0 |     600 |     -1 | A           |
+    | 1021 | _float4                      |        0 |     700 |     -1 | A           |
+    | 1022 | _float8                      |        0 |     701 |     -1 | A           |
+    | 1043 | varchar                      |     1015 |       0 |     -1 | S           |
+    | 1114 | timestamp without time zone  |     1115 |       0 |      8 | D           |
+    | 1115 | _timestamp without time zone |        0 |    1114 |     -1 | A           |
+    | 1184 | timestamptz                  |     1185 |       0 |      8 | D           |
+    | 1185 | _timestamptz                 |        0 |    1184 |     -1 | A           |
+    | 1186 | interval                     |     1187 |       0 |     16 | T           |
+    | 1187 | _interval                    |        0 |    1186 |     -1 | A           |
+    +------+------------------------------+----------+---------+--------+-------------+
     SELECT 27 rows in set (... sec)
 
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -37,13 +37,13 @@ import org.elasticsearch.cluster.ClusterState;
 
 import java.util.Map;
 
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.STRING;
 
 public class PgTypeTable extends StaticTableInfo<PGType> {
 
@@ -64,11 +64,35 @@ public class PgTypeTable extends StaticTableInfo<PGType> {
             .register("typdelim", STRING, () -> forFunction(PGType::typDelim))
             .register("typelem", INTEGER, () -> forFunction(PGType::typElem))
             .register("typlen", SHORT, () -> forFunction(PGType::typeLen))
+            .register("typbyval", BOOLEAN, () -> constant(true))
             .register("typtype", STRING, () -> constant(TYPTYPE))
+            .register("typcategory", STRING, () -> forFunction(PGType::typeCategory))
+            .register("typowner", INTEGER, () -> constant(null))
+            .register("typisdefined", BOOLEAN, () -> constant(true))
+            // Zero for non-composite types, otherwise should point
+            // to the pg_class table entry.
+            .register("typrelid", INTEGER, () -> constant(0))
+            .register("typndims", INTEGER, () -> constant(0))
+            .register("typcollation", INTEGER, () -> constant(0))
+            .register("typdefault", STRING, () -> constant(null))
             .register("typbasetype", INTEGER, () -> constant(0))
             .register("typtypmod", INTEGER, () -> constant(-1))
             .register("typnamespace", INTEGER, () -> constant(TYPE_NAMESPACE_OID))
             .register("typarray", INTEGER, () -> forFunction(PGType::typArray))
+            .register("typinput", STRING, () -> forFunction(t -> {
+                if (t.typArray() == 0) {
+                    return "array_in";
+                } else {
+                    return t.typName() + "_in";
+                }
+            }))
+            .register("typoutput", STRING, () -> forFunction(t -> {
+                if (t.typArray() == 0) {
+                    return "array_out";
+                } else {
+                    return t.typName() + "_out";
+                }
+            }))
             .register("typnotnull", BOOLEAN, () -> constant(false));
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/types/BaseTimestampType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BaseTimestampType.java
@@ -49,6 +49,11 @@ abstract class BaseTimestampType extends PGType {
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
+    @Override
+    public String typeCategory() {
+        return TypeCategory.DATETIME.code();
+    }
+
     /**
      * Convert a crate timestamp (unix timestamp in ms) into a postgres timestamp
      * (long microseconds since 2000-01-01)

--- a/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
@@ -54,6 +54,11 @@ class BigIntType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
         return Long.toString(((long) value)).getBytes(StandardCharsets.UTF_8);
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/BooleanType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BooleanType.java
@@ -58,6 +58,11 @@ class BooleanType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         byte byteValue = (byte) ((boolean) value ? 1 : 0);
         buffer.writeInt(TYPE_LEN);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
@@ -44,6 +44,11 @@ class CharType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.STRING.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         buffer.writeInt(1);
         buffer.writeByte(((byte) value));

--- a/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
@@ -46,6 +46,11 @@ class DoubleType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeDouble(((double) value));

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
@@ -47,6 +47,11 @@ class IntegerType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeInt(((int) value));

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
@@ -46,6 +46,11 @@ public class IntervalType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.TIMESPAN.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         Period period = (Period) value;
         buffer.writeInt(TYPE_LEN);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
@@ -52,6 +52,10 @@ class JsonType extends PGType {
         return PGArray.JSON_ARRAY.oid();
     }
 
+    @Override
+    public String typeCategory() {
+        return TypeCategory.USER_DEFINED_TYPES.code();
+    }
 
     @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -61,6 +61,11 @@ class PGArray extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.ARRAY.code();
+    }
+
+    @Override
     public int typElem() {
         return innerType.oid();
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -23,13 +23,40 @@
 package io.crate.protocols.postgres.types;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
 public abstract class PGType {
+
+    enum TypeCategory {
+
+        ARRAY("A"),
+        BOOLEAN("B"),
+        COMPOSITE("C"),
+        DATETIME("D"),
+        GEOMETRIC("G"),
+        NETWORK("I"),
+        NUMERIC("N"),
+        RANGE("R"),
+        STRING("S"),
+        TIMESPAN("T"),
+        USER_DEFINED_TYPES("U"),
+        BIT_STRING("V"),
+        UNKNOWN("X");
+
+        private final String code;
+
+        TypeCategory(String code) {
+            this.code = code;
+        }
+
+        public String code() {
+            return code;
+        }
+    }
 
     static final int INT32_BYTE_SIZE = Integer.SIZE / 8;
     private static final Logger LOGGER = LogManager.getLogger(PGType.class);
@@ -71,6 +98,8 @@ public abstract class PGType {
     public String typDelim() {
         return ",";
     }
+
+    public abstract String typeCategory();
 
     /**
      * Write the value as text into the buffer.

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PointType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PointType.java
@@ -49,6 +49,11 @@ public final class PointType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.GEOMETRIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         Point point = (Point) value;
         buffer.writeInt(TYPE_LEN);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
@@ -46,6 +46,11 @@ class RealType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeFloat(((float) value));

--- a/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
@@ -46,6 +46,11 @@ class SmallIntType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeShort((short) value);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -54,6 +54,11 @@ class VarCharType extends PGType {
     }
 
     @Override
+    public String typeCategory() {
+        return TypeCategory.STRING.code();
+    }
+
+    @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
         assert value instanceof String : "value must be a string, got: " + value;
         byte[] bytes = ((String) value).getBytes(StandardCharsets.UTF_8);

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -589,7 +589,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(728, response.rowCount());
+        assertEquals(738, response.rowCount());
     }
 
     @Test
@@ -638,20 +638,29 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "where table_schema = 'pg_catalog' " +
                 "and table_name = 'pg_type' " +
                 "order by 1 asc");
-        assertThat(response.rowCount(), is(11L));
         assertThat(printedTable(response.rows()), is(
             "oid| integer\n" +
             "typarray| integer\n" +
             "typbasetype| integer\n" +
+            "typbyval| boolean\n" +
+            "typcategory| text\n" +
+            "typcollation| integer\n" +
+            "typdefault| text\n" +
             "typdelim| text\n" +
             "typelem| integer\n" +
+            "typinput| text\n" +
+            "typisdefined| boolean\n" +
             "typlen| smallint\n" +
             "typname| text\n" +
             "typnamespace| integer\n" +
+            "typndims| integer\n" +
             "typnotnull| boolean\n" +
+            "typoutput| text\n" +
+            "typowner| integer\n" +
+            "typrelid| integer\n" +
             "typtype| text\n" +
-            "typtypmod| integer\n"
-        ));
+            "typtypmod| integer\n")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Columns:
 - typbyval
 - typcategory
 - typowner
 - typisdefined
 - typrelid
 - typndims
 - typcollation
 - typinput
 - typoutput
 - typndefault

References https://github.com/crate/crate/issues/9545

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
