### PR TITLE
Revert "Update minimum wire compat version to 4.1"

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/Version.java
+++ b/es/es-server/src/main/java/org/elasticsearch/Version.java
@@ -336,21 +336,14 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     }
 
     /**
-     * The minimum version other nodes need to have to communicate with this node.
-     *
-     * We support rolling upgrades between successive versions.
-     * So:
-     *
-     * <pre>
-     *  current | min support
-     *      4.1 |         4.0
-     *      4.2 |         4.1
-     *      ...
-     *      5.0 |         4.x where x is the last within 4.
-     * </pre>
+     * Returns the minimum compatible version based on the current
+     * version. Ie a node needs to have at least the return version in order
+     * to communicate with a node running the current version. The returned version
+     * is in most of the cases the smallest major version release unless the current version
+     * is a beta or RC release then the version itself is returned.
      */
     public Version minimumCompatibilityVersion() {
-        return V_4_1_0;
+        return V_4_0_0;
     }
 
     /**

--- a/es/es-server/src/test/java/org/elasticsearch/VersionTest.java
+++ b/es/es-server/src/test/java/org/elasticsearch/VersionTest.java
@@ -30,13 +30,13 @@ import static org.junit.Assert.assertThat;
 public class VersionTest {
 
     @Test
-    public void test_compatible_current_version_is_compatible_to_4_1_0() {
-        assertThat(Version.CURRENT.isCompatible(Version.V_4_1_0), is(true));
+    public void test_compatible_current_version_is_compatible_to_4_0_0() {
+        assertThat(Version.CURRENT.isCompatible(Version.V_4_0_0), is(true));
     }
 
     @Test
-    public void test_min_version_is_4_1_0() {
-        assertThat(Version.CURRENT.minimumCompatibilityVersion(), is(Version.V_4_1_0));
+    public void test_min_version_is_4_0_0() {
+        assertThat(Version.CURRENT.minimumCompatibilityVersion(), is(Version.V_4_0_0));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit 06f8f2e1acf0c60ac839bd2427a31d91043fcbaf.

It broke the rolling upgrade tests because nodes use their
`minimumCompatbilityVersion` initially in the handshake. See

https://github.com/crate/crate/blob/master/es/es-server/src/main/java/org/elasticsearch/transport/TcpTransport.java#L1384

So a 4.1 node sends 4.0 as version.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)