### PR TITLE
Add support for GROUP BY on analyzed columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,9 @@ None
 Changes
 =======
 
+- Added support for ``GROUP BY`` operations on analysed columns of type
+  ``text``.
+
 - Added the :ref:`trunc <scalar-trunc>` scalar function.
 
 - Added the :ref:`now <now>` scalar function.

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -1045,10 +1045,6 @@ This is useful if used in conjunction with aggregation functions::
    subquery using :ref:`unnest`, it is then possible to use GROUP BY on the
    subquery.
 
-   GROUP BY doesn't work on columns of type :ref:`TEXT <data-type-text>` if
-   the column is indexed using a fulltext analyzer. By default TEXT columns
-   are indexed using a plain analyzer which allows GROUP BY operations.
-
 .. _sql_dql_having:
 
 ``HAVING``

--- a/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
@@ -22,10 +22,7 @@
 package io.crate.planner.node.dql;
 
 import io.crate.analyze.WhereClause;
-import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
-import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.format.SymbolPrinter;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
@@ -33,8 +30,6 @@ import io.crate.metadata.doc.DocTableInfo;
 import java.util.List;
 
 public class GroupByConsumer {
-
-    private static final GroupByValidator GROUP_BY_VALIDATOR = new GroupByValidator();
 
     public static boolean groupedByClusteredColumnOrPrimaryKeys(DocTableInfo tableInfo,
                                                                 WhereClause whereClause,
@@ -76,28 +71,5 @@ public class GroupByConsumer {
             }
         }
         return true;
-    }
-
-    public static void validateGroupBySymbols(List<Symbol> groupBySymbols) {
-        for (Symbol symbol : groupBySymbols) {
-            symbol.accept(GROUP_BY_VALIDATOR, null);
-        }
-    }
-
-    private static class GroupByValidator extends DefaultTraversalSymbolVisitor<Void, Void> {
-
-        @Override
-        public Void visitReference(Reference symbol, Void context) {
-            if (symbol.indexType() == Reference.IndexType.ANALYZED) {
-                throw new IllegalArgumentException(
-                        SymbolPrinter.format("Cannot GROUP BY '%s': grouping on analyzed/fulltext columns is not possible", symbol));
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitField(Field field, Void context) {
-            return field.pointer().accept(this, context);
-        }
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -106,7 +106,6 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         this.outputs = Lists2.concat(groupKeys, aggregates);
         this.groupKeys = groupKeys;
         this.aggregates = aggregates;
-        GroupByConsumer.validateGroupBySymbols(groupKeys);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -182,14 +182,13 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testGroupByOnAnalyzedColumn() throws Exception {
-        expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot GROUP BY 'col1': grouping on analyzed/fulltext columns is not possible");
-
         execute("create table test1 (col1 string index using fulltext)");
-        ensureYellow();
         execute("insert into test1 (col1) values ('abc def, ghi. jkl')");
         refresh();
-        execute("select count(col1) from test1 group by col1");
+        assertThat(
+            printedTable(execute("select count(col1) from test1 group by col1").rows()),
+            is("1\n")
+        );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -519,20 +519,6 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testGroupByOnAnalyzed() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot GROUP BY 'text': grouping on analyzed/fulltext columns is not possible");
-        e.plan("select text from users u group by 1");
-    }
-
-    @Test
-    public void testSelectAnalyzedReferenceInFunctionGroupBy() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot GROUP BY 'text': grouping on analyzed/fulltext columns is not possible");
-        e.plan("select substr(text, 0, 2) from users u group by 1");
-    }
-
-    @Test
     public void testDistributedGroupByProjectionHasShardLevelGranularity() throws Exception {
         Merge distributedGroupByMerge = e.plan("select count(*) from users group by name");
         Merge reduceMerge = (Merge) distributedGroupByMerge.subPlan();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This removes the restriction in the planner. The operation already
worked because the `LuceneReferenceResolver` does an implicit rewrite to
source lookup if there are no doc-values or if the field-type is
missing.

The validation could also have been bypassed by using `UNION`, because
it relied on pointer chasing on `Field` instances:

    select count(*), x from
      (select 'foo' as x union all select prose from tbl) as t group by 2;
    +----------+-------------+
    | count(*) | x           |
    +----------+-------------+
    |        1 | foo         |
    |        1 | hello world |
    +----------+-------------+

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)