### PR TITLE
Improve PGType type saftey and fix record serialization

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
@@ -28,7 +28,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class BigIntType extends PGType {
+class BigIntType extends PGType<Long> {
 
     public static final BigIntType INSTANCE = new BigIntType();
     static final int OID = 20;
@@ -47,9 +47,9 @@ class BigIntType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Long value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeLong(((long) value));
+        buffer.writeLong(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
@@ -59,19 +59,19 @@ class BigIntType extends PGType {
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Long.toString(((long) value)).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Long value) {
+        return Long.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Long readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because long is int64. Actual length: " +
                                          valueLength;
         return buffer.readLong();
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Long decodeUTF8Text(byte[] bytes) {
         return Long.parseLong(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/BooleanType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BooleanType.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
-class BooleanType extends PGType {
+class BooleanType extends PGType<Boolean> {
 
     public static final PGType INSTANCE = new BooleanType();
     static final int OID = 16;
@@ -63,23 +63,20 @@ class BooleanType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
-        byte byteValue = (byte) ((boolean) value ? 1 : 0);
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Boolean value) {
+        byte byteValue = (byte) (value ? 1 : 0);
         buffer.writeInt(TYPE_LEN);
         buffer.writeByte(byteValue);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        if ((boolean) value) {
-            return TEXT_TRUE;
-        }
-        return TEXT_FALSE;
+    byte[] encodeAsUTF8Text(@Nonnull Boolean value) {
+        return value ? TEXT_TRUE : TEXT_FALSE;
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Boolean readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN +
                                          " because boolean is just a byte. Actual length: " + valueLength;
         byte value = buffer.readByte();
@@ -94,7 +91,7 @@ class BooleanType extends PGType {
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Boolean decodeUTF8Text(byte[] bytes) {
         return TRUTH_VALUES.contains(ByteBuffer.wrap(bytes));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
@@ -28,9 +28,9 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class CharType extends PGType {
+class CharType extends PGType<Byte> {
 
-    public static final PGType INSTANCE = new CharType();
+    public static final CharType INSTANCE = new CharType();
     static final int OID = 18;
 
 
@@ -49,25 +49,25 @@ class CharType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Byte value) {
         buffer.writeInt(1);
-        buffer.writeByte(((byte) value));
+        buffer.writeByte(value);
         return 5;
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Byte readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == 1 : "char must have 1 byte";
         return buffer.readByte();
     }
 
     @Override
-    byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Byte.toString((byte) value).getBytes(StandardCharsets.UTF_8);
+    byte[] encodeAsUTF8Text(@Nonnull Byte value) {
+        return Byte.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Byte decodeUTF8Text(byte[] bytes) {
         return Byte.parseByte(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
@@ -28,7 +28,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class DoubleType extends PGType {
+class DoubleType extends PGType<Double> {
 
     public static final DoubleType INSTANCE = new DoubleType();
     static final int OID = 701;
@@ -51,26 +51,26 @@ class DoubleType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Double value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeDouble(((double) value));
+        buffer.writeDouble(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Double.toString(((double) value)).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Double value) {
+        return Double.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Double readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because double is int64. Actual length: " +
                                          valueLength;
         return buffer.readDouble();
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Double decodeUTF8Text(byte[] bytes) {
         return Double.parseDouble(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
@@ -28,7 +28,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class IntegerType extends PGType {
+class IntegerType extends PGType<Integer> {
 
     static final int OID = 23;
 
@@ -52,26 +52,26 @@ class IntegerType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Integer value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeInt(((int) value));
+        buffer.writeInt(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Integer.toString(((int) value)).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Integer value) {
+        return Integer.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
-        assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because int is int32. Actual length: " +
-                                         valueLength;
+    public Integer readBinaryValue(ByteBuf buffer, int valueLength) {
+        assert valueLength == TYPE_LEN
+            : "length should be " + TYPE_LEN + " because int is int32. Actual length: " + valueLength;
         return buffer.readInt();
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Integer decodeUTF8Text(byte[] bytes) {
         return Integer.parseInt(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
@@ -29,7 +29,7 @@ import org.joda.time.ReadablePeriod;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-public class IntervalType extends PGType {
+public class IntervalType extends PGType<Period> {
 
     private static final int OID = 1186;
     private static final int TYPE_LEN = 16;
@@ -51,8 +51,7 @@ public class IntervalType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
-        Period period = (Period) value;
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Period period) {
         buffer.writeInt(TYPE_LEN);
         // from PostgreSQL code:
         // pq_sendint64(&buf, interval->time);
@@ -70,7 +69,7 @@ public class IntervalType extends PGType {
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Period readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because interval is 16. Actual length: " +
                                          valueLength;
         long micros = buffer.readLong();
@@ -100,14 +99,14 @@ public class IntervalType extends PGType {
     }
 
     @Override
-    byte[] encodeAsUTF8Text(@Nonnull Object value) {
+    byte[] encodeAsUTF8Text(@Nonnull Period value) {
         StringBuffer sb = new StringBuffer();
         io.crate.types.IntervalType.PERIOD_FORMATTER.printTo(sb, (ReadablePeriod) value);
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Period decodeUTF8Text(byte[] bytes) {
         return io.crate.types.IntervalType.PERIOD_FORMATTER.parsePeriod(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
@@ -35,9 +35,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-class JsonType extends PGType {
+class JsonType extends PGType<Object> {
 
-    public static final PGType INSTANCE = new JsonType();
+    public static final JsonType INSTANCE = new JsonType();
     static final int OID = 114;
 
     private static final int TYPE_LEN = -1;

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-public abstract class PGType {
+public abstract class PGType<T> {
 
     enum TypeCategory {
 
@@ -112,14 +112,14 @@ public abstract class PGType {
      *
      * @return the number of bytes written. (4 (int32)  + N)
      */
-    public int writeAsText(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsText(ByteBuf buffer, @Nonnull T value) {
         byte[] bytes = encodeAsUTF8Text(value);
         buffer.writeInt(bytes.length);
         buffer.writeBytes(bytes);
         return INT32_BYTE_SIZE + bytes.length;
     }
 
-    public Object readTextValue(ByteBuf buffer, int valueLength) {
+    public T readTextValue(ByteBuf buffer, int valueLength) {
         byte[] bytes = new byte[valueLength];
         buffer.readBytes(bytes);
         try {
@@ -143,19 +143,19 @@ public abstract class PGType {
      *
      * @return the number of bytes written. (4 (int32)  + N)
      */
-    public abstract int writeAsBinary(ByteBuf buffer, @Nonnull Object value);
+    public abstract int writeAsBinary(ByteBuf buffer, @Nonnull T value);
 
-    public abstract Object readBinaryValue(ByteBuf buffer, int valueLength);
+    public abstract T readBinaryValue(ByteBuf buffer, int valueLength);
 
 
     /**
      * Return the UTF8 encoded text representation of the value
      */
-    abstract byte[] encodeAsUTF8Text(@Nonnull Object value);
+    abstract byte[] encodeAsUTF8Text(@Nonnull T value);
 
     /**
      * Convert a UTF8 encoded text representation into the actual value
      */
-    abstract Object decodeUTF8Text(byte[] bytes);
+    abstract T decodeUTF8Text(byte[] bytes);
 
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PointType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PointType.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
-public final class PointType extends PGType {
+public final class PointType extends PGType<Point> {
 
     public static final PointType INSTANCE = new PointType();
     static final int OID = 600;
@@ -54,8 +54,7 @@ public final class PointType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
-        Point point = (Point) value;
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Point point) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeDouble(point.getX());
         buffer.writeDouble(point.getY());
@@ -63,20 +62,19 @@ public final class PointType extends PGType {
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Point readBinaryValue(ByteBuf buffer, int valueLength) {
         double x = buffer.readDouble();
         double y = buffer.readDouble();
         return new PointImpl(x, y, JtsSpatialContext.GEO);
     }
 
     @Override
-    byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        Point point = (Point) value;
+    byte[] encodeAsUTF8Text(@Nonnull Point point) {
         return ('(' + String.valueOf(point.getX()) + ',' + point.getY() + ')').getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Point decodeUTF8Text(byte[] bytes) {
         String value = new String(bytes, StandardCharsets.UTF_8);
         StringTokenizer tokenizer = new StringTokenizer(value, ",()");
         double x;

--- a/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
@@ -28,7 +28,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class RealType extends PGType {
+class RealType extends PGType<Float> {
 
     public static final RealType INSTANCE = new RealType();
     static final int OID = 700;
@@ -51,26 +51,26 @@ class RealType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Float value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeFloat(((float) value));
+        buffer.writeFloat(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Float.toString(((float) value)).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Float value) {
+        return Float.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Float readBinaryValue(ByteBuf buffer, int valueLength) {
         assert valueLength == TYPE_LEN : "length should be " + TYPE_LEN + " because float is int32. Actual length: " +
                                          valueLength;
         return buffer.readFloat();
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Float decodeUTF8Text(byte[] bytes) {
         return Float.parseFloat(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
@@ -28,7 +28,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class SmallIntType extends PGType {
+class SmallIntType extends PGType<Short> {
 
     public static final SmallIntType INSTANCE = new SmallIntType();
     static final int OID = 21;
@@ -51,19 +51,19 @@ class SmallIntType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Short value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeShort((short) value);
+        buffer.writeShort(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return Short.toString(((short) value)).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Short value) {
+        return Short.toString(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public Short readBinaryValue(ByteBuf buffer, int valueLength) {
         assert
             valueLength == TYPE_LEN :
             "length should be " + TYPE_LEN + " because short is int16. Actual length: " + valueLength;
@@ -71,7 +71,7 @@ class SmallIntType extends PGType {
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    Short decodeUTF8Text(byte[] bytes) {
         return Short.parseShort(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -27,14 +27,14 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class VarCharType extends PGType {
+class VarCharType extends PGType<String> {
 
     static final int OID = 1043;
     private static final int ARRAY_OID = 1015;
     private static final int TYPE_LEN = -1;
     private static final int TYPE_MOD = -1;
 
-    public static final PGType INSTANCE = new VarCharType(ARRAY_OID);
+    public static final VarCharType INSTANCE = new VarCharType(ARRAY_OID);
 
     private final int typArray;
 
@@ -59,34 +59,32 @@ class VarCharType extends PGType {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
-        assert value instanceof String : "value must be a string, got: " + value;
-        byte[] bytes = ((String) value).getBytes(StandardCharsets.UTF_8);
+    public int writeAsBinary(ByteBuf buffer, @Nonnull String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
         buffer.writeInt(bytes.length);
         buffer.writeBytes(bytes);
         return INT32_BYTE_SIZE + bytes.length;
     }
 
     @Override
-    public int writeAsText(ByteBuf buffer, @Nonnull Object value) {
+    public int writeAsText(ByteBuf buffer, @Nonnull String value) {
         return writeAsBinary(buffer, value);
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        assert value instanceof String : "value must be a string";
-        return ((String) value).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object readBinaryValue(ByteBuf buffer, int valueLength) {
+    public String readBinaryValue(ByteBuf buffer, int valueLength) {
         byte[] utf8 = new byte[valueLength];
         buffer.readBytes(utf8);
         return new String(utf8, StandardCharsets.UTF_8);
     }
 
     @Override
-    Object decodeUTF8Text(byte[] bytes) {
+    String decodeUTF8Text(byte[] bytes) {
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
@@ -95,6 +93,6 @@ class VarCharType extends PGType {
         private static final int ARRAY_OID = -1;
         private static final int TYPE_LEN = 64;
 
-        static final PGType INSTANCE = new VarCharType(OID, ARRAY_OID, TYPE_LEN, "name");
+        static final VarCharType INSTANCE = new VarCharType(OID, ARRAY_OID, TYPE_LEN, "name");
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -67,7 +67,7 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
     }
 
     public void test_json_array_encode_decode_round_trip() {
-        var actual = List.of(
+        List<Object> actual = List.of(
             Map.of("names", List.of("Arthur", "Trillian")),
             Map.of("names", List.of("Ford", "Slarti")));
 
@@ -167,12 +167,12 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
     @Ignore // For multi-dimensions -1 is used both for "padding" until the max length of the dimension,
             // but also for null handling, therefore we cannot distinguish between the two
     public void testBinaryEncodingDecodingRoundtrip_MultipleDimensionsWithNulls() {
-        Object sourceArray = new Object[][] {
-            {1, 2, 3},
-            {4, 5, null},
-            {null, 6, 7, 8},
-            {null, null, 9, null}
-        };
+        List<Object> sourceArray = List.of(
+            Arrays.asList(1, 2, 3),
+            Arrays.asList(4, 5, null),
+            Arrays.asList(null, 6, 7, 8),
+            Arrays.asList(null, null, 9, null)
+        );
 
         ByteBuf buffer = Unpooled.buffer();
         pgArray.writeAsBinary(buffer, sourceArray);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I forgot to update `writeAsBinary` from using a List to Row in the PR
that introduced the RowType/RecordType.

This wasn't caught earlier because the test for binary streaming is in crate-qa
(https://github.com/crate/crate-qa/pull/138).

The JDBC client uses text serialization for records.

The commit here fixes the issue and adds generics to PGType, to prevent
this kind of mistake in the future.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)