### PR TITLE
Fix ON CONFLICT (..) UPDATE SET with CASE statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that led to an ``ArrayIndexOutOfBoundsException`` if using
+  ``ON CONFLICT (...) UPDATE SET`` in an ``INSERT`` statement.
+
 - Fixed an issue that could lead to a ``Values less than -1 bytes are not
   supported`` error, if one or more CrateDB nodes have few disk space
   available.

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1466,4 +1466,19 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
                "5| cr8\n")
         );
     }
+
+    @Test
+    public void test_insert_with_on_conflict_containing_case() {
+        execute("create table test(a int primary key, b timestamp)");
+        execute("insert into test (a, b) values (1, '2020-01-01')");
+        execute("insert into test (a, b)\n" +
+                "  values (1, '2020-01-02T00:00:00Z'::timestamp)\n" +
+                "  on conflict (a)\n" +
+                "  do update set b = case when excluded.b > b then excluded.b else b end");
+        execute("select date_format('%Y-%m-%d', b) from test where a = 1");
+        assertThat(
+            printedTable(response.rows()),
+            is("2020-01-02\n")
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

468ef007fa837696f37380360ab7aae665d5fe4e fixed this in master (4.2).

The target columns / assignment expressions didn't match if a column
occurred multiple times in the UPDATE SET assignment expression.

Fixes https://github.com/crate/crate/issues/9723

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)