### PR TITLE
Migrate to junit5 / JUnitPlatform

### DIFF
--- a/blob/build.gradle
+++ b/blob/build.gradle
@@ -4,6 +4,7 @@ archivesBaseName = 'crate-blob'
 
 dependencies {
     implementation project(':es:es-server')
+    implementation project(':shared')
     implementation project(':common')
     implementation project(':http')
     implementation project(':es:es-transport')

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ allprojects {
     apply plugin: 'jacoco'
 
     tasks.withType(Test) {
+        useJUnitPlatform()
+
         // force run, see: http://gradle.1045684.n5.nabble.com/how-does-gradle-decide-when-to-run-tests-td3314172.html
         outputs.upToDateWhen { false }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,11 +4,16 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 archivesBaseName = 'crate-common'
 
 dependencies {
-    compile project(':shared')
+    implementation project(':shared')
     implementation project(':pgwire')
     implementation project(':es:es-server')
     implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
     testImplementation project(':integration-testing')
+    testImplementation("org.junit.jupiter:junit-jupiter:${versions.junit5}")
+    testImplementation("junit:junit:${versions.junit}")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 4 tests to run'
+    }
 }
 
 test {

--- a/dex/build.gradle
+++ b/dex/build.gradle
@@ -11,7 +11,11 @@ dependencies {
     implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
     implementation project(':shared')
 
+    testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
     testImplementation "junit:junit:${versions.junit}"
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
     testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
 }

--- a/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
+++ b/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
@@ -24,7 +24,6 @@ package io.crate.data;
 
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.FailingBatchIterator;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +35,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class BatchIteratorsTest {
 

--- a/es/build.gradle
+++ b/es/build.gradle
@@ -27,8 +27,4 @@ subprojects {
             setFailOnNoMatchingTests(false)
         }
     }
-
-    tasks.withType(Pmd) {
-        enabled = false
-    }
 }

--- a/es/es-testing/build.gradle
+++ b/es/es-testing/build.gradle
@@ -14,4 +14,9 @@ dependencies {
     implementation "commons-logging:commons-logging:${versions.commonslogging}"
     implementation "commons-codec:commons-codec:${versions.commonscodec}"
     implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+
+    implementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
+    runtimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -66,7 +66,6 @@ test {
     // by default `-D` arguments are "caught" in the gradle process
     // and not passed-through to the test process.
     // this enables test options like '-Dtests.iters=20'
-
     System.properties.each { k, v ->
         if (k.startsWith('tests.')) {
             systemProperty k, v

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -46,6 +46,7 @@ jna=4.2.2
 
 # ES test
 randomizedrunner=2.7.3
+junit5=5.6.0
 junit=4.12
 httpclient=4.5.2
 httpcore=4.4.5

--- a/pgwire/build.gradle
+++ b/pgwire/build.gradle
@@ -19,7 +19,11 @@ dependencies {
     implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
 
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
     testImplementation "junit:junit:${versions.junit}"
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jacksondatabind}"
 }
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,6 +4,10 @@ archivesBaseName = 'crate-shared'
 
 dependencies {
     implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
-    testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+    testImplementation("org.junit.jupiter:junit-jupiter:${versions.junit5}")
+    testImplementation("junit:junit:${versions.junit}")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 4 tests to run'
+    }
 }

--- a/sql-parser/build.gradle
+++ b/sql-parser/build.gradle
@@ -20,8 +20,12 @@ dependencies {
     compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
     compile "com.google.guava:guava:${versions.guava}"
 
-    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
-    testCompile "junit:junit:${versions.junit}"
+    testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
+    testImplementation "junit:junit:${versions.junit}"
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 task antlrOutputDir {


### PR DESCRIPTION
Adds junit5 and switches gradle to JUnitPlatform.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)