### PR TITLE
Tests: Update hadoop version to 2.8.5

### DIFF
--- a/blackbox/test_hdfs.py
+++ b/blackbox/test_hdfs.py
@@ -35,7 +35,7 @@ from crate.client import connect
 from urllib.error import HTTPError
 from urllib.request import urlretrieve
 
-HADOOP_VERSION = '2.8.4'
+HADOOP_VERSION = '2.8.5'
 HADOOP_SOURCE = ('http://www-eu.apache.org/dist/hadoop/common/'
                  'hadoop-{version}/hadoop-{version}.tar.gz'.format(version=HADOOP_VERSION))
 CACHE_DIR = os.environ.get(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Looks like 2.8.4 is no longer available

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)