### PR TITLE
Fix `/ by zero` error in average row size calculation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -132,6 +132,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression that caused a ``ArithmeticException: / by zero`` error
+  when querying an empty table, or a non-empty table with outdated table
+  statistics.
+
 - Fixed a regression that caused ``INSERT INTO`` statements containing an
   ``object`` column as target and a matching JSON string literal in the source
   to fail with a type cast error.

--- a/sql/src/main/java/io/crate/statistics/Stats.java
+++ b/sql/src/main/java/io/crate/statistics/Stats.java
@@ -88,8 +88,11 @@ public class Stats implements Writeable {
     public long averageSizePerRowInBytes() {
         if (numDocs == -1) {
             return -1;
+        } else if (numDocs == 0) {
+            return 0;
+        } else {
+            return sizeInBytes / numDocs;
         }
-        return sizeInBytes / numDocs;
     }
 
     public Map<ColumnIdent, ColumnStats> statsByColumn() {

--- a/sql/src/test/java/io/crate/statistics/StatsTest.java
+++ b/sql/src/test/java/io/crate/statistics/StatsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+
+package io.crate.statistics;
+
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import io.crate.test.integration.CrateUnitTest;
+
+public class StatsTest extends CrateUnitTest {
+
+    @Test
+    public void test_average_size_calc_if_numDocs_is_zero() throws Exception {
+        Stats stats = new Stats(0L, 200L, Map.of());
+        assertThat(stats.averageSizePerRowInBytes(), Matchers.is(0L));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/9656


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)