### PR TITLE
Fix a NPE that occurred on GROUP BY nested partition column

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that led to a ``NullPointerException`` when using ``GROUP BY``
+  on a nested ``PARTITIONED BY`` column.
+
 - Fixed an issue that led to an ``ArrayIndexOutOfBoundsException`` if using
   ``ON CONFLICT (...) UPDATE SET`` in an ``INSERT`` statement.
 

--- a/sql/src/main/java/io/crate/metadata/MapBackedRefResolver.java
+++ b/sql/src/main/java/io/crate/metadata/MapBackedRefResolver.java
@@ -45,7 +45,7 @@ public final class MapBackedRefResolver implements ReferenceResolver<NestableInp
         }
         NestableInput<?> rootImpl = implByColumn.get(column.getRoot());
         if (rootImpl == null) {
-            return null;
+            return implByColumn.get(column);
         }
         return NestableInput.getChildByPath(rootImpl, column.path());
     }

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1308,4 +1308,16 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         execute("select obj['x'] from (select obj from tbl) as t group by obj['x']");
         assertThat(printedTable(response.rows()), Is.is("10\n"));
     }
+
+    @Test
+    public void test_group_by_nested_partition_by_column() {
+        execute("create table tbl (pk object as (id text primary key, part text primary key)) partitioned by (pk['part'])");
+        execute("insert into tbl (pk) values ({ id = '1', part = 'x' })");
+        execute("refresh table tbl");
+        execute("select distinct pk['part'] from tbl");
+        assertThat(
+            printedTable(response.rows()),
+            is("x\n")
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is already fixed in master via https://github.com/crate/crate/commit/07b982adf80cbc60b5f23a156cfda9fdd905aadc

Fixes https://github.com/crate/crate/issues/9725

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)