### PR TITLE
Allow using the system JDK  to compile code and execute tests.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,12 @@ task release(dependsOn: 'distTar') {
     }
 }
 
+task releaseZip(dependsOn: 'distZip') {
+    doLast {
+        logger.info("released version: " + project(':es:es-server').getVersion.version)
+    }
+}
+
 task nightly(dependsOn: 'distTar') {
     doLast {
         logger.info("nightly version: " + project(':es:es-server').getVersion.version)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import org.gradle.api.JavaVersion
-import io.crate.gradle.OS
 import io.crate.gradle.TestLogger;
 
 buildscript {
@@ -29,31 +28,8 @@ def download(File downloadDir, String url, String name) {
 }
 
 apply from: 'gradle/dependencies.gradle'
+apply from: 'gradle/jdkRuntime.gradle'
 apply plugin: 'base'
-apply plugin: 'jdk-download'
-
-def getJdkBundleOSFromPropertiesOrDefault = {
-    System.getProperty(
-        "bundled_jdk_os",
-        versions['bundled_jdk_os'] != null
-            ? "${versions['bundled_jdk_os']}"
-            : OS.current().name().toLowerCase())
-}
-
-def getJdkBundleArchFromPropertiesOrDefault = {
-    System.getProperty(
-        "bundled_jdk_arch",
-        versions['bundled_jdk_arch'] != null ? "${versions['bundled_jdk_arch']}" : "x64")
-}
-
-jdks {
-    runtime {
-        vendor = "${System.getProperty("bundled_jdk_vendor", versions['bundled_jdk_vendor'])}"
-        version = "${System.getProperty("bundled_jdk_version", versions['bundled_jdk_version'])}"
-        os = getJdkBundleOSFromPropertiesOrDefault()
-        arch = getJdkBundleArchFromPropertiesOrDefault()
-    }
-}
 
 repositories {
     mavenCentral()
@@ -67,24 +43,9 @@ if (runSlowTests) {
 allprojects {
     apply plugin: 'jacoco'
 
-    tasks.withType(JavaCompile) {
-        dependsOn rootProject.jdks.runtime
-        doFirst {
-            options.fork = true
-            options.forkOptions.javaHome = rootProject.jdks.runtime.getJavaHome()
-            options.forkOptions.executable = rootProject.jdks.runtime.getBinJavaPath()
-        }
-        sourceCompatibility = rootProject.jdks.runtime.major()
-        targetCompatibility = rootProject.jdks.runtime.major()
-        options.encoding = 'UTF-8'
-    }
-
     tasks.withType(Test) {
         // force run, see: http://gradle.1045684.n5.nabble.com/how-does-gradle-decide-when-to-run-tests-td3314172.html
         outputs.upToDateWhen { false }
-
-        dependsOn rootProject.jdks.runtime
-        executable = rootProject.jdks.runtime.getBinJavaPath()
 
         minHeapSize = "1024m"
         maxHeapSize = "1024m"

--- a/devs/docs/basics.rst
+++ b/devs/docs/basics.rst
@@ -6,9 +6,9 @@ Prerequisites
 =============
 
 CrateDB is written in Java_ and includes pre-configured bundled version of
-OpenJDK_ in its build. Nevertheless, to develop CrateDB you'd still have to
-install Java_ to run Gradle_ build tool. Some of the tools that are used for
-documentation building, tests, etc. require Python_. To set up you minimal
+OpenJDK_ in its build. Nevertheless, to develop CrateDB, you'd still have to
+install Java_ to run the Gradle_ build tool. Some of the tools that are used
+for documentation building, tests, etc. require Python_. To set up you minimal
 development environment, you'll need:
 
  - Java_ (>= 11)
@@ -27,7 +27,7 @@ Manual Build
 
 This project uses Gradle_ as build tool.
 
-The most convenient way to  build and run CrateDB while you are working on the
+The most convenient way to build and run CrateDB while you are working on the
 code is to do so directly from within your IDE. See the section on IDE
 integration later in this document. However, if you want to, you can work with
 Gradle directly.
@@ -74,14 +74,37 @@ To get a full list of all available tasks, run::
 
     $ ./gradlew tasks
 
-Such as CrateDB uses the pre-configured bundled version of OpenJDK_, it is
-possible to run, compile, and test CrateDB by configuring the target JDK.
-For instance::
+By default, CrateDB uses the pre-configured bundled version of OpenJDK_. It
+is also possible to run, compile, and test CrateDB by configuring the target
+JDK. For instance::
 
     $ ./gradlew distTar -Dbundled_jdk_os=linux \
                         -Dbundled_jdk_arch=aarch64 \
                         -Dbundled_jdk_vendor=adoptopenjdk \
                         -Dbundled_jdk_version=13.0.2+8
+
+It is possible to compile the code base and run tests with the host system JDK.
+To achieve that, pass the ``-DuseSystemJdk`` system parameter along with a
+Gradle task. For example, to run unit tests with the host system JDK, execute
+the following command::
+
+    $ ./gradlew test -DuseSystemJdk
+
+All the tasks related to packaging and releasing (``distTar``, ``release``) or
+tasks that depend on them (``itest``) will ignore the ``-DuseSystemJdk``
+parameter. This means that the compilation and test execution can be
+done with the system JDK, but releasing and packaging will still use the
+bundled JDK. The ``-DuseSystemJdk`` is useful for doing releases and
+cross-platform builds. For instance, you can build a CrateDB package for
+Windows with the corresponding to the platform bundled JDK on a Linux
+machine::
+
+    $ ./gradlew distZip \
+                -Dbundled_jdk_os=windows \
+                -Dbundled_jdk_arch=x64 \
+                -Dbundled_jdk_vendor=adoptopenjdk \
+                -Dbundled_jdk_version=13.0.2+8 \
+                -DuseSystemJdk
 
 Currently, we support the following ``JDK`` operation systems and
 architectures:

--- a/es/build.gradle
+++ b/es/build.gradle
@@ -13,20 +13,12 @@ subprojects {
     }
 
     compileJava {
-        dependsOn rootProject.jdks.runtime
-        doFirst {
-            options.fork = true
-            options.forkOptions.javaHome = rootProject.jdks.runtime.getJavaHome()
-            options.forkOptions.executable = rootProject.jdks.runtime.getBinJavaPath()
-        }
         options.warnings = false
         options.deprecation = false
         options.compilerArgs << '-XDignore.symbol.file'
     }
 
     test {
-        dependsOn rootProject.jdks.runtime
-        executable = rootProject.jdks.runtime.getBinJavaPath()
         jacoco {
             enabled = false
         }

--- a/es/es-server/build.gradle
+++ b/es/es-server/build.gradle
@@ -50,7 +50,9 @@ task getVersion(dependsOn: 'classes') {
     doLast {
         def stdout = new ByteArrayOutputStream()
         javaexec {
-            executable = rootProject.jdks.runtime.getBinJavaPath()
+            if (System.getProperty('useSystemJdk') == null) {
+                executable = rootProject.jdks.runtime.getBinJavaPath()
+            }
             classpath = sourceSets.main.runtimeClasspath
             main = 'org.elasticsearch.Version'
             standardOutput = stdout

--- a/gradle/jdkRuntime.gradle
+++ b/gradle/jdkRuntime.gradle
@@ -1,0 +1,50 @@
+import io.crate.gradle.OS
+
+apply plugin: 'jdk-download'
+
+def getJdkBundleOSFromPropertiesOrDefault = {
+    System.getProperty(
+        "bundled_jdk_os",
+        versions['bundled_jdk_os'] != null
+            ? "${versions['bundled_jdk_os']}"
+            : OS.current().name().toLowerCase())
+}
+
+def getJdkBundleArchFromPropertiesOrDefault = {
+    System.getProperty(
+        "bundled_jdk_arch",
+        versions['bundled_jdk_arch'] != null ? "${versions['bundled_jdk_arch']}" : "x64")
+}
+
+jdks {
+    runtime {
+        vendor = "${System.getProperty("bundled_jdk_vendor", versions['bundled_jdk_vendor'])}"
+        version = "${System.getProperty("bundled_jdk_version", versions['bundled_jdk_version'])}"
+        os = getJdkBundleOSFromPropertiesOrDefault()
+        arch = getJdkBundleArchFromPropertiesOrDefault()
+    }
+}
+
+allprojects {
+    tasks.withType(JavaCompile) {
+        dependsOn rootProject.jdks.runtime
+        doFirst {
+            if (System.getProperty('useSystemJdk') == null) {
+                options.fork = true
+                options.forkOptions.javaHome = rootProject.jdks.runtime.getJavaHome()
+                options.forkOptions.executable = rootProject.jdks.runtime.getBinJavaPath()
+            }
+        }
+        sourceCompatibility = rootProject.jdks.runtime.major()
+        targetCompatibility = rootProject.jdks.runtime.major()
+        options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Test) {
+        dependsOn rootProject.jdks.runtime
+        if (System.getProperty('useSystemJdk') == null) {
+            test.dependsOn rootProject.jdks.runtime
+            test.executable = rootProject.jdks.runtime.getBinJavaPath()
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

By default, the bundled JDK is used to compile code and run tests.
The new system parameter makes Gradle run its compile and test
tasks with the host system JDK.

Related to https://github.com/crate/crate/issues/9754

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
