### PR TITLE
Migrate SysOperationsLogTableInfo, SysSummitsTableInfo and SysSnapshotsTableInfo to SystemTable

### DIFF
--- a/sql/src/main/java/io/crate/metadata/SystemTable.java
+++ b/sql/src/main/java/io/crate/metadata/SystemTable.java
@@ -47,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,17 +58,17 @@ public final class SystemTable<T> implements TableInfo {
     private final Map<ColumnIdent, RowCollectExpressionFactory<T>> expressions;
     private final List<ColumnIdent> primaryKeys;
     private final List<Reference> rootColumns;
-    private final Function<DiscoveryNodes, Routing> getRouting;
+    private final BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting;
 
     public SystemTable(RelationName name,
                        Map<ColumnIdent, Reference> columns,
                        Map<ColumnIdent, RowCollectExpressionFactory<T>> expressions,
                        List<ColumnIdent> primaryKeys,
-                       @Nullable Function<DiscoveryNodes, Routing> getRouting) {
+                       @Nullable BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting) {
         this.name = name;
         this.columns = columns;
         this.getRouting = getRouting == null
-            ? nodes -> Routing.forTableOnSingleNode(name, nodes.getLocalNodeId())
+            ? (nodes, routingProvider) -> Routing.forTableOnSingleNode(name, nodes.getLocalNodeId())
             : getRouting;
         this.rootColumns = columns.values().stream()
             .filter(x -> x.column().isTopLevel())
@@ -94,7 +95,7 @@ public final class SystemTable<T> implements TableInfo {
                               WhereClause whereClause,
                               RoutingProvider.ShardSelection shardSelection,
                               SessionContext sessionContext) {
-        return getRouting.apply(state.getNodes());
+        return getRouting.apply(state.getNodes(), routingProvider);
     }
 
     @Override
@@ -171,9 +172,9 @@ public final class SystemTable<T> implements TableInfo {
 
         private final ArrayList<Column<T, ?>> columns = new ArrayList<>();
         private List<ColumnIdent> primaryKeys = List.of();
-        private Function<DiscoveryNodes, Routing> getRouting;
+        private BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting;
 
-        public RelationBuilder<T> withRouting(Function<DiscoveryNodes, Routing> getRouting) {
+        public RelationBuilder<T> withRouting(BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting) {
             this.getRouting = getRouting;
             return this;
         }

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -56,7 +56,7 @@ public class SysJobsLogTableInfo {
                 .add("id", STRING, ignored -> localNode.get().getId())
                 .add("name", STRING, ignored -> localNode.get().getName())
             .endObject()
-            .withRouting(nodes -> Routing.forTableOnAllNodes(IDENT, nodes))
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnAllNodes(IDENT, nodes))
             .setPrimaryKeys(new ColumnIdent("id"))
             .build(IDENT);
     }

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -48,7 +48,7 @@ public class SysJobsTableInfo {
             .endObject()
             .add("stmt", STRING, JobContext::stmt)
             .add("started", TIMESTAMPZ, JobContext::started)
-            .withRouting(nodes -> Routing.forTableOnAllNodes(IDENT, nodes))
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnAllNodes(IDENT, nodes))
             .setPrimaryKeys(new ColumnIdent("id"))
             .build(IDENT);
     }

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -65,7 +65,7 @@ public class SysMetricsTableInfo {
                 .add("type", STRING, x -> x.classification().type().name())
                 .add("labels", STRING_ARRAY, x -> List.copyOf(x.classification().labels()))
             .endObject()
-            .withRouting(nodes -> Routing.forTableOnAllNodes(NAME, nodes))
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnAllNodes(NAME, nodes))
             .build(NAME);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -53,12 +53,12 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysJobsTableInfo.IDENT.name(), SysJobsTableInfo.create(localNode));
         tableInfos.put(SysJobsLogTableInfo.IDENT.name(), SysJobsLogTableInfo.create(localNode));
         tableInfos.put(SysOperationsTableInfo.IDENT.name(), new SysOperationsTableInfo(localNode));
-        tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), new SysOperationsLogTableInfo());
+        tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), SysOperationsLogTableInfo.create());
         tableInfos.put(SysChecksTableInfo.IDENT.name(), SysChecksTableInfo.create());
         tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), new SysNodeChecksTableInfo());
         tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), new SysRepositoriesTableInfo(clusterService.getClusterSettings().maskedSettings()));
