### PR TITLE
Make sure inserts from lazy table functions are throttled

### DIFF
--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -197,8 +197,8 @@ public class AsyncOperationBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
-        return source.involvesIO();
+    public boolean hasLazyResultSet() {
+        return source.hasLazyResultSet();
     }
 
     @Override

--- a/dex/src/main/java/io/crate/data/BatchIterator.java
+++ b/dex/src/main/java/io/crate/data/BatchIterator.java
@@ -129,7 +129,10 @@ public interface BatchIterator<T> extends Killable {
     boolean allLoaded();
 
     /**
-     * @return true if any IO (disk, network) is used
+     * @return true if the records returned by this BatchIterator are generated on-demand.
+     *              If the underlying data is materialized in-memory
+     *              *and* could be re-released after this batch-iterator is done,
+     *              then this should return false - even if there is an on-demand transformation.
      */
-    boolean involvesIO();
+    boolean hasLazyResultSet();
 }

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -94,7 +94,7 @@ public class CloseAssertingBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
-        return delegate.involvesIO();
+    public boolean hasLazyResultSet() {
+        return delegate.hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -82,7 +82,7 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
             source::close,
             source::kill,
             () -> BatchIterators.collect(source, collector),
-            source.involvesIO()
+            source.hasLazyResultSet()
         );
     }
 
@@ -164,7 +164,7 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
+    public boolean hasLazyResultSet() {
         return involvesIO;
     }
 }

--- a/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
@@ -117,9 +117,9 @@ public final class CompositeBatchIterator {
         }
 
         @Override
