### PR TITLE
Use small block size if table stats are not available

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -77,7 +77,12 @@ public class HashJoinOperation implements CompletionListenable {
                             getHashBuilderFromSymbols(txnCtx, inputFactory, joinLeftInputs),
                             getHashBuilderFromSymbols(txnCtx, inputFactory, joinRightInputs),
                             rowAccounting,
-                            new RamBlockSizeCalculator(Paging.PAGE_SIZE, circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
+                            new RamBlockSizeCalculator(
+                                Paging.PAGE_SIZE,
+                                circuitBreaker,
+                                estimatedRowSizeForLeft,
+                                numberOfRowsForLeft
+                            )
                         );
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {

--- a/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -158,7 +158,11 @@ public class NestedLoopOperation implements CompletionListenable {
                                                                   boolean blockNestedLoop) {
         if (blockNestedLoop) {
             IntSupplier blockSizeCalculator = new RamBlockSizeCalculator(
-                Paging.PAGE_SIZE, circuitBreaker, estimatedRowsSizeLeft, estimatedNumberOfRowsLeft);
+                Paging.PAGE_SIZE,
+                circuitBreaker,
+                estimatedRowsSizeLeft,
+                estimatedNumberOfRowsLeft
+            );
             RowAccountingWithEstimators rowAccounting = new RowAccountingWithEstimators(leftSideColumnTypes, ramAccounting);
             return JoinBatchIterators.crossJoinBlockNL(left, right, combiner, blockSizeCalculator, rowAccounting);
         } else {

--- a/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
@@ -31,15 +31,17 @@ import java.util.function.IntSupplier;
  */
 public class RamBlockSizeCalculator implements IntSupplier {
 
+    public static final int FALLBACK_SIZE = 500;
+
     private final int defaultBlockSize;
     private final CircuitBreaker circuitBreaker;
     private final long estimatedRowSizeForLeft;
     private final long numberOfRowsForLeft;
 
     public RamBlockSizeCalculator(int defaultBlockSize,
-                           CircuitBreaker circuitBreaker,
-                           long estimatedRowSizeForLeft,
-                           long numberOfRowsForLeft) {
+                                  CircuitBreaker circuitBreaker,
+                                  long estimatedRowSizeForLeft,
+                                  long numberOfRowsForLeft) {
         this.defaultBlockSize = defaultBlockSize;
         this.circuitBreaker = circuitBreaker;
         this.estimatedRowSizeForLeft = estimatedRowSizeForLeft;
@@ -49,7 +51,7 @@ public class RamBlockSizeCalculator implements IntSupplier {
     @Override
     public int getAsInt() {
         if (statisticsUnavailable(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)) {
-            return defaultBlockSize;
+            return FALLBACK_SIZE;
         }
         long availableMemory = circuitBreaker.getLimit() - circuitBreaker.getUsed();
         long numRowsFittingIntoAvailableMemory = availableMemory / estimatedRowSizeForLeft;

--- a/sql/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
@@ -39,32 +39,62 @@ public class RamBlockSizeCalculatorTest {
     public void testCalculationOfBlockSize() {
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
-        RamBlockSizeCalculator blockCalculator100leftRows = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 5, 100);
+        RamBlockSizeCalculator blockCalculator100leftRows = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            5,
+            100
+        );
         assertThat(blockCalculator100leftRows.getAsInt(), is(20));
-        RamBlockSizeCalculator blockCalculator10LeftRows = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 5, 10);
+        RamBlockSizeCalculator blockCalculator10LeftRows = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            5,
+            10
+        );
         assertThat(blockCalculator10LeftRows.getAsInt(), is(10));
     }
 
     @Test
     public void testCalculationOfBlockSizeWithMissingStats() {
         when(circuitBreaker.getLimit()).thenReturn(-1L);
-        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 10, 10);
-        assertThat(blockSizeCalculator.getAsInt(), is(defaultBlockSize));
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            10,
+            10
+        );
+        assertThat(blockSizeCalculator.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
 
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
-        RamBlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 10, -1);
-        assertThat(blockCalculatorNoNumberOrRowsStats.getAsInt(), is(defaultBlockSize));
+        RamBlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            10,
+            -1
+        );
+        assertThat(blockCalculatorNoNumberOrRowsStats.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
 
-        RamBlockSizeCalculator blockCalculatorNoRowSizeStats = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, -1, 10);
-        assertThat(blockCalculatorNoRowSizeStats.getAsInt(), is(defaultBlockSize));
+        RamBlockSizeCalculator blockCalculatorNoRowSizeStats = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            -1,
+            10
+        );
+        assertThat(blockCalculatorNoRowSizeStats.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
     }
 
     @Test
     public void testCalculationOfBlockSizeWithNoMemLeft() {
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(110L);
-        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 10, 10);
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            10,
+            10
+        );
         assertThat(blockSizeCalculator.getAsInt(), is(10));
     }
 
@@ -72,7 +102,12 @@ public class RamBlockSizeCalculatorTest {
     public void testCalculationOfBlockSizeWithIntegerOverflow() {
         when(circuitBreaker.getLimit()).thenReturn(Integer.MAX_VALUE + 1L);
         when(circuitBreaker.getUsed()).thenReturn(0L);
-        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 1, 1);
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            1,
+            1
+        );
         assertThat(blockSizeCalculator.getAsInt(), is(1));
     }
 
@@ -80,7 +115,12 @@ public class RamBlockSizeCalculatorTest {
     public void testBlockSizeIsNotGreaterThanPageSize() {
         when(circuitBreaker.getLimit()).thenReturn(defaultBlockSize * 2L);
         when(circuitBreaker.getUsed()).thenReturn(0L);
-        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(defaultBlockSize, circuitBreaker, 1, defaultBlockSize * 2L);
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
+            defaultBlockSize,
+            circuitBreaker,
+            1,
+            defaultBlockSize * 2L
+        );
         assertThat(blockSizeCalculator.getAsInt(), is(defaultBlockSize));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -977,7 +977,12 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             tableStats.updateTableStats(newStats);
         }
 
-        RamBlockSizeCalculator ramBlockSizeCalculator = new RamBlockSizeCalculator(500_000, circuitBreaker, rowSizeBytes, rowsCount);
+        RamBlockSizeCalculator ramBlockSizeCalculator = new RamBlockSizeCalculator(
+            500_000,
+            circuitBreaker,
+            rowSizeBytes,
+            rowsCount
+        );
         logger.info("\n\tThe block size for relation {}, total size {} bytes, with row count {} and row size {} bytes, " +
                     "if it would be used in a block join algorithm, would be {}",
             relationName, tableSizeInBytes, rowsCount, rowSizeBytes, ramBlockSizeCalculator.getAsInt());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For system tables there are no table stats. This caused the hash join
operation to default to 500_000 as block size, which is way too much for
small tables. A lot of time is then spent creating hash tables which
caused a couple of joins on system tables to take several seconds.

This adds a much smaller fallback block size.

`test_select_from_virtual_table_with_window_function_and_column_pruning`
ran into timeouts because of this.

Real fix would be to provide stats for system tables, but I think lowering the fallback size also doesn't hurt.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)