### PR TITLE
Fix top-n-distinct for cases where the group columns are a sub-set of the source

### DIFF
--- a/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
@@ -22,7 +22,7 @@
 
 package io.crate.data;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -43,7 +43,7 @@ public final class TopNDistinctBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public void kill(@Nullable Throwable throwable) {
+    public void kill(@Nonnull Throwable throwable) {
         source.kill(throwable);
     }
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -148,4 +148,5 @@ Changes
 Fixes
 =====
 
-None
+Fixed a regression introduced in 4.1 that led to a ``ClassCastException``
+running queries with ``GROUP BY``, no aggregations and a ``LIMIT`` clause.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`TopNDistinct.outputs` contained all outputs of the source instead of
the *actual* outputs of the operator. This led to `ClassCastException`s
on execution.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)