### PR TITLE
Use column stats to derive size of a row in collect operator

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -78,7 +78,7 @@ public class Collect implements LogicalPlan {
     final AbstractTableRelation<?> relation;
     private final boolean preferSourceLookup;
     private final List<Symbol> outputs;
-    private final List<AbstractTableRelation> baseTables;
+    private final List<AbstractTableRelation<?>> baseTables;
     final TableInfo tableInfo;
     private final long numExpectedRows;
     private final long estimatedRowSize;
@@ -266,7 +266,7 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return baseTables;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -98,7 +98,7 @@ public class Collect implements LogicalPlan {
             toCollect,
             where,
             SelectivityFunctions.estimateNumRows(stats, where.queryOrFallback(), params),
-            stats.averageSizePerRowInBytes()
+            stats.estimateSizeForColumns(toCollect)
         );
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -125,7 +125,7 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return List.of(tableRelation);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -61,7 +61,7 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return source.baseTables();
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -151,7 +151,7 @@ public class Get implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return List.of(tableRelation);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -214,7 +214,7 @@ public class HashJoin implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return Lists2.concat(lhs.baseTables(), rhs.baseTables());
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -99,7 +99,7 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return Collections.emptyList();
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -769,7 +769,7 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -109,7 +109,7 @@ public interface LogicalPlan extends Plan {
         return false;
     }
 
-    List<AbstractTableRelation> baseTables();
+    List<AbstractTableRelation<?>> baseTables();
 
     List<LogicalPlan> sources();
 

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -70,7 +70,7 @@ public class NestedLoopJoin implements LogicalPlan {
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final List<Symbol> outputs;
-    private final List<AbstractTableRelation> baseTables;
+    private final List<AbstractTableRelation<?>> baseTables;
     private final Map<LogicalPlan, SelectSymbol> dependencies;
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
@@ -232,7 +232,7 @@ public class NestedLoopJoin implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return baseTables;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/sql/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -115,7 +115,7 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -135,7 +135,7 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public List<AbstractTableRelation> baseTables() {
+    public List<AbstractTableRelation<?>> baseTables() {
         return Lists2.concat(lhs.baseTables(), rhs.baseTables());
     }
 

--- a/sql/src/main/java/io/crate/statistics/MostCommonValues.java
+++ b/sql/src/main/java/io/crate/statistics/MostCommonValues.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public final class MostCommonValues {
 
-    static final MostCommonValues EMPTY = new MostCommonValues(new Object[0], new double[0]);
+    public static final MostCommonValues EMPTY = new MostCommonValues(new Object[0], new double[0]);
     static final int MCV_TARGET = 100;
 
     private final Object[] values;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)