### PR TITLE
Update docker run instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ The fastest way to try CrateDB out is by running::
 
 Or spin up the official `Docker image`_::
 
-    $ docker run -p 4200:4200 crate
+    $ docker run -p 4200:4200 crate -Cdiscovery.type=single-node
 
 Visit the `getting started`_ page to see all the available download and install options.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds `-Cdiscovery.type=single-node` so that bootstrap checks are
not enforced.

Otherwise on many systems CrateDB won't start up because of:

    max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144] by adding `vm.max_map_count = 262144` to `/etc/sysctl.conf` or invoking `sysctl -w vm.max_map_count=262144`

To try out CrateDB, setting `-Cdiscovery.type=single-node` should be
fine.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)