### PR TITLE
Fix WindowAgg column pruning

### DIFF
--- a/sql/src/main/java/io/crate/breaker/EstimateRowSize.java
+++ b/sql/src/main/java/io/crate/breaker/EstimateRowSize.java
@@ -22,12 +22,13 @@
 
 package io.crate.breaker;
 
-import io.crate.data.Row;
-import io.crate.types.DataType;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.function.ToLongFunction;
+
+import io.crate.data.Row;
+import io.crate.types.DataType;
 
 public final class EstimateRowSize implements ToLongFunction<Row> {
 
@@ -35,14 +36,15 @@ public final class EstimateRowSize implements ToLongFunction<Row> {
 
     public EstimateRowSize(Collection<? extends DataType> columnTypes) {
         this.estimators = new ArrayList<>(columnTypes.size());
-        for (DataType columnType : columnTypes) {
+        for (DataType<?> columnType : columnTypes) {
             estimators.add(SizeEstimatorFactory.create(columnType));
         }
     }
 
     @Override
     public long applyAsLong(Row row) {
-        assert row.numColumns() == estimators.size() : "Size of row must match the number of estimators";
+        assert row.numColumns() == estimators.size()
+            : String.format(Locale.ENGLISH, "row.numColumns=%d estimators.size=%d - the number must match. ", row.numColumns(), estimators.size());
         long size = 0;
         for (int i = 0; i < row.numColumns(); i++) {
             size += estimators.get(i).estimateSize(row.get(i));

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -108,21 +108,19 @@ public class WindowAgg extends ForwardingLogicalPlan {
     @Override
     public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
         HashSet<Symbol> toKeep = new HashSet<>();
-        ArrayList<Symbol> newStandalone = new ArrayList<>();
         ArrayList<WindowFunction> newWindowFunctions = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, windowFunctions, newWindowFunctions::add);
-            SymbolVisitors.intersection(outputToKeep, standalone, newStandalone::add);
+            SymbolVisitors.intersection(outputToKeep, standalone, toKeep::add);
         }
         for (WindowFunction newWindowFunction : newWindowFunctions) {
             SymbolVisitors.intersection(newWindowFunction, source.outputs(), toKeep::add);
         }
-        toKeep.addAll(newStandalone);
         LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
         if (newSource == source) {
             return this;
         }
-        return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), List.copyOf(newStandalone));
+        return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), newSource.outputs());
     }
 
     List<WindowFunction> windowFunctions() {

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1716,4 +1716,57 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         // not supported by the TopFieldCollector
         execute("select x from tbl where x > 5000 order by x limit 1500");
     }
+
+    @Test
+    public void test_select_from_virtual_table_with_window_function_and_column_pruning() throws Exception {
+        // push down of columns used in WHERE on top of join results in column pruning
+        // This triggered a bug in the prune implementation of the WindowAgg operator
+        execute("create table doc.metrics (id int primary key, x int)");
+        execute("SELECT"
+            + "    * "
+            + " FROM ("
+            + "     SELECT"
+            + "         n.nspname,"
+            + "         c.relname,"
+            + "         a.attname,"
+            + "         a.atttypid,"
+            + "         a.attnotnull"
+            + "         OR (t.typtype = 'd'"
+            + "             AND t.typnotnull) AS attnotnull,"
+            + "         a.atttypmod,"
+            + "         a.attlen,"
+            + "         row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS attnum,"
+            + "         pg_catalog.pg_get_expr(def.adbin, def.adrelid) AS adsrc,"
+            + "         dsc.description,"
+            + "         t.typbasetype,"
+            + "         t.typtype"
+            + "     FROM"
+            + "         pg_catalog.pg_namespace n"
+            + "         JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid)"
+            + "         JOIN pg_catalog.pg_attribute a ON (a.attrelid = c.oid)"
+            + "         JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid)"
+            + "         LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid = def.adrelid"
+            + "                 AND a.attnum = def.adnum)"
+            + "         LEFT JOIN pg_catalog.pg_description dsc ON (c.oid = dsc.objoid"
+            + "                 AND a.attnum = dsc.objsubid)"
+            + "         LEFT JOIN pg_catalog.pg_class dc ON (dc.oid = dsc.classoid"
+            + "                 AND dc.relname = 'pg_class')"
+            + "         LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace = dn.oid"
+            + "                 AND dn.nspname = 'pg_catalog')"
+            + "     WHERE"
+            + "         c.relkind IN ('r', 'v', 'f', 'm')"
+            + "         AND a.attnum > 0"
+            + "         AND NOT a.attisdropped"
+            + "         AND c.relname LIKE E'metrics') c"
+            + " WHERE"
+            + "     TRUE"
+            + " ORDER BY"
+            + "     nspname,"
+            + "     c.relname,"
+            + "     attnum");
+        assertThat(printedTable(response.rows()),
+            is("doc| metrics| id| 23| false| -1| 4| 1| NULL| NULL| 0| b\n" +
+               "doc| metrics| x| 23| false| -1| 4| 2| NULL| NULL| 0| b\n")
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The standalone outputs must match the outputs of the source operator.  This wasn't the case.
That led to assertion errors or class-cast exceptions.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)