### PR TITLE
WIP: refactor function registration and resolving 

### DIFF
--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -61,6 +61,16 @@ public class ArrayType<T> extends DataType<List<T>> {
         return arrayType;
     }
 
+    @Override
+    public TypeSignature getTypeSignature() {
+        return new TypeSignature(NAME, List.of(TypeSignatureParameter.of(innerType.getTypeSignature())));
+    }
+
+    @Override
+    public List<DataType<?>> getTypeParameters() {
+        return List.of(innerType);
+    }
+
     /**
      * Defaults to the {@link ArrayStreamer} but subclasses may override this method.
      */

--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -83,7 +83,7 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Override
     public String getName() {
-        return innerType.getName() + "_" + NAME;
+        return NAME + "(" + innerType.getName() + ")";
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/DataType.java
+++ b/common/src/main/java/io/crate/types/DataType.java
@@ -26,7 +26,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -82,6 +84,14 @@ public abstract class DataType<T> implements Comparable, Writeable {
     public abstract T value(Object value) throws IllegalArgumentException, ClassCastException;
 
     public abstract int compareValueTo(T val1, T val2);
+
+    public TypeSignature getTypeSignature() {
+        return new TypeSignature(getName());
+    }
+
+    public List<DataType<?>> getTypeParameters() {
+        return Collections.emptyList();
+    }
 
     /**
      * Returns true if this DataType precedes the supplied DataType.

--- a/common/src/main/java/io/crate/types/ParameterKind.java
+++ b/common/src/main/java/io/crate/types/ParameterKind.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+public enum ParameterKind {
+    TYPE,
+    NAMED_TYPE,
+    LONG,
+    VARIABLE
+}

--- a/common/src/main/java/io/crate/types/TypeSignature.java
+++ b/common/src/main/java/io/crate/types/TypeSignature.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.lang.Character.isDigit;
+import static java.lang.String.format;
+
+public class TypeSignature {
+
+    public static TypeSignature parseTypeSignature(String signature) {
+        return parseTypeSignature(signature, new HashSet<>());
+    }
+
+    public static TypeSignature parseTypeSignature(String signature, Set<String> literalCalculationParameters) {
+        if (!signature.contains("<") && !signature.contains("(")) {
+            return new TypeSignature(signature);
+        }
+
+        String baseName = null;
+        List<TypeSignatureParameter> parameters = new ArrayList<>();
+        int parameterStart = -1;
+        int bracketCount = 0;
+
+        for (int i = 0; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            // TODO: remove angle brackets support once ROW<TYPE>(name) will be dropped
+            // Angle brackets here are checked not for the support of ARRAY<> and MAP<>
+            // but to correctly parse ARRAY(row<BIGINT, BIGINT>('a','b'))
+            if (c == '(' || c == '<') {
+                if (bracketCount == 0) {
+                    assert baseName == null : "Expected baseName to be null";
+                    assert parameterStart == -1 : "Expected parameter start to be -1";
+                    baseName = signature.substring(0, i);
+                    //checkArgument(!literalCalculationParameters.contains(baseName), "Bad type signature: '%s'", signature);
+                    parameterStart = i + 1;
+                }
+                bracketCount++;
+            } else if (c == ')' || c == '>') {
+                bracketCount--;
+                assert bracketCount >= 0 : "Bad type signature: '" + signature + "'";
+                if (bracketCount == 0) {
+                    assert parameterStart >= 0 : "Bad type signature: '" + signature + "'";
+                    parameters.add(parseTypeSignatureParameter(signature,
+                                                               parameterStart,
+                                                               i,
+                                                               literalCalculationParameters));
+                    parameterStart = i + 1;
+                    if (i == signature.length() - 1) {
+                        return new TypeSignature(baseName, parameters);
+                    }
+                }
+            } else if (c == ',') {
+                if (bracketCount == 1) {
+                    assert parameterStart >= 0 : "Bad type signature: '" + signature + "'";
+                    parameters.add(parseTypeSignatureParameter(signature,
+                                                               parameterStart,
+                                                               i,
+                                                               literalCalculationParameters));
+                    parameterStart = i + 1;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    private static TypeSignatureParameter parseTypeSignatureParameter(
+        String signature,
+        int begin,
+        int end,
+        Set<String> literalCalculationParameters) {
+        String parameterName = signature.substring(begin, end).trim();
+        if (isDigit(signature.charAt(begin))) {
+            return TypeSignatureParameter.of(Long.parseLong(parameterName));
+        } else if (literalCalculationParameters.contains(parameterName)) {
+            return TypeSignatureParameter.of(parameterName);
+        } else {
+            return TypeSignatureParameter.of(parseTypeSignature(parameterName, literalCalculationParameters));
+        }
+    }
+
+    public enum Mode {
+        IN,
+        VARIADIC
+    }
+
+    private final String base;
+    private final List<TypeSignatureParameter> parameters;
+    private final boolean calculated;
+    private final Predicate<DataType<?>> predicate;
+    private final Mode mode;
+    private final Map<String, TypeSignature> captures;
+
+    public TypeSignature(String base) {
+        this(base, t -> true, Mode.IN);
+    }
+
+    public TypeSignature(String base, List<TypeSignatureParameter> parameters) {
+        this(base, t -> true, Mode.IN, Collections.emptyMap(), parameters);
+    }
+
+    public TypeSignature(String base, Predicate<DataType<?>> predicate) {
+        this(base, predicate, Mode.IN);
+    }
+
+    public TypeSignature(String base, Predicate<DataType<?>> predicate, Mode mode) {
+        this(base, predicate, mode, Collections.emptyMap(), Collections.emptyList());
+    }
+
+    public TypeSignature(String base,
+                         Predicate<DataType<?>> predicate,
+                         Mode mode,
+                         Map<String, TypeSignature> captures,
+                         List<TypeSignatureParameter> parameters) {
+        this.base = base;
+        this.predicate = predicate;
+        this.mode = mode;
+        this.captures = captures;
+        this.parameters = parameters;
+        this.calculated = false;
+    }
+
+    public Mode mode() {
+        return mode;
+    }
+
+    public String getBase() {
+        return base;
+    }
+
+    public List<TypeSignatureParameter> getParameters() {
+        return parameters;
+    }
+
+    public List<TypeSignature> getTypeParametersAsTypeSignatures() {
+        List<TypeSignature> result = new ArrayList<>();
+        for (TypeSignatureParameter parameter : parameters) {
+            if (parameter.getKind() != ParameterKind.TYPE) {
+                throw new IllegalStateException(
+                    format("Expected all parameters to be TypeSignatures but [%s] was found", parameter.toString()));
+            }
+            result.add(parameter.getTypeSignature());
+        }
+        return result;
+    }
+
+    public boolean isCalculated() {
+        return calculated;
+    }
+
+    public boolean match(DataType<?> type) {
+        return predicate.test(type);
+    }
+
+    public DataType<?> apply(DataType<?> type) {
+        return type;
+    }
+
+    public TypeSignature withCapture(String name, Function<DataType<?>, DataType<?>> capture) {
+        HashMap<String, TypeSignature> captures = new HashMap<>(this.captures);
+        captures.put(name, new WithCapture(name, capture));
+        return new TypeSignature(name, predicate, Mode.IN, captures, parameters);
+    }
+
+    @Nullable
+    public TypeSignature capture(String name) {
+        return captures.get(name);
+    }
+
+    @Override
+    public String toString() {
+        if (parameters.isEmpty()) {
+            return base;
+        }
+
+        StringBuilder typeName = new StringBuilder(base);
+        typeName.append("(").append(parameters.get(0));
+        for (int i = 1; i < parameters.size(); i++) {
+            typeName.append(",").append(parameters.get(i));
+        }
+        typeName.append(")");
+        return typeName.toString();
+    }
+
+    private static class WithCapture extends TypeSignature {
+
+        private final Function<DataType<?>, DataType<?>> capture;
+
+        public WithCapture(String name, Function<DataType<?>, DataType<?>> capture) {
+            super(name, t -> true);
+            this.capture = capture;
+        }
+
+        @Override
+        public DataType<?> apply(DataType<?> type) {
+            return capture.apply(type);
+        }
+    }
+}

--- a/common/src/main/java/io/crate/types/TypeSignatureParameter.java
+++ b/common/src/main/java/io/crate/types/TypeSignatureParameter.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TypeSignatureParameter {
+
+    private final ParameterKind kind;
+    private final Object value;
+
+    public static TypeSignatureParameter of(TypeSignature typeSignature) {
+        return new TypeSignatureParameter(ParameterKind.TYPE, typeSignature);
+    }
+
+    public static TypeSignatureParameter of(long longLiteral) {
+        return new TypeSignatureParameter(ParameterKind.LONG, longLiteral);
+    }
+
+    /*
+    public static TypeSignatureParameter of(NamedTypeSignature namedTypeSignature) {
+        return new TypeSignatureParameter(ParameterKind.NAMED_TYPE, namedTypeSignature);
+    }
+    */
+
+    public static TypeSignatureParameter of(String variable) {
+        return new TypeSignatureParameter(ParameterKind.VARIABLE, variable);
+    }
+
+    private TypeSignatureParameter(ParameterKind kind, Object value) {
+        this.kind = requireNonNull(kind, "kind is null");
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    public ParameterKind getKind() {
+        return kind;
+    }
+
+    public boolean isTypeSignature() {
+        return kind == ParameterKind.TYPE;
+    }
+
+    public boolean isLongLiteral() {
+        return kind == ParameterKind.LONG;
+    }
+
+    public boolean isNamedTypeSignature() {
+        return kind == ParameterKind.NAMED_TYPE;
+    }
+
+    public boolean isVariable() {
+        return kind == ParameterKind.VARIABLE;
+    }
+
+    private <A> A getValue(ParameterKind expectedParameterKind, Class<A> target) {
+        if (kind != expectedParameterKind) {
+            throw new IllegalArgumentException(String.format("ParameterKind is [%s] but expected [%s]",
+                                                             kind,
+                                                             expectedParameterKind));
+        }
+        return target.cast(value);
+    }
+
+    public TypeSignature getTypeSignature() {
+        return getValue(ParameterKind.TYPE, TypeSignature.class);
+    }
+
+    public Long getLongLiteral() {
+        return getValue(ParameterKind.LONG, Long.class);
+    }
+
+    /*
+    public NamedTypeSignature getNamedTypeSignature() {
+        return getValue(ParameterKind.NAMED_TYPE, NamedTypeSignature.class);
+    }
+     */
+
+    public String getVariable() {
+        return getValue(ParameterKind.VARIABLE, String.class);
+    }
+
+    public Optional<TypeSignature> getTypeSignatureOrNamedTypeSignature() {
+        switch (kind) {
+            case TYPE:
+                return Optional.of(getTypeSignature());
+            //case NAMED_TYPE:
+            //    return Optional.of(getNamedTypeSignature().getTypeSignature());
+            default:
+                return Optional.empty();
+        }
+    }
+
+    public boolean isCalculated() {
+        switch (kind) {
+            case TYPE:
+                return getTypeSignature().isCalculated();
+            //case NAMED_TYPE:
+            //    return getNamedTypeSignature().getTypeSignature().isCalculated();
+            case LONG:
+                return false;
+            case VARIABLE:
+                return true;
+            default:
+                throw new IllegalArgumentException("Unexpected parameter kind: " + kind);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeSignatureParameter other = (TypeSignatureParameter) o;
+
+        return Objects.equals(this.kind, other.kind) &&
+               Objects.equals(this.value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, value);
+    }
+
+}

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -23,14 +23,13 @@ package io.crate.expression.scalar;
 
 import com.google.common.base.Preconditions;
 import io.crate.data.Input;
-import io.crate.metadata.BaseFunctionResolver;
+import io.crate.metadata.FuncResolver;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.functions.params.FuncParams;
-import io.crate.metadata.functions.params.Param;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -39,12 +38,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
 class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
 
     public static final String NAME = "array_cat";
     private final FunctionInfo functionInfo;
 
     public static FunctionInfo createInfo(List<DataType> types) {
+        validateInnerTypes(types);
         ArrayType arrayType = (ArrayType) types.get(0);
         if (arrayType.innerType().equals(DataTypes.UNDEFINED)) {
             arrayType = (ArrayType) types.get(1);
@@ -53,7 +56,21 @@ class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
     }
 
     public static void register(ScalarFunctionModule module) {
-        module.register(NAME, new Resolver());
+        Signature signature = new Signature(
+            new FunctionName(null, NAME),
+            FunctionInfo.Type.SCALAR,
+            List.of(typeVariable("E")),
+            List.of(parseTypeSignature("array(E)"), parseTypeSignature("array(E)")),
+            parseTypeSignature("array(E)"),
+            false
+        );
+
+        module.register(
+            new FuncResolver(
+                signature,
+                args -> new ArrayCatFunction(ArrayCatFunction.createInfo(args))
+            )
+        );
     }
 
     ArrayCatFunction(FunctionInfo functionInfo) {
@@ -82,35 +99,19 @@ class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
         return resultList;
     }
 
+    static void validateInnerTypes(List<DataType> dataTypes) {
+        DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
+        DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
 
-    private static class Resolver extends BaseFunctionResolver {
+        Preconditions.checkArgument(
+            !innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
+            "When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
 
-        protected Resolver() {
-            super(FuncParams.builder(Param.ANY_ARRAY, Param.ANY_ARRAY).build());
-        }
-
-        @Override
-        public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            for (int i = 0; i < dataTypes.size(); i++) {
-                Preconditions.checkArgument(dataTypes.get(i) instanceof ArrayType, String.format(Locale.ENGLISH,
-                    "Argument %d of the array_cat function cannot be converted to array", i + 1));
-            }
-
-            DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
-            DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
-
-            Preconditions.checkArgument(
-                !innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
-                "One of the arguments of the array_cat function can be of undefined inner type, but not both");
-
-            if (!innerType0.equals(DataTypes.UNDEFINED)) {
-                Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
-                    String.format(Locale.ENGLISH,
-                        "Second argument's inner type (%s) of the array_cat function cannot be converted to the first argument's inner type (%s)",
-                        innerType1, innerType0));
-            }
-
-            return new ArrayCatFunction(createInfo(dataTypes));
+        if (!innerType0.equals(DataTypes.UNDEFINED)) {
+            Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
+                                        String.format(Locale.ENGLISH,
+                                                      "Second argument's inner type (%s) of the array_cat function cannot be converted to the first argument's inner type (%s)",
+                                                      innerType1, innerType0));
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -21,12 +21,15 @@
 
 package io.crate.expression.scalar;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
+import io.crate.metadata.FuncResolver;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TimestampType;
@@ -34,6 +37,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.util.List;
+import java.util.function.Function;
+
+import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class DateFormatFunction extends Scalar<String, Object> {
 
@@ -41,23 +47,45 @@ public class DateFormatFunction extends Scalar<String, Object> {
     public static final String DEFAULT_FORMAT = "%Y-%m-%dT%H:%i:%s.%fZ";
 
     public static void register(ScalarFunctionModule module) {
+        FunctionName name = new FunctionName(null, NAME);
+        Function<List<DataType>, FunctionImplementation> functionFactory = args -> new DateFormatFunction(
+            new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
+        );
+
         List<DataType> supportedTimestampTypes = List.of(
             DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP, DataTypes.LONG, DataTypes.STRING);
         for (DataType dataType : supportedTimestampTypes) {
             // without format
-            module.register(new DateFormatFunction(new FunctionInfo(
-                new FunctionIdent(NAME, ImmutableList.of(dataType)),
-                DataTypes.STRING)
+            module.register(new FuncResolver(
+                new Signature(
+                    name,
+                    FunctionInfo.Type.SCALAR,
+                    List.of(parseTypeSignature(dataType.getName())),
+                    parseTypeSignature("text")
+                ),
+                functionFactory
             ));
+
             // with format
-            module.register(new DateFormatFunction(new FunctionInfo(
-                new FunctionIdent(NAME, ImmutableList.of(DataTypes.STRING, dataType)),
-                DataTypes.STRING)
+            module.register(new FuncResolver(
+                new Signature(
+                    name,
+                    FunctionInfo.Type.SCALAR,
+                    List.of(parseTypeSignature("text"), parseTypeSignature(dataType.getName())),
+                    parseTypeSignature("text")
+                ),
+                functionFactory
             ));
+
             // time zone aware variant
-            module.register(new DateFormatFunction(new FunctionInfo(
-                new FunctionIdent(NAME, ImmutableList.of(DataTypes.STRING, DataTypes.STRING, dataType)),
-                DataTypes.STRING)
+            module.register(new FuncResolver(
+                new Signature(
+                    name,
+                    FunctionInfo.Type.SCALAR,
+                    List.of(parseTypeSignature("text"), parseTypeSignature("text"), parseTypeSignature(dataType.getName())),
+                    parseTypeSignature("text")
+                ),
+                functionFactory
             ));
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -62,7 +62,12 @@ public class CastFunctionResolver {
     }
 
     static String castFuncName(DataType type) {
-        return TO_PREFIX + type.getName();
+        var typeName = type.getName();
+        // turn new `array(elementType)` name into old `elementType_array` name for BWC
+        if (type.id() == ArrayType.ID) {
+            typeName = ((ArrayType<?>) type).innerType().getName() + "_" + ArrayType.NAME;
+        }
+        return TO_PREFIX + typeName;
     }
 
     public static Symbol generateCastFunction(Symbol sourceSymbol, DataType targetType, boolean tryCast) {

--- a/sql/src/main/java/io/crate/metadata/FuncResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FuncResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class FuncResolver implements Function<List<DataType>, FunctionImplementation> {
+
+    private final Signature signature;
+    private final Function<List<DataType>, FunctionImplementation> functionResolver;
+
+    public FuncResolver(Signature signature,
+                        Function<List<DataType>, FunctionImplementation> functionResolver) {
+        this.signature = signature;
+        this.functionResolver = functionResolver;
+    }
+
+    public Signature getSignature() {
+        return signature;
+    }
+
+    @Override
+    public FunctionImplementation apply(List<DataType> dataTypes) {
+        return functionResolver.apply(dataTypes);
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -25,7 +25,11 @@ package io.crate.metadata;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.FuncArg;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.functions.SignatureBinder;
+import io.crate.metadata.functions.TypeManager;
 import io.crate.metadata.functions.params.FuncParams;
 import io.crate.types.DataType;
 import org.elasticsearch.common.collect.Tuple;
@@ -33,9 +37,11 @@ import org.elasticsearch.common.inject.Inject;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -45,12 +51,20 @@ public class Functions {
 
     private final Map<FunctionName, FunctionResolver> functionResolvers;
     private final Map<FunctionName, FunctionResolver> udfResolvers = new ConcurrentHashMap<>();
+    private final Map<FunctionName, List<FuncResolver>> functionImplementations;
 
     @Inject
     public Functions(Map<FunctionIdent, FunctionImplementation> functionImplementations,
-                     Map<FunctionName, FunctionResolver> functionResolvers) {
+                     Map<FunctionName, FunctionResolver> functionResolvers,
+                     Map<FunctionName, List<FuncResolver>> functionImplementationsBySignature) {
         this.functionResolvers = Maps.newHashMap(functionResolvers);
         this.functionResolvers.putAll(generateFunctionResolvers(functionImplementations));
+        this.functionImplementations = functionImplementationsBySignature;
+    }
+
+    public Functions(Map<FunctionIdent, FunctionImplementation> functionImplementations,
+                     Map<FunctionName, FunctionResolver> functionResolvers) {
+        this(functionImplementations, functionResolvers, Collections.emptyMap());
     }
 
     public Map<FunctionName, FunctionResolver> functionResolvers() {
@@ -60,6 +74,7 @@ public class Functions {
     public Map<FunctionName, FunctionResolver> udfFunctionResolvers() {
         return udfResolvers;
     }
+
 
     private Map<FunctionName, FunctionResolver> generateFunctionResolvers(Map<FunctionIdent, FunctionImplementation> functionImplementations) {
         Multimap<FunctionName, Tuple<FunctionIdent, FunctionImplementation>> signatures = getSignatures(functionImplementations);
@@ -150,6 +165,11 @@ public class Functions {
      */
     @Nullable
     private FunctionImplementation getBuiltin(FunctionName functionName, List<DataType> dataTypes) {
+        // V2
+        FunctionImplementation impl = resolveFunctionBySignature(functionName, dataTypes, SearchPath.pathWithPGCatalogAndDoc());
+        if (impl != null) {
+            return impl;
+        }
         FunctionResolver resolver = functionResolvers.get(functionName);
         if (resolver == null) {
             return null;
@@ -169,12 +189,47 @@ public class Functions {
     private FunctionImplementation getBuiltinByArgs(FunctionName functionName,
                                                     List<? extends FuncArg> argumentsTypes,
                                                     SearchPath searchPath) {
+        // V2
+        FunctionImplementation impl = resolveFunctionBySignature(functionName, Lists2.map(argumentsTypes, FuncArg::valueType), searchPath);
+        if (impl != null) {
+            return impl;
+        }
+
         FunctionResolver resolver = lookupFunctionResolver(functionName, searchPath, functionResolvers::get);
         if (resolver == null) {
             return null;
         }
         return resolveFunctionForArgumentTypes(argumentsTypes, resolver);
     }
+
+    @Nullable
+    public FunctionImplementation resolveFunctionBySignature(FunctionName name,
+                                                             List<DataType> arguments,
+                                                             SearchPath searchPath) {
+        var candidates = functionImplementations.get(name);
+        if (candidates == null && name.schema() == null) {
+            for (String pathSchema : searchPath) {
+                FunctionName searchPathFunctionName = new FunctionName(pathSchema, name.name());
+                candidates = functionImplementations.get(searchPathFunctionName);
+                if (candidates != null) {
+                    break;
+                }
+            }
+        }
+        if (candidates != null) {
+            var typeManager = new TypeManager();
+            for (FuncResolver candidate : candidates) {
+                Optional<Signature> boundSignature = new SignatureBinder(typeManager, candidate.getSignature(), true)
+                    .bind(arguments);
+                if (boundSignature.isPresent()) {
+                    // TODO: check for more specific function
+                    return candidate.apply(Lists2.map(boundSignature.get().getArgumentTypes(), typeManager::getType));
+                }
+            }
+        }
+        return null;
+    }
+
 
     /**
      * Returns the user-defined function implementation for the given function name and argTypes.

--- a/sql/src/main/java/io/crate/metadata/functions/BoundVariables.java
+++ b/sql/src/main/java/io/crate/metadata/functions/BoundVariables.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.types.DataType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class BoundVariables {
+
+    private final Map<String, DataType<?>> typeVariables;
+    private final Map<String, Long> longVariables;
+
+    public BoundVariables(Map<String, DataType<?>> typeVariables,
+                          Map<String, Long> longVariables) {
+        requireNonNull(typeVariables, "typeVariableBindings is null");
+        requireNonNull(longVariables, "longVariableBindings is null");
+        this.typeVariables = ImmutableMap.copyOf(typeVariables);
+        this.longVariables = ImmutableMap.copyOf(longVariables);
+    }
+
+    public DataType<?> getTypeVariable(String variableName) {
+        return getValue(typeVariables, variableName);
+    }
+
+    public boolean containsTypeVariable(String variableName) {
+        return containsValue(typeVariables, variableName);
+    }
+
+    public Map<String, DataType<?>> getTypeVariables() {
+        return typeVariables;
+    }
+
+    public Long getLongVariable(String variableName) {
+        return getValue(longVariables, variableName);
+    }
+
+    public boolean containsLongVariable(String variableName) {
+        return containsValue(longVariables, variableName);
+    }
+
+    public Map<String, Long> getLongVariables() {
+        return longVariables;
+    }
+
+    private static <T> T getValue(Map<String, T> map, String variableName) {
+        checkState(variableName != null, "variableName is null");
+        T value = map.get(variableName);
+        checkState(value != null, "value for variable '%s' is null", variableName);
+        return value;
+    }
+
+    private static boolean containsValue(Map<String, ?> map, String variableName) {
+        checkState(variableName != null, "variableName is null");
+        return map.containsKey(variableName);
+    }
+
+    private static <T> void setValue(Map<String, T> map, String variableName, T value) {
+        checkState(variableName != null, "variableName is null");
+        checkState(value != null, "value for variable '%s' is null", variableName);
+        map.put(variableName, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BoundVariables that = (BoundVariables) o;
+        return Objects.equals(typeVariables, that.typeVariables) &&
+               Objects.equals(longVariables, that.longVariables);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(typeVariables, longVariables);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+            .add("typeVariables", typeVariables)
+            .add("longVariables", longVariables)
+            .toString();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<String, DataType<?>> typeVariables = new HashMap<>();
+        private final Map<String, Long> longVariables = new HashMap<>();
+
+        public DataType<?> getTypeVariable(String variableName) {
+            return getValue(typeVariables, variableName);
+        }
+
+        public Builder setTypeVariable(String variableName, DataType<?> variableValue) {
+            setValue(typeVariables, variableName, variableValue);
+            return this;
+        }
+
+        public boolean containsTypeVariable(String variableName) {
+            return containsValue(typeVariables, variableName);
+        }
+
+        public Map<String, DataType<?>> getTypeVariables() {
+            return typeVariables;
+        }
+
+        public Long getLongVariable(String variableName) {
+            return getValue(longVariables, variableName);
+        }
+
+        public Builder setLongVariable(String variableName, Long variableValue) {
+            setValue(longVariables, variableName, variableValue);
+            return this;
+        }
+
+        public boolean containsLongVariable(String variableName) {
+            return containsValue(longVariables, variableName);
+        }
+
+        public Map<String, Long> getLongVariables() {
+            return longVariables;
+        }
+
+        public BoundVariables build() {
+            return new BoundVariables(typeVariables, longVariables);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/sql/src/main/java/io/crate/metadata/functions/Signature.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.expression.symbol.FuncArg;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
+import io.crate.types.TypeSignature;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toList;
+
+public class Signature {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private FunctionName name;
+        private FunctionInfo.Type kind = FunctionInfo.Type.SCALAR;
+        private List<TypeSignature> args = Collections.emptyList();
+        private List<TypeVariableConstraint> typeVariableConstraints = new ArrayList<>();
+        private TypeSignature returnType;
+        private Consumer<List<? extends FuncArg>> validation = a -> {
+        };
+        private boolean variableArity = false;
+
+        public Builder name(FunctionName name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder args(TypeSignature... args) {
+            this.args = List.of(args);
+            return this;
+        }
+
+        public Builder returnType(TypeSignature returnType) {
+            this.returnType = returnType;
+            return this;
+        }
+
+        public Builder withVariableConstraint(TypeVariableConstraint typeVariableConstraint) {
+            typeVariableConstraints.add(typeVariableConstraint);
+            return this;
+        }
+
+        public Builder withValidation(Consumer<List<? extends FuncArg>> validation) {
+            this.validation = validation;
+            return this;
+        }
+
+        public Builder withVariableArity() {
+            this.variableArity = true;
+            return this;
+        }
+
+        public Signature build() {
+            assert returnType != null : "returnType not set";
+            return new Signature(name, kind, typeVariableConstraints, args, returnType, validation, variableArity);
+        }
+
+    }
+
+    private final FunctionName name;
+    private final FunctionInfo.Type kind;
+    private final List<TypeSignature> args;
+    private final TypeSignature returnType;
+    private final List<TypeVariableConstraint> typeVariableConstraints;
+    private final Consumer<List<? extends FuncArg>> validation;
+    private final boolean variableArity;
+
+    public Signature(FunctionName name, FunctionInfo.Type kind, List<TypeSignature> args, TypeSignature returnType) {
+        this(name, kind, Collections.emptyList(), args, returnType, a -> {
+        }, false);
+    }
+
+    public Signature(FunctionName name,
+                     FunctionInfo.Type kind,
+                     List<TypeVariableConstraint> typeVariableConstraints,
+                     List<TypeSignature> args,
+                     TypeSignature returnType,
+                     boolean variableArity) {
+        this(name, kind, typeVariableConstraints, args, returnType, a -> {
+        }, variableArity);
+    }
+
+    public Signature(FunctionName name,
+                     FunctionInfo.Type kind,
+                     List<TypeVariableConstraint> typeVariableConstraints,
+                     List<TypeSignature> args,
+                     TypeSignature returnType,
+                     Consumer<List<? extends FuncArg>> validation,
+                     boolean variableArity) {
+        this.name = name;
+        this.kind = kind;
+        this.args = args;
+        this.typeVariableConstraints = typeVariableConstraints;
+        this.returnType = returnType;
+        this.validation = validation;
+        this.variableArity = variableArity;
+    }
+
+    public FunctionName getName() {
+        return name;
+    }
+
+    public FunctionInfo.Type getKind() {
+        return kind;
+    }
+
+    public List<TypeSignature> getArgumentTypes() {
+        return args;
+    }
+
+    public TypeSignature getReturnType() {
+        return returnType;
+    }
+
+    public List<TypeVariableConstraint> getTypeVariableConstraints() {
+        return typeVariableConstraints;
+    }
+
+    public boolean isVariableArity() {
+        return variableArity;
+    }
+
+    public boolean match(List<? extends FuncArg> args) {
+        if (this.args.size() == 0) {
+            return args.size() == 0;
+        }
+        TypeSignature lastParam = null;
+        for (int i = 0; i < args.size(); i++) {
+            FuncArg arg = args.get(i);
+            if (i < this.args.size()) {
+                var param = lastParam = this.args.get(i);
+                if (!param.match(arg.valueType())) {
+                    return false;
+                }
+            } else {
+                if (lastParam.mode() != TypeSignature.Mode.VARIADIC) {
+                    return false;
+                }
+                if (!lastParam.match(arg.valueType())) {
+                    return false;
+                }
+            }
+        }
+        validation.accept(args);
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        List<String> allConstraints = typeVariableConstraints.stream().map(TypeVariableConstraint::toString)
+            .collect(toList());
+
+        return name + (allConstraints.isEmpty() ? "" : "<" + String.join(",", allConstraints) + ">") +
+               "(" + String.join(",", args.stream().map(TypeSignature::toString).collect(toList())) + "):" + returnType;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/sql/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -1,0 +1,762 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.crate.common.collections.Lists2;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
+import io.crate.types.ParameterKind;
+import io.crate.types.TypeSignature;
+import io.crate.types.TypeSignatureParameter;
+import io.crate.types.UndefinedType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+
+/**
+ * Determines whether, and how, a callsite matches a generic function signature.
+ * Which is equivalent to finding assignments for the variables in the generic signature,
+ * such that all of the function's declared parameters are super types of the corresponding
+ * arguments, and also satisfy the declared constraints (such as a given type parameter must
+ * bind to an orderable type)
+ * <p>
+ * This implementation has made assumptions. When any of the assumptions is not satisfied, it will fail loudly.
+ * <p><ul>
+ * <li>A type cannot have both type parameter and literal parameter.
+ * <li>A literal parameter cannot be be used across types. see {@link #checkNoLiteralVariableUsageAcrossTypes(TypeSignature, Map)}.
+ * </ul><p>
+ * Here are some known implementation limitations:
+ * <p><ul>
+ * <li>Binding signature {@code (decimal(x,2))boolean} with arguments {@code decimal(1,0)} fails.
+ * It should produce {@code decimal(3,1)}.
+ * </ul>
+ */
+public class SignatureBinder {
+    // 4 is chosen arbitrarily here. This limit is set to avoid having infinite loops in iterative solving.
+    private static final int SOLVE_ITERATION_LIMIT = 4;
+
+    private final TypeManager typeManager;
+    private final Signature declaredSignature;
+    private final boolean allowCoercion;
+    private final Map<String, TypeVariableConstraint> typeVariableConstraints;
+
+    public SignatureBinder(TypeManager typeManager, Signature declaredSignature, boolean allowCoercion) {
+        checkNoLiteralVariableUsageAcrossTypes(declaredSignature);
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.declaredSignature = requireNonNull(declaredSignature, "parametrizedSignature is null");
+        this.allowCoercion = allowCoercion;
+        this.typeVariableConstraints = declaredSignature.getTypeVariableConstraints().stream()
+            .collect(toMap(TypeVariableConstraint::getName, identity()));
+    }
+
+    public Optional<Signature> bind(List<DataType> actualArgumentTypes) {
+        Optional<BoundVariables> boundVariables = bindVariables(Lists2.map(actualArgumentTypes,
+                                                                           DataType::getTypeSignature));
+        if (!boundVariables.isPresent()) {
+            return Optional.empty();
+        }
+        return Optional.of(applyBoundVariables(declaredSignature, boundVariables.get(), actualArgumentTypes.size()));
+    }
+
+    public Optional<BoundVariables> bindVariables(List<TypeSignature> actualArgumentTypes) {
+        ImmutableList.Builder<TypeConstraintSolver> constraintSolvers = ImmutableList.builder();
+        if (!appendConstraintSolversForArguments(constraintSolvers, actualArgumentTypes)) {
+            return Optional.empty();
+        }
+
+        return iterativeSolve(constraintSolvers.build());
+    }
+
+    public static Signature applyBoundVariables(Signature signature, BoundVariables boundVariables, int arity) {
+        List<TypeSignature> argumentSignatures;
+        if (signature.isVariableArity()) {
+            argumentSignatures = expandVarargFormalTypeSignature(signature.getArgumentTypes(), arity);
+        } else {
+            checkArgument(signature.getArgumentTypes().size() == arity);
+            argumentSignatures = signature.getArgumentTypes();
+        }
+        List<TypeSignature> boundArgumentSignatures = applyBoundVariables(argumentSignatures, boundVariables);
+        TypeSignature boundReturnTypeSignature = applyBoundVariables(signature.getReturnType(), boundVariables);
+
+        return new Signature(
+            signature.getName(),
+            signature.getKind(),
+            ImmutableList.of(),
+            boundArgumentSignatures,
+            boundReturnTypeSignature,
+            false);
+    }
+
+    public static List<TypeSignature> applyBoundVariables(List<TypeSignature> typeSignatures,
+                                                          BoundVariables boundVariables) {
+        ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
+        for (TypeSignature typeSignature : typeSignatures) {
+            builder.add(applyBoundVariables(typeSignature, boundVariables));
+        }
+        return builder.build();
+    }
+
+    public static TypeSignature applyBoundVariables(TypeSignature typeSignature, BoundVariables boundVariables) {
+        String baseType = typeSignature.getBase();
+        if (boundVariables.containsTypeVariable(baseType)) {
+            checkState(typeSignature.getParameters().isEmpty(), "Type parameters cannot have parameters");
+            return boundVariables.getTypeVariable(baseType).getTypeSignature();
+        }
+
+        List<TypeSignatureParameter> parameters = typeSignature.getParameters().stream()
+            .map(typeSignatureParameter -> applyBoundVariables(typeSignatureParameter, boundVariables))
+            .collect(toList());
+
+        return new TypeSignature(baseType, parameters);
+    }
+
+    public static List<DataType<?>> applyBoundVariables(TypeManager typeManager,
+                                                        List<TypeSignature> typeSignatures,
+                                                        BoundVariables boundVariables) {
+        ImmutableList.Builder<DataType<?>> builder = ImmutableList.builder();
+        for (TypeSignature typeSignature : typeSignatures) {
+            builder.add(applyBoundVariables(typeManager, typeSignature, boundVariables));
+        }
+        return builder.build();
+    }
+
+    public static DataType<?> applyBoundVariables(TypeManager typeManager,
+                                                  TypeSignature typeSignature,
+                                                  BoundVariables boundVariables) {
+        String baseType = typeSignature.getBase();
+        if (boundVariables.containsTypeVariable(baseType)) {
+            checkState(typeSignature.getParameters().isEmpty(), "Type parameters cannot have parameters");
+            return boundVariables.getTypeVariable(baseType);
+        }
+
+        List<TypeSignatureParameter> parameters = typeSignature.getParameters().stream()
+            .map(typeSignatureParameter -> applyBoundVariables(typeSignatureParameter, boundVariables))
+            .collect(toList());
+
+        return typeManager.getParameterizedType(baseType, parameters);
+    }
+
+    /**
+     * Example of not allowed literal variable usages across typeSignatures:
+     * <p><ul>
+     * <li>x used in different base types: char(x) and varchar(x)
+     * <li>x used in different positions of the same base type: decimal(x,y) and decimal(z,x)
+     * <li>p used in combination with different literals, types, or literal variables: decimal(p,s1) and decimal(p,s2)
+     * </ul>
+     */
+    private static void checkNoLiteralVariableUsageAcrossTypes(Signature declaredSignature) {
+        Map<String, TypeSignature> existingUsages = new HashMap<>();
+        for (TypeSignature parameter : declaredSignature.getArgumentTypes()) {
+            checkNoLiteralVariableUsageAcrossTypes(parameter, existingUsages);
+        }
+    }
+
+    private static void checkNoLiteralVariableUsageAcrossTypes(TypeSignature typeSignature,
+                                                               Map<String, TypeSignature> existingUsages) {
+        List<TypeSignatureParameter> variables = typeSignature.getParameters().stream()
+            .filter(TypeSignatureParameter::isVariable)
+            .collect(toList());
+        for (TypeSignatureParameter variable : variables) {
+            TypeSignature existing = existingUsages.get(variable.getVariable());
+            if (existing != null && !existing.equals(typeSignature)) {
+                throw new UnsupportedOperationException("Literal parameters may not be shared across different types");
+            }
+            existingUsages.put(variable.getVariable(), typeSignature);
+        }
+
+        for (TypeSignatureParameter parameter : typeSignature.getParameters()) {
+            if (parameter.isLongLiteral() || parameter.isVariable()) {
+                continue;
+            }
+            checkNoLiteralVariableUsageAcrossTypes(parameter.getTypeSignatureOrNamedTypeSignature().get(),
+                                                   existingUsages);
+        }
+    }
+
+    private boolean appendConstraintSolversForArguments(ImmutableList.Builder<TypeConstraintSolver> resultBuilder,
+                                                        List<TypeSignature> actualTypeSignatures) {
+        boolean variableArity = declaredSignature.isVariableArity();
+        List<TypeSignature> formalTypeSignatures = declaredSignature.getArgumentTypes();
+        if (variableArity) {
+            if (actualTypeSignatures.size() < formalTypeSignatures.size() - 1) {
+                return false;
+            }
+            formalTypeSignatures = expandVarargFormalTypeSignature(formalTypeSignatures, actualTypeSignatures.size());
+        }
+
+        if (formalTypeSignatures.size() != actualTypeSignatures.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < formalTypeSignatures.size(); i++) {
+            if (!appendTypeRelationshipConstraintSolver(resultBuilder,
+                                                        formalTypeSignatures.get(i),
+                                                        actualTypeSignatures.get(i),
+                                                        allowCoercion)) {
+                return false;
+            }
+        }
+
+        return appendConstraintSolvers(resultBuilder, formalTypeSignatures, actualTypeSignatures, allowCoercion);
+    }
+
+    private boolean appendConstraintSolvers(ImmutableList.Builder<TypeConstraintSolver> resultBuilder,
+                                            List<? extends TypeSignature> formalTypeSignatures,
+                                            List<TypeSignature> actualTypeSignatures,
+                                            boolean allowCoercion) {
+        if (formalTypeSignatures.size() != actualTypeSignatures.size()) {
+            return false;
+        }
+        for (int i = 0; i < formalTypeSignatures.size(); i++) {
+            if (!appendConstraintSolvers(resultBuilder,
+                                         formalTypeSignatures.get(i),
+                                         actualTypeSignatures.get(i),
+                                         allowCoercion)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean appendConstraintSolvers(ImmutableList.Builder<TypeConstraintSolver> resultBuilder,
+                                            TypeSignature formalTypeSignature,
+                                            TypeSignature actualTypeSignature,
+                                            boolean allowCoercion) {
+        // formalTypeSignature can be categorized into one of the 5 cases below:
+        // * function type
+        // * type without type parameter
+        // * type parameter of type/named_type kind
+        // * type with type parameter of literal/variable kind
+        // * type with type parameter of type/named_type kind (except function type)
+
+        /*
+        if (FunctionType.NAME.equals(formalTypeSignature.getBase())) {
+            List<TypeSignature> formalTypeParameterTypeSignatures = formalTypeSignature.getTypeParametersAsTypeSignatures();
+            resultBuilder.add(new FunctionSolver(
+                getLambdaArgumentTypeSignatures(formalTypeSignature),
+                formalTypeParameterTypeSignatures.get(formalTypeParameterTypeSignatures.size() - 1),
+                actualType));
+            return true;
+        }
+
+        if (actualType.hasDependency()) {
+            return false;
+        }
+
+         */
+
+        if (formalTypeSignature.getParameters().isEmpty()) {
+            TypeVariableConstraint typeVariableConstraint = typeVariableConstraints.get(formalTypeSignature.getBase());
+            if (typeVariableConstraint == null) {
+                return true;
+            }
+            resultBuilder.add(new TypeParameterSolver(
+                formalTypeSignature.getBase(),
+                typeManager.getType(actualTypeSignature),
+                typeVariableConstraint.isComparableRequired(),
+                typeVariableConstraint.isOrderableRequired(),
+                Optional.ofNullable(typeVariableConstraint.getVariadicBound())));
+            return true;
+        }
+
+        DataType<?> actualType = typeManager.getType(actualTypeSignature);
+        if (isTypeWithLiteralParameters(formalTypeSignature)) {
+            resultBuilder.add(new TypeWithLiteralParametersSolver(formalTypeSignature, actualType));
+            return true;
+        }
+
+        List<TypeSignature> actualTypeParametersTypeSignatureProvider;
+        if (UndefinedType.ID == actualType.id()) {
+            actualTypeParametersTypeSignatureProvider = Collections.nCopies(formalTypeSignature.getParameters().size(),
+                                                                            UndefinedType.INSTANCE.getTypeSignature());
+        } else {
+            actualTypeParametersTypeSignatureProvider = fromTypes(actualType.getTypeParameters());
+        }
+
+        ImmutableList.Builder<TypeSignature> formalTypeParameterTypeSignatures = ImmutableList.builder();
+        for (TypeSignatureParameter formalTypeParameter : formalTypeSignature.getParameters()) {
+            Optional<TypeSignature> typeSignature = formalTypeParameter.getTypeSignatureOrNamedTypeSignature();
+            if (!typeSignature.isPresent()) {
+                throw new UnsupportedOperationException(
+                    "Types with both type parameters and literal parameters at the same time are not supported");
+            }
+            formalTypeParameterTypeSignatures.add(typeSignature.get());
+        }
+
+        return appendConstraintSolvers(
+            resultBuilder,
+            formalTypeParameterTypeSignatures.build(),
+            actualTypeParametersTypeSignatureProvider,
+            allowCoercion && isCovariantTypeBase(formalTypeSignature.getBase()));
+    }
+
+    public static boolean isCovariantTypeBase(String typeBase) {
+        return typeBase.equals(ArrayType.NAME) || typeBase.equals(ObjectType.NAME);
+    }
+
+    public static List<TypeSignature> fromTypes(List<DataType<?>> types) {
+        return types.stream()
+            .map(DataType::getTypeSignature)
+            .collect(toImmutableList());
+    }
+
+    private Set<String> typeVariablesOf(TypeSignature typeSignature) {
+        if (typeVariableConstraints.containsKey(typeSignature.getBase())) {
+            return ImmutableSet.of(typeSignature.getBase());
+        }
+        Set<String> variables = new HashSet<>();
+        for (TypeSignatureParameter parameter : typeSignature.getParameters()) {
+            switch (parameter.getKind()) {
+                case TYPE:
+                    variables.addAll(typeVariablesOf(parameter.getTypeSignature()));
+                    break;
+                //case NAMED_TYPE:
+                //    variables.addAll(typeVariablesOf(parameter.getNamedTypeSignature().getTypeSignature()));
+                //    break;
+                case LONG:
+                    break;
+                case VARIABLE:
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        return variables;
+    }
+
+    private static Set<String> longVariablesOf(TypeSignature typeSignature) {
+        Set<String> variables = new HashSet<>();
+        for (TypeSignatureParameter parameter : typeSignature.getParameters()) {
+            switch (parameter.getKind()) {
+                case TYPE:
+                    variables.addAll(longVariablesOf(parameter.getTypeSignature()));
+                    break;
+                //case NAMED_TYPE:
+                //    variables.addAll(longVariablesOf(parameter.getNamedTypeSignature().getTypeSignature()));
+                //    break;
+                case LONG:
+                    break;
+                case VARIABLE:
+                    variables.add(parameter.getVariable());
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        return variables;
+    }
+
+    private static boolean isTypeWithLiteralParameters(TypeSignature typeSignature) {
+        return typeSignature.getParameters().stream()
+            .map(TypeSignatureParameter::getKind)
+            .allMatch(kind -> kind == ParameterKind.LONG || kind == ParameterKind.VARIABLE);
+    }
+
+    private Optional<BoundVariables> iterativeSolve(List<TypeConstraintSolver> constraints) {
+        BoundVariables.Builder boundVariablesBuilder = BoundVariables.builder();
+        for (int i = 0; true; i++) {
+            if (i == SOLVE_ITERATION_LIMIT) {
+                throw new VerifyException(format("SignatureBinder.iterativeSolve does not converge after %d iterations.",
+                                                 SOLVE_ITERATION_LIMIT));
+            }
+            SolverReturnStatusMerger statusMerger = new SolverReturnStatusMerger();
+            for (TypeConstraintSolver constraint : constraints) {
+                statusMerger.add(constraint.update(boundVariablesBuilder));
+                if (statusMerger.getCurrent() == SolverReturnStatus.UNSOLVABLE) {
+                    return Optional.empty();
+                }
+            }
+            switch (statusMerger.getCurrent()) {
+                case UNCHANGED_SATISFIED:
+                    break;
+                case UNCHANGED_NOT_SATISFIED:
+                    return Optional.empty();
+                case CHANGED:
+                    continue;
+                case UNSOLVABLE:
+                    throw new VerifyException();
+                default:
+                    throw new UnsupportedOperationException("unknown status");
+            }
+            break;
+        }
+
+        //calculateVariableValuesForLongConstraints(boundVariablesBuilder);
+
+        BoundVariables boundVariables = boundVariablesBuilder.build();
+        if (!allTypeVariablesBound(boundVariables)) {
+            return Optional.empty();
+        }
+        return Optional.of(boundVariables);
+    }
+
+    /*
+    private void calculateVariableValuesForLongConstraints(BoundVariables.Builder variableBinder)
+    {
+        for (LongVariableConstraint longVariableConstraint : declaredSignature.getLongVariableConstraints()) {
+            String calculation = longVariableConstraint.getExpression();
+            String variableName = longVariableConstraint.getName();
+            Long calculatedValue = calculateLiteralValue(calculation, variableBinder.getLongVariables());
+            if (variableBinder.containsLongVariable(variableName)) {
+                Long currentValue = variableBinder.getLongVariable(variableName);
+                checkState(Objects.equals(currentValue, calculatedValue),
+                           "variable '%s' is already set to %s when trying to set %s", variableName, currentValue, calculatedValue);
+            }
+            variableBinder.setLongVariable(variableName, calculatedValue);
+        }
+    }
+
+     */
+
+    private boolean allTypeVariablesBound(BoundVariables boundVariables) {
+        return boundVariables.getTypeVariables().keySet().equals(typeVariableConstraints.keySet());
+    }
+
+    private static TypeSignatureParameter applyBoundVariables(TypeSignatureParameter parameter,
+                                                              BoundVariables boundVariables) {
+        ParameterKind parameterKind = parameter.getKind();
+        switch (parameterKind) {
+            case TYPE: {
+                TypeSignature typeSignature = parameter.getTypeSignature();
+                return TypeSignatureParameter.of(applyBoundVariables(typeSignature, boundVariables));
+            }
+            /*
+            case NAMED_TYPE: {
+                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
+                TypeSignature typeSignature = namedTypeSignature.getTypeSignature();
+                return TypeSignatureParameter.of(new NamedTypeSignature(
+                    namedTypeSignature.getFieldName(),
+                    applyBoundVariables(typeSignature, boundVariables)));
+            }
+
+             */
+            case VARIABLE: {
+                String variableName = parameter.getVariable();
+                checkState(boundVariables.containsLongVariable(variableName),
+                           "Variable is not bound: %s", variableName);
+                Long variableValue = boundVariables.getLongVariable(variableName);
+                return TypeSignatureParameter.of(variableValue);
+            }
+            case LONG: {
+                return parameter;
+            }
+            default:
+                throw new IllegalStateException("Unknown parameter kind: " + parameter.getKind());
+        }
+    }
+
+    private static List<TypeSignature> expandVarargFormalTypeSignature(List<TypeSignature> formalTypeSignatures,
+                                                                       int actualArity) {
+        int variableArityArgumentsCount = actualArity - formalTypeSignatures.size() + 1;
+        if (variableArityArgumentsCount == 0) {
+            return formalTypeSignatures.subList(0, formalTypeSignatures.size() - 1);
+        }
+        if (variableArityArgumentsCount == 1) {
+            return formalTypeSignatures;
+        }
+        checkArgument(variableArityArgumentsCount > 1 && !formalTypeSignatures.isEmpty());
+
+        ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
+        builder.addAll(formalTypeSignatures);
+        TypeSignature lastTypeSignature = formalTypeSignatures.get(formalTypeSignatures.size() - 1);
+        for (int i = 1; i < variableArityArgumentsCount; i++) {
+            builder.add(lastTypeSignature);
+        }
+        return builder.build();
+    }
+
+    private boolean satisfiesCoercion(boolean allowCoercion, DataType<?> fromType, TypeSignature toTypeSignature) {
+        if (allowCoercion) {
+            return typeManager.canCoerce(fromType, typeManager.getType(toTypeSignature));
+        } else {
+            return fromType.getTypeSignature().equals(toTypeSignature);
+        }
+    }
+
+    private static List<TypeSignature> getLambdaArgumentTypeSignatures(TypeSignature lambdaTypeSignature) {
+        List<TypeSignature> typeParameters = lambdaTypeSignature.getTypeParametersAsTypeSignatures();
+        return typeParameters.subList(0, typeParameters.size() - 1);
+    }
+
+    private interface TypeConstraintSolver {
+        SolverReturnStatus update(BoundVariables.Builder bindings);
+    }
+
+    private enum SolverReturnStatus {
+        UNCHANGED_SATISFIED,
+        UNCHANGED_NOT_SATISFIED,
+        CHANGED,
+        UNSOLVABLE,
+    }
+
+    private static class SolverReturnStatusMerger {
+        // This class gives the overall status when multiple status are seen from different parts.
+        // The logic is simple and can be summarized as finding the right most item (based on the list below) seen so far:
+        //   UNCHANGED_SATISFIED, UNCHANGED_NOT_SATISFIED, CHANGED, UNSOLVABLE
+        // If no item was seen ever, it provides UNCHANGED_SATISFIED.
+
+        private SolverReturnStatus current = SolverReturnStatus.UNCHANGED_SATISFIED;
+
+        public void add(SolverReturnStatus newStatus) {
+            switch (newStatus) {
+                case UNCHANGED_SATISFIED:
+                    break;
+                case UNCHANGED_NOT_SATISFIED:
+                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED) {
+                        current = SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+                    }
+                    break;
+                case CHANGED:
+                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED ||
+                        current == SolverReturnStatus.UNCHANGED_NOT_SATISFIED) {
+                        current = SolverReturnStatus.CHANGED;
+                    }
+                    break;
+                case UNSOLVABLE:
+                default:
+                    current = SolverReturnStatus.UNSOLVABLE;
+                    break;
+            }
+        }
+
+        public SolverReturnStatus getCurrent() {
+            return current;
+        }
+    }
+
+    private class TypeParameterSolver implements TypeConstraintSolver {
+        private final String typeParameter;
+        private final DataType<?> actualType;
+        private final boolean comparableRequired;
+        private final boolean orderableRequired;
+        private final Optional<String> requiredBaseName;
+
+        public TypeParameterSolver(String typeParameter,
+                                   DataType<?> actualType,
+                                   boolean comparableRequired,
+                                   boolean orderableRequired,
+                                   Optional<String> requiredBaseName) {
+            this.typeParameter = typeParameter;
+            this.actualType = actualType;
+            this.comparableRequired = comparableRequired;
+            this.orderableRequired = orderableRequired;
+            this.requiredBaseName = requiredBaseName;
+        }
+
+        @Override
+        public SolverReturnStatus update(BoundVariables.Builder bindings) {
+            if (!bindings.containsTypeVariable(typeParameter)) {
+                if (!satisfiesConstraints(actualType)) {
+                    return SolverReturnStatus.UNSOLVABLE;
+                }
+                bindings.setTypeVariable(typeParameter, actualType);
+                return SolverReturnStatus.CHANGED;
+            }
+            DataType<?> originalType = bindings.getTypeVariable(typeParameter);
+            Optional<DataType<?>> commonSuperType = typeManager.getCommonSuperType(originalType, actualType);
+            if (!commonSuperType.isPresent()) {
+                return SolverReturnStatus.UNSOLVABLE;
+            }
+            if (!satisfiesConstraints(commonSuperType.get())) {
+                // This check must not be skipped even if commonSuperType is equal to originalType
+                return SolverReturnStatus.UNSOLVABLE;
+            }
+            if (commonSuperType.get().equals(originalType)) {
+                return SolverReturnStatus.UNCHANGED_SATISFIED;
+            }
+            bindings.setTypeVariable(typeParameter, commonSuperType.get());
+            return SolverReturnStatus.CHANGED;
+        }
+
+        private boolean satisfiesConstraints(DataType<?> type) {
+            /*
+            if (comparableRequired && !type.isComparable()) {
+                return false;
+            }
+            if (orderableRequired && !type.isOrderable()) {
+                return false;
+            }
+
+             */
+            if (requiredBaseName.isPresent() && !UndefinedType.INSTANCE.equals(type) &&
+                !requiredBaseName.get().equals(type.getTypeSignature().getBase())) {
+                // TODO: the case below should be properly handled:
+                // * `type` does not have the `requiredBaseName` but can be coerced to some type that has the `requiredBaseName`.
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private class TypeWithLiteralParametersSolver implements TypeConstraintSolver {
+        private final TypeSignature formalTypeSignature;
+        private final DataType<?> actualType;
+
+        public TypeWithLiteralParametersSolver(TypeSignature formalTypeSignature, DataType<?> actualType) {
+            this.formalTypeSignature = formalTypeSignature;
+            this.actualType = actualType;
+        }
+
+        @Override
+        public SolverReturnStatus update(BoundVariables.Builder bindings) {
+            ImmutableList.Builder<TypeSignatureParameter> originalTypeTypeParametersBuilder = ImmutableList.builder();
+            List<TypeSignatureParameter> parameters = formalTypeSignature.getParameters();
+            for (int i = 0; i < parameters.size(); i++) {
+                TypeSignatureParameter typeSignatureParameter = parameters.get(i);
+                if (typeSignatureParameter.getKind() == ParameterKind.VARIABLE) {
+                    if (bindings.containsLongVariable(typeSignatureParameter.getVariable())) {
+                        originalTypeTypeParametersBuilder.add(TypeSignatureParameter.of(bindings.getLongVariable(
+                            typeSignatureParameter.getVariable())));
+                    } else {
+                        return SolverReturnStatus.UNSOLVABLE;
+                        /*
+                        // if an existing value doesn't exist for the given variable name, use the value that comes from the actual type.
+                        Optional<DataType<?>> type = typeManager.coerceTypeBase(actualType, formalTypeSignature.getBase());
+                        if (!type.isPresent()) {
+                            return SolverReturnStatus.UNSOLVABLE;
+                        }
+                        TypeSignature typeSignature = type.get().getTypeSignature();
+                        originalTypeTypeParametersBuilder.add(TypeSignatureParameter.of(typeSignature.getParameters().get(i).getLongLiteral()));
+
+                         */
+                    }
+                } else {
+                    verify(typeSignatureParameter.getKind() == ParameterKind.LONG);
+                    originalTypeTypeParametersBuilder.add(typeSignatureParameter);
+                }
+            }
+            DataType<?> originalType = typeManager.getType(new TypeSignature(formalTypeSignature.getBase(),
+                                                                             originalTypeTypeParametersBuilder.build()));
+            Optional<DataType<?>> commonSuperType = typeManager.getCommonSuperType(originalType, actualType);
+            if (!commonSuperType.isPresent()) {
+                return SolverReturnStatus.UNSOLVABLE;
+            }
+            TypeSignature commonSuperTypeSignature = commonSuperType.get().getTypeSignature();
+            if (!commonSuperTypeSignature.getBase().equals(formalTypeSignature.getBase())) {
+                return SolverReturnStatus.UNSOLVABLE;
+            }
+            SolverReturnStatus result = SolverReturnStatus.UNCHANGED_SATISFIED;
+            for (int i = 0; i < parameters.size(); i++) {
+                TypeSignatureParameter typeSignatureParameter = parameters.get(i);
+                long commonSuperLongLiteral = commonSuperTypeSignature.getParameters().get(i).getLongLiteral();
+                if (typeSignatureParameter.getKind() == ParameterKind.VARIABLE) {
+                    String variableName = typeSignatureParameter.getVariable();
+                    if (!bindings.containsLongVariable(variableName) ||
+                        !bindings.getLongVariable(variableName).equals(commonSuperLongLiteral)) {
+                        bindings.setLongVariable(variableName, commonSuperLongLiteral);
+                        result = SolverReturnStatus.CHANGED;
+                    }
+                } else {
+                    verify(typeSignatureParameter.getKind() == ParameterKind.LONG);
+                    if (commonSuperLongLiteral != typeSignatureParameter.getLongLiteral()) {
+                        return SolverReturnStatus.UNSOLVABLE;
+                    }
+                }
+            }
+            return result;
+        }
+    }
+
+    private boolean appendTypeRelationshipConstraintSolver(ImmutableList.Builder<TypeConstraintSolver> resultBuilder,
+                                                           TypeSignature formalTypeSignature,
+                                                           TypeSignature actualTypeSignature,
+                                                           boolean allowCoercion) {
+        /*
+        if (actualTypeSignatureProvider.hasDependency()) {
+            // Fail if the formal type is not function.
+            // Otherwise do nothing because FunctionConstraintSolver will handle type relationship constraint directly
+            return FunctionType.NAME.equals(formalTypeSignature.getBase());
+        }
+         */
+        Set<String> typeVariables = typeVariablesOf(formalTypeSignature);
+        Set<String> longVariables = longVariablesOf(formalTypeSignature);
+        resultBuilder.add(new TypeRelationshipConstraintSolver(
+            formalTypeSignature,
+            typeVariables,
+            longVariables,
+            typeManager.getType(actualTypeSignature),
+            allowCoercion));
+        return true;
+    }
+
+    private class TypeRelationshipConstraintSolver implements TypeConstraintSolver {
+        private final TypeSignature superTypeSignature;
+        private final Set<String> typeVariables;
+        private final Set<String> longVariables;
+        private final DataType<?> actualType;
+        private final boolean allowCoercion;
+
+        public TypeRelationshipConstraintSolver(TypeSignature superTypeSignature,
+                                                Set<String> typeVariables,
+                                                Set<String> longVariables,
+                                                DataType<?> actualType,
+                                                boolean allowCoercion) {
+            this.superTypeSignature = superTypeSignature;
+            this.typeVariables = typeVariables;
+            this.longVariables = longVariables;
+            this.actualType = actualType;
+            this.allowCoercion = allowCoercion;
+        }
+
+        @Override
+        public SolverReturnStatus update(BoundVariables.Builder bindings) {
+            for (String variable : typeVariables) {
+                if (!bindings.containsTypeVariable(variable)) {
+                    return SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+                }
+            }
+            for (String variable : longVariables) {
+                if (!bindings.containsLongVariable(variable)) {
+                    return SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+                }
+            }
+
+            TypeSignature boundSignature = applyBoundVariables(superTypeSignature, bindings.build());
+            return satisfiesCoercion(allowCoercion,
+                                     actualType,
+                                     boundSignature) ? SolverReturnStatus.UNCHANGED_SATISFIED : SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/TypeManager.java
+++ b/sql/src/main/java/io/crate/metadata/functions/TypeManager.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import io.crate.types.TypeSignature;
+import io.crate.types.TypeSignatureParameter;
+import io.crate.types.UndefinedType;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+public class TypeManager {
+
+    /**
+     * Gets the type with the specified signature.
+     */
+    public DataType<?> getType(TypeSignature signature) {
+        String base = signature.getBase();
+        if (base.equalsIgnoreCase(ArrayType.NAME)) {
+            List<TypeSignatureParameter> parameters = signature.getParameters();
+            if (parameters.size() == 0) {
+                return new ArrayType<>(UndefinedType.INSTANCE);
+            }
+            DataType<?> innerType = getType(parameters.get(0).getTypeSignature());
+            return new ArrayType<>(innerType);
+        }
+        return DataTypes.ofName(signature.getBase());
+    }
+
+    /**
+     * Gets the type with the specified base type, and the given parameters.
+     */
+    public DataType<?> getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters) {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    public Optional<DataType<?>> getCommonSuperType(DataType<?> firstType, DataType<?> secondType) {
+        TypeCompatibility compatibility = compatibility(firstType, secondType);
+        if (!compatibility.isCompatible()) {
+            return Optional.empty();
+        }
+        return Optional.of(compatibility.getCommonSuperType());
+    }
+
+    public boolean canCoerce(DataType<?> fromType, DataType<?> toType) {
+        return fromType.isConvertableTo(toType);
+    }
+
+    private TypeCompatibility compatibility(DataType<?> fromType, DataType<?> toType) {
+        if (fromType.equals(toType)) {
+            return TypeCompatibility.compatible(toType, true);
+        }
+
+        if (fromType.equals(UndefinedType.INSTANCE)) {
+            return TypeCompatibility.compatible(toType, true);
+        }
+
+        if (toType.equals(UndefinedType.INSTANCE)) {
+            return TypeCompatibility.compatible(fromType, false);
+        }
+
+        String fromTypeBaseName = fromType.getTypeSignature().getBase();
+        String toTypeBaseName = toType.getTypeSignature().getBase();
+        if (fromTypeBaseName.equals(toTypeBaseName)) {
+            if (isCovariantParametrizedType(fromType)) {
+                return typeCompatibilityForCovariantParametrizedType(fromType, toType);
+            }
+            return TypeCompatibility.compatible(fromType, false);
+        }
+
+        DataType<?> commonSuperType = convertType(fromType, toType);
+        if (commonSuperType != null) {
+            return TypeCompatibility.compatible(commonSuperType, commonSuperType.equals(toType));
+        }
+        Optional<DataType<?>> coercedType = coerceTypeBase(fromType, toType.getTypeSignature().getBase());
+        if (coercedType.isPresent()) {
+            return compatibility(coercedType.get(), toType);
+        }
+
+        coercedType = coerceTypeBase(toType, fromType.getTypeSignature().getBase());
+        if (coercedType.isPresent()) {
+            TypeCompatibility typeCompatibility = compatibility(fromType, coercedType.get());
+            if (!typeCompatibility.isCompatible()) {
+                return TypeCompatibility.incompatible();
+            }
+            return TypeCompatibility.compatible(typeCompatibility.getCommonSuperType(), false);
+        }
+
+        return TypeCompatibility.incompatible();
+    }
+
+    @Nullable
+    private DataType<?> convertType(DataType<?> arg1, DataType<?> arg2) {
+        final DataType<?> higherPrecedenceArg;
+        final DataType<?> lowerPrecedenceArg;
+        if (arg1.precedes(arg2)) {
+            higherPrecedenceArg = arg1;
+            lowerPrecedenceArg = arg2;
+        } else {
+            higherPrecedenceArg = arg2;
+            lowerPrecedenceArg = arg1;
+        }
+
+        final boolean lowerPrecedenceCastable = lowerPrecedenceArg.isConvertableTo(higherPrecedenceArg);
+        final boolean higherPrecedenceCastable = higherPrecedenceArg.isConvertableTo(lowerPrecedenceArg);
+
+        // Check if one of the two arguments is a value symbol which can be converted easily, e.g. Literal
+        // We also allow downcasts in this case because we can check during analyzing the statement if
+        // the downcast succeeds.
+        if (lowerPrecedenceCastable) {
+            return higherPrecedenceArg;
+        } else if (higherPrecedenceCastable) {
+            return lowerPrecedenceArg;
+        }
+
+        return null;
+    }
+
+    private Optional<DataType<?>> coerceTypeBase(DataType<?> sourceType, String resultTypeBase) {
+        DataType<?> resultType = getType(parseTypeSignature(resultTypeBase));
+        if (resultType.equals(sourceType)) {
+            return Optional.of(sourceType);
+        }
+        return Optional.ofNullable(convertType(sourceType, resultType));
+    }
+
+    private static boolean isCovariantParametrizedType(DataType<?> type) {
+        // if we ever introduce contravariant, this function should be changed to return an enumeration: INVARIANT, COVARIANT, CONTRAVARIANT
+        return type instanceof ObjectType || type instanceof ArrayType;
+    }
+
+    private TypeCompatibility typeCompatibilityForCovariantParametrizedType(DataType<?> fromType, DataType<?> toType) {
+        checkState(fromType.getClass().equals(toType.getClass()));
+        ImmutableList.Builder<TypeSignatureParameter> commonParameterTypes = ImmutableList.builder();
+        List<DataType<?>> fromTypeParameters = fromType.getTypeParameters();
+        List<DataType<?>> toTypeParameters = toType.getTypeParameters();
+
+        if (fromTypeParameters.size() != toTypeParameters.size()) {
+            return TypeCompatibility.incompatible();
+        }
+
+        boolean coercible = true;
+        for (int i = 0; i < fromTypeParameters.size(); i++) {
+            TypeCompatibility compatibility = compatibility(fromTypeParameters.get(i), toTypeParameters.get(i));
+            if (!compatibility.isCompatible()) {
+                return TypeCompatibility.incompatible();
+            }
+            coercible &= compatibility.isCoercible();
+            commonParameterTypes.add(TypeSignatureParameter.of(compatibility.getCommonSuperType().getTypeSignature()));
+        }
+        String typeBase = fromType.getTypeSignature().getBase();
+        return TypeCompatibility.compatible(getType(new TypeSignature(typeBase, commonParameterTypes.build())),
+                                            coercible);
+    }
+
+    public static class TypeCompatibility {
+        private final Optional<DataType<?>> commonSuperType;
+        private final boolean coercible;
+
+        // Do not call constructor directly. Use factory methods.
+        private TypeCompatibility(Optional<DataType<?>> commonSuperType, boolean coercible) {
+            // Assert that: coercible => commonSuperType.isPresent
+            // The factory API is designed such that this is guaranteed.
+            checkArgument(!coercible || commonSuperType.isPresent());
+
+            this.commonSuperType = commonSuperType;
+            this.coercible = coercible;
+        }
+
+        private static TypeCompatibility compatible(DataType<?> commonSuperType, boolean coercible) {
+            return new TypeCompatibility(Optional.of(commonSuperType), coercible);
+        }
+
+        private static TypeCompatibility incompatible() {
+            return new TypeCompatibility(Optional.empty(), false);
+        }
+
+        public boolean isCompatible() {
+            return commonSuperType.isPresent();
+        }
+
+        public DataType<?> getCommonSuperType() {
+            checkState(commonSuperType.isPresent(), "Types are not compatible");
+            return commonSuperType.get();
+        }
+
+        public boolean isCoercible() {
+            return coercible;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
+++ b/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class TypeVariableConstraint {
+
+    public static TypeVariableConstraint typeVariable(String name) {
+        return new TypeVariableConstraint(name, false, false, null);
+    }
+
+    private final String name;
+    private final boolean comparableRequired;
+    private final boolean orderableRequired;
+    @Nullable
+    private final String variadicBound;
+
+    public TypeVariableConstraint(String name,
+                                  boolean comparableRequired,
+                                  boolean orderableRequired,
+                                  @Nullable String variadicBound) {
+        this.name = name;
+        this.comparableRequired = comparableRequired;
+        this.orderableRequired = orderableRequired;
+        this.variadicBound = variadicBound;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isComparableRequired() {
+        return comparableRequired;
+    }
+
+    public boolean isOrderableRequired() {
+        return orderableRequired;
+    }
+
+    @Nullable
+    public String getVariadicBound() {
+        return variadicBound;
+    }
+
+
+    @Override
+    public String toString() {
+        String value = name;
+        if (comparableRequired) {
+            value += ":comparable";
+        }
+        if (orderableRequired) {
+            value += ":orderable";
+        }
+        if (variadicBound != null) {
+            value += ":" + variadicBound + "<*>";
+        }
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TypeVariableConstraint that = (TypeVariableConstraint) o;
+        return comparableRequired == that.comparableRequired &&
+               orderableRequired == that.orderableRequired &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(variadicBound, that.variadicBound);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound);
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -324,7 +324,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCopyFromInvalidTypedExpression() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("fileUri must be of type STRING or STRING ARRAY. Got integer_array");
+        expectedException.expectMessage("fileUri must be of type STRING or STRING ARRAY. Got array(integer)");
         Object[] files = $(1, 2, 3);
         analyze("COPY users FROM ?", new Object[]{files});
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -800,7 +800,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArrayCompareInvalidArray() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `name` of type `text` to type `undefined_array`");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `array(undefined)`");
         analyze("select * from users where 'George' = ANY (name)");
     }
 
@@ -843,7 +843,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `friends['id']` of type `array(bigint)` to type `bigint`");
         analyze("select * from users where 5 = friends['id']");
     }
 
@@ -911,7 +911,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testOrderByOnArray() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'friends': invalid data type 'object_array'.");
+        expectedException.expectMessage("Cannot ORDER BY 'friends': invalid data type 'array(object)'.");
         analyze("select * from users order by friends");
     }
 
@@ -981,14 +981,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAnyLikeInvalidArray() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `name` of type `text` to type `undefined_array`");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `array(undefined)`");
         analyze("select * from users where 'awesome' LIKE ANY (name)");
     }
 
     @Test
     public void testPositionalArgumentOrderByArrayType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'friends': invalid data type 'object_array'.");
+        expectedException.expectMessage("Cannot ORDER BY 'friends': invalid data type 'array(object)'.");
         analyze("SELECT id, friends FROM users ORDER BY 2");
     }
 
@@ -1092,7 +1092,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchPredicateWithWrongQueryTerm() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `[10, 20]` of type `bigint_array` to type `text`");
+        expectedException.expectMessage("Cannot cast `[10, 20]` of type `array(bigint)` to type `text`");
         analyze("select name from users order by match(name, [10, 20])");
     }
 
@@ -1690,7 +1690,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `1` of type `bigint` to type `undefined_array`");
+        expectedException.expectMessage("Cannot cast `1` of type `bigint` to type `array(undefined)`");
         analyze("select * from unnest(1, 'foo')");
     }
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -376,7 +376,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `xs` of type `array(integer)` to type `bigint`");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 
@@ -395,14 +395,14 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void windowDefinitionOrderedByArrayTypeIsUnsupported() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'xs': invalid data type 'integer_array'");
+        expectedException.expectMessage("Cannot ORDER BY 'xs': invalid data type 'array(integer)'");
         executor.analyze("select count(*) over(order by xs) from tarr");
     }
 
     @Test
     public void windowDefinitionPartitionedByArrayTypeIsUnsupported() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot PARTITION BY 'xs': invalid data type 'integer_array'");
+        expectedException.expectMessage("Cannot PARTITION BY 'xs': invalid data type 'array(integer)'");
         executor.analyze("select count(*) over(partition by xs) from tarr");
     }
 

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -279,7 +279,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnyInvalidArrayType() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `['foo', 'bar', 'baz']` of type `text_array` to type `boolean_array`");
+        expectedException.expectMessage("Cannot cast `['foo', 'bar', 'baz']` of type `array(text)` to type `array(boolean)`");
         analyzeSelectWhere("select * from users_multi_pk where awesome = any(['foo', 'bar', 'baz'])");
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayBoundFunctionResolverTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayBoundFunctionResolverTest.java
@@ -36,7 +36,7 @@ public class ArrayBoundFunctionResolverTest extends AbstractScalarFunctionsTest 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array)");
+        expectedException.expectMessage("unknown function: array_lower(array(bigint))");
         assertEvaluate("array_lower([1])", null);
     }
 
@@ -50,7 +50,7 @@ public class ArrayBoundFunctionResolverTest extends AbstractScalarFunctionsTest 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `[2]` of type `bigint_array` to type `integer`");
+        expectedException.expectMessage("Cannot cast `[2]` of type `array(bigint)` to type `integer`");
         assertEvaluate("array_lower([1], [2])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -61,20 +61,20 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(bigint_array)");
+        expectedException.expectMessage("unknown function: array_cat(array(bigint))");
         assertEvaluate("array_cat([1])", null);
     }
 
     @Test
     public void testThreeArguments() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The number of arguments is incorrect");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: array_cat(array(bigint), array(bigint), array(bigint))");
         assertEvaluate("array_cat([1], [2], [3])", null);
     }
 
     @Test
     public void testDifferentConvertableInnerTypes() throws Exception {
-        assertEvaluate("array_cat([1::integer], [1::long])", Arrays.asList(1, 1));
+        assertEvaluate("array_cat([1::integer], [1::long])", Arrays.asList(1L, 1L));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEmptyArrays() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("One of the arguments of the array_cat function can be of undefined inner type, but not both");
+        expectedException.expectMessage("When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
         assertNormalize("array_cat([], [])", null);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -92,7 +92,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_difference(bigint_array)");
+        expectedException.expectMessage("unknown function: array_difference(array(bigint))");
         assertNormalize("array_difference([1])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -105,14 +105,14 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testConvertNonNumericStringToNumber() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `['foo', 'bar']` of type `text_array` to type `bigint_array`");
+        expectedException.expectMessage("Cannot cast `['foo', 'bar']` of type `array(text)` to type `array(bigint)`");
         assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `_array(geopoint)` of type `geo_point_array` to type `boolean_array`");
+        expectedException.expectMessage("Cannot cast `_array(geopoint)` of type `array(geo_point)` to type `array(boolean)`");
         assertEvaluate("array_unique([geopoint], [true])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.scalar;
 
-import io.crate.exceptions.ConversionException;
 import org.junit.Test;
 
 import java.util.List;
@@ -31,16 +30,14 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
-    public void testTooFewArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(text)");
-        assertNormalize("concat('foo')", null);
+    public void testOneArgument() {
+        assertNormalize("concat('foo')", isLiteral("foo"));
     }
 
     @Test
     public void testArgumentThatHasNoStringRepr() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint_array`");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: concat(text, array(bigint))");
         assertNormalize("concat('foo', [1])", null);
     }
 
@@ -71,6 +68,11 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void testNumberAndString() {
+        assertNormalize("concat(3, 2, 'foo')", isLiteral("32foo"));
+    }
+
+    @Test
     public void testTwoArrays() throws Exception {
         assertNormalize("concat([1, 2], [2, 3])", isLiteral(List.of(1L, 2L, 2L, 3L)));
     }
@@ -82,15 +84,16 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `_array(1, 2)` of type `bigint_array` to type `text`");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: concat(array(bigint), array(array(bigint)))");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 
     @Test
     public void testTwoArraysOfUndefinedTypes() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
+        expectedException.expectMessage(
+            "When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
         assertNormalize("concat([], [])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataTypes;
@@ -122,8 +123,8 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidTimestamp() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text 'NO TIMESTAMP' could not be parsed");
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast `'NO TIMESTAMP'` of type `text` to type `timestamp with time zone`");
         assertEvaluate("date_format('%d.%m.%Y', 'NO TIMESTAMP')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -71,7 +71,7 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
     public void testIndexExpressionIsNotInteger() throws Exception {
         expectedException.expectMessage(
             "`index` in subscript expression (`base[index]`) " +
-            "must be a numeric type if the base expression is text_array");
+            "must be a numeric type if the base expression is array(text)");
         assertNormalize("subscript(['Youri', 'Ruben'], '1')", isLiteral("Ruben"));
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -87,7 +87,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_cannot_cast_text_to_object_array() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast expressions from type `text` to type `object_array`");
+        expectedException.expectMessage("Cannot cast expressions from type `text` to type `array(object)`");
         assertEvaluate("cast(name as array(object))", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -68,7 +68,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeWithInvalidReferences() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `name` of type `text` to type `double precision_array`");
+        expectedException.expectMessage("Cannot cast `name` of type `text` to type `array(double precision)`");
         assertNormalize("distance(name, [10.04, 28.02])", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -73,7 +73,7 @@ public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foobar'` of type `text` to type `bigint_array`");
+        expectedException.expectMessage("Cannot cast `'foobar'` of type `text` to type `array(bigint)`");
 
         assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
     }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -102,7 +102,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_function_arguments_must_have_array_types() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `200` of type `bigint` to type `undefined_array`");
+        expectedException.expectMessage("Cannot cast `200` of type `bigint` to type `array(undefined)`");
         assertExecute("_values(200)", "");
     }
 }

--- a/sql/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetaDataTest.java
+++ b/sql/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetaDataTest.java
@@ -141,7 +141,7 @@ public class UserDefinedFunctionsMetaDataTest extends CrateUnitTest {
     @Test
     public void testSpecificName() throws Exception {
         assertThat(specificName("my_func", ImmutableList.of()), is("my_func()"));
-        assertThat(specificName("my_func", ImmutableList.of(DataTypes.BOOLEAN, new ArrayType(DataTypes.BOOLEAN))),
-            is("my_func(boolean, boolean_array)"));
+        assertThat(specificName("my_func", ImmutableList.of(DataTypes.BOOLEAN, new ArrayType<>(DataTypes.BOOLEAN))),
+            is("my_func(boolean, array(boolean))"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -521,7 +521,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(TestingHelpers.getColumn(response.rows(), 0),
             is(Matchers.<Object>arrayContaining("col1", "col1['col2']", "col1['col2']['col3']")));
         assertThat(TestingHelpers.getColumn(response.rows(), 1),
-            is(Matchers.arrayContaining("object", "object", "text_array")));
+            is(Matchers.arrayContaining("object", "object", "array(text)")));
 
         execute("DROP TABLE my_table");
         ensureYellow();
@@ -536,7 +536,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(TestingHelpers.getColumn(response.rows(), 0),
             is(Matchers.<Object>arrayContaining("col1", "col1['col2']", "col1['col2']['col3']", "col1['col2']['col3']['col4']")));
         assertThat(TestingHelpers.getColumn(response.rows(), 1),
-            is(Matchers.arrayContaining("object", "object", "object", "bigint_array")));
+            is(Matchers.arrayContaining("object", "object", "object", "array(bigint)")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -674,7 +674,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast `[10.3, 20.2]` of type `double precision_array` to type `integer`"));
+                assertThat(e.getMessage(), Matchers.containsString("Cannot cast `[10.3, 20.2]` of type `array(double precision)` to type `integer`"));
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -210,7 +210,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast `['a']` of type `text_array` to type `char_array`");
+        expectedException.expectMessage("Cannot cast `['a']` of type `array(text)` to type `array(char)`");
 
         setUpSimple();
         execute("update t1 set byte_field=0 where byte_field in ('a')");

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -176,7 +176,7 @@ public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTes
         waitForMappingUpdateOnAll("foo", "bar");
         execute("select data_type from information_schema.columns where table_name = 'foo' and column_name = 'bar'");
         // integer values for unknown columns will be result in a long type for range safety
-        assertThat(response.rows()[0][0], is("bigint_array"));
+        assertThat(response.rows()[0][0], is("array(bigint)"));
     }
 
     @Test


### PR DESCRIPTION
Our current function registry does not provide the information needed by a proper `pg_proc` table implementation. Also the current implementation has other known limitations or even bugs.

 - [ ] Support iteration over registered function incl. all info’s required by `pg_proc` (Relates #9567)
 - [x] Support function overloading
 - [x] Use existing type precendence and cast if needed
 - [ ] Move (down-)cast lucene optimization to a rule (Relates #9652)
