### PR TITLE
Implement proper formatting for window functions

### DIFF
--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -215,22 +215,23 @@ public class OrderBy implements Writeable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("OrderBy{");
-        explainRepresentation(sb, orderBySymbols, reverseFlags, nullsFirst);
+        explainRepresentation(sb, orderBySymbols, reverseFlags, nullsFirst, Symbol::toString);
         return sb.toString();
     }
 
     public String explainRepresentation() {
         StringBuilder sb = new StringBuilder();
-        return explainRepresentation(sb, orderBySymbols, reverseFlags, nullsFirst).toString();
+        return explainRepresentation(sb, orderBySymbols, reverseFlags, nullsFirst, Symbol::toString).toString();
     }
 
     public static StringBuilder explainRepresentation(StringBuilder sb,
                                                       List<? extends Symbol> symbols,
                                                       boolean[] reverseFlags,
-                                                      boolean[] nullsFirst) {
+                                                      boolean[] nullsFirst,
+                                                      Function<? super Symbol, String> toString) {
         for (int i = 0; i < symbols.size(); i++) {
             Symbol symbol = symbols.get(i);
-            sb.append(symbol.toString());
+            sb.append(toString.apply(symbol));
             sb.append(" ");
             if (reverseFlags[i]) {
                 sb.append("DESC");

--- a/sql/src/main/java/io/crate/execution/dsl/projection/OrderedTopNProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/OrderedTopNProjection.java
@@ -174,7 +174,7 @@ public class OrderedTopNProjection extends Projection {
             "offset", offset,
             "outputs", Lists2.joinOn(", ", outputs, Symbol::toString),
             "orderBy", OrderBy.explainRepresentation(
-                new StringBuilder("["), orderBy, reverseFlags, nullsFirst).append("]").toString()
+                new StringBuilder("["), orderBy, reverseFlags, nullsFirst, Symbol::toString).append("]").toString()
         );
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
@@ -156,7 +156,7 @@ public class ExplainLogicalPlan {
         public ImmutableMap.Builder<String, Object> visitOrder(Order logicalPlan, Context context) {
             OrderBy orderBy = logicalPlan.orderBy;
             StringBuilder sb = new StringBuilder();
-            OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst());
+            OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst(), Symbol::toString);
             return createMap(logicalPlan, createSubMap()
                 .put("orderBy", sb.toString())
                 .put("source", explainMap(logicalPlan.source, context)));

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -127,7 +127,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testWindowFunction() throws Exception {
         Symbol f = sqlExpressions.asSymbol("avg(idx) over (partition by idx order by foo)");
-        assertPrint(f, "avg(doc.formatter.idx)");
+        assertPrint(f, "avg(doc.formatter.idx) OVER (PARTITION BY doc.formatter.idx ORDER BY doc.formatter.foo ASC)");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -911,9 +911,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "   unnest(ARRAY[2.5, 4, 5, 6, 7.5, 8.5, 10, 12]) as t(col1)";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "RootBoundary[col1, sum(col1)]\n" +
-            "Eval[col1, sum(col1)]\n" +
-            "WindowAgg[sum(col1) | ORDER BY power(col1, 2.0) ASC]\n" +
+            "RootBoundary[col1, sum(col1) OVER (ORDER BY power(col1, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
+            "Eval[col1, sum(col1) OVER (ORDER BY power(col1, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
+            "WindowAgg[sum(col1) OVER (ORDER BY power(col1, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
             "Eval[col1, power(col1, 2.0)]\n" +
             "Rename[col1] AS t\n" +
             "TableFunction[unnest | [col1] | true]\n";

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -71,8 +71,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAvgWindowFunction() {
         LogicalPlan plan = plan("select avg(x) OVER() from t1");
-        assertThat(plan, isPlan("Eval[avg(x)]\n" +
-                                "WindowAgg[avg(x)]\n" +
+        assertThat(plan, isPlan("Eval[avg(x) OVER ()]\n" +
+                                "WindowAgg[avg(x) OVER ()]\n" +
                                 "Collect[doc.t1 | [x] | true]\n"));
     }
 
@@ -436,7 +436,9 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                     sb,
                     order.orderBy.orderBySymbols(),
                     order.orderBy.reverseFlags(),
-                    order.orderBy.nullsFirst());
+                    order.orderBy.nullsFirst(),
+                    Symbol::toString
+                );
                 sb.append("]\n");
                 plan = order.source;
             }
@@ -554,15 +556,6 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 WindowAgg windowAgg = (WindowAgg) plan;
                 startLine("WindowAgg[");
                 addSymbolsList(windowAgg.windowFunctions());
-                if (!windowAgg.windowDefinition.partitions().isEmpty()) {
-                    sb.append(" | PARTITION BY ");
-                    addSymbolsList(windowAgg.windowDefinition.partitions());
-                }
-                OrderBy orderBy = windowAgg.windowDefinition.orderBy();
-                if (orderBy != null) {
-                    sb.append(" | ORDER BY ");
-                    OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst());
-                }
                 sb.append("]\n");
                 plan = windowAgg.source;
             }

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -396,9 +396,9 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "WHERE sums.x = 10 "
         );
         var expectedPlan =
