### PR TITLE
Remove Set/Object[] support recurse sorting from LiteralValueFormatter

### DIFF
--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
@@ -290,7 +290,7 @@ public final class SymbolPrinter {
 
         @Override
         public Void visitLiteral(Literal symbol, SymbolPrinterContext context) {
-            LiteralValueFormatter.INSTANCE.format(symbol.value(), context.builder);
+            LiteralValueFormatter.format(symbol.value(), context.builder);
             return null;
         }
 

--- a/sql/src/test/java/io/crate/expression/symbol/LiteralValueFormatterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/LiteralValueFormatterTest.java
@@ -32,7 +32,7 @@ public class LiteralValueFormatterTest {
     @Test
     public void testFormatOnArrayWithNullEntriesDoesNotCauseNPE() throws Exception {
         StringBuilder sb = new StringBuilder();
-        LiteralValueFormatter.INSTANCE.format(new Object[] { null, null}, sb);
+        LiteralValueFormatter.format(new Object[] { null, null}, sb);
         assertThat(sb.toString(), is("[NULL, NULL]"));
     }
 }

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
@@ -210,13 +211,11 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testObjectLiteral() throws Exception {
-        Literal<Map<String, Object>> l = Literal.of(new HashMap<String, Object>() {{
-            put("field", "value");
-            put("array", new Integer[]{1, 2, 3});
-            put("nestedMap", new HashMap<String, Object>() {{
-                put("inner", -0.00005d);
-            }});
-        }});
+        Literal<Map<String, Object>> l = Literal.of(Map.ofEntries(
+            Map.entry("field", "value"),
+            Map.entry("array", List.of(1, 2, 3)),
+            Map.entry("nestedMap", Map.of("inner", -0.00005d))
+        ));
         assertPrint(l, "{\"array\"=[1, 2, 3], \"field\"='value', \"nestedMap\"={\"inner\"=-5.0E-5}}");
     }
 
@@ -287,8 +286,12 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNativeArray() throws Exception {
         assertPrint(
-            Literal.of(DataTypes.GEO_SHAPE, ImmutableMap.of("type", "Point", "coordinates", new double[]{1.0d, 2.0d})),
-            "{\"coordinates\"=[1.0, 2.0], \"type\"='Point'}");
+            Literal.of(
+                DataTypes.GEO_SHAPE,
+                DataTypes.GEO_SHAPE.value(Map.of("type", "Point", "coordinates", new double[]{1.0d, 2.0d}))
+            ),
+            "{\"coordinates\"=[1.0, 2.0], \"type\"='Point'}"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We don't have a Set type anymore and arrays are always a List, never a
object array.

The `Sorted.sortRecursive` call for maps can also be replaced with a
non-recursive sort because the value formatting itself is recursing into
the elements.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)