-        tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), new SysSnapshotsTableInfo());
-        tableInfos.put(SysSummitsTableInfo.IDENT.name(), new SysSummitsTableInfo());
+        tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), SysSnapshotsTableInfo.create());
+        tableInfos.put(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.create());
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), new SysAllocationsTableInfo());
         tableInfos.put(SysHealth.IDENT.name(), SysHealth.create());
         tableInfos.put(SysMetricsTableInfo.NAME.name(), SysMetricsTableInfo.create(localNode));

--- a/sql/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
@@ -21,73 +21,41 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
 import io.crate.expression.reference.sys.snapshot.SysSnapshot;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
+import io.crate.metadata.SystemTable;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 
-import java.util.Map;
 
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 
-public class SysSnapshotsTableInfo extends StaticTableInfo<SysSnapshot> {
+public class SysSnapshotsTableInfo {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "snapshots");
-    private static final RowGranularity GRANULARITY = RowGranularity.DOC;
 
-    public static class Columns {
-        public static final ColumnIdent NAME = new ColumnIdent("name");
+    static SystemTable<SysSnapshot> create() {
+        return SystemTable.<SysSnapshot>builder()
+            .add("name", STRING, SysSnapshot::name)
+            .add("repository", STRING, SysSnapshot::repository)
+            .add("concrete_indices", STRING_ARRAY, SysSnapshot::concreteIndices)
+            .add("started", TIMESTAMPZ, SysSnapshot::started)
+            .add("finished", TIMESTAMPZ, SysSnapshot::finished)
+            .add("version", STRING, SysSnapshot::version)
+            .add("state", STRING, SysSnapshot::state)
+            .add("failures", STRING_ARRAY, SysSnapshot::failures)
+            .setPrimaryKeys(new ColumnIdent("name"), new ColumnIdent("repository"))
+            .withRouting(SysSnapshotsTableInfo::getRouting)
+            .build(IDENT);
     }
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<SysSnapshot>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    private static ColumnRegistrar<SysSnapshot> columnRegistrar() {
-        return new ColumnRegistrar<SysSnapshot>(IDENT, GRANULARITY)
-          .register("name", STRING, () -> forFunction(SysSnapshot::name))
-          .register("repository", STRING, () -> forFunction(SysSnapshot::repository))
-          .register("concrete_indices", STRING_ARRAY, () -> forFunction(SysSnapshot::concreteIndices))
-          .register("started", TIMESTAMPZ, () -> forFunction(SysSnapshot::started))
-          .register("finished", TIMESTAMPZ, () -> forFunction(SysSnapshot::finished))
-          .register("version", STRING, () -> forFunction(SysSnapshot::version))
-          .register("state", STRING, () -> forFunction(SysSnapshot::state))
-          .register("failures", STRING_ARRAY, () -> forFunction(SysSnapshot::failures));
-    }
-
-    SysSnapshotsTableInfo() {
-        super(IDENT, columnRegistrar(), "name","repository");
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return GRANULARITY;
-    }
-
-    @Override
-    public RelationName ident() {
-        return IDENT;
-    }
-
-    @Override
-    public Routing getRouting(ClusterState clusterState,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
+    private static Routing getRouting(DiscoveryNodes nodes, RoutingProvider routingProvider) {
         // route to random master or data node,
         // because RepositoriesService (and so snapshots info) is only available there
-        return routingProvider.forRandomMasterOrDataNode(IDENT, clusterState.getNodes());
+        return routingProvider.forRandomMasterOrDataNode(IDENT, nodes);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
@@ -22,63 +22,33 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
 import io.crate.execution.engine.collect.files.SummitsContext;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
+import io.crate.metadata.SystemTable;
 
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.GEO_POINT;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 
-public class SysSummitsTableInfo extends StaticTableInfo<SummitsContext> {
+public class SysSummitsTableInfo {
 
-    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "summits");
-    private static final RowGranularity GRANULARITY = RowGranularity.DOC;
+    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME,"summits");
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<SummitsContext>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    public SysSummitsTableInfo() {
-        super(IDENT, columnRegistrar(), "mountain");
-    }
-
-    private static ColumnRegistrar<SummitsContext> columnRegistrar() {
-        return new ColumnRegistrar<SummitsContext>(IDENT, GRANULARITY)
-            .register("mountain", STRING, () -> forFunction(SummitsContext::mountain))
-            .register("height", INTEGER, () -> forFunction(SummitsContext::height))
-            .register("prominence", INTEGER, () -> forFunction(SummitsContext::prominence))
-            .register("coordinates", GEO_POINT, () -> forFunction(SummitsContext::coordinates))
-            .register("range", STRING, () -> forFunction(SummitsContext::range))
-            .register("classification", STRING, () -> forFunction(SummitsContext::classification))
-            .register("region", STRING, () -> forFunction(SummitsContext::region))
-            .register("country", STRING, () -> forFunction(SummitsContext::country))
-            .register("first_ascent", INTEGER, () -> forFunction(SummitsContext::firstAscent));
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return GRANULARITY;
-    }
-
-    @Override
-    public Routing getRouting(ClusterState clusterState,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(IDENT, clusterState.getNodes().getLocalNodeId());
+    public static SystemTable<SummitsContext> create() {
+        return SystemTable.<SummitsContext>builder()
+            .add("mountain", STRING, SummitsContext::mountain)
+            .add("height", INTEGER, SummitsContext::height)
+            .add("prominence", INTEGER, SummitsContext::prominence)
+            .add("coordinates", GEO_POINT, SummitsContext::coordinates)
+            .add("range", STRING, SummitsContext::range)
+            .add("classification", STRING, SummitsContext::classification)
+            .add("region", STRING, SummitsContext::region)
+            .add("country", STRING, SummitsContext::country)
+            .add("first_ascent", INTEGER, SummitsContext::firstAscent)
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnSingleNode(IDENT, nodes.getLocalNodeId()))
+            .setPrimaryKeys(new ColumnIdent("mountain"))
+            .build(IDENT);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -88,7 +88,7 @@ public class SysTableDefinitions {
             false));
         tableDefinitions.put(SysOperationsLogTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.operationsLog()),
-            SysOperationsLogTableInfo.expressions(),
+            SysOperationsLogTableInfo.create().expressions(),
             false));
 
         SysChecker<SysCheck> sysChecker = new SysChecker<>(sysChecks);
@@ -107,7 +107,7 @@ public class SysTableDefinitions {
             false));
         tableDefinitions.put(SysSnapshotsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysSnapshots.currentSnapshots()),
-            SysSnapshotsTableInfo.expressions(),
+            SysSnapshotsTableInfo.create().expressions(),
             true));
 
         tableDefinitions.put(SysAllocationsTableInfo.IDENT, new StaticTableDefinition<>(
@@ -119,7 +119,7 @@ public class SysTableDefinitions {
         SummitsIterable summits = new SummitsIterable();
         tableDefinitions.put(SysSummitsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(summits),
-            SysSummitsTableInfo.expressions(),
+            SysSummitsTableInfo.create().expressions(),
             false));
 
         SystemTable<TableHealth> sysHealth = SysHealth.create();

--- a/sql/src/test/java/io/crate/expression/reference/information/TablesSettingsExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/information/TablesSettingsExpressionTest.java
@@ -34,7 +34,7 @@ public class TablesSettingsExpressionTest {
     public void testValueOfStringSettingIsNullOnUnknownParam() {
         TablesSettingsExpression.StringTableParameterExpression foo =
             new TablesSettingsExpression.StringTableParameterExpression("foo");
-        foo.setNextRow(new SysSummitsTableInfo());
+        foo.setNextRow(SysSummitsTableInfo.create());
         assertThat(foo.value(), Matchers.nullValue());
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
