### PR TITLE
Add ``mod`` alias for the ``modulus`` scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ None
 Changes
 =======
 
+- Added a ``mod`` alias for the :ref:`modulus <scalar-modulus>` function for
+  improved PostgreSQL compatibility.
+
 - Added the :ref:`atan2 <scalar-atan2>` trigonometric scalar function.
 
 - Added the :ref:`exp <scalar-exp>` scalar function.

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1294,6 +1294,8 @@ The second argument (``b``) is optional. If not present, base 10 is used::
     The same is true for arguments which lead to a ``division by zero``, as
     e.g. log(10, 1) does.
 
+.. _scalar-modulus:
+
 ``modulus(y, x)``
 -----------------
 
@@ -1310,6 +1312,12 @@ Returns: Same as argument types.
     |             1 |
     +---------------+
     SELECT 1 row in set (... sec)
+
+``mod(y, x)``
+-----------------
+
+This is an alias for :ref:`modulus <scalar-modulus>`.
+
 
 ``power(a: number, b: number)``
 -------------------------------

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1294,6 +1294,23 @@ The second argument (``b``) is optional. If not present, base 10 is used::
     The same is true for arguments which lead to a ``division by zero``, as
     e.g. log(10, 1) does.
 
+``modulus(y, x)``
+-----------------
+
+Returns the remainder of ``y/x``.
+
+Returns: Same as argument types.
+
+::
+
+    cr> select modulus(5, 4);
+    +---------------+
+    | modulus(5, 4) |
+    +---------------+
+    |             1 |
+    +---------------+
+    SELECT 1 row in set (... sec)
+
 ``power(a: number, b: number)``
 -------------------------------
 

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -70,6 +70,7 @@ public class ArithmeticFunctions {
         public static final String DIVIDE = "divide";
         public static final String POWER = "power";
         public static final String MODULUS = "modulus";
+        public static final String MOD = "mod";
     }
 
     public static void register(ScalarFunctionModule module) {
@@ -109,15 +110,20 @@ public class ArithmeticFunctions {
             (arg0, arg1) -> arg0 / arg1,
             (arg0, arg1) -> arg0 / arg1
         ));
-        module.register(Names.MODULUS, new ArithmeticFunctionResolver(
-            Names.MODULUS,
-            "%",
-            FunctionInfo.DETERMINISTIC_ONLY,
-            (arg0, arg1) -> arg0 % arg1,
-            (arg0, arg1) -> arg0 % arg1,
-            (arg0, arg1) -> arg0 % arg1,
-            (arg0, arg1) -> arg0 % arg1
-        ));
+
+        java.util.function.Function<String, ArithmeticFunctionResolver> modFunctionResolverFactory =
+            name -> new ArithmeticFunctionResolver(
+                name,
+                "%",
+                FunctionInfo.DETERMINISTIC_ONLY,
+                (arg0, arg1) -> arg0 % arg1,
+                (arg0, arg1) -> arg0 % arg1,
+                (arg0, arg1) -> arg0 % arg1,
+                (arg0, arg1) -> arg0 % arg1
+            );
+
+        module.register(Names.MODULUS, modFunctionResolverFactory.apply(Names.MODULUS));
+        module.register(Names.MOD, modFunctionResolverFactory.apply(Names.MOD));
         module.register(Names.POWER, new DoubleFunctionResolver(
             Names.POWER,
             Math::pow

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
@@ -41,4 +41,9 @@ public class ModulusFunctionTest extends AbstractScalarFunctionsTest {
     public void test_modulus_operator() {
         assertNormalize("3 % 2", isLiteral(1L));
     }
+
+    @Test
+    public void test_mod_works_as_alias_for_modulus() {
+        assertNormalize("mod(3, 2)", isLiteral(1L));
+    }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.arithmetic;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class ModulusFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_modulus_scalar() {
+        assertNormalize("modulus(3, 2)", isLiteral(1L));
+        assertNormalize("modulus(3::int, 2::int)", isLiteral(1));
+        assertNormalize("modulus(3.5, 2)", isLiteral(1.5d));
+        assertNormalize("modulus(3.5::real, 2)", isLiteral(1.5f));
+    }
+
+    @Test
+    public void test_modulus_operator() {
+        assertNormalize("3 % 2", isLiteral(1L));
+    }
+}


### PR DESCRIPTION
Also adds missing documentation and tests for the `modulus` scalar function.

Supersedes #9637 (We could backport the dedicated commit later on if wanted).