### PR TITLE
Add a `now()` scalar

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,8 @@ None
 Changes
 =======
 
+- Added the :ref:`now <now>` scalar function.
+
 - Introduced new optional ``RETURNING`` clause for :ref:`Insert <ref-insert>` to
   return specified values from each row inserted.
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -782,6 +782,22 @@ are given.
    ``System.currentTimeMillis()``. So its actual result depends on the
    underlying operating system.
 
+.. _now:
+
+``now()``
+---------
+
+Returns the current date and time.
+
+This is the same as ``current_timestamp``
+
+Returns: ``timestamp with time zone``
+
+Synopsis::
+
+  now()
+
+
 ``date_format([format_string, [timezone,]] timestamp)``
 -------------------------------------------------------
 

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -69,6 +69,7 @@ import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
 import io.crate.expression.scalar.systeminformation.VersionFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
+import io.crate.expression.scalar.timestamp.NowFunction;
 import io.crate.expression.scalar.timestamp.TimezoneFunction;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -136,6 +137,7 @@ public class ScalarFunctionModule extends AbstractModule {
         DateTruncFunction.register(this);
         ExtractFunctions.register(this);
         CurrentTimestampFunction.register(this);
+        NowFunction.register(this);
         TimezoneFunction.register(this);
         DateFormatFunction.register(this);
         CastFunction.register(this);

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.timestamp;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+public final class NowFunction extends Scalar<Long, Object> {
+
+    public static final String NAME = "now";
+    private static final FunctionInfo INFO = new FunctionInfo(
+        new FunctionIdent(null, NAME, List.of()),
+        DataTypes.TIMESTAMPZ,
+        FunctionInfo.Type.SCALAR
+    );
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new NowFunction());
+    }
+
+    @Override
+    @SafeVarargs
+    public final Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        return txnCtx.currentTimeMillis();
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return INFO;
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.timestamp;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NowFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final long EXPECTED_TIMESTAMP = 1422294644581L;
+
+    @Before
+    public void prepare() {
+        DateTimeUtils.setCurrentMillisFixed(EXPECTED_TIMESTAMP);
+    }
+
+    @After
+    public void cleanUp() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void test_now_returns_current_timestamp() {
+        assertEvaluate("now()", EXPECTED_TIMESTAMP);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It is part of the escaped date/time functions of PostgreSQL JDBC:

https://jdbc.postgresql.org/documentation/head/escaped-functions.html

The behavior is the same as `current_timestamp`.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)