### PR TITLE
Add column pruning

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -84,9 +84,16 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             return null;
         }
         Symbol field = relation.getField(childColumnName, operation);
-        return field == null
-            ? null
-            : new ScopedSymbol(alias, column, field.valueType());
+        if (field == null) {
+            return null;
+        }
+        ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
+        // If the scopedSymbol exists in `outputs`, return that instance so that IdentityHashMaps work
+        int i = outputs.indexOf(scopedSymbol);
+        if (i >= 0) {
+            return outputs.get(i);
+        }
+        return scopedSymbol;
     }
 
     public AnalyzedRelation relation() {

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -82,9 +82,15 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
     @Override
     public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
         Symbol field = relation.getField(column, operation);
-        return field == null
-            ? null
-            : new ScopedSymbol(name, column, field.valueType());
+        if (field == null) {
+            return null;
+        }
+        ScopedSymbol scopedSymbol = new ScopedSymbol(name, column, field.valueType());
+        int i = outputSymbols.indexOf(scopedSymbol);
+        if (i >= 0) {
+            return outputSymbols.get(i);
+        }
+        return scopedSymbol;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -55,6 +55,8 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -277,6 +279,27 @@ public class Collect implements LogicalPlan {
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         assert sources.isEmpty() : "Collect has no sources, cannot replace them";
         return this;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        ArrayList<Symbol> newOutputs = new ArrayList<>();
+        for (Symbol output : outputs) {
+            if (outputsToKeep.contains(output)) {
+                newOutputs.add(output);
+            }
+        }
+        if (newOutputs.equals(outputs)) {
+            return this;
+        }
+        return new Collect(
+            preferSourceLookup,
+            relation,
+            newOutputs,
+            where,
+            numExpectedRows,
+            estimatedRowSize
+        );
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -45,6 +45,7 @@ import io.crate.planner.node.dql.CountPlan;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -136,6 +137,11 @@ public class Count implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         assert sources.isEmpty() : "Count has no sources, cannot replace them";
+        return this;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
         return this;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Eval.java
+++ b/sql/src/main/java/io/crate/planner/operators/Eval.java
@@ -35,6 +35,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 
 
@@ -85,6 +86,15 @@ public final class Eval extends ForwardingLogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return new Eval(Lists2.getOnlyElement(sources), outputs);
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+        if (source == newSource) {
+            return this;
+        }
+        return new Eval(newSource, List.copyOf(outputsToKeep));
     }
 
     private ExecutionPlan addEvalProjection(PlannerContext plannerContext,

--- a/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -27,6 +27,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,15 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
 
     public LogicalPlan source() {
         return source;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+        if (newSource == source) {
+            return this;
+        }
+        return replaceSources(List.of(newSource));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -114,6 +114,15 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(source.outputs());
+        if (newSource == source) {
+            return this;
+        }
+        return replaceSources(List.of(newSource));
+    }
+
+    @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
         return source.dependencies();
     }

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -784,6 +784,11 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        return this;
+    }
+
+    @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
         return Map.of();
     }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -214,7 +214,8 @@ public class LogicalPlanner {
             hints,
             tableStats,
             plannerContext.params());
-        return optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
+        LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
+        return optimizedPlan.pruneOutputsExcept(relation.outputs());
     }
 
     static LogicalPlan plan(AnalyzedRelation relation,

--- a/sql/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/sql/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -43,6 +43,7 @@ import io.crate.planner.node.dql.Collect;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -127,6 +128,14 @@ public final class TableFunction implements LogicalPlan {
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         assert sources.isEmpty() : "TableFunction has no sources, cannot replace them";
         return this;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+        if (outputsToKeep.containsAll(toCollect)) {
+            return this;
+        }
+        return new TableFunction(relation, List.copyOf(outputsToKeep), where);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
@@ -31,7 +31,6 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
-import io.crate.statistics.TableStats;
 import io.crate.planner.WhereClauseOptimizer;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Get;
@@ -39,6 +38,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
 
 import java.util.Optional;
 
@@ -81,7 +81,7 @@ public final class RewriteCollectToGet implements Rule<Collect> {
         Optional<DocKeys> docKeys = detailedQuery.docKeys();
         //noinspection OptionalIsPresent no capturing lambda allocation
         if (docKeys.isPresent()) {
-            return new Get(relation, docKeys.get(), collect.outputs(), tableStats);
+            return new Get(relation, docKeys.get(), collect.outputs(), tableStats.estimatedSizePerRow(relation.relationName()));
         } else {
             return null;
         }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -933,7 +933,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "Eval[word]\n" +
             "OrderBy[word ASC]\n" +
             "Filter[(catcode = 'R')]\n" +
-            "TableFunction[pg_get_keywords | [word, catcode, catdesc] | true]\n";
+            "TableFunction[pg_get_keywords | [word, catcode] | true]\n";
         assertThat(plan, isPlan(e.functions(), expectedPlan));
 
     }

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -31,7 +31,6 @@ import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.TopNProjection;
-import io.crate.metadata.RowGranularity;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -88,7 +87,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
             isTopN(3, 0),
             instanceOf(EvalProjection.class)
         ));
