### PR TITLE
tests: Add Ignore annotation to flaky test

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -59,6 +59,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -183,6 +184,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
     }
 
     @Test
+    @Ignore("Currently flaky, needs fixing")
     public void test_lucene_ordered_collector_thread_dies_on_kill() throws Exception {
         LuceneOrderedDocCollector luceneOrderedDocCollector = createOrderedCollector(searcher1, 1);
         AtomicReference<Thread> collectThread = new AtomicReference<>();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`test_lucene_ordered_collector_thread_dies_on_kill` is flaky.

    java.lang.AssertionError:
    Expected: is <false>
        but: was <true>
            at __randomizedtesting.SeedInfo.seed([E8DA75A1B1860703:78E50535B47434B6]:0)
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
            at org.junit.Assert.assertThat(Assert.java:956)
            at org.junit.Assert.assertThat(Assert.java:923)
            at io.crate.execution.engine.collect.collectors.OrderedLuceneBatchIteratorFactoryTest.lambda$test_lucene_ordered_collector_thread_dies_on_kill$8(OrderedLuceneBatchIteratorFactoryTest.java:214)
            at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:828)
            at io.crate.execution.engine.collect.collectors.OrderedLuceneBatchIteratorFactoryTest.test_lucene_ordered_collector_thread_dies_on_kill(OrderedLuceneBatchIteratorFactoryTest.java:214)

This adds an Ignore annotation for now, to unblock other PRs.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)