### PR TITLE
Prevent join filter push down rule from matching infinitely

### DIFF
--- a/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -52,6 +52,7 @@ final class FilterOnJoinsUtil {
             ));
         }
         Map<Set<QualifiedName>, Symbol> splitQuery = QuerySplitter.split(query);
+        int initialParts = splitQuery.size();
         if (splitQuery.size() == 1 && splitQuery.keySet().iterator().next().size() > 1) {
             return null;
         }
@@ -67,6 +68,8 @@ final class FilterOnJoinsUtil {
         LogicalPlan newJoin = join.replaceSources(List.of(newLhs, newRhs));
         if (splitQuery.isEmpty()) {
             return newJoin;
+        } else if (initialParts == splitQuery.size()) {
+            return null;
         } else {
             return new Filter(newJoin, AndOperator.join(splitQuery.values()));
         }


### PR DESCRIPTION
Not sure about backport and release notes entry. The query that triggers
this doesn't run in 4.1 for other reasons.


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)