-        assertThat(projections.get(0).outputs(), isSQL("INPUT(1), INPUT(1), INPUT(2)"));
+        assertThat(projections.get(0).outputs(), isSQL("INPUT(1), INPUT(1)"));
         assertThat(projections.get(5).outputs(), isSQL("INPUT(0)"));
     }
 

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -334,15 +334,14 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             plan,
             isPlan(
                 "TopNDistinct[20 | [name, other_id]\n" +
-                "Rename[name, awesome, other_id] AS u\n" +
-                "Collect[doc.users | [name, awesome, other_id] | true]\n"
+                "Rename[name, other_id] AS u\n" +
+                "Collect[doc.users | [name, other_id] | true]\n"
             )
         );
         io.crate.planner.node.dql.Collect collect = sqlExecutor.plan(statement);
         assertThat(
             collect.collectPhase().projections(),
             contains(
-                instanceOf(EvalProjection.class),
                 instanceOf(TopNDistinctProjection.class)
             )
         );

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -83,7 +83,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                    "Rename[name] AS a\n" +
                    "Eval[name]\n" +
                    "OrderBy[name ASC]\n" +
-                   "Collect[doc.users | [name, text] | true]\n" +
+                   "Collect[doc.users | [name] | true]\n" +
                    "---\n" +
                    "OrderBy[text ASC]\n" +
                    "Collect[doc.users | [text] | true]\n" +
@@ -235,16 +235,16 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testWhereClauseIsPushedDownIntoSubQuery() {
-        LogicalPlan plan = sqlExecutor.logicalPlan("SELECT name FROM (SELECT id, name FROM sys.nodes) t " +
-                                                   "WHERE id = 'nodeName'");
-
+        LogicalPlan plan = sqlExecutor.logicalPlan(
+            "SELECT name FROM (SELECT id, name FROM sys.nodes) t " +
+            "WHERE id = 'nodeName'");
         assertThat(
             plan,
             LogicalPlannerTest.isPlan(sqlExecutor.functions(),
                 "RootBoundary[name]\n" +
                 "Eval[name]\n" +
-                "Rename[id, name] AS t\n" +
-                "Collect[sys.nodes | [id, name] | (id = 'nodeName')]\n"));
+                "Rename[name] AS t\n" +
+                "Collect[sys.nodes | [name] | (id = 'nodeName')]\n"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -50,7 +50,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             "Eval[id]\n" +
             "OrderBy[(id + 10) ASC]\n" +
             "GroupBy[id | ]\n" +
-            "Collect[doc.users | [id, (id + 10)] | true]\n"));
+            "Collect[doc.users | [id] | true]\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For cases like

```
SELECT x FROM my_view
```

Where `my_view` resolves to `SELECT x, y, z FROM tbl`
We don't need to collect `y` and `z`.

This was previously done implicitly to some degree with the fetch
optimization, but it didn't work in all cases.

This adds a new `pruneOutputsExcept` that can be triggered on a root
node and propagates through the whole tree to remove any unused outputs.

This is not done as an optimization rule. Optimizations rule are ideal
when an optimization decisicion can be done in isolation looking at a
small sub-tree. But in the case of column pruning it is necessary to
build a lot of context.

For example in:

```
  Limit
    └ Collect
```

The `Limit` operator itself doesn't know which outputs are needed
without involving its parent.

## TODO 

- [x] Add pruning for TableFunction
- [x] Add pruning for HashJoin
- [x] Add pruning for NestedLoopJoin
- [x] Figure out how to deal with subscripts in a better way
- [x] Add pruning for Union

## Follow up

- [ ] Remove eager output propagation from LogicalPlanner (requires us to add `_doc` and other sys-columns to the `TableRelation.outputs()`)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