-        public boolean involvesIO() {
+        public boolean hasLazyResultSet() {
             for (BatchIterator<T> iterator : iterators) {
-                if (iterator.involvesIO()) {
+                if (iterator.hasLazyResultSet()) {
                     return true;
                 }
             }

--- a/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/FlatMapBatchIterator.java
@@ -99,7 +99,7 @@ public final class FlatMapBatchIterator<TIn, TOut> implements BatchIterator<TOut
     }
 
     @Override
-    public boolean involvesIO() {
-        return source.involvesIO();
+    public boolean hasLazyResultSet() {
+        return source.hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/ForwardingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/ForwardingBatchIterator.java
@@ -34,7 +34,7 @@ public abstract class ForwardingBatchIterator<T> extends MappedForwardingBatchIt
 
 
     @Override
-    public boolean involvesIO() {
-        return delegate().involvesIO();
+    public boolean hasLazyResultSet() {
+        return delegate().hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -37,7 +37,7 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
 
     private final Iterable<? extends T> items;
     private final T sentinel;
-    private final boolean involvesIO;
+    private final boolean hasLazyResultSet;
 
     private Iterator<? extends T> it;
     private T current;
@@ -53,19 +53,19 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     /**
      * @param items An iterable over the items. It has to be repeatable if {@code moveToStart()} is used.
      * @param sentinel the value for {@link #currentElement()} if un-positioned
-     * @param involvesIO true if consuming the items or properties of the items can involve disk or network IO
+     * @param hasLazyResultSet See {@link BatchIterator#hasLazyResultSet()}
      */
-    public static <T> BatchIterator<T> of(Iterable<? extends T> items, @Nullable T sentinel, boolean involvesIO) {
-        return new CloseAssertingBatchIterator<>(new InMemoryBatchIterator<>(items, sentinel, involvesIO));
+    public static <T> BatchIterator<T> of(Iterable<? extends T> items, @Nullable T sentinel, boolean hasLazyResultSet) {
+        return new CloseAssertingBatchIterator<>(new InMemoryBatchIterator<>(items, sentinel, hasLazyResultSet));
     }
 
     @VisibleForTesting
-    public InMemoryBatchIterator(Iterable<? extends T> items, T sentinel, boolean involvesIO) {
+    public InMemoryBatchIterator(Iterable<? extends T> items, T sentinel, boolean hasLazyResultSet) {
         this.items = items;
         this.it = items.iterator();
         this.current = sentinel;
         this.sentinel = sentinel;
-        this.involvesIO = involvesIO;
+        this.hasLazyResultSet = hasLazyResultSet;
     }
 
     @Override
@@ -109,7 +109,7 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
-        return involvesIO;
+    public boolean hasLazyResultSet() {
+        return hasLazyResultSet;
     }
 }

--- a/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/MappedForwardingBatchIterator.java
@@ -63,7 +63,7 @@ public abstract class MappedForwardingBatchIterator<I, O> implements BatchIterat
     }
 
     @Override
-    public boolean involvesIO() {
-        return delegate().involvesIO();
+    public boolean hasLazyResultSet() {
+        return delegate().hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/TopNDistinctBatchIterator.java
@@ -90,7 +90,7 @@ public final class TopNDistinctBatchIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
-        return source.involvesIO();
+    public boolean hasLazyResultSet() {
+        return source.hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
@@ -113,10 +113,7 @@ public abstract class JoinBatchIterator<L, R, C> implements BatchIterator<C> {
     }
 
     @Override
-    public boolean involvesIO() {
-        if (left.involvesIO()) {
-            return true;
-        }
-        return right.involvesIO();
+    public boolean hasLazyResultSet() {
+        return left.hasLazyResultSet() || right.hasLazyResultSet();
     }
 }

--- a/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
@@ -161,7 +161,7 @@ class SemiJoinNLBatchIterator<L, R, C> implements BatchIterator<L> {
     }
 
     @Override
-    public boolean involvesIO() {
+    public boolean hasLazyResultSet() {
         return false;
     }
 }

--- a/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
+++ b/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
@@ -152,7 +152,7 @@ public class BatchSimulatingIterator<T> implements BatchIterator<T> {
     }
 
     @Override
-    public boolean involvesIO() {
-        return delegate.involvesIO();
+    public boolean hasLazyResultSet() {
+        return delegate.hasLazyResultSet();
     }
 }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,5 +57,8 @@ None
 Fixes
 =====
 
-Fixed a regression introduced in 4.1 that led to a ``ClassCastException``
-running queries with ``GROUP BY``, no aggregations and a ``LIMIT`` clause.
+- Improved the resiliency of ``INSERT INTO ..`` queries that have a table
+  function like ``generate_series`` as a source.
+
+- Fixed a regression introduced in 4.1 that led to a ``ClassCastException``
+  running queries with ``GROUP BY``, no aggregations and a ``LIMIT`` clause.

--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -166,7 +166,7 @@ public class CollectTask extends AbstractTask {
 
     @Override
     protected void innerStart() {
-        String threadPoolName = threadPoolName(collectPhase, batchIterator.involvesIO());
+        String threadPoolName = threadPoolName(collectPhase, batchIterator.hasLazyResultSet());
         collectOperation.launch(() -> consumer.accept(batchIterator, null), threadPoolName);
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -197,7 +197,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     }
 
     @Override
-    public boolean involvesIO() {
+    public boolean hasLazyResultSet() {
         return true;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -269,7 +269,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     }
 
     @Override
-    public boolean involvesIO() {
+    public boolean hasLazyResultSet() {
         return true;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -69,7 +69,7 @@ public class TableFunctionCollectSource implements CollectSource {
         TableInfo tableInfo = functionImplementation.createTableInfo();
 
         //noinspection unchecked  Only literals can be passed to table functions. Anything else is invalid SQL
-        List<Input<?>> inputs = (List<Input<?>>) (List) phase.functionArguments();
+        List<Input<?>> inputs = (List<Input<?>>) (List<?>) phase.functionArguments();
         List<Reference> columns = new ArrayList<>(tableInfo.columns());
 
         List<Input<?>> topLevelInputs = new ArrayList<>(phase.toCollect().size());
@@ -89,6 +89,6 @@ public class TableFunctionCollectSource implements CollectSource {
         if (orderBy != null) {
             rows = RowsTransformer.sortRows(Iterables.transform(rows, Row::materialize), phase);
         }
-        return InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, false);
+        return InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, functionImplementation.hasLazyResultSet());
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -147,7 +147,7 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
     }
 
     @Override
-    public boolean involvesIO() {
+    public boolean hasLazyResultSet() {
         return true;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -132,7 +132,7 @@ public class ColumnIndexWriterProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.involvesIO());
+        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.hasLazyResultSet());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/DMLProjector.java
@@ -37,7 +37,7 @@ public class DMLProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, batchAccumulator, batchIterator.involvesIO());
+        return CollectingBatchIterator.newInstance(batchIterator, batchAccumulator, batchIterator.hasLazyResultSet());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -137,7 +137,7 @@ public class IndexWriterProjector implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.involvesIO());
+        return CollectingBatchIterator.newInstance(batchIterator, shardingUpsertExecutor, batchIterator.hasLazyResultSet());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -126,7 +126,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         // If the source batch iterator does not involve IO, mostly in-memory structures are used which we want to free
         // as soon as possible. We do not want to throttle based on the targets node counter in such cases.
         Predicate<TReq> shouldPause = ignored -> true;
-        if (batchIterator.involvesIO()) {
+        if (batchIterator.hasLazyResultSet()) {
             shouldPause = ignored ->
                 nodeJobsCounter.getInProgressJobsForNode(localNodeId) >= MAX_NODE_CONCURRENT_OPERATIONS;
         }

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -267,7 +267,7 @@ public class ShardingUpsertExecutor
         // fast as possible to free resources.
         Predicate<ShardedRequests<ShardUpsertRequest, ShardUpsertRequest.Item>> shouldPause =
             this::shouldPauseOnPartitionCreation;
-        if (batchIterator.involvesIO()) {
+        if (batchIterator.hasLazyResultSet()) {
             shouldPause = shouldPause.or(this::shouldPauseOnTargetNodeJobsCounter);
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -112,7 +112,7 @@ public final class WindowFunctionBatchIterator {
                     args
                 ))
                 .thenApply(rows -> Iterables.transform(rows, Buckets.arrayToSharedRow()::apply)),
-            source.involvesIO()
+            source.hasLazyResultSet()
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -90,6 +90,11 @@ public class EmptyRowTableFunction {
                 }
             };
         }
+
+        @Override
+        public boolean hasLazyResultSet() {
+            return false;
+        }
     }
 
     public static void register(TableFunctionModule module) {

--- a/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -239,6 +239,11 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         };
     }
 
+    @Override
+    public boolean hasLazyResultSet() {
+        return true;
+    }
+
     private static class GenerateSeriesIntervals extends TableFunctionImplementation<Object> {
 
         private final FunctionInfo info;
@@ -318,5 +323,9 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 .plusNanos(step.getMillis() * 1000_0000L);
         }
 
+        @Override
+        public boolean hasLazyResultSet() {
+            return true;
+        }
     }
 }

--- a/sql/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -147,4 +147,9 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
     public FunctionInfo info() {
         return info;
     }
+
+    @Override
+    public boolean hasLazyResultSet() {
+        return false;
+    }
 }

--- a/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -126,5 +126,10 @@ public class TableFunctionFactory {
                 }
             };
         }
+
+        @Override
+        public boolean hasLazyResultSet() {
+            return true;
+        }
     }
 }

--- a/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -77,6 +77,11 @@ public class UnnestFunction {
             return info;
         }
 
+        @Override
+        public boolean hasLazyResultSet() {
+            return false;
+        }
+
         /**
          *
          * @param arguments collection of array-literals

--- a/sql/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/sql/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -128,6 +128,11 @@ public class ValuesFunction {
                 }
             };
         }
+
+        @Override
+        public boolean hasLazyResultSet() {
+            return false;
+        }
     }
 
     public static void register(TableFunctionModule module) {

--- a/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
@@ -22,6 +22,7 @@
 
 package io.crate.metadata.tablefunctions;
 
+import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
@@ -34,6 +35,13 @@ import io.crate.metadata.table.TableInfo;
  * Interface which needs to be implemented by functions returning whole tables as result.
  */
 public abstract class TableFunctionImplementation<T> extends Scalar<Iterable<Row>, T> {
+
+
+    /**
+     * @return true if the records returned by this table function are generated on-demand.
+     *         See also {@link BatchIterator#hasLazyResultSet()}
+     */
+    public abstract boolean hasLazyResultSet();
 
     @Override
     public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Table functions like `generate_series` can generate a large result set.
This ensures that inserts from such tables are using the throttle
mechanism to not overload the cluster.

(cherry picked from commit ac62329f46e16dba4ea8c2edaadad724f3a9238b)
Backport of https://github.com/crate/crate/pull/9753

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)