### PR TITLE
Remove custom normalize from CurrentTimestampFunction

### DIFF
--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -25,13 +25,11 @@ import com.google.common.math.LongMath;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
 import java.math.RoundingMode;
@@ -56,7 +54,8 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
 
 
     @Override
-    public Long evaluate(TransactionContext txnCtx, Input<Integer>... args) {
+    @SafeVarargs
+    public final Long evaluate(TransactionContext txnCtx, Input<Integer>... args) {
         long millis = txnCtx.currentTimeMillis();
         Integer precision = 3;
         if (args.length == 1) {
@@ -92,28 +91,6 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
     @Override
     public FunctionInfo info() {
         return INFO;
-    }
-
-    @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
-        // use evaluatedFunctions map to make sure multiple occurrences of current_timestamp within a query result in the same result
-        return eval(function, txnCtx.currentTimeMillis());
-    }
-
-    private Symbol eval(Function function, long currentTimeMillis) {
-        Symbol symbol;
-        if (function.arguments().isEmpty()) {
-            symbol = Literal.of(INFO.returnType(), currentTimeMillis);
-        } else {
-            Symbol precision = function.arguments().get(0);
-            if (precision.symbolType().isValueSymbol()) {
-                symbol = Literal.of(INFO.returnType(),
-                    applyPrecision(currentTimeMillis, (Integer) ((Input) precision).value()));
-            } else {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Invalid argument to %s", NAME));
-            }
-        }
-        return symbol;
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The custom normalize implementation was added before we had a
`evaluate` implementation for `current_timestamp`. But that changed a
while ago (https://github.com/crate/crate/commit/e18fe9bbb0d25b5eb6f9073b0660a07fa7f89eeb)

It isn't required anymore as far as I can tell.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)