### PR TITLE
Fix rtrim to trim the right side in all cases

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -134,4 +134,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that caused :ref:`RTRIM <scalar-rtrim>` to behave like
+  :ref:`LRTRIM <scalar-ltrim>`.

--- a/sql/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -73,8 +73,8 @@ public final class TrimFunctions {
             }
         });
 
-        module.register(LTRIM_NAME, new SingleSideTrimFunctionResolver((i, c) -> trimChars(i, c, TrimMode.LEADING)));
-        module.register(RTRIM_NAME, new SingleSideTrimFunctionResolver((i, c) -> trimChars(i, c, TrimMode.TRAILING)));
+        module.register(LTRIM_NAME, new SingleSideTrimFunctionResolver(LTRIM_NAME, (i, c) -> trimChars(i, c, TrimMode.LEADING)));
+        module.register(RTRIM_NAME, new SingleSideTrimFunctionResolver(RTRIM_NAME, (i, c) -> trimChars(i, c, TrimMode.TRAILING)));
     }
 
     private static class TrimFunction extends Scalar<String, String> {
@@ -207,9 +207,11 @@ public final class TrimFunctions {
     }
 
     private static class SingleSideTrimFunctionResolver extends BaseFunctionResolver {
+
+        private final String functionName;
         private final BiFunction<String, String, String> trimFunction;
 
-        SingleSideTrimFunctionResolver(BiFunction<String, String, String> trimFunction) {
+        SingleSideTrimFunctionResolver(String functionName, BiFunction<String, String, String> trimFunction) {
             super(
                 FuncParams
                     .builder(Param.STRING)
@@ -217,15 +219,14 @@ public final class TrimFunctions {
                     .limitVarArgOccurrences(1)
                     .build()
             );
+            this.functionName = functionName;
             this.trimFunction = trimFunction;
         }
 
         @Override
         public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
             return new SingleSideTrimFunction(
-                new FunctionInfo(
-                    new FunctionIdent(LTRIM_NAME, dataTypes), DataTypes.STRING
-                ),
+                new FunctionInfo(new FunctionIdent(functionName, dataTypes), DataTypes.STRING),
                 trimFunction
             );
         }

--- a/sql/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
@@ -29,7 +29,6 @@ import org.hamcrest.core.IsSame;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
 
 public class TrimFunctionTest extends AbstractScalarFunctionsTest {
@@ -49,6 +48,11 @@ public class TrimFunctionTest extends AbstractScalarFunctionsTest {
         String input = "  Hello World   ";
         assertNormalize(String.format("ltrim('%s')", input), isLiteral("Hello World   "));
         assertNormalize(String.format("rtrim('%s')", input), isLiteral("  Hello World"));
+    }
+
+    @Test
+    public void test_rtrim_trims_right_side_on_evaluate() {
+        assertEvaluate("rtrim(name)", "  Arthur", Literal.of("  Arthur  "));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`rtrim` only worked in the normalization case, but not in the late
evaluation case because the functionInfo of the implementation contained
the wrong name.

Found this while working on https://github.com/crate/crate/pull/9688/files 

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)