### PR TITLE
Make sure undefined type can be streamed as text to clients

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -22,12 +22,13 @@
 
 package io.crate.protocols.postgres.types;
 
+import io.crate.types.DataTypes;
 import io.netty.buffer.ByteBuf;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
-class VarCharType extends PGType<String> {
+class VarCharType extends PGType<Object> {
 
     static final int OID = 1043;
     private static final int ARRAY_OID = 1015;
@@ -59,21 +60,21 @@ class VarCharType extends PGType<String> {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, @Nonnull String value) {
-        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    public int writeAsBinary(ByteBuf buffer, @Nonnull Object value) {
+        byte[] bytes = DataTypes.STRING.value(value).getBytes(StandardCharsets.UTF_8);
         buffer.writeInt(bytes.length);
         buffer.writeBytes(bytes);
         return INT32_BYTE_SIZE + bytes.length;
     }
 
     @Override
-    public int writeAsText(ByteBuf buffer, @Nonnull String value) {
+    public int writeAsText(ByteBuf buffer, @Nonnull Object value) {
         return writeAsBinary(buffer, value);
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(@Nonnull String value) {
-        return value.getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
+        return DataTypes.STRING.value(value).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -66,6 +66,12 @@ public class PGTypesTest extends CrateUnitTest {
     }
 
     @Test
+    public void test_undefined_type_can_stream_non_string_values() {
+        PGType pgType = PGTypes.get(DataTypes.UNDEFINED);
+        pgType.writeAsBinary(Unpooled.buffer(), 30);
+    }
+
+    @Test
     public void testPG2CrateType() {
         assertThat(PGTypes.fromOID(VarCharType.OID), instanceOf(StringType.class));
         assertThat(PGTypes.fromOID(JsonType.OID), instanceOf(ObjectType.class));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

f013bbeae63e7e73f11c6d96268d04faa46e8ed4 enabled support for queries
like:

    SELECT obj['x'] FROM unnest([{x=10}]);

This worked via HTTP, but didn't via pg-wire because `obj['x']` has
type `undefined`. `undefined` is mapped to `VarCharType` which didn't
handle any instances other than `String`.

(I also want to follow up on giving `obj['x']` the proper type, but I think that the streaming should work anyways)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)