### PR TITLE
Extend PR template with reminder about sql_features table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@
 
 ## Checklist
 
- - [ ] User relevant changes are recorded in ``CHANGES.txt``
+ - [ ] Added an entry in `CHANGES.txt` for user facing changes
+ - [ ] Updated documentation & `sql_features` table for user facing changes
  - [ ] Touched code is covered by tests
- - [ ] Documentation has been updated if necessary
  - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
  - [ ] This does not contain breaking changes, or if it does:
     - It is released within a major release


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)