### PR TITLE
Remove process method from AnalyzedRelationVisitor

### DIFF
--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -19,45 +19,45 @@
 package io.crate.auth.user;
 
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.AnalyzedAlterUser;
 import io.crate.analyze.AnalyzedAlterBlobTable;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterTableRename;
+import io.crate.analyze.AnalyzedAlterUser;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.AnalyzedCopyTo;
 import io.crate.analyze.AnalyzedCreateAnalyzer;
-import io.crate.analyze.AnalyzedCreateSnapshot;
-import io.crate.analyze.AnalyzedCreateTable;
-import io.crate.analyze.AnalyzedDeleteStatement;
-import io.crate.analyze.AnalyzedRefreshTable;
-import io.crate.analyze.AnalyzedDropTable;
-import io.crate.analyze.AnalyzedRestoreSnapshot;
-import io.crate.analyze.AnalyzedStatement;
-import io.crate.analyze.AnalyzedStatementVisitor;
-import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.analyze.AnalyzedCreateBlobTable;
 import io.crate.analyze.AnalyzedCreateFunction;
 import io.crate.analyze.AnalyzedCreateRepository;
+import io.crate.analyze.AnalyzedCreateSnapshot;
+import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateUser;
-import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.AnalyzedDeallocate;
+import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedDropFunction;
 import io.crate.analyze.AnalyzedDropRepository;
 import io.crate.analyze.AnalyzedDropSnapshot;
+import io.crate.analyze.AnalyzedDropTable;
 import io.crate.analyze.AnalyzedDropUser;
 import io.crate.analyze.AnalyzedDropView;
-import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedKill;
 import io.crate.analyze.AnalyzedPrivileges;
-import io.crate.analyze.QueriedSelectRelation;
+import io.crate.analyze.AnalyzedRefreshTable;
 import io.crate.analyze.AnalyzedResetStatement;
+import io.crate.analyze.AnalyzedRestoreSnapshot;
 import io.crate.analyze.AnalyzedSetStatement;
 import io.crate.analyze.AnalyzedShowCreateTable;
+import io.crate.analyze.AnalyzedStatement;
+import io.crate.analyze.AnalyzedStatementVisitor;
+import io.crate.analyze.AnalyzedUpdateStatement;
+import io.crate.analyze.CreateViewStmt;
+import io.crate.analyze.ExplainAnalyzedStatement;
+import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.AnalyzedView;
@@ -147,8 +147,8 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitUnionSelect(UnionSelect unionSelect, RelationContext context) {
-            process(unionSelect.left(), context);
-            process(unionSelect.right(), context);
+            unionSelect.left().accept(this, context);
+            unionSelect.right().accept(this, context);
             return null;
         }
 
@@ -203,7 +203,7 @@ public final class AccessControlImpl implements AccessControl {
             }
             User currentUser = context.user;
             context.user = owner;
-            process(analyzedView.relation(), context);
+            analyzedView.relation().accept(this, context);
             context.user = currentUser;
             return null;
         }
@@ -220,7 +220,7 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         private void visitRelation(AnalyzedRelation relation, User user, Privilege.Type type) {
-            relationVisitor.process(relation, new RelationContext(user, type));
+            relation.accept(relationVisitor, new RelationContext(user, type));
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
@@ -60,7 +60,7 @@ public class AnalyzedShowCreateTable implements AnalyzedStatement, AnalyzedRelat
 
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
-        return visitor.process(this, context);
+        return visitor.visitShowCreateTable(this, context);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/Relations.java
+++ b/sql/src/main/java/io/crate/analyze/Relations.java
@@ -69,14 +69,14 @@ public class Relations {
         private static final TraverseDeepSymbolsRelations INSTANCE = new TraverseDeepSymbolsRelations();
 
         static void traverse(AnalyzedRelation relation, Consumer<? super Symbol> consumer) {
-            INSTANCE.process(relation, consumer);
+            relation.accept(INSTANCE, consumer);
         }
 
         @Override
         public Void visitUnionSelect(UnionSelect unionSelect, Consumer<? super Symbol> consumer) {
             unionSelect.visitSymbols(consumer);
-            process(unionSelect.left(), consumer);
-            process(unionSelect.right(), consumer);
+            unionSelect.left().accept(this, consumer);
+            unionSelect.right().accept(this, consumer);
             return null;
         }
 
@@ -110,7 +110,7 @@ public class Relations {
         @Override
         public Void visitView(AnalyzedView analyzedView, Consumer<? super Symbol> consumer) {
             analyzedView.visitSymbols(consumer);
-            process(analyzedView.relation(), consumer);
+            analyzedView.relation().accept(this, consumer);
             return null;
         }
     }

--- a/sql/src/main/java/io/crate/analyze/TableIdentsExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/TableIdentsExtractor.java
@@ -144,7 +144,7 @@ public class TableIdentsExtractor {
 
         @Override
         public Collection<RelationName> visitSelectSymbol(SelectSymbol selectSymbol, Void context) {
-            return RELATION_TABLE_IDENT_EXTRACTOR.process(selectSymbol.relation(), context);
+            return selectSymbol.relation().accept(RELATION_TABLE_IDENT_EXTRACTOR, context);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
@@ -21,17 +21,13 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.analyze.AnalyzedShowCreateTable;
 import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.QueriedSelectRelation;
 
-import javax.annotation.Nullable;
 import java.util.Locale;
 
 public abstract class AnalyzedRelationVisitor<C, R> {
-
-    public R process(AnalyzedRelation relation, @Nullable C context) {
-        return relation.accept(this, context);
-    }
 
     protected R visitAnalyzedRelation(AnalyzedRelation relation, C context) {
         throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "relation \"%s\" is not supported", relation));
@@ -67,5 +63,9 @@ public abstract class AnalyzedRelationVisitor<C, R> {
 
     public R visitAliasedAnalyzedRelation(AliasedAnalyzedRelation relation, C context) {
         return relation.relation().accept(this, context);
+    }
+
+    public R visitShowCreateTable(AnalyzedShowCreateTable analyzedShowCreateTable, C context) {
+        return visitAnalyzedRelation(analyzedShowCreateTable, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
+++ b/sql/src/main/java/io/crate/planner/IsStatementExecutionAllowed.java
@@ -77,7 +77,7 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
 
         @Override
         public boolean test(AnalyzedRelation relation) {
-            return process(relation, null);
+            return relation.accept(this, null);
         }
 
         @Override
@@ -87,7 +87,7 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
 
         @Override
         public Boolean visitUnionSelect(UnionSelect unionSelect, Void context) {
-            return process(unionSelect.left(), context) && process(unionSelect.right(), context);
+            return unionSelect.left().accept(this, context) && unionSelect.right().accept(this, context);
         }
 
         @Override
@@ -117,7 +117,7 @@ final class IsStatementExecutionAllowed implements Predicate<AnalyzedStatement> 
 
         @Override
         public Boolean visitView(AnalyzedView analyzedView, Void context) {
-            return process(analyzedView.relation(), context);
+            return analyzedView.relation().accept(this, context);
         }
     }
 }


### PR DESCRIPTION
The method adds a useless indirection and makes debugging more annoying.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)