### PR TITLE
Fix doctests (nail crash to <0.25.0)

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -1,7 +1,7 @@
 # don't pin crate version numbers so the latest will always be pulled when you
 # set up your environment from scratch
 
-crash
+crash<0.25.0
 crate
 crate-docs-theme
 cr8>=0.15.1


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

0.25.0 has API changes. We will need to adapt the testing setup. This is
a temporary quick fix.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)