### PR TITLE
Fix exact matches of function signatures

### DIFF
--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -23,40 +23,30 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.expression.symbol.FuncArg;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionResolver;
-import io.crate.metadata.functions.params.FuncParams;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
-import java.util.List;
+import static io.crate.metadata.functions.Signature.scalar;
 
 public final class AbsFunction {
 
     public static final String NAME = "abs";
 
     public static void register(ScalarFunctionModule module) {
-        module.register(NAME, new Resolver());
-    }
-
-    private static class Resolver implements FunctionResolver {
-
-        @Override
-        public FunctionImplementation getForTypes(List<DataType> argTypes) throws IllegalArgumentException {
-            DataType argType = argTypes.get(0);
-            return new UnaryScalar<>(
-                NAME,
-                argType,
-                argType,
-                x -> argType.value(Math.abs(((Number) x).doubleValue()))
+        for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            var typeSignature = type.getTypeSignature();
+            module.register(
+                scalar(NAME, typeSignature, typeSignature),
+                args -> {
+                    DataType<?> argType = args.get(0);
+                    return new UnaryScalar<>(
+                        NAME,
+                        argType,
+                        argType,
+                        x -> argType.value(Math.abs(((Number) x).doubleValue()))
+                    );
+                }
             );
-        }
-
-        @Nullable
-        @Override
-        public List<DataType> getSignature(List<? extends FuncArg> symbols) {
-            return FuncParams.SINGLE_NUMERIC.match(symbols);
         }
     }
 }

--- a/sql/src/main/java/io/crate/metadata/FuncResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FuncResolver.java
@@ -47,4 +47,9 @@ public class FuncResolver implements Function<List<DataType>, FunctionImplementa
     public FunctionImplementation apply(List<DataType> dataTypes) {
         return factory.apply(dataTypes);
     }
+
+    @Override
+    public String toString() {
+        return "FuncResolver{" + "signature=" + signature + '}';
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/sql/src/main/java/io/crate/metadata/functions/Signature.java
@@ -27,10 +27,38 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.types.TypeSignature;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public final class Signature {
+
+    /**
+     * See {@link #scalar(FunctionName, TypeSignature...)}
+     */
+    public static Signature scalar(String name, TypeSignature... types) {
+        return scalar(new FunctionName(null, name), types);
+    }
+
+    /**
+     * Shortcut for creating a signature of type {@link FunctionInfo.Type#SCALAR}.
+     * The last element of the given types is handled as the return type.
+     *
+     * @param name      The fqn function name.
+     * @param types     The argument and return (last element) types
+     * @return          The created signature
+     */
+    public static Signature scalar(FunctionName name, TypeSignature... types) {
+        assert types.length > 0 : "Types must contain at least the return type (last element), 0 types given";
+        Builder builder = Signature.builder()
+            .name(name)
+            .kind(FunctionInfo.Type.SCALAR)
+            .returnType(types[types.length - 1]);
+        if (types.length > 1) {
+            builder.argumentTypes(Arrays.copyOf(types, types.length - 1));
+        }
+        return builder.build();
+    }
 
     public static Builder builder() {
         return new Builder();

--- a/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -123,8 +123,8 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidTimestamp() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'NO TIMESTAMP'` of type `text` to type `timestamp with time zone`");
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Text 'NO TIMESTAMP' could not be parsed");
         assertEvaluate("date_format('%d.%m.%Y', 'NO TIMESTAMP')", null);
     }
 


### PR DESCRIPTION
In order to support correct function signature overloading, signature
matching must be done in 3 steps:
 1) try exact candidates (no type variables, no coercion allowed)
 2) try generic candidates (with type variables, no coercion allowed)
 3) try all candidates with allowed coercion

Follow up of 507cf5d7320b6d2cb29290fd72a0b7076a8c4842