### PR TITLE
Enforce Literal returnType / dataType relationship with type system

### DIFF
--- a/common/src/main/java/io/crate/types/DataTypes.java
+++ b/common/src/main/java/io/crate/types/DataTypes.java
@@ -25,13 +25,13 @@ import io.crate.Streamer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 import org.locationtech.spatial4j.shape.jts.JtsPoint;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -179,7 +179,7 @@ public final class DataTypes {
         LONG.id(), Set.of(TIMESTAMPZ, TIMESTAMP, DOUBLE),
         FLOAT.id(), Set.of(DOUBLE));
 
-    public static boolean isArray(DataType type) {
+    public static boolean isArray(DataType<?> type) {
         return type.id() == ArrayType.ID;
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -72,7 +72,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             inputs[i] = ((Input) function.arguments().get(i));
         }
         //noinspection unchecked
-        return Literal.of(functionInfo.returnType(), evaluate(txnCtx, inputs));
+        return Literal.ofUnchecked(functionInfo.returnType(), evaluate(txnCtx, inputs));
     }
 
     private static class StringConcatFunction extends ConcatFunction {

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -91,7 +91,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
         if (argument instanceof Input) {
             Object value = ((Input<?>) argument).value();
             try {
-                return Literal.of(returnType, returnType.value(value));
+                return Literal.ofUnchecked(returnType, returnType.value(value));
             } catch (ClassCastException | IllegalArgumentException e) {
                 return onNormalizeException.apply(argument, returnType);
             }
@@ -110,9 +110,9 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
 
     @Override
     public String afterArgs(Function function) {
-        DataType dataType = function.valueType();
+        DataType<?> dataType = function.valueType();
         if (DataTypes.isArray(dataType)) {
-            ArrayType arrayType = ((ArrayType) dataType);
+            ArrayType<?> arrayType = ((ArrayType<?>) dataType);
             return " AS " + ArrayType.NAME +
                    PAREN_OPEN + arrayType.innerType().getName() + PAREN_CLOSE
                    + PAREN_CLOSE;

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -122,7 +122,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             idx++;
         }
         //noinspection unchecked
-        return Literal.of(function.info().returnType(), scalar.evaluate(txnCtx, inputs));
+        return Literal.ofUnchecked(function.info().returnType(), scalar.evaluate(txnCtx, inputs));
     }
 
     public static class OperatorScalar<R, I> extends Scalar<R, I> implements OperatorFormatSpec {

--- a/sql/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/sql/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -22,8 +22,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.Locale;
-
 import io.crate.data.Row;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Literal;
@@ -32,6 +30,8 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+
+import java.util.Locale;
 
 public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
     implements java.util.function.Function<Symbol, Symbol> {
@@ -63,7 +63,7 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
     @Override
     public Symbol visitSelectSymbol(SelectSymbol selectSymbol, Void context) {
         Object value = subQueryResults.getSafe(selectSymbol);
-        return Literal.of(selectSymbol.valueType(), selectSymbol.valueType().value(value));
+        return Literal.ofUnchecked(selectSymbol.valueType(), selectSymbol.valueType().value(value));
     }
 
     @Override
@@ -87,6 +87,6 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
         if (type.equals(DataTypes.UNDEFINED)) {
             type = DataTypes.guessType(value);
         }
-        return Literal.of(type, type.value(value));
+        return Literal.ofUnchecked(type, type.value(value));
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/sql/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -80,7 +80,7 @@ public final class TableFunction implements LogicalPlan {
         for (Symbol arg : args) {
             // It's not possible to use columns as argument to a table function, so it's safe to evaluate at this point.
             functionArguments.add(
-                Literal.of(
+                Literal.ofUnchecked(
                     arg.valueType(),
                     SymbolEvaluator.evaluate(
                         plannerContext.transactionContext(), plannerContext.functions(), arg, params, subQueryResults)

--- a/sql/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -398,13 +398,14 @@ public final class CopyFromPlan implements Plan {
 
     private static Symbol validateAndConvertToLiteral(Object uri) {
         if (uri instanceof String) {
-            return Literal.of(DataTypes.STRING, uri);
+            return Literal.of(DataTypes.STRING.value(uri));
         } else if (uri instanceof List) {
             Object value = ((List) uri).get(0);
             if (!(value instanceof String)) {
                 throw AnalyzedCopyFrom.raiseInvalidType(DataTypes.guessType(uri));
             }
-            return Literal.of(new ArrayType<>(DataTypes.STRING), uri);
+            ArrayType<String> strArray = new ArrayType<>(DataTypes.STRING);
+            return Literal.of(strArray, strArray.value(uri));
         }
         throw AnalyzedCopyFrom.raiseInvalidType(DataTypes.guessType(uri));
     }

--- a/sql/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -271,7 +271,7 @@ public final class CopyToPlan implements Plan {
 
         return new BoundCopyTo(
             subRelation,
-            Literal.of(DataTypes.STRING, eval.apply(copyTo.uri())),
+            Literal.of(DataTypes.STRING.value(eval.apply(copyTo.uri()))),
             compressionType,
             outputFormat,
             outputNames,

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -198,7 +198,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     public void test_try_cast_for_all_data_types() {
         for (DataType dataType : DataTypes.PRIMITIVE_TYPES) {
             DataType<?> randomType = randomType();
-            Literal val = Literal.of(randomType, getDataGenerator(randomType).get());
+            Literal val = Literal.ofUnchecked(randomType, getDataGenerator(randomType).get());
             assertEvaluate(
                 "try_cast(" + SymbolPrinter.INSTANCE.printQualified(val) + " as " + dataType.getName() + ")",
                 anyOf(notNullValue(), nullValue()));

--- a/sql/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
@@ -24,7 +24,6 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Literal;
-import io.crate.types.DataTypes;
 import org.junit.Test;
 
 public class EncodeDecodeFunctionTest extends AbstractScalarFunctionsTest {
@@ -105,7 +104,7 @@ public class EncodeDecodeFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEncodeFuncBase64() {
         // input in hex format
-        final Literal<Object> name = Literal.of(DataTypes.STRING, "\\x3132330001");
+        final Literal<String> name = Literal.of("\\x3132330001");
         assertEvaluate("encode('\\x3132330001', 'base64')", "MTIzAAE=");
         assertEvaluate("encode(name, 'Base64')", "MTIzAAE=", name);
         // input in escape format
@@ -115,7 +114,7 @@ public class EncodeDecodeFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testDecodeFuncBase64() {
-        final Literal<Object> name = Literal.of(DataTypes.STRING, "MTIzAAE=");
+        Literal<String> name = Literal.of("MTIzAAE=");
         assertEvaluate("decode('MTIzAAE=', 'base64')", "\\x3132330001");
         assertEvaluate("decode('MTIzAAE=', 'BASE64')", "\\x3132330001");
         assertEvaluate("decode(name, 'base64')", "\\x3132330001", name);

--- a/sql/src/test/java/io/crate/expression/scalar/string/StringLeftRightFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/StringLeftRightFunctionTest.java
@@ -24,14 +24,13 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Literal;
-import io.crate.types.DataTypes;
 import org.junit.Test;
 
 public class StringLeftRightFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateLeftFunc() throws Exception {
-        Literal<Object> value = Literal.of(DataTypes.STRING, "crate.io");
+        Literal<String> value = Literal.of("crate.io");
         assertEvaluate("left(name, 10)", null, Literal.of((String) null));
         assertEvaluate("left(name, null)", null, value);
         assertEvaluate("left(name, 0)", "", value);
@@ -44,7 +43,7 @@ public class StringLeftRightFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateRightFunc() throws Exception {
-        Literal<Object> value = Literal.of(DataTypes.STRING, "crate.io");
+        Literal<String> value = Literal.of("crate.io");
         assertEvaluate("right(name, 10)", null, Literal.of((String) null));
         assertEvaluate("right(name, null)", null, value);
         assertEvaluate("right(name, 0)", "", value);

--- a/sql/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -53,7 +53,7 @@ public class LiteralTest extends CrateUnitTest {
                 value = type.value("0");
             }
             var nestedValue = List.of(List.of(value));
-            Literal nestedLiteral = Literal.of(nestedType, nestedValue);
+            Literal nestedLiteral = Literal.ofUnchecked(nestedType, nestedValue);
             assertThat(nestedLiteral.valueType(), is(nestedType));
             assertThat(nestedLiteral.value(), is(nestedValue));
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Both Literal and DataType were already using generics for the value.

We can enforce the relationship between Literal value and DataType value
with the type system.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)