### PR TITLE
Return `issued_to` value if license is loading

### DIFF
--- a/common/src/main/java/io/crate/license/LicenseService.java
+++ b/common/src/main/java/io/crate/license/LicenseService.java
@@ -35,6 +35,11 @@ public interface LicenseService {
         MAX_NODES_VIOLATED
     }
 
+    enum Mode {
+        CE,
+        ENTERPRISE
+    }
+
 
     CompletableFuture<Long> registerLicense(String licenseKey);
 
@@ -45,4 +50,8 @@ public interface LicenseService {
 
     @Nullable
     ClusterStateListener clusterStateListener();
+
+    default Mode getMode() {
+        return Mode.CE;
+    }
 }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -127,4 +127,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue which may result in showing the CE admin-ui view even if
+  running in Enterprise mode on early node startup.
+

--- a/enterprise/licensing/src/main/java/io/crate/license/EnterpriseLicenseService.java
+++ b/enterprise/licensing/src/main/java/io/crate/license/EnterpriseLicenseService.java
@@ -28,13 +28,13 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.transport.TransportService;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -93,6 +93,11 @@ public class EnterpriseLicenseService implements LicenseService, ClusterStateLis
         this.transportService = transportService;
         this.transportSetLicenseAction = transportSetLicenseAction;
         this.logger = LogManager.getLogger(getClass());
+    }
+
+    @Override
+    public Mode getMode() {
+        return Mode.ENTERPRISE;
     }
 
     public CompletableFuture<Long> registerLicense(final String licenseKey) {

--- a/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
@@ -41,6 +41,8 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
     public static final String ISSUED_TO = "issued_to";
     public static final String MAX_NODES = "max_nodes";
 
+    public static final String LICENSE_IS_LOADING = "License is loading";
+
     private final LicenseService licenseService;
 
     @Inject
@@ -66,6 +68,12 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
             }));
             childImplementations.put(ISSUED_TO, forFunction(ignored -> licenseData.issuedTo()));
             childImplementations.put(MAX_NODES, forFunction(ignored -> licenseData.maxNumberOfNodes()));
+        } else if (licenseService.getMode() == LicenseService.Mode.ENTERPRISE) {
+            // The admin-ui will switch it's view between CE and Enterprise based on a non-null value of `issued_to`.
+            // To prevent a race-condition (wrong admin-ui view) on node startup, we set a dummy value here.
+            childImplementations.put(EXPIRY_DATE, constant(null));
+            childImplementations.put(ISSUED_TO, constant(LICENSE_IS_LOADING));
+            childImplementations.put(MAX_NODES, constant(null));
         } else {
             childImplementations.put(EXPIRY_DATE, constant(null));
             childImplementations.put(ISSUED_TO, constant(null));


### PR DESCRIPTION
Return a static “loading” value for `sys.cluster.license.issued_to` if running in Enterprise mode and the license data is not yet available on node startup.
This prevents the admin-ui from showing the wrong view/style because it’s current view decision is based on a non-null value of that column.