### PR TITLE
CI: Kill stale CrateDB processes before itest run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
           steps {
             sh 'git clean -xdff'
             checkout scm
+            sh 'python3 ./blackbox/kill_4200.py'
             sh './gradlew --no-daemon itest'
           }
         }
@@ -51,6 +52,7 @@ pipeline {
           steps {
             sh 'git clean -xdff'
             checkout scm
+            sh 'python3 ./blackbox/kill_4200.py'
             sh './gradlew --no-daemon ceItest'
           }
         }

--- a/blackbox/kill_4200.py
+++ b/blackbox/kill_4200.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import socket
+import os
+import signal
+import subprocess
+
+
+def is_up(host: str, port: int) -> bool:
+    try:
+        conn = socket.create_connection((host, port))
+        conn.close()
+        return True
+    except (socket.gaierror, ConnectionRefusedError):
+        return False
+
+
+def kill():
+    if not is_up('localhost', 4200):
+        return
+
+    output = subprocess.check_output(['jps'], universal_newlines=True)
+    for line in output.split('\n'):
+        try:
+            pid, procname = line.split(' ')
+        except ValueError:
+            continue
+        if procname == 'CrateDB':
+            print(f'CrateDB process with pid {pid} found. Killing it')
+            os.kill(int(pid), signal.SIGKILL)
+
+
+if __name__ == "__main__":
+    kill()


### PR DESCRIPTION
The approach used here https://github.com/crate/crate/pull/9735 led to stuck tests. Looks like this approach now works.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)