### PR TITLE
Add primary keys to pg_class and pg_index

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,8 @@ None
 Changes
 =======
 
+- Added entries for primary keys to ``pg_class`` and ``pg_index`` table.
+
 - Added support for ``GROUP BY`` operations on analysed columns of type
   ``text``.
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
@@ -22,28 +22,37 @@
 
 package io.crate.metadata.pgcatalog;
 
+import io.crate.common.collections.Lists2;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationInfo;
 import org.apache.lucene.util.BytesRef;
 
 import static org.apache.lucene.util.StringHelper.murmurhash3_x86_32;
 
-final class OidHash {
+public final class OidHash {
 
     enum Type {
         SCHEMA,
         TABLE,
         VIEW,
-        CONSTRAINT
+        CONSTRAINT,
+        PRIMARY_KEY
     }
 
-    static int relationOid(RelationInfo relationInfo) {
+    public static int relationOid(RelationInfo relationInfo) {
         Type t = relationInfo.relationType() == RelationInfo.RelationType.VIEW ? Type.VIEW : Type.TABLE;
         BytesRef b = new BytesRef(t.toString() + relationInfo.ident().fqn());
         return murmurhash3_x86_32(b.bytes, b.offset, b.length, 0);
     }
 
-    static int schemaOid(String name) {
+    public static int schemaOid(String name) {
         BytesRef b = new BytesRef(Type.SCHEMA.toString() + name);
+        return murmurhash3_x86_32(b.bytes, b.offset, b.length, 0);
+    }
+
+    public static int primaryKeyOid(RelationInfo relationInfo) {
+        var primaryKey = Lists2.joinOn(" ", relationInfo.primaryKey(), ColumnIdent::name);
+        var b = new BytesRef(Type.PRIMARY_KEY.toString() + relationInfo.ident().fqn() + primaryKey);
         return murmurhash3_x86_32(b.bytes, b.offset, b.length, 0);
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -25,6 +25,7 @@ package io.crate.metadata.pgcatalog;
 import com.google.common.collect.ImmutableSortedMap;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
+import io.crate.metadata.SystemTable;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.ViewInfo;
@@ -43,7 +44,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
     public static final String NAME = "pg_catalog";
     private final ImmutableSortedMap<String, TableInfo> tableInfoMap;
     private final UserDefinedFunctionService udfService;
-    private final PgClassTable pgClassTable;
+    private final SystemTable<PgClassTable.Entry> pgClassTable;
 
     @Inject
     public PgCatalogSchemaInfo(UserDefinedFunctionService udfService, TableStats tableStats) {
@@ -56,7 +57,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgNamespaceTable.IDENT.name(), new PgNamespaceTable())
             .put(PgAttrDefTable.IDENT.name(), new PgAttrDefTable())
             .put(PgAttributeTable.IDENT.name(), new PgAttributeTable())
-            .put(PgIndexTable.IDENT.name(), new PgIndexTable())
+            .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
             .put(PgConstraintTable.IDENT.name(), new PgConstraintTable())
             .put(PgDatabaseTable.NAME.name(), new PgDatabaseTable())
             .put(PgDescriptionTable.NAME.name(), new PgDescriptionTable())
@@ -64,7 +65,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .build();
     }
 
-    PgClassTable pgClassTable() {
+    SystemTable<PgClassTable.Entry> pgClassTable() {
         return pgClassTable;
     }
 

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -62,10 +62,10 @@ public class PgCatalogTableDefinitions {
             PgTypeTable.expressions(),
             false));
         tableDefinitions.put(PgClassTable.IDENT, new StaticTableDefinition<>(
-            informationSchemaIterables::relations,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident().fqn())
+            informationSchemaIterables::pgClasses,
+            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident.fqn())
                          // we also need to check for views which have privileges set
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident().fqn()),
+                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident.fqn()),
             pgCatalogSchemaInfo.pgClassTable().expressions()
         ));
         tableDefinitions.put(PgDatabaseTable.NAME, new StaticTableDefinition<>(
@@ -88,8 +88,8 @@ public class PgCatalogTableDefinitions {
             PgAttributeTable.expressions()
         ));
         tableDefinitions.put(PgIndexTable.IDENT, new StaticTableDefinition<>(
-            () -> completedFuture(Collections.emptyList()),
-            PgIndexTable.expressions(),
+            () -> completedFuture(informationSchemaIterables.pgIndices()),
+            PgIndexTable.create().expressions(),
             false));
         tableDefinitions.put(PgConstraintTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,
@@ -101,7 +101,6 @@ public class PgCatalogTableDefinitions {
             PgDescriptionTable.expressions(),
             false)
         );
-
         Iterable<NamedSessionSetting> sessionSettings =
             () -> SessionSettingRegistry.SETTINGS.entrySet().stream()
                 .map(s -> new NamedSessionSetting(s.getKey(), s.getValue()))


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will add entries for primary keys to `pg_class` and `pg_index` to address https://github.com/crate/crate/issues/9712

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
