### PR TITLE
Make subscript expression behavior more consistent

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -39,7 +39,6 @@ import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CurrentTime;
-import io.crate.sql.tree.RecordSubscript;
 import io.crate.sql.tree.DoubleLiteral;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.ExistsPredicate;
@@ -67,6 +66,7 @@ import io.crate.sql.tree.ObjectColumnType;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.RecordSubscript;
 import io.crate.sql.tree.SearchedCaseExpression;
 import io.crate.sql.tree.SimpleCaseExpression;
 import io.crate.sql.tree.SortItem;
@@ -213,7 +213,7 @@ public final class ExpressionFormatter {
 
         @Override
         protected String visitSubscriptExpression(SubscriptExpression node, @Nullable List<Expression> parameters) {
-            return node.name() + "[" + node.index() + "]";
+            return node.base() + "[" + node.index() + "]";
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/SubscriptExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SubscriptExpression.java
@@ -22,18 +22,30 @@
 package io.crate.sql.tree;
 
 
+/**
+ * <pre>
+ * {@code
+ *      <base>[<index>]
+ *
+ *  Examples:
+ *
+ *      obj['fieldName']
+ *      arr[2]
+ * }
+ * </pre>
+ */
 public class SubscriptExpression extends Expression {
 
-    private Expression name;
+    private Expression base;
     private Expression index;
 
-    public SubscriptExpression(Expression nameExpression, Expression indexExpression) {
-        this.name = nameExpression;
-        this.index = indexExpression;
+    public SubscriptExpression(Expression base, Expression index) {
+        this.base = base;
+        this.index = index;
     }
 
-    public Expression name() {
-        return name;
+    public Expression base() {
+        return base;
     }
 
     public Expression index() {
@@ -47,7 +59,7 @@ public class SubscriptExpression extends Expression {
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
+        int result = base != null ? base.hashCode() : 0;
         result = 31 * result + (index != null ? index.hashCode() : 0);
         return result;
     }
@@ -60,7 +72,7 @@ public class SubscriptExpression extends Expression {
         SubscriptExpression that = (SubscriptExpression) o;
 
         if (index != null ? !index.equals(that.index) : that.index != null) return false;
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (base != null ? !base.equals(that.base) : that.base != null) return false;
 
         return true;
     }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1221,14 +1221,14 @@ public class TestStatementBuilder {
         assertThat(subscript.index(), instanceOf(StringLiteral.class));
         assertThat(((StringLiteral) subscript.index()).getValue(), is("sub"));
 
-        assertThat(subscript.name(), instanceOf(QualifiedNameReference.class));
+        assertThat(subscript.base(), instanceOf(QualifiedNameReference.class));
 
         expression = SqlParser.createExpression("[1,2,3][1]");
         assertThat(expression, instanceOf(SubscriptExpression.class));
         subscript = (SubscriptExpression) expression;
         assertThat(subscript.index(), instanceOf(LongLiteral.class));
         assertThat(((LongLiteral) subscript.index()).getValue(), is(1L));
-        assertThat(subscript.name(), instanceOf(ArrayLiteral.class));
+        assertThat(subscript.base(), instanceOf(ArrayLiteral.class));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
+++ b/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
@@ -51,7 +51,7 @@ public class OutputNameFormatter {
 
         @Override
         protected String visitSubscriptExpression(SubscriptExpression node, List<Expression> parameters) {
-            return node.name().accept(this, null) + '[' + node.index().accept(this, null) + ']';
+            return node.base().accept(this, null) + '[' + node.index().accept(this, null) + ']';
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
+++ b/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Preconditions;
 import io.crate.sql.tree.ArrayLiteral;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Cast;
@@ -34,6 +33,7 @@ import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.StringLiteral;
+import io.crate.sql.tree.SubqueryExpression;
 import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.TryCast;
 
@@ -57,7 +57,7 @@ public final class SubscriptValidator {
         @Override
         protected Void visitSubscriptExpression(SubscriptExpression node, SubscriptContext context) {
             node.index().accept(SubscriptIndexVisitor.INSTANCE, context);
-            node.name().accept(this, context);
+            node.base().accept(this, context);
             return null;
         }
 
@@ -69,9 +69,6 @@ public final class SubscriptValidator {
 
         @Override
         public Void visitArrayLiteral(ArrayLiteral node, SubscriptContext context) {
-            Preconditions.checkArgument(
-                context.index() != null,
-                "Array literals can only be accessed via numeric index.");
             context.expression(node);
             return null;
         }
@@ -96,6 +93,12 @@ public final class SubscriptValidator {
 
         @Override
         protected Void visitFunctionCall(FunctionCall node, SubscriptContext context) {
+            context.expression(node);
+            return null;
+        }
+
+        @Override
+        protected Void visitSubqueryExpression(SubqueryExpression node, SubscriptContext context) {
             context.expression(node);
             return null;
         }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
@@ -79,14 +79,12 @@ public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List
     @Override
     protected ColumnIdent visitSubscriptExpression(SubscriptExpression node, List<String> context) {
         if (node.index() instanceof QualifiedNameReference) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "Key of subscript must not be a reference")
-            );
+            throw new IllegalArgumentException("Key of subscript must not be a reference");
         }
         if (context == null) {
             context = new ArrayList<>();
         }
-        ColumnIdent colIdent = node.name().accept(this, context);
+        ColumnIdent colIdent = node.base().accept(this, context);
         node.index().accept(this, context);
 
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToObjectVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToObjectVisitor.java
@@ -91,7 +91,7 @@ public class ExpressionToObjectVisitor extends AstVisitor<Object, Row> {
     @Override
     protected String visitSubscriptExpression(SubscriptExpression node, Row context) {
         return String.format(Locale.ENGLISH, "%s.%s",
-                             node.name().accept(this, context),
+                             node.base().accept(this, context),
                              node.index().accept(this, context));
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
@@ -99,7 +99,7 @@ public class ExpressionToStringVisitor extends AstVisitor<String, Row> {
     @Override
     protected String visitSubscriptExpression(SubscriptExpression node, Row context) {
         return String.format(Locale.ENGLISH, "%s.%s",
-                             node.name().accept(this, context),
+                             node.base().accept(this, context),
                              node.index().accept(this, context));
     }
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1424,7 +1424,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(arguments.size(), is(2));
 
         assertThat(arguments.get(0), isFunction(MatchesFunction.NAME));
-        assertThat(arguments.get(1), isLiteral(1L));
+        assertThat(arguments.get(1), isLiteral(1));
 
         List<Symbol> scalarArguments = ((Function) arguments.get(0)).arguments();
         assertThat(scalarArguments.size(), is(2));

--- a/sql/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
@@ -114,13 +114,6 @@ public class SubscriptValidatorTest extends CrateUnitTest {
     }
 
     @Test
-    public void testStringSubscriptOnArrayLiteral() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array literals can only be accessed via numeric index.");
-        analyzeSubscript("[1,2,3]['abc']");
-    }
-
-    @Test
     public void testNestedArrayAccess() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Nested array access is not supported");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There was a bit of inconsistency with subscript expressions:

- `obj_array['x']` worked if `obj_array` was a column, but not on literals

- The behavior with sub-queries was also odd:

```
cr> SELECT (SELECT {x=10})['x'];
SQLActionException[UnsupportedFeatureException: An expression of type SubqueryExpression cannot have an index accessor ([])]
cr> SELECT (SELECT {x=10})::object['x'];
+-----------------------------------------+
| CAST((SELECT {"x"= 10}) AS object)['x'] |
+-----------------------------------------+
|                                      10 |
+-----------------------------------------+
```


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
