### PR TITLE
Change optimizer to re-try rules after children have been optimized

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -71,6 +71,7 @@ public class NestedLoopJoin implements LogicalPlan {
     private final List<AbstractTableRelation> baseTables;
     private final Map<LogicalPlan, SelectSymbol> dependencies;
     private boolean orderByWasPushedDown = false;
+    private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
 
     NestedLoopJoin(LogicalPlan lhs,
                    LogicalPlan rhs,
@@ -99,9 +100,15 @@ public class NestedLoopJoin implements LogicalPlan {
                           @Nullable Symbol joinCondition,
                           boolean isFiltered,
                           AnalyzedRelation topMostLeftRelation,
-                          boolean orderByWasPushedDown) {
+                          boolean orderByWasPushedDown,
+                          boolean rewriteFilterOnOuterJoinToInnerJoinDone) {
         this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation);
         this.orderByWasPushedDown = orderByWasPushedDown;
+        this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
+    }
+
+    public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {
+        return rewriteFilterOnOuterJoinToInnerJoinDone;
     }
 
     public boolean isFiltered() {
@@ -241,7 +248,8 @@ public class NestedLoopJoin implements LogicalPlan {
             joinCondition,
             isFiltered,
             topMostLeftRelation,
-            orderByWasPushedDown
+            orderByWasPushedDown,
+            rewriteFilterOnOuterJoinToInnerJoinDone
         );
     }
 

--- a/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -49,7 +49,11 @@ public class Optimizer {
 
     public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, TransactionContext txnCtx) {
         LogicalPlan optimizedRoot = tryApplyRules(plan, tableStats, txnCtx);
-        return optimizedRoot.replaceSources(Lists2.map(optimizedRoot.sources(), x -> optimize(x, tableStats, txnCtx)));
+        return tryApplyRules(
+            optimizedRoot.replaceSources(Lists2.map(optimizedRoot.sources(), x -> optimize(x, tableStats, txnCtx))),
+            tableStats,
+            txnCtx
+        );
     }
 
     private LogicalPlan tryApplyRules(LogicalPlan plan, TableStats tableStats, TransactionContext txnCtx) {

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -28,7 +28,6 @@ import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
@@ -36,6 +35,7 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -99,7 +99,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
                     nestedLoop.topMostLeftRelation(),
-                    true
+                    true,
+                    nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone()
                 );
             }
         }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -31,7 +31,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -41,6 +40,7 @@ import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.sql.tree.QualifiedName;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -109,7 +109,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         this.nlCapture = new Capture<>();
         this.pattern = typeOf(Filter.class)
                 .with(source(), typeOf(NestedLoopJoin.class).capturedAs(nlCapture)
-                    .with(nl -> nl.joinType().isOuter())
+                    .with(nl -> nl.joinType().isOuter() && !nl.isRewriteFilterOnOuterJoinToInnerJoinDone())
                 );
     }
 
@@ -204,8 +204,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                  * +------+------+
                  */
 
-                // Don't repeat pushing down a query, if source is a Filter we expect that the push-down already happened.
-                if (couldMatchOnNull(leftQuery) || (lhs instanceof Filter)) {
+                if (couldMatchOnNull(leftQuery)) {
                     newLhs = lhs;
                 } else {
                     newLhs = getNewSource(leftQuery, lhs);
@@ -213,7 +212,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                         splitQueries.put(leftName, leftQuery);
                     }
                 }
-                if (couldMatchOnNull(rightQuery) || (rhs instanceof Filter)) {
+                if (couldMatchOnNull(rightQuery)) {
                     newRhs = rhs;
                 } else {
                     newRhs = getNewSource(rightQuery, rhs);
@@ -257,7 +256,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             nl.joinCondition(),
             nl.isFiltered(),
             nl.topMostLeftRelation(),
-            nl.orderByWasPushedDown()
+            nl.orderByWasPushedDown(),
+            true
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -449,8 +449,8 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         // the ORDER BY id, name is here to avoid a collect-then-fetch, which would (currently) break the Get optimization
         var plan = plan(
             "SELECT id, name FROM (SELECT id, name FROM users ORDER BY id, name) AS u WHERE id = 1 ORDER BY 1, 2");
-        var expectedPlan = "OrderBy[id ASC name ASC]\n" +
-                           "Boundary[id, name]\n" +
+        var expectedPlan = "Boundary[id, name]\n" +
+                           "OrderBy[id ASC name ASC]\n" +
                            "Boundary[id, name]\n" +
                            "OrderBy[id ASC name ASC]\n" +
                            "Get[doc.users | id, name | DocKeys{1}";


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In https://github.com/crate/crate/pull/9684 the initial LogicalPlan
changes a bit. For example a `WhereClause` is never initially passed to
the `Collect` operator, instead, a separate `Filter` is created.

This `Filter` is then merged with `Collect` via the
`MergeFilterAndCollect`, but this new reliance on this rule breaks the
`MergeAggregateAndCollectToCount` because it wasn't re-applied after the
children have been optimized.

Changing the optimizer behavior then broke the `(lhs instanceof Filter)`
checks within the `RewriteFilterOnOuterJoinToInnerJoin` rule because the
source might already be a `Collect`.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)