-            "RootBoundary[x, \"sum(x)\"]\n" +
-            "Rename[x, \"sum(x)\"] AS sums\n" +     // Aliased relation boundary
-            "WindowAgg[sum(x) | PARTITION BY x]\n" +
+            "RootBoundary[x, \"sum(x) OVER (PARTITION BY x)\"]\n" +
+            "Rename[x, \"sum(x) OVER (PARTITION BY x)\"] AS sums\n" +     // Aliased relation boundary
+            "WindowAgg[sum(x) OVER (PARTITION BY x)]\n" +
             "Collect[doc.t1 | [x] | (x = 10)]\n";
         assertThat(plan, isPlan(sqlExecutor.functions(), expectedPlan));
     }

--- a/sql/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -59,9 +59,9 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
     public void testTwoWindowFunctionsWithDifferentWindowDefinitionResultsInTwoOperators() {
         LogicalPlan plan = plan("select avg(x) over (partition by x), avg(x) over (partition by y) from t1");
         var expectedPlan =
-            "Eval[avg(x), avg(x)]\n" +
-            "WindowAgg[avg(x) | PARTITION BY y]\n" +
-            "WindowAgg[avg(x) | PARTITION BY x]\n" +
+            "Eval[avg(x) OVER (PARTITION BY x), avg(x) OVER (PARTITION BY y)]\n" +
+            "WindowAgg[avg(x) OVER (PARTITION BY y)]\n" +
+            "WindowAgg[avg(x) OVER (PARTITION BY x)]\n" +
             "Collect[doc.t1 | [x, y] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }
@@ -69,8 +69,8 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_window_agg_output_for_select_with_standalone_ref_and_window_func_with_filter() {
         var plan = plan("SELECT y, AVG(x) FILTER (WHERE x > 1) OVER() FROM t1");
-        var expectedPlan = "Eval[y, avg(x) FILTER (WHERE (x > 1))]\n" +
-                           "WindowAgg[avg(x) FILTER (WHERE (x > 1))]\n" +
+        var expectedPlan = "Eval[y, avg(x) FILTER (WHERE (x > 1)) OVER ()]\n" +
+                           "WindowAgg[avg(x) FILTER (WHERE (x > 1)) OVER ()]\n" +
                            "Collect[doc.t1 | [x, (x > 1), y] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }
@@ -78,8 +78,8 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_window_agg_with_filter_that_contains_column_that_is_not_in_outputs() {
         var plan = plan("SELECT x, COUNT(*) FILTER (WHERE y > 1) OVER() FROM t1");
-        var expectedPlan = "Eval[x, count(*) FILTER (WHERE (y > 1))]\n" +
-                           "WindowAgg[count(*) FILTER (WHERE (y > 1))]\n" +
+        var expectedPlan = "Eval[x, count(*) FILTER (WHERE (y > 1)) OVER ()]\n" +
+                           "WindowAgg[count(*) FILTER (WHERE (y > 1)) OVER ()]\n" +
                            "Collect[doc.t1 | [(y > 1), x] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `OVER ()` clause was missing from formatted window functions


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)