### PR TITLE
Change doctests setup and require crash >= 0.25

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -1,7 +1,7 @@
 # don't pin crate version numbers so the latest will always be pulled when you
 # set up your environment from scratch
 
-crash<0.25.0
+crash>=0.25.0
 crate
 crate-docs-theme
 cr8>=0.15.1

--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -65,13 +65,6 @@ class CrateTestShell(CrateShell):
         super(CrateTestShell, self).__init__(is_tty=False)
         self.logger = ColorPrinter(False, stream=PrintWrapper(), line_end='\n')
 
-    def stmt(self, stmt):
-        stmt = stmt.replace('\n', ' ')
-        if stmt.startswith('\\'):
-            self.process(stmt)
-        else:
-            self.execute(stmt)
-
 
 cmd = CrateTestShell()
 
@@ -118,7 +111,7 @@ def crash_transform(s):
         return s[1:]
     if hasattr(crate, 'addresses'):
         s = s.replace(':4200', ':{0}'.format(crate.addresses.http.port))
-    return u'cmd.stmt({0})'.format(repr(s.strip().rstrip(';')))
+    return u'cmd.process({0})'.format(repr(s.strip().rstrip(';')))
 
 
 def bash_transform(s):
@@ -129,7 +122,7 @@ def bash_transform(s):
         s = s.replace(':4200', ':{0}'.format(crate.addresses.http.port))
     if s.startswith("crash"):
         s = re.search(r"crash\s+-c\s+\"(.*?)\"", s).group(1)
-        return u'cmd.stmt({0})'.format(repr(s.strip().rstrip(';')))
+        return u'cmd.process({0})'.format(repr(s.strip().rstrip(';')))
     return (r'pretty_print(sh("""%s""").stdout.decode("utf-8"))' % s) + '\n'
 
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

crash 0.25.0 doesn't have an `execute` method anymore.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)