### PR TITLE
Add new signature based function registry 

### DIFF
--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -60,6 +60,16 @@ public class ArrayType<T> extends DataType<List<T>> {
         return arrayType;
     }
 
+    @Override
+    public TypeSignature getTypeSignature() {
+        return new TypeSignature(NAME, List.of(innerType.getTypeSignature()));
+    }
+
+    @Override
+    public List<DataType<?>> getTypeParameters() {
+        return List.of(innerType);
+    }
+
     /**
      * Defaults to the {@link ArrayStreamer} but subclasses may override this method.
      */

--- a/common/src/main/java/io/crate/types/DataType.java
+++ b/common/src/main/java/io/crate/types/DataType.java
@@ -26,7 +26,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -82,6 +84,14 @@ public abstract class DataType<T> implements Comparable, Writeable {
     public abstract T value(Object value) throws IllegalArgumentException, ClassCastException;
 
     public abstract int compareValueTo(T val1, T val2);
+
+    public TypeSignature getTypeSignature() {
+        return new TypeSignature(getName());
+    }
+
+    public List<DataType<?>> getTypeParameters() {
+        return Collections.emptyList();
+    }
 
     /**
      * Returns true if this DataType precedes the supplied DataType.

--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -255,5 +256,27 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             out.writeString(entry.getKey());
             DataTypes.toStream(entry.getValue(), out);
         }
+    }
+
+    @Override
+    public TypeSignature getTypeSignature() {
+        ArrayList<TypeSignature> parameters = new ArrayList<>(innerTypes.size() * 2);
+        for (var type : innerTypes.values()) {
+            // all keys are of type 'text'
+            parameters.add(StringType.INSTANCE.getTypeSignature());
+            parameters.add(type.getTypeSignature());
+        }
+        return new TypeSignature(NAME, parameters);
+    }
+
+    @Override
+    public List<DataType<?>> getTypeParameters() {
+        ArrayList<DataType<?>> parameters = new ArrayList<>(innerTypes.size() * 2);
+        for (var type : innerTypes.values()) {
+            // all keys are of type 'text'
+            parameters.add(StringType.INSTANCE);
+            parameters.add(type);
+        }
+        return parameters;
     }
 }

--- a/common/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/common/src/main/java/io/crate/types/TypeCompatibility.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class TypeCompatibility {
+
+    @Nullable
+    public static DataType<?> getCommonType(DataType<?> firstType, DataType<?> secondType) {
+        return compatibility(firstType, secondType);
+    }
+
+    @Nullable
+    private static DataType<?> compatibility(DataType<?> fromType, DataType<?> toType) {
+        if (fromType.equals(toType)) {
+            return toType;
+        }
+
+        if (fromType.equals(UndefinedType.INSTANCE)) {
+            return toType;
+        }
+
+        if (toType.equals(UndefinedType.INSTANCE)) {
+            return fromType;
+        }
+
+        String fromTypeBaseName = fromType.getTypeSignature().getBaseTypeName();
+        String toTypeBaseName = toType.getTypeSignature().getBaseTypeName();
+        if (fromTypeBaseName.equals(toTypeBaseName)) {
+            // If given types share the same base, e.g. arrays, parameter types must be compatible.
+            if (!fromType.getTypeParameters().isEmpty() || !toType.getTypeParameters().isEmpty()) {
+                return typeCompatibilityForParametrizedType(fromType, toType);
+            }
+            return fromType;
+        }
+
+        return convertTypeByPrecedence(fromType, toType);
+    }
+
+    @Nullable
+    private static DataType<?> convertTypeByPrecedence(DataType<?> arg1, DataType<?> arg2) {
+        final DataType<?> higherPrecedenceArg;
+        final DataType<?> lowerPrecedenceArg;
+        if (arg1.precedes(arg2)) {
+            higherPrecedenceArg = arg1;
+            lowerPrecedenceArg = arg2;
+        } else {
+            higherPrecedenceArg = arg2;
+            lowerPrecedenceArg = arg1;
+        }
+
+        final boolean lowerPrecedenceCastable = lowerPrecedenceArg.isConvertableTo(higherPrecedenceArg);
+        final boolean higherPrecedenceCastable = higherPrecedenceArg.isConvertableTo(lowerPrecedenceArg);
+
+        if (lowerPrecedenceCastable) {
+            return higherPrecedenceArg;
+        } else if (higherPrecedenceCastable) {
+            return lowerPrecedenceArg;
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static DataType<?> typeCompatibilityForParametrizedType(DataType<?> fromType, DataType<?> toType) {
+        ArrayList<TypeSignature> commonParameterTypes = new ArrayList<>();
+        List<DataType<?>> fromTypeParameters = fromType.getTypeParameters();
+        List<DataType<?>> toTypeParameters = toType.getTypeParameters();
+
+        if (fromTypeParameters.size() != toTypeParameters.size()) {
+            return null;
+        }
+
+        for (int i = 0; i < fromTypeParameters.size(); i++) {
+            DataType<?> compatibility = compatibility(fromTypeParameters.get(i), toTypeParameters.get(i));
+            if (compatibility == null) {
+                return null;
+            }
+            commonParameterTypes.add(compatibility.getTypeSignature());
+        }
+        String typeBase = fromType.getTypeSignature().getBaseTypeName();
+        return new TypeSignature(typeBase, Collections.unmodifiableList(commonParameterTypes)).createType();
+    }
+}

--- a/common/src/main/java/io/crate/types/TypeSignature.java
+++ b/common/src/main/java/io/crate/types/TypeSignature.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class TypeSignature {
+
+    /**
+     * Creates a type signature out of the given signature string.
+     * A signature type string may contain parameters inside parenthesis:
+     * <p>
+     *   base_type_name(parameter [, parameter])
+     * </p>
+     *
+     * Custom parameterized type handling must also be supported by {@link #createType()}.
+     *
+     * Some examples:
+     * <p>
+     *      integer
+     *      array(integer)
+     *      array(E)
+     *      object(text, integer)
+     *      object(text, V)
+     * <p>
+     */
+    public static TypeSignature parseTypeSignature(String signature) {
+        if (!signature.contains("(")) {
+            return new TypeSignature(signature);
+        }
+
+        String baseName = null;
+        List<TypeSignature> parameters = new ArrayList<>();
+        int parameterStart = -1;
+        int bracketCount = 0;
+
+        for (int i = 0; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            if (c == '(') {
+                if (bracketCount == 0) {
+                    assert baseName == null : "Expected baseName to be null";
+                    baseName = signature.substring(0, i);
+                    parameterStart = i + 1;
+                }
+                bracketCount++;
+            } else if (c == ')') {
+                bracketCount--;
+                if (bracketCount == 0) {
+                    assert parameterStart >= 0 : "Expected parameter start to be >= 0";
+                    parameters.add(parseTypeSignatureParameter(signature, parameterStart, i));
+                    parameterStart = i + 1;
+                    if (i == signature.length() - 1) {
+                        return new TypeSignature(baseName, parameters);
+                    }
+                }
+            } else if (c == ',') {
+                if (bracketCount == 1) {
+                    assert parameterStart >= 0 : "Expected parameter start to be >= 0";
+                    parameters.add(parseTypeSignatureParameter(signature, parameterStart, i));
+                    parameterStart = i + 1;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(format(Locale.ENGLISH, "Bad type signature: '%s'", signature));
+    }
+
+    private static TypeSignature parseTypeSignatureParameter(String signature, int begin, int end) {
+        String parameterName = signature.substring(begin, end).trim();
+        return parseTypeSignature(parameterName);
+    }
+
+    private final String baseTypeName;
+    private final List<TypeSignature> parameters;
+
+    public TypeSignature(String baseTypeName) {
+        this(baseTypeName, Collections.emptyList());
+    }
+
+    public TypeSignature(String baseTypeName, List<TypeSignature> parameters) {
+        this.baseTypeName = baseTypeName;
+        this.parameters = parameters;
+    }
+
+    public String getBaseTypeName() {
+        return baseTypeName;
+    }
+
+    public List<TypeSignature> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Create the concrete {@link DataType} for this type signature.
+     * Only `array` and `object` parameterized type signatures are supported.
+     */
+    public DataType<?> createType() {
+        if (baseTypeName.equalsIgnoreCase(ArrayType.NAME)) {
+            if (parameters.size() == 0) {
+                return new ArrayType<>(UndefinedType.INSTANCE);
+            }
+            DataType<?> innerType = parameters.get(0).createType();
+            return new ArrayType<>(innerType);
+        }
+        if (baseTypeName.equalsIgnoreCase(ObjectType.NAME)) {
+            var builder = ObjectType.builder();
+            for (int i = 0; i < parameters.size() - 1;) {
+                var valTypeSignature = parameters.get(i + 1);
+                builder.setInnerType(String.valueOf(i), valTypeSignature.createType());
+                i += 2;
+            }
+            return builder.build();
+        }
+        return DataTypes.ofName(baseTypeName);
+    }
+
+    @Override
+    public String toString() {
+        if (parameters.isEmpty()) {
+            return baseTypeName;
+        }
+
+        StringBuilder typeName = new StringBuilder(baseTypeName);
+        typeName.append("(").append(parameters.get(0));
+        for (int i = 1; i < parameters.size(); i++) {
+            typeName.append(",").append(parameters.get(i));
+        }
+        typeName.append(")");
+        return typeName.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TypeSignature that = (TypeSignature) o;
+        return baseTypeName.equals(that.baseTypeName) &&
+               parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseTypeName, parameters);
+    }
+}

--- a/common/src/test/java/io/crate/types/TypeSignatureTest.java
+++ b/common/src/test/java/io/crate/types/TypeSignatureTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import static io.crate.types.TypeSignature.parseTypeSignature;
+import static org.hamcrest.Matchers.is;
+
+public class TypeSignatureTest extends CrateUnitTest {
+
+    @Test
+    public void testParsingOfPrimitiveDataTypes() {
+        for (var type : DataTypes.PRIMITIVE_TYPES) {
+            assertThat(parseTypeSignature(type.getName()), is(type.getTypeSignature()));
+        }
+    }
+
+    @Test
+    public void testParsingOfArray() {
+        ArrayType<Integer> integerArrayType = new ArrayType<>(IntegerType.INSTANCE);
+        assertThat(parseTypeSignature("array(integer)"), is(integerArrayType.getTypeSignature()));
+    }
+
+    @Test
+    public void testParsingOfObject() {
+        ObjectType objectType = ObjectType.builder().setInnerType("V", IntegerType.INSTANCE).build();
+        assertThat(parseTypeSignature("object(text, integer)"), is(objectType.getTypeSignature()));
+    }
+
+    @Test
+    public void testParsingOfNestedArray() {
+        var type = new ArrayType<>(
+            ObjectType.builder()
+                .setInnerType("x", new ArrayType<>(IntegerType.INSTANCE))
+            .build()
+        );
+        assertThat(parseTypeSignature("array(object(text, array(integer)))"), is(type.getTypeSignature()));
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1011,7 +1011,7 @@ public class ExpressionAnalyzer {
                 mapArgs.add(Literal.of(e.getKey()));
                 mapArgs.add(e.getValue().accept(this, context));
             }
-            Symbol options = allocateFunction(MapFunction.NAME, mapArgs, context);
+            Symbol options = mapArgs.isEmpty() ? Literal.of(Map.of()) : allocateFunction(MapFunction.NAME, mapArgs, context);
             return new io.crate.expression.symbol.MatchPredicate(identBoostMap, queryTerm, matchType, options);
         }
 

--- a/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -21,28 +21,19 @@
 
 package io.crate.expression.scalar;
 
-import com.google.common.base.Preconditions;
 import io.crate.data.Input;
-import io.crate.exceptions.ConversionException;
-import io.crate.expression.symbol.FuncArg;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.FunctionResolver;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.functions.params.FuncParams;
-import io.crate.metadata.functions.params.Param;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Locale;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public abstract class ConcatFunction extends Scalar<String, String> {
 
@@ -50,7 +41,44 @@ public abstract class ConcatFunction extends Scalar<String, String> {
     private FunctionInfo functionInfo;
 
     public static void register(ScalarFunctionModule module) {
-        module.register(NAME, new Resolver());
+        module.register(
+            Signature.builder()
+                .name(NAME)
+                .kind(FunctionInfo.Type.SCALAR)
+                .argumentTypes(parseTypeSignature("text"), parseTypeSignature("text"))
+                .returnType(parseTypeSignature("text"))
+                .setVariableArity(false)
+                .build(),
+            args -> new StringConcatFunction(
+                new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
+            )
+        );
+
+        module.register(
+            Signature.builder()
+                .name(NAME)
+                .kind(FunctionInfo.Type.SCALAR)
+                .argumentTypes(parseTypeSignature("text"))
+                .returnType(parseTypeSignature("text"))
+                .setVariableArity(true)
+                .build(),
+            args -> new GenericConcatFunction(
+                new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
+            )
+        );
+
+        // concat(array[], array[]) -> same as `array_cat(...)`
+        module.register(
+            Signature.builder()
+                .name(NAME)
+                .kind(FunctionInfo.Type.SCALAR)
+                .typeVariableConstraints(typeVariable("E"))
+                .argumentTypes(parseTypeSignature("array(E)"), parseTypeSignature("array(E)"))
+                .returnType(parseTypeSignature("array(E)"))
+                .setVariableArity(false)
+                .build(),
+            args -> new ArrayCatFunction(ArrayCatFunction.createInfo(args))
+        );
     }
 
     ConcatFunction(FunctionInfo functionInfo) {
@@ -114,62 +142,6 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 }
             }
             return sb.toString();
-        }
-    }
-
-    private static class Resolver implements FunctionResolver {
-
-        private static final FuncParams STRINGS = FuncParams
-            .builder(Param.STRING, Param.STRING)
-            .withVarArgs(Param.STRING)
-            .build();
-        private static final FuncParams ARRAYS = FuncParams
-            .builder(
-                Param.of(new ArrayType<>(DataTypes.UNDEFINED)).withInnerType(Param.ANY),
-                Param.of(new ArrayType<>(DataTypes.UNDEFINED)).withInnerType(Param.ANY)
-            )
-            .build();
-
-        @Nullable
-        @Override
-        public List<DataType> getSignature(List<? extends FuncArg> funcArgs) {
-            try {
-                return STRINGS.match(funcArgs);
-            } catch (ConversionException e1) {
-                try {
-                    return ARRAYS.match(funcArgs);
-                } catch (ConversionException e2) {
-                    throw e1; // prefer error message with casts to string instead of casts to arrays
-                }
-            }
-        }
-
-        @Override
-        public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            if (dataTypes.size() == 2 && dataTypes.get(0).equals(DataTypes.STRING) &&
-                       dataTypes.get(1).equals(DataTypes.STRING)) {
-                return new StringConcatFunction(new FunctionInfo(new FunctionIdent(NAME, dataTypes), DataTypes.STRING));
-            } else if (dataTypes.size() == 2 && dataTypes.get(0) instanceof ArrayType &&
-                       dataTypes.get(1) instanceof ArrayType) {
-
-                DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
-                DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
-
-                Preconditions.checkArgument(
-                    !innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
-                    "When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
-
-                if (!innerType0.equals(DataTypes.UNDEFINED)) {
-                    Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
-                        String.format(Locale.ENGLISH,
-                            "Second argument's inner type (%s) of the array_cat function cannot be converted to the first argument's inner type (%s)",
-                            innerType1, innerType0));
-                }
-
-                return new ArrayCatFunction(ArrayCatFunction.createInfo(dataTypes));
-            } else {
-                return new GenericConcatFunction(new FunctionInfo(new FunctionIdent(NAME, dataTypes), DataTypes.STRING));
-            }
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -73,15 +73,22 @@ import io.crate.expression.scalar.systeminformation.VersionFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.scalar.timestamp.NowFunction;
 import io.crate.expression.scalar.timestamp.TimezoneFunction;
+import io.crate.metadata.FuncResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.TypeLiteral;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class ScalarFunctionModule extends AbstractModule {
 
@@ -90,17 +97,40 @@ public class ScalarFunctionModule extends AbstractModule {
     private MapBinder<FunctionIdent, FunctionImplementation> functionBinder;
     private MapBinder<FunctionName, FunctionResolver> resolverBinder;
 
+    private HashMap<FunctionName, List<FuncResolver>> functionImplementations = new HashMap<>();
+    private MapBinder<FunctionName, List<FuncResolver>> implementationsBinder;
+
+    /**
+     * @deprecated Use {@link #register(Signature, Function)} instead.
+     */
+    @Deprecated()
     public void register(FunctionImplementation impl) {
         functions.put(impl.info().ident(), impl);
     }
 
+    /**
+     * @deprecated Use {@link #register(Signature, Function)} instead.
+     */
+    @Deprecated()
     public void register(String name, FunctionResolver functionResolver) {
         register(new FunctionName(name), functionResolver);
     }
 
+    /**
+     * @deprecated Use {@link #register(Signature, Function)} instead.
+     */
+    @Deprecated()
     public void register(FunctionName qualifiedName, FunctionResolver functionResolver) {
         resolver.put(qualifiedName, functionResolver);
     }
+
+    public void register(Signature signature, Function<List<DataType>, FunctionImplementation> factory) {
+        List<FuncResolver> functions = functionImplementations.computeIfAbsent(
+            signature.getName(),
+            k -> new ArrayList<>());
+        functions.add(new FuncResolver(signature, factory));
+    }
+
 
     @Override
     protected void configure() {
@@ -197,7 +227,6 @@ public class ScalarFunctionModule extends AbstractModule {
         resolverBinder = MapBinder.newMapBinder(binder(), FunctionName.class, FunctionResolver.class);
         for (Map.Entry<FunctionIdent, FunctionImplementation> entry : functions.entrySet()) {
             functionBinder.addBinding(entry.getKey()).toInstance(entry.getValue());
-
         }
         for (Map.Entry<FunctionName, FunctionResolver> entry : resolver.entrySet()) {
             resolverBinder.addBinding(entry.getKey()).toInstance(entry.getValue());
@@ -206,6 +235,18 @@ public class ScalarFunctionModule extends AbstractModule {
         // clear registration maps
         functions = null;
         resolver = null;
+
+        // New signature registry
+        implementationsBinder = MapBinder.newMapBinder(
+            binder(),
+            new TypeLiteral<FunctionName>() {},
+            new TypeLiteral<List<FuncResolver>>() {});
+        for (Map.Entry<FunctionName, List<FuncResolver>> entry : functionImplementations.entrySet()) {
+            implementationsBinder.addBinding(entry.getKey()).toProvider(entry::getValue);
+        }
+
+        // clear registration maps
+        functionImplementations = null;
     }
 
 }

--- a/sql/src/main/java/io/crate/metadata/FuncResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FuncResolver.java
@@ -20,38 +20,31 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.metadata;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.junit.Test;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.function.Function;
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
+public class FuncResolver implements Function<List<DataType>, FunctionImplementation> {
 
-    @Test
-    public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, bigint, text)");
-        assertEvaluate("_map('foo', 1, 'bar')", null);
+    private final Signature signature;
+    private final Function<List<DataType>, FunctionImplementation> factory;
+
+    public FuncResolver(Signature signature,
+                        Function<List<DataType>, FunctionImplementation> factory) {
+        this.signature = signature;
+        this.factory = factory;
     }
 
-    @Test
-    public void testKeyNotOfTypeString() {
-        assertEvaluate("_map(10, 2)", Collections.singletonMap("10", 2L));
+    public Signature getSignature() {
+        return signature;
     }
 
-    @Test
-    public void testEvaluation() {
-        Map<String, Object> m = new HashMap<>();
-        m.put("foo", 10L);
-        // minimum args
-        assertEvaluate("_map('foo', 10)", m);
-
-        // variable args
-        m.put("bar", "some");
-        assertEvaluate("_map('foo', 10, 'bar', 'some')", m);
+    @Override
+    public FunctionImplementation apply(List<DataType> dataTypes) {
+        return factory.apply(dataTypes);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/functions/BoundVariables.java
+++ b/sql/src/main/java/io/crate/metadata/functions/BoundVariables.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.types.DataType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class BoundVariables {
+
+    private final Map<String, DataType<?>> typeVariables;
+
+    public BoundVariables(Map<String, DataType<?>> typeVariables) {
+        this.typeVariables = Map.copyOf(typeVariables);
+    }
+
+    public DataType<?> getTypeVariable(String variableName) {
+        return typeVariables.get(variableName);
+    }
+
+    public boolean containsTypeVariable(String variableName) {
+        return typeVariables.containsKey(variableName);
+    }
+
+    public Set<String> getTypeVariableNames() {
+        return typeVariables.keySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BoundVariables that = (BoundVariables) o;
+        return Objects.equals(typeVariables, that.typeVariables);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(typeVariables);
+    }
+
+    @Override
+    public String toString() {
+        return "BoundVariables{" + "typeVariables=" + typeVariables + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<String, DataType<?>> typeVariables = new HashMap<>();
+
+        public DataType<?> getTypeVariable(String variableName) {
+            return typeVariables.get(variableName);
+        }
+
+        public void setTypeVariable(String variableName, DataType<?> variableValue) {
+            typeVariables.put(variableName, variableValue);
+        }
+
+        public boolean containsTypeVariable(String variableName) {
+            return typeVariables.containsKey(variableName);
+        }
+
+        public BoundVariables build() {
+            return new BoundVariables(typeVariables);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/sql/src/main/java/io/crate/metadata/functions/Signature.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.common.collections.Lists2;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
+import io.crate.types.TypeSignature;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class Signature {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private FunctionName name;
+        private FunctionInfo.Type kind;
+        private List<TypeSignature> argumentTypes = Collections.emptyList();
+        private TypeSignature returnType;
+        private List<TypeVariableConstraint> typeVariableConstraints = Collections.emptyList();
+        private List<TypeSignature> variableArityGroup = Collections.emptyList();
+        private boolean variableArity = false;
+
+        public Builder name(String name) {
+            return name(new FunctionName(null, name));
+        }
+
+        public Builder name(FunctionName name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder kind(FunctionInfo.Type kind) {
+            this.kind = kind;
+            return this;
+        }
+
+        public Builder argumentTypes(TypeSignature... argumentTypes) {
+            return argumentTypes(List.of(argumentTypes));
+        }
+
+        public Builder argumentTypes(List<TypeSignature> argumentTypes) {
+            this.argumentTypes = argumentTypes;
+            return this;
+        }
+
+        public Builder returnType(TypeSignature returnType) {
+            this.returnType = returnType;
+            return this;
+        }
+
+        public Builder typeVariableConstraints(TypeVariableConstraint... typeVariableConstraints) {
+            return typeVariableConstraints(List.of(typeVariableConstraints));
+        }
+
+        public Builder typeVariableConstraints(List<TypeVariableConstraint> typeVariableConstraints) {
+            this.typeVariableConstraints = typeVariableConstraints;
+            return this;
+        }
+
+        public Builder variableArityGroup(List<TypeSignature> variableArityGroup) {
+            this.variableArityGroup = variableArityGroup;
+            this.variableArity = !variableArityGroup.isEmpty();
+            return this;
+        }
+
+        public Builder setVariableArity(boolean variableArity) {
+            this.variableArity = variableArity;
+            return this;
+        }
+
+        public Signature build() {
+            assert name != null : "Signature requires the 'name' to be set";
+            assert kind != null : "Signature requires the 'kind' to be set";
+            assert returnType != null : "Signature requires the 'returnType' to be set";
+            return new Signature(
+                name,
+                kind,
+                typeVariableConstraints,
+                argumentTypes,
+                returnType,
+                variableArityGroup,
+                variableArity);
+        }
+    }
+
+
+    private final FunctionName name;
+    private final FunctionInfo.Type kind;
+    private final List<TypeSignature> argumentTypes;
+    private final TypeSignature returnType;
+    private final List<TypeVariableConstraint> typeVariableConstraints;
+    private final List<TypeSignature> variableArityGroup;
+    private final boolean variableArity;
+
+    private Signature(FunctionName name,
+                      FunctionInfo.Type kind,
+                      List<TypeVariableConstraint> typeVariableConstraints,
+                      List<TypeSignature> argumentTypes,
+                      TypeSignature returnType,
+                      List<TypeSignature> variableArityGroup,
+                      boolean variableArity) {
+        this.name = name;
+        this.kind = kind;
+        this.argumentTypes = argumentTypes;
+        this.typeVariableConstraints = typeVariableConstraints;
+        this.returnType = returnType;
+        this.variableArityGroup = variableArityGroup;
+        this.variableArity = variableArity;
+    }
+
+    public FunctionName getName() {
+        return name;
+    }
+
+    public FunctionInfo.Type getKind() {
+        return kind;
+    }
+
+    public List<TypeSignature> getArgumentTypes() {
+        return argumentTypes;
+    }
+
+    public TypeSignature getReturnType() {
+        return returnType;
+    }
+
+    public List<TypeVariableConstraint> getTypeVariableConstraints() {
+        return typeVariableConstraints;
+    }
+
+    public List<TypeSignature> getVariableArityGroup() {
+        return variableArityGroup;
+    }
+
+    public boolean isVariableArity() {
+        return variableArity;
+    }
+
+    @Override
+    public String toString() {
+        List<String> allConstraints = Lists2.map(typeVariableConstraints, TypeVariableConstraint::toString);
+
+        return name + (allConstraints.isEmpty() ? "" : "<" + String.join(",", allConstraints) + ">") +
+               "(" + Lists2.joinOn(",", argumentTypes, TypeSignature::toString) + "):" + returnType;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/sql/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -1,0 +1,518 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.common.collections.Lists2;
+import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
+import io.crate.types.UndefinedType;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
+import static io.crate.types.TypeCompatibility.getCommonType;
+import static java.lang.String.format;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+
+/**
+ * Determines whether, and how, a callsite matches a generic function signature.
+ * Which is equivalent to finding assignments for the variables in the generic signature,
+ * such that all of the function's declared parameters are super types of the corresponding
+ * arguments, and also satisfy the declared constraints (such as a given type parameter must
+ * be of the same type or not)
+ */
+public class SignatureBinder {
+    // 4 is chosen arbitrarily here. This limit is set to avoid having infinite loops in iterative solving.
+    private static final int SOLVE_ITERATION_LIMIT = 4;
+
+    private static final Logger LOGGER = Loggers.getLogger(SignatureBinder.class);
+
+    private final Signature declaredSignature;
+    private final boolean allowCoercion;
+    private final Map<String, TypeVariableConstraint> typeVariableConstraints;
+
+    public SignatureBinder(Signature declaredSignature, boolean allowCoercion) {
+        this.declaredSignature = declaredSignature;
+        this.allowCoercion = allowCoercion;
+        this.typeVariableConstraints = declaredSignature.getTypeVariableConstraints().stream()
+            .collect(toMap(TypeVariableConstraint::getName, identity()));
+    }
+
+    @Nullable
+    public Signature bind(List<DataType> actualArgumentTypes) {
+        BoundVariables boundVariables = bindVariables(Lists2.map(actualArgumentTypes, DataType::getTypeSignature));
+        if (boundVariables == null) {
+            return null;
+        }
+        return applyBoundVariables(declaredSignature, boundVariables, typeVariableConstraints, actualArgumentTypes.size());
+    }
+
+    @Nullable
+    BoundVariables bindVariables(List<TypeSignature> actualArgumentTypes) {
+        ArrayList<TypeConstraintSolver> constraintSolvers = new ArrayList<>();
+        if (!appendConstraintSolversForArguments(constraintSolvers, actualArgumentTypes)) {
+            return null;
+        }
+
+        return iterativeSolve(Collections.unmodifiableList(constraintSolvers));
+    }
+
+    private static Signature applyBoundVariables(Signature signature,
+                                                 BoundVariables boundVariables,
+                                                 Map<String, TypeVariableConstraint> typeVariableConstraints,
+                                                 int arity) {
+        List<TypeSignature> argumentSignatures;
+        if (signature.isVariableArity()) {
+            argumentSignatures = expandVarargFormalTypeSignature(
+                signature.getArgumentTypes(),
+                signature.getVariableArityGroup(),
+                typeVariableConstraints,
+                arity);
+            if (argumentSignatures == null) {
+                throw new IllegalArgumentException(
+                    "Size of argument types does not match a multiple of the defined variable arguments");
+            }
+        } else {
+            if (signature.getArgumentTypes().size() != arity) {
+                throw new IllegalArgumentException("Size of argument types does not match given arity");
+            }
+            argumentSignatures = signature.getArgumentTypes();
+        }
+        List<TypeSignature> boundArgumentSignatures = applyBoundVariables(argumentSignatures, boundVariables);
+        TypeSignature boundReturnTypeSignature = applyBoundVariables(signature.getReturnType(), boundVariables);
+
+        return Signature.builder()
+            .name(signature.getName())
+            .kind(signature.getKind())
+            .argumentTypes(boundArgumentSignatures)
+            .returnType(boundReturnTypeSignature)
+            .setVariableArity(false)
+            .build();
+    }
+
+    private static List<TypeSignature> applyBoundVariables(List<TypeSignature> typeSignatures,
+                                                           BoundVariables boundVariables) {
+        ArrayList<TypeSignature> builder = new ArrayList<>();
+        for (TypeSignature typeSignature : typeSignatures) {
+            builder.add(applyBoundVariables(typeSignature, boundVariables));
+        }
+        return Collections.unmodifiableList(builder);
+    }
+
+    private static TypeSignature applyBoundVariables(TypeSignature typeSignature, BoundVariables boundVariables) {
+        String baseType = typeSignature.getBaseTypeName();
+        if (boundVariables.containsTypeVariable(baseType)) {
+            if (typeSignature.getParameters().isEmpty() == false) {
+                throw new IllegalStateException("Type parameters cannot have parameters");
+            }
+            return boundVariables.getTypeVariable(baseType).getTypeSignature();
+        }
+
+        List<TypeSignature> parameters = Lists2.map(
+            typeSignature.getParameters(),
+            typeSignatureParameter -> applyBoundVariables(typeSignatureParameter, boundVariables));
+
+        return new TypeSignature(baseType, parameters);
+    }
+
+    private boolean appendConstraintSolversForArguments(List<TypeConstraintSolver> resultBuilder,
+                                                        List<TypeSignature> actualTypeSignatures) {
+        boolean variableArity = declaredSignature.isVariableArity();
+        List<TypeSignature> formalTypeSignatures = declaredSignature.getArgumentTypes();
+        if (variableArity) {
+            int variableGroupCount = declaredSignature.getVariableArityGroup().size();
+            int variableArgumentCount = variableGroupCount > 0 ? variableGroupCount : 1;
+            if (actualTypeSignatures.size() < formalTypeSignatures.size() - variableArgumentCount) {
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace(
+                        "Given signature size {} is not smaller than minimum variableArity of formal signature size {}",
+                        actualTypeSignatures.size(),
+                        formalTypeSignatures.size() - variableArgumentCount);
+                }
+                return false;
+            }
+            formalTypeSignatures = expandVarargFormalTypeSignature(
+                formalTypeSignatures,
+                declaredSignature.getVariableArityGroup(),
+                typeVariableConstraints,
+                actualTypeSignatures.size());
+            if (formalTypeSignatures == null) {
+                // var args expanding detected a no-match
+                return false;
+            }
+        }
+
+        if (formalTypeSignatures.size() != actualTypeSignatures.size()) {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Given signature size {} does not match formal signature size {}",
+                             actualTypeSignatures.size(), formalTypeSignatures.size());
+            }
+            return false;
+        }
+
+        for (int i = 0; i < formalTypeSignatures.size(); i++) {
+            appendTypeRelationshipConstraintSolver(resultBuilder,
+                                                   formalTypeSignatures.get(i),
+                                                   actualTypeSignatures.get(i),
+                                                   allowCoercion);
+        }
+
+        return appendConstraintSolvers(resultBuilder, formalTypeSignatures, actualTypeSignatures, allowCoercion);
+    }
+
+    private boolean appendConstraintSolvers(List<TypeConstraintSolver> resultBuilder,
+                                            List<? extends TypeSignature> formalTypeSignatures,
+                                            List<TypeSignature> actualTypeSignatures,
+                                            boolean allowCoercion) {
+        if (formalTypeSignatures.size() != actualTypeSignatures.size()) {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Given signature size {} does not match formal signature size {}",
+                             actualTypeSignatures.size(), formalTypeSignatures.size());
+            }
+            return false;
+        }
+        for (int i = 0; i < formalTypeSignatures.size(); i++) {
+            if (!appendConstraintSolvers(resultBuilder,
+                                         formalTypeSignatures.get(i),
+                                         actualTypeSignatures.get(i),
+                                         allowCoercion)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean appendConstraintSolvers(List<TypeConstraintSolver> resultBuilder,
+                                            TypeSignature formalTypeSignature,
+                                            TypeSignature actualTypeSignature,
+                                            boolean allowCoercion) {
+        if (formalTypeSignature.getParameters().isEmpty()) {
+            TypeVariableConstraint typeVariableConstraint = typeVariableConstraints.get(formalTypeSignature.getBaseTypeName());
+            if (typeVariableConstraint == null) {
+                return true;
+            }
+            resultBuilder.add(new TypeParameterSolver(formalTypeSignature.getBaseTypeName(), actualTypeSignature.createType()));
+            return true;
+        }
+
+        DataType<?> actualType = actualTypeSignature.createType();
+
+        List<TypeSignature> actualTypeParametersTypeSignatureProvider;
+        if (UndefinedType.ID == actualType.id()) {
+            actualTypeParametersTypeSignatureProvider = Collections.nCopies(formalTypeSignature.getParameters().size(),
+                                                                            UndefinedType.INSTANCE.getTypeSignature());
+        } else {
+            actualTypeParametersTypeSignatureProvider = Lists2.map(
+                actualType.getTypeParameters(),
+                DataType::getTypeSignature
+            );
+        }
+
+        return appendConstraintSolvers(
+            resultBuilder,
+            Collections.unmodifiableList(formalTypeSignature.getParameters()),
+            actualTypeParametersTypeSignatureProvider,
+            allowCoercion);
+    }
+
+    private void appendTypeRelationshipConstraintSolver(List<TypeConstraintSolver> resultBuilder,
+                                                        TypeSignature formalTypeSignature,
+                                                        TypeSignature actualTypeSignature,
+                                                        boolean allowCoercion) {
+        Set<String> typeVariables = typeVariablesOf(formalTypeSignature);
+        resultBuilder.add(new TypeRelationshipConstraintSolver(
+            formalTypeSignature,
+            typeVariables,
+            actualTypeSignature.createType(),
+            allowCoercion));
+    }
+
+    private Set<String> typeVariablesOf(TypeSignature typeSignature) {
+        if (typeVariableConstraints.containsKey(typeSignature.getBaseTypeName())) {
+            return Set.of(typeSignature.getBaseTypeName());
+        }
+        HashSet<String> variables = new HashSet<>();
+        for (TypeSignature parameter : typeSignature.getParameters()) {
+            variables.addAll(typeVariablesOf(parameter));
+        }
+
+        return variables;
+    }
+
+    @Nullable
+    private BoundVariables iterativeSolve(List<TypeConstraintSolver> constraints) {
+        BoundVariables.Builder boundVariablesBuilder = BoundVariables.builder();
+        for (int i = 0; true; i++) {
+            if (i == SOLVE_ITERATION_LIMIT) {
+                throw new IllegalStateException(format(
+                    Locale.ENGLISH,
+                    "SignatureBinder.iterativeSolve does not converge after %d iterations.",
+                    SOLVE_ITERATION_LIMIT));
+            }
+            SolverReturnStatusMerger statusMerger = new SolverReturnStatusMerger();
+            for (TypeConstraintSolver constraint : constraints) {
+                var constraintStatus = constraint.update(boundVariablesBuilder);
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("Status after updating constraint={}: {}", constraint, constraintStatus);
+                }
+                statusMerger.add(constraintStatus);
+                if (statusMerger.getCurrent() == SolverReturnStatus.UNSOLVABLE) {
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("Status merger resulted in UNSOLVABLE state");
+                    }
+                    return null;
+                }
+            }
+            switch (statusMerger.getCurrent()) {
+                case UNCHANGED_SATISFIED:
+                    break;
+                case UNCHANGED_NOT_SATISFIED:
+                    return null;
+                case CHANGED:
+                    continue;
+                default:
+                case UNSOLVABLE:
+                    throw new UnsupportedOperationException("Signature binding unsolvable");
+            }
+            break;
+        }
+
+        BoundVariables boundVariables = boundVariablesBuilder.build();
+        if (!allTypeVariablesBound(boundVariables)) {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Not all variables are bound. Defined variables={}, bound={}",
+                             typeVariableConstraints,
+                             boundVariables);
+            }
+            return null;
+        }
+        return boundVariables;
+    }
+
+    private boolean allTypeVariablesBound(BoundVariables boundVariables) {
+        return boundVariables.getTypeVariableNames().equals(typeVariableConstraints.keySet());
+    }
+
+    @Nullable
+    private static List<TypeSignature> expandVarargFormalTypeSignature(List<TypeSignature> formalTypeSignatures,
+                                                                       List<TypeSignature> variableArityGroup,
+                                                                       Map<String, TypeVariableConstraint> typeVariableConstraints,
+                                                                       int actualArity) {
+        int variableArityGroupCount = variableArityGroup.size();
+        if (variableArityGroupCount > 0 && actualArity % variableArityGroupCount != 0) {
+            // no match
+            return null;
+        }
+        int arityCountIncludedInsideFormalSignature = variableArityGroupCount == 0 ? 1 : variableArityGroupCount;
+        int variableArityArgumentsCount = actualArity - formalTypeSignatures.size() + arityCountIncludedInsideFormalSignature;
+        if (variableArityArgumentsCount == 0) {
+            return formalTypeSignatures.subList(0, formalTypeSignatures.size() - arityCountIncludedInsideFormalSignature);
+        }
+        if (variableArityArgumentsCount == arityCountIncludedInsideFormalSignature) {
+            return formalTypeSignatures;
+        }
+        if (variableArityArgumentsCount > arityCountIncludedInsideFormalSignature && formalTypeSignatures.isEmpty()) {
+            throw new IllegalArgumentException("Found variable argument(s) but list of formal type signatures is empty");
+        }
+
+        ArrayList<TypeSignature> builder = new ArrayList<>(formalTypeSignatures);
+        if (variableArityGroup.isEmpty()) {
+            TypeSignature lastTypeSignature = formalTypeSignatures.get(formalTypeSignatures.size() - 1);
+            for (int i = 1; i < variableArityArgumentsCount; i++) {
+                addVarArgTypeSignature(lastTypeSignature, typeVariableConstraints, builder, i);
+            }
+        } else {
+            for (int i = 0; i < variableArityArgumentsCount - formalTypeSignatures.size(); ) {
+                i += variableArityGroupCount;
+                for (var typeSignature : variableArityGroup) {
+                    addVarArgTypeSignature(typeSignature, typeVariableConstraints, builder, i);
+                }
+            }
+        }
+        return Collections.unmodifiableList(builder);
+    }
+
+    private static void addVarArgTypeSignature(TypeSignature typeSignature,
+                                               Map<String, TypeVariableConstraint> typeVariableConstraints,
+                                               List<TypeSignature> builder,
+                                               int actualArity) {
+        TypeVariableConstraint typeVariableConstraint = typeVariableConstraints.get(typeSignature.getBaseTypeName());
+        if (typeVariableConstraint != null && typeVariableConstraint.isAnyAllowed()) {
+            // Type variables defaults to be bound to the same type.
+            // To support independent variable type arguments, each vararg must be bound to a dedicated type variable.
+            String constraintName = "_generated_" + typeSignature.getBaseTypeName() + actualArity;
+            TypeSignature newTypeSignature = new TypeSignature(constraintName);
+            typeVariableConstraints.put(constraintName, typeVariableOfAnyType(constraintName));
+            builder.add(newTypeSignature);
+        } else {
+            builder.add(typeSignature);
+        }
+
+    }
+
+    private static boolean satisfiesCoercion(boolean allowCoercion,
+                                             DataType<?> fromType,
+                                             TypeSignature toTypeSignature) {
+        if (allowCoercion) {
+            return fromType.isConvertableTo(toTypeSignature.createType());
+        } else {
+            return fromType.getTypeSignature().equals(toTypeSignature);
+        }
+    }
+
+    private interface TypeConstraintSolver {
+        SolverReturnStatus update(BoundVariables.Builder bindings);
+    }
+
+    private enum SolverReturnStatus {
+        UNCHANGED_SATISFIED,
+        UNCHANGED_NOT_SATISFIED,
+        CHANGED,
+        UNSOLVABLE,
+    }
+
+    private static class SolverReturnStatusMerger {
+        // This class gives the overall status when multiple status are seen from different parts.
+        // The logic can be summarized as finding the right most item (based on the list below) seen so far:
+        //   UNCHANGED_SATISFIED, UNCHANGED_NOT_SATISFIED, CHANGED, UNSOLVABLE
+        // If no item was seen ever, it provides UNCHANGED_SATISFIED.
+
+        private SolverReturnStatus current = SolverReturnStatus.UNCHANGED_SATISFIED;
+
+        public void add(SolverReturnStatus newStatus) {
+            switch (newStatus) {
+                case UNCHANGED_SATISFIED:
+                    break;
+                case UNCHANGED_NOT_SATISFIED:
+                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED) {
+                        current = SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+                    }
+                    break;
+                case CHANGED:
+                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED ||
+                        current == SolverReturnStatus.UNCHANGED_NOT_SATISFIED) {
+                        current = SolverReturnStatus.CHANGED;
+                    }
+                    break;
+                case UNSOLVABLE:
+                default:
+                    current = SolverReturnStatus.UNSOLVABLE;
+                    break;
+            }
+        }
+
+        public SolverReturnStatus getCurrent() {
+            return current;
+        }
+    }
+
+    private static class TypeParameterSolver implements TypeConstraintSolver {
+        private final String typeParameter;
+        private final DataType<?> actualType;
+
+        public TypeParameterSolver(String typeParameter,
+                                   DataType<?> actualType) {
+            this.typeParameter = typeParameter;
+            this.actualType = actualType;
+        }
+
+        @Override
+        public SolverReturnStatus update(BoundVariables.Builder bindings) {
+            if (!bindings.containsTypeVariable(typeParameter)) {
+                bindings.setTypeVariable(typeParameter, actualType);
+                return SolverReturnStatus.CHANGED;
+            }
+            DataType<?> originalType = bindings.getTypeVariable(typeParameter);
+            DataType<?> commonType = getCommonType(originalType, actualType);
+            if (commonType == null) {
+                return SolverReturnStatus.UNSOLVABLE;
+            }
+            if (commonType.equals(originalType)) {
+                return SolverReturnStatus.UNCHANGED_SATISFIED;
+            }
+            bindings.setTypeVariable(typeParameter, commonType);
+            return SolverReturnStatus.CHANGED;
+        }
+
+        @Override
+        public String toString() {
+            return "TypeParameterSolver{" +
+                   "typeParameter='" + typeParameter + "'" +
+                   ", actualType=" + actualType +
+                   '}';
+        }
+    }
+
+    private static class TypeRelationshipConstraintSolver implements TypeConstraintSolver {
+        private final TypeSignature superTypeSignature;
+        private final Set<String> typeVariables;
+        private final DataType<?> actualType;
+        private final boolean allowCoercion;
+
+        public TypeRelationshipConstraintSolver(TypeSignature superTypeSignature,
+                                                Set<String> typeVariables,
+                                                DataType<?> actualType,
+                                                boolean allowCoercion) {
+            this.superTypeSignature = superTypeSignature;
+            this.typeVariables = typeVariables;
+            this.actualType = actualType;
+            this.allowCoercion = allowCoercion;
+        }
+
+        @Override
+        public SolverReturnStatus update(BoundVariables.Builder bindings) {
+            for (String variable : typeVariables) {
+                if (!bindings.containsTypeVariable(variable)) {
+                    return SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+                }
+            }
+
+            TypeSignature boundSignature = applyBoundVariables(superTypeSignature, bindings.build());
+            if (satisfiesCoercion(allowCoercion, actualType, boundSignature)) {
+                return SolverReturnStatus.UNCHANGED_SATISFIED;
+            }
+            return SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
+        }
+
+        @Override
+        public String toString() {
+            return "TypeRelationshipConstraintSolver{" +
+                   "superTypeSignature=" + superTypeSignature +
+                   ", typeVariables=" + typeVariables +
+                   ", actualType=" + actualType +
+                   ", allowCoercion=" + allowCoercion +
+                   '}';
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
+++ b/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import java.util.Objects;
+
+public class TypeVariableConstraint {
+
+    public static TypeVariableConstraint typeVariable(String name) {
+        return new TypeVariableConstraint(name, false);
+    }
+
+    public static TypeVariableConstraint typeVariableOfAnyType(String name) {
+        return new TypeVariableConstraint(name, true);
+    }
+
+    private final String name;
+    private final boolean anyAllowed;
+
+    private TypeVariableConstraint(String name, boolean anyAllowed) {
+        this.name = name;
+        this.anyAllowed = anyAllowed;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isAnyAllowed() {
+        return anyAllowed;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TypeVariableConstraint that = (TypeVariableConstraint) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -67,14 +67,14 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testThreeArguments() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The number of arguments is incorrect");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: array_cat(bigint_array, bigint_array, bigint_array)");
         assertEvaluate("array_cat([1], [2], [3])", null);
     }
 
     @Test
     public void testDifferentConvertableInnerTypes() throws Exception {
-        assertEvaluate("array_cat([1::integer], [1::long])", Arrays.asList(1, 1));
+        assertEvaluate("array_cat([1::integer], [1::long])", Arrays.asList(1L, 1L));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEmptyArrays() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("One of the arguments of the array_cat function can be of undefined inner type, but not both");
+        expectedException.expectMessage("When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
         assertNormalize("array_cat([], [])", null);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataTypes;
@@ -122,8 +123,8 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidTimestamp() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text 'NO TIMESTAMP' could not be parsed");
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast `'NO TIMESTAMP'` of type `text` to type `timestamp with time zone`");
         assertEvaluate("date_format('%d.%m.%Y', 'NO TIMESTAMP')", null);
     }
 

--- a/sql/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.metadata.FunctionInfo.Type.SCALAR;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SignatureBinderTest extends CrateUnitTest {
+
+    private static Signature.Builder functionSignature() {
+        return Signature.builder()
+            .name("function")
+            .kind(SCALAR);
+    }
+
+    @Test
+    public void testBasic() {
+        Signature function = functionSignature()
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("T"))
+            .build();
+
+        assertThat(function)
+            .boundTo("bigint")
+            .produces(new BoundVariables(Map.of("T", type("bigint"))));
+
+        assertThat(function)
+            .boundTo("text")
+            .produces(new BoundVariables(Map.of("T", type("text"))));
+
+        assertThat(function)
+            .boundTo("text", "bigint")
+            .fails();
+
+        assertThat(function)
+            .boundTo("array(bigint)")
+            .produces(new BoundVariables(Map.of("T", type("array(bigint)"))));
+    }
+
+    @Test
+    public void testBindUnknownToConcreteArray() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("array(boolean)"))
+            .build();
+
+        assertThat(function)
+            .boundTo("undefined")
+            .withCoercion()
+            .succeeds();
+    }
+
+    @Test
+    public void testBindTypeVariablesBasedOnTheSecondArgument() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("array(T)"), parseTypeSignature("T"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(function)
+            .boundTo("undefined", "bigint")
+            .withCoercion()
+            .produces(new BoundVariables(Map.of("T", type("bigint"))));
+    }
+
+    @Test
+    public void testBindParametricTypeParameterToUnknown() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("array(T)"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(function)
+            .boundTo("undefined")
+            .fails();
+
+        assertThat(function)
+            .withCoercion()
+            .boundTo("undefined")
+            .succeeds();
+    }
+
+    @Test
+    public void testBindUnknownToTypeParameter() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("T"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(function)
+            .boundTo("undefined")
+            .withCoercion()
+            .produces(new BoundVariables(Map.of("T", type("undefined"))));
+    }
+
+    @Test
+    public void testBindDoubleToBigint() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("double precision"), parseTypeSignature("double precision"))
+            .build();
+
+        assertThat(function)
+            .boundTo("double precision", "bigint")
+            .withCoercion()
+            .succeeds();
+    }
+
+    @Test
+    public void testMismatchedArgumentCount() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("bigint"), parseTypeSignature("bigint"))
+            .build();
+
+        assertThat(function)
+            .boundTo("bigint", "bigint", "bigint")
+            .fails();
+
+        assertThat(function)
+            .boundTo("bigint")
+            .fails();
+    }
+
+    @Test
+    public void testArray() {
+        Signature getFunction = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("array(T)"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(getFunction)
+            .boundTo("array(bigint)")
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))));
+
+        assertThat(getFunction)
+            .boundTo("bigint")
+            .withCoercion()
+            .fails();
+
+        Signature containsFunction = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("array(T)"), parseTypeSignature("T"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(containsFunction)
+            .boundTo("array(bigint)", "bigint")
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))));
+
+        assertThat(containsFunction)
+            .boundTo("array(bigint)", "geo_point")
+            .withCoercion()
+            .fails();
+
+        Signature castFunction = functionSignature()
+            .returnType(parseTypeSignature("array(T2)"))
+            .argumentTypes(parseTypeSignature("array(T1)"), parseTypeSignature("array(T2)"))
+            .typeVariableConstraints(List.of(typeVariable("T1"), typeVariable("T2")))
+            .build();
+
+        assertThat(castFunction)
+            .boundTo("array(undefined)", "array(bigint)")
+            .withCoercion()
+            .produces(new BoundVariables(
+                Map.of(
+                    "T1", type("undefined"),
+                    "T2", type("bigint"))
+            ));
+
+        Signature fooFunction = functionSignature()
+            .returnType(parseTypeSignature("T"))
+            .argumentTypes(parseTypeSignature("array(T)"), parseTypeSignature("array(T)"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(fooFunction)
+            .boundTo("array(bigint)", "array(bigint)")
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))
+            ));
+
+        assertThat(fooFunction)
+            .boundTo("array(bigint)", "array(geo_point)")
+            .withCoercion()
+            .fails();
+    }
+
+    @Test
+    public void testMap() {
+        Signature getValueFunction = functionSignature()
+            .returnType(parseTypeSignature("V"))
+            .argumentTypes(parseTypeSignature("object(K,V)"), parseTypeSignature("K"))
+            .typeVariableConstraints(List.of(typeVariable("K"), typeVariable("V")))
+            .build();
+
+        assertThat(getValueFunction)
+            .boundTo("object(text, bigint)", "text")
+            .produces(new BoundVariables(
+                Map.of(
+                    "K", type("text"),
+                    "V", type("bigint"))
+            ));
+
+        assertThat(getValueFunction)
+            .boundTo("object(text, bigint)", "bigint")
+            .withoutCoercion()
+            .fails();
+    }
+
+    @Test
+    public void testVariableArityGroup() {
+        Signature mapFunction = functionSignature()
+            .returnType(parseTypeSignature("object(text, V)"))
+            .argumentTypes(parseTypeSignature("text"), parseTypeSignature("V"))
+            .typeVariableConstraints(List.of(typeVariable("V")))
+            .variableArityGroup(List.of(parseTypeSignature("text"), parseTypeSignature("V")))
+            .build();
+
+        assertThat(mapFunction)
+            .boundTo("text", "integer")
+            .produces(new BoundVariables(
+                Map.of(
+                    "V", type("integer"))
+            ));
+
+        assertThat(mapFunction)
+            .boundTo("text", "integer", "text", "integer")
+            .produces(new BoundVariables(
+                Map.of(
+                    "V", type("integer"))
+            ));
+
+        assertThat(mapFunction)
+            .boundTo("text")
+            .fails();
+
+        assertThat(mapFunction)
+            .boundTo("text", "integer", "text")
+            .fails();
+    }
+
+    @Test
+    public void testVariableArityOfAnyTypeConstraint() {
+        Signature fooFunction = functionSignature()
+            .returnType(parseTypeSignature("text"))
+            .argumentTypes(parseTypeSignature("text"), parseTypeSignature("V"))
+            .typeVariableConstraints(List.of(typeVariableOfAnyType("V")))
+            .setVariableArity(true)
+            .build();
+
+        assertThat(fooFunction)
+            .boundTo("text", "integer")
+            .produces(new BoundVariables(
+                Map.of(
+                    "V", type("integer")
+                )
+            ));
+
+        assertThat(fooFunction)
+            .boundTo("text", "integer", "text", "geo_point")
+            .produces(new BoundVariables(
+                Map.of(
+                    "V", type("integer"),
+                    "_generated_V1", type("text"),
+                    "_generated_V2", type("geo_point")
+                )
+            ));
+    }
+
+    @Test
+    public void testVarArgs() {
+        Signature variableArityFunction = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("T"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .setVariableArity(true)
+            .build();
+
+        assertThat(variableArityFunction)
+            .boundTo("bigint")
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))
+            ));
+
+        assertThat(variableArityFunction)
+            .boundTo("text")
+            .produces(new BoundVariables(
+                Map.of("T", type("text"))
+            ));
+
+        assertThat(variableArityFunction)
+            .boundTo("bigint", "bigint")
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))
+            ));
+
+        assertThat(variableArityFunction)
+            .boundTo(Collections.emptyList())
+            .fails();
+
+        assertThat(variableArityFunction)
+            .boundTo("bigint", "geo_point")
+            .withCoercion()
+            .fails();
+    }
+
+    @Test
+    public void testCoercion() {
+        Signature function = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("T"), parseTypeSignature("double precision"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(function)
+            .boundTo("double precision", "double precision")
+            .withCoercion()
+            .produces(new BoundVariables(
+                Map.of("T", type("double"))
+            ));
+
+        assertThat(function)
+            .boundTo("bigint", "bigint")
+            .withCoercion()
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))
+            ));
+
+        assertThat(function)
+            .boundTo("text", "bigint")
+            .withCoercion()
+            .produces(new BoundVariables(
+                Map.of("T", type("text"))
+            ));
+
+        assertThat(function)
+            .boundTo("bigint", "geo_point")
+            .withCoercion()
+            .fails();
+    }
+
+    @Test
+    public void testUnknownCoercion() {
+        Signature foo = functionSignature()
+            .returnType(parseTypeSignature("boolean"))
+            .argumentTypes(parseTypeSignature("T"), parseTypeSignature("T"))
+            .typeVariableConstraints(List.of(typeVariable("T")))
+            .build();
+
+        assertThat(foo)
+            .boundTo("undefined", "undefined")
+            .produces(new BoundVariables(
+                Map.of("T", type("undefined"))
+            ));
+
+        assertThat(foo)
+            .boundTo("undefined", "bigint")
+            .withCoercion()
+            .produces(new BoundVariables(
+                Map.of("T", type("bigint"))
+            ));
+
+        assertThat(foo)
+            .boundTo("geo_point", "bigint")
+            .withCoercion()
+            .fails();
+    }
+
+    private DataType<?> type(String signature) {
+        TypeSignature typeSignature = TypeSignature.parseTypeSignature(signature);
+        return typeSignature.createType();
+    }
+
+    private BindSignatureAssertion assertThat(Signature function) {
+        return new BindSignatureAssertion(function);
+    }
+
+    private static class BindSignatureAssertion {
+        private final Signature function;
+        private List<TypeSignature> argumentTypes;
+        private boolean allowCoercion;
+
+        private BindSignatureAssertion(Signature function) {
+            this.function = function;
+        }
+
+        public BindSignatureAssertion withCoercion() {
+            allowCoercion = true;
+            return this;
+        }
+
+        public BindSignatureAssertion withoutCoercion() {
+            allowCoercion = false;
+            return this;
+        }
+
+        public BindSignatureAssertion boundTo(Object... arguments) {
+            return boundTo(List.of(arguments));
+        }
+
+        public BindSignatureAssertion boundTo(List<Object> arguments) {
+            ArrayList<TypeSignature> builder = new ArrayList<>(arguments.size());
+            for (Object argument : arguments) {
+                if (argument instanceof String) {
+                    builder.add(TypeSignature.parseTypeSignature((String) argument));
+                    continue;
+                }
+                if (argument instanceof TypeSignature) {
+                    builder.add((TypeSignature) argument);
+                    continue;
+                }
+                throw new IllegalArgumentException(format(
+                    "argument is of type %s. It should be String or TypeSignature",
+                    argument.getClass()));
+            }
+            this.argumentTypes = Collections.unmodifiableList(builder);
+            return this;
+        }
+
+        public void succeeds() {
+            assertThat(bindVariables(), notNullValue());
+        }
+
+        public void fails() {
+            assertThat(bindVariables(), nullValue());
+        }
+
+        public void produces(BoundVariables expected) {
+            BoundVariables actual = bindVariables();
+            assertThat(actual, is(expected));
+        }
+
+        @Nullable
+        private BoundVariables bindVariables() {
+            assertNotNull(argumentTypes);
+            SignatureBinder signatureBinder = new SignatureBinder(function, allowCoercion);
+            return signatureBinder.bindVariables(argumentTypes);
+        }
+    }
+}


### PR DESCRIPTION
Our current function registry does not provide the information needed by a proper `pg_proc` table implementation. Also the current implementation has other known limitations or even bugs.

Signatures can be defined with type variables constraints to support constraints across given argument types, e.g. a `array(E), array(E)` signature requires all `E` types to either have a common super type or being convertible.
Special logic of literal downcasts (avoid table-scans) is omitted, this should be re-implemented decoupled later on (Relates #9652).

Each function can be registered with different signatures (function overloading).
The registry can be iterated to get all registered signatures (Relates #9567).

This concept is heavily inspired by https://prestodb.io/.