### PR TITLE
Adapt the start of ordinal_position for columns to 1 in SystemTable

### DIFF
--- a/sql/src/main/java/io/crate/metadata/SystemTable.java
+++ b/sql/src/main/java/io/crate/metadata/SystemTable.java
@@ -180,7 +180,7 @@ public final class SystemTable<T> implements TableInfo {
             LinkedHashMap<ColumnIdent, Reference> refByColumns = new LinkedHashMap<>();
             HashMap<ColumnIdent, RowCollectExpressionFactory<T>> expressions = new HashMap<>();
             columns.sort(Comparator.comparing(x -> x.column));
-            int rootColIdx = 0;
+            int rootColIdx = 1;
             for (int i = 0; i < columns.size(); i++) {
                 Column<T, ?> column = columns.get(i);
                 refByColumns.put(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
