### PR TITLE
Allow eager normalization of functions on non-literals

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -67,7 +67,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.expression.symbol.format.SymbolFormatter;
 import io.crate.interval.IntervalParser;
@@ -1133,7 +1132,7 @@ public class ExpressionAnalyzer {
                 filter,
                 windowDefinition);
         }
-        if (context.isEagerNormalizationAllowed() && functionInfo.isDeterministic() && Symbols.allLiterals(newFunction)) {
+        if (context.isEagerNormalizationAllowed() && functionInfo.isDeterministic()) {
             return funcImpl.normalizeSymbol(newFunction, coordinatorTxnCtx);
         }
         return newFunction;

--- a/sql/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -42,7 +42,6 @@ import java.util.function.Predicate;
 public class Symbols {
 
     private static final HasColumnVisitor HAS_COLUMN_VISITOR = new HasColumnVisitor();
-    private static final AllLiteralsMatcher ALL_LITERALS_MATCHER = new AllLiteralsMatcher();
 
     public static final Predicate<Symbol> IS_COLUMN = s -> s instanceof Field || s instanceof Reference;
     public static final Predicate<Symbol> IS_GENERATED_COLUMN = input -> input instanceof GeneratedReference;
@@ -95,11 +94,6 @@ public class Symbols {
             }
         }
         return false;
-    }
-
-    public static boolean allLiterals(Symbol symbol) {
-        assert symbol != null : "symbol must not be null";
-        return symbol.accept(ALL_LITERALS_MATCHER, null);
     }
 
     public static void toStream(Collection<? extends Symbol> symbols, StreamOutput out) throws IOException {
@@ -185,26 +179,4 @@ public class Symbols {
             return column.equals(symbol.column());
         }
     }
-
-    /**
-     * Returns true if all symbols in an expression are literals and false otherwise.
-     */
-    private static class AllLiteralsMatcher extends SymbolVisitor<Void, Boolean> {
-
-        @Override
-        public Boolean visitFunction(Function function, Void context) {
-            return function.arguments().stream().allMatch(arg -> arg.accept(this, null));
-        }
-
-        @Override
-        public Boolean visitLiteral(Literal symbol, Void context) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitSymbol(Symbol symbol, Void context) {
-            return false;
-        }
-    }
-
 }

--- a/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -28,6 +28,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,6 +50,7 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws Exception {
         expressions = new SqlExpressions(T3.sources(clusterService));
+        expressions.context().allowEagerNormalize(false);
     }
 
     private Symbol asSymbol(String expression) {

--- a/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -44,6 +44,7 @@ public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws Exception {
         sqlExpressions = new SqlExpressions(T3.sources(clusterService));
+        sqlExpressions.context().allowEagerNormalize(false);
     }
 
     private void assertReplaced(String expression, String expectedString) {

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -129,12 +129,13 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
      * If the result of normalize is a Literal and all arguments were Literals evaluate is also called and
      * compared to the result of normalize - the resulting value of normalize must match evaluate.
      */
-    @SuppressWarnings("unchecked")
     public void assertNormalize(String functionExpression, Matcher<? super Symbol> expectedSymbol) {
         assertNormalize(functionExpression, expectedSymbol, true);
     }
 
     public void assertNormalize(String functionExpression, Matcher<? super Symbol> expectedSymbol, boolean evaluate) {
+        // Explicit normalization happens further below
+        sqlExpressions.context().allowEagerNormalize(false);
         Symbol functionSymbol = sqlExpressions.asSymbol(functionExpression);
         if (functionSymbol instanceof Literal) {
             assertThat(functionSymbol, expectedSymbol);
@@ -175,6 +176,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
         if (expectedValue == null) {
             expectedValue = (Matcher<T>) nullValue();
         }
+        sqlExpressions.context().allowEagerNormalize(true);
         Symbol functionSymbol = sqlExpressions.asSymbol(functionExpression);
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         if (functionSymbol instanceof Literal) {

--- a/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -83,7 +83,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `[1, 2]` of type `bigint_array` to type `text`");
+        expectedException.expectMessage("Cannot cast `_array(1, 2)` of type `bigint_array` to type `text`");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 

--- a/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/sql/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -41,6 +41,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_eq_null_value_is_always_0() {
         SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
+        expressions.context().allowEagerNormalize(false);
         Symbol query = expressions.asSymbol("x = null");
         var numbers = IntStream.range(1, 50)
             .boxed()

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -114,6 +114,10 @@ public class SqlExpressions {
         return expressionAnalyzer.convert(SqlParser.createExpression(expression), expressionAnalysisCtx);
     }
 
+    public ExpressionAnalysisContext context() {
+        return expressionAnalysisCtx;
+    }
+
     public Symbol normalize(Symbol symbol) {
         return normalizer.normalize(symbol, coordinatorTxnCtx);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I don't see a reason why it shouldn't be allowed.

We can normalize condititions like `field = null` to `false` and `column
and true` to `column`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)