### PR TITLE
Enable query-then-fetch for more cases

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
@@ -21,22 +21,12 @@
 
 package io.crate.execution.dsl.projection;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.monitor.jvm.JvmInfo;
-
 import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Paging;
@@ -47,6 +37,14 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.fetch.FetchSource;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class FetchProjection extends Projection {
 
@@ -126,14 +124,6 @@ public class FetchProjection extends Projection {
 
     public Map<String, IntSet> nodeReaders() {
         return nodeReaders;
-    }
-
-    public TreeMap<Integer, String> readerIndices() {
-        return readerIndices;
-    }
-
-    public Map<String, RelationName> indicesToIdents() {
-        return indicesToIdents;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/symbol/FetchMarker.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FetchMarker.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.expression.symbol.format.Style;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.types.DataType;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+public final class FetchMarker extends Symbol {
+
+    private final RelationName relationName;
+    private final List<Reference> fetchRefs;
+    private final Reference fetchId;
+
+    public FetchMarker(RelationName relationName, List<Reference> fetchRefs) {
+        this.relationName = relationName;
+        this.fetchRefs = fetchRefs;
+        this.fetchId = DocSysColumns.forTable(relationName, DocSysColumns.FETCHID);
+    }
+
+    public List<Reference> fetchRefs() {
+        return fetchRefs;
+    }
+
+    public RelationName relationName() {
+        return relationName;
+    }
+
+    @Override
+    public SymbolType symbolType() {
+        return SymbolType.REFERENCE;
+    }
+
+    @Override
+    public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
+        return visitor.visitReference(fetchId, context);
+    }
+
+    @Override
+    public DataType<?> valueType() {
+        return fetchId.valueType();
+    }
+
+    @Override
+    public String toString(Style style) {
+        return fetchId.toString(style);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        fetchId.writeTo(out);
+    }
+}

--- a/sql/src/main/java/io/crate/expression/symbol/SymbolType.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SymbolType.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 public enum SymbolType {
@@ -54,7 +55,10 @@ public enum SymbolType {
         throw new UnsupportedOperationException("SelectSymbol is not streamable");
     }),
     // Added in 4.2
-    ALIAS(AliasSymbol::new);
+    ALIAS(AliasSymbol::new),
+    FETCH_STUB(in -> {
+        throw new UnsupportedEncodingException("FetchStub is not streamable");
+    });
 
     public static final List<SymbolType> VALUES = ImmutableList.copyOf(values());
 

--- a/sql/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
@@ -81,5 +81,13 @@ public class SymbolVisitor<C, R> {
     public R visitAlias(AliasSymbol aliasSymbol, C context) {
         return visitSymbol(aliasSymbol, context);
     }
+
+    public R visitFetchMarker(FetchMarker fetchMarker, C context) {
+        return fetchMarker.fetchId().accept(this, context);
+    }
+
+    public R visitFetchStub(FetchStub fetchStub, C context) {
+        return visitSymbol(fetchStub, context);
+    }
 }
 

--- a/sql/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/sql/src/main/java/io/crate/planner/operators/Fetch.java
@@ -48,6 +48,35 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * <p>
+ *   The fetch operator represents a 2 phase execution that is used to reduce value look-ups.
+ * </p>
+ *
+ * For example:
+ *
+ * <pre>
+ *     Limit[10]
+ *      └ OrderBy [a]
+ *        └ Collect [a, b, c]
+ * </pre>
+ *
+ * Would fetch the values for all columns ([a, b, c]) {@code 10 * num_nodes} times.
+ * With the fetch operator:
+ *
+ * <pre>
+ *     Fetch [a, b, c]
+ *      └ Limit [10]
+ *        └ OrderBy [a]
+ *          └ Collect [_fetchid, a]
+ * </pre>
+ *
+ * In a first phase we can fetch the values for [_fetchid, a],
+ * then do a sorted merge to apply the limit of 10, and afterwards fetch the values [b, c] for the remaining 10 _fetchids.
+ *
+ * Note: Fetch always requires a merge to the coordinator node.
+ * That's why it is best used after a `Limit`, because a `Limit` requires a merge as well.
+ */
 public final class Fetch extends ForwardingLogicalPlan {
 
     private final List<Symbol> outputs;

--- a/sql/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/sql/src/main/java/io/crate/planner/operators/Fetch.java
@@ -27,10 +27,8 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.FetchPhase;
 import io.crate.execution.dsl.projection.FetchProjection;
+import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
-import io.crate.expression.symbol.FetchReference;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -40,7 +38,6 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ReaderAllocations;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.fetch.FetchSource;
-import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -82,13 +79,15 @@ public final class Fetch extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
     private final List<Reference> fetchRefs;
     private final Map<RelationName, FetchSource> fetchSourceByRelation;
+    private final Map<Symbol, Symbol> replacedOutputs;
 
-    public Fetch(List<Symbol> outputs,
+    public Fetch(Map<Symbol, Symbol> replacedOutputs,
                  List<Reference> fetchRefs,
                  Map<RelationName, FetchSource> fetchSourceByRelation,
                  LogicalPlan source) {
         super(source);
-        this.outputs = outputs;
+        this.outputs = List.copyOf(replacedOutputs.keySet());
+        this.replacedOutputs = replacedOutputs;
         this.fetchRefs = fetchRefs;
         this.fetchSourceByRelation = fetchSourceByRelation;
     }
@@ -125,18 +124,7 @@ public final class Fetch extends ForwardingLogicalPlan {
             ),
             plannerContext
         );
-        Function<Symbol, Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults)
-            .andThen(s -> {
-                int idx = source.outputs().indexOf(s);
-                if (idx >= 0) {
-                    return new InputColumn(idx, source.outputs().get(idx).valueType());
-                }
-                return RefReplacer.replaceRefs(
-                    s,
-                    ref -> new FetchReference(new InputColumn(0, DataTypes.LONG), ref)
-                );
-            });
-        List<Symbol> boundOutputs = Lists2.map(outputs, paramBinder);
+        Function<Symbol, Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
         FetchPhase fetchPhase = new FetchPhase(
             plannerContext.nextExecutionPhaseId(),
@@ -145,11 +133,13 @@ public final class Fetch extends ForwardingLogicalPlan {
             readerAllocations.tableIndices(),
             fetchRefs
         );
+        List<Symbol> boundOutputs = Lists2.map(replacedOutputs.values(), paramBinder);
+        List<Symbol> fetchOutputs = InputColumns.create(boundOutputs, new InputColumns.SourceSymbols(source.outputs()));
         FetchProjection fetchProjection = new FetchProjection(
             fetchPhase.phaseId(),
             plannerContext.fetchSize(),
             fetchSourceByRelation,
-            boundOutputs,
+            fetchOutputs,
             readerAllocations.nodeReaders(),
             readerAllocations.indices(),
             readerAllocations.indicesToIdents()
@@ -160,7 +150,7 @@ public final class Fetch extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Fetch(outputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
+        return new Fetch(replacedOutputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchRewrite.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchRewrite.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.expression.symbol.FetchMarker;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.planner.node.fetch.FetchSource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class FetchRewrite {
+
+    private final LogicalPlan plan;
+
+    public FetchRewrite(LogicalPlan plan) {
+        this.plan = plan;
+    }
+
+    public LogicalPlan newPlan() {
+        return plan;
+    }
+
+    public List<Reference> extractFetchRefs() {
+        ArrayList<Reference> allFetchReferences = new ArrayList<>();
+        for (Symbol output : plan.outputs()) {
+            if (output instanceof FetchMarker) {
+                allFetchReferences.addAll(((FetchMarker) output).fetchRefs());
+            }
+        }
+        return allFetchReferences;
+    }
+
+    public Map<RelationName, FetchSource> createFetchSources() {
+        HashMap<RelationName, FetchSource> fetchSources = new HashMap<>();
+        List<Symbol> outputs = plan.outputs();
+        for (int i = 0; i < outputs.size(); i++) {
+            Symbol output = outputs.get(i);
+            if (output instanceof FetchMarker) {
+                FetchMarker fetchMarker = (FetchMarker) output;
+                FetchSource fetchSource = new FetchSource();
+                fetchSource.addFetchIdColumn(new InputColumn(i, fetchMarker.valueType()));
+                for (Reference fetchRef : fetchMarker.fetchRefs()) {
+                    fetchSource.addRefToFetch(fetchRef);
+                }
+                fetchSources.put(fetchMarker.relationName(), fetchSource);
+            }
+        }
+        return fetchSources;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -149,6 +149,11 @@ public interface LogicalPlan extends Plan {
      */
     LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep);
 
+    @Nullable
+    default FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+        return null;
+    }
+
     /**
      * SubQueries that this plan depends on to be able to execute it.
      *

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -149,6 +149,40 @@ public interface LogicalPlan extends Plan {
      */
     LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep);
 
+    /**
+     * Rewrite an operator and its children to utilize a "query-then-fetch" approach.
+     * See {@link Fetch} for an explanation of query-then-fetch.
+     * <pre>
+     * This must propagate if possible. Example:
+     *
+     *     Limit[10]            // calls source.rewriteToFetch
+     *      └ Order [a ASC]     // should call source.rewriteToFetch
+     *        └ Collect [x, a, b]
+     *
+     * This results in:
+     *
+     *      Fetch[x, a, b]
+     *       └ Limit[10]
+     *         └ Order [a ASC]
+     *           └ Collect [_fetchid, a]
+     *
+     * Note that propagation only needs to happen if all operators can forward the `_fetchid`. Consider the following:
+     *
+     *      Limit[10]
+     *        └ HashAggregate[min(x), min(y)]
+     *          └ Limit[5]
+     *            └ Collect [x, y]
+     *
+     * In this case a call on `HashAggregate.rewriteToFetch` can return `null` to indicate that there is nothing to fetch,
+     * because `HashAggregate` needs all columns to produce its result.
+     * It is *NOT* responsible to insert a `Fetch` below itself.
+     * </pre>
+     *
+     * @param usedColumns The columns that the ancestor operators use intermediately to produce their result.
+     *                    For example, a `Filter (x > 10)` uses `x > 10`, a `Order [a ASC]` uses `a`.
+     *                    An operator that uses *all* of its sources outputs to produce a result should return `null`
+     *                    to indicate that there is no reason to use query-then-fetch.
+     */
     @Nullable
     default FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
         return null;

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -281,6 +282,44 @@ public class NestedLoopJoin implements LogicalPlan {
             topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone
+        );
+    }
+
+    @Nullable
+    @Override
+    public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+        ArrayList<Symbol> usedFromLeft = new ArrayList<>();
+        ArrayList<Symbol> usedFromRight = new ArrayList<>();
+        for (Symbol usedColumn : usedColumns) {
+            SymbolVisitors.intersection(usedColumn, lhs.outputs(), usedFromLeft::add);
+            SymbolVisitors.intersection(usedColumn, rhs.outputs(), usedFromRight::add);
+        }
+        if (joinCondition != null) {
+            SymbolVisitors.intersection(joinCondition, lhs.outputs(), usedFromLeft::add);
+            SymbolVisitors.intersection(joinCondition, rhs.outputs(), usedFromRight::add);
+        }
+        FetchRewrite lhsFetchRewrite = lhs.rewriteToFetch(usedFromLeft);
+        if (lhsFetchRewrite == null) {
+            return null;
+        }
+        FetchRewrite rhsFetchRewrite = rhs.rewriteToFetch(usedFromRight);
+        if (rhsFetchRewrite == null) {
+            return null;
+        }
+        LinkedHashMap<Symbol, Symbol> allReplacedOutputs = new LinkedHashMap<>(lhsFetchRewrite.replacedOutputs());
+        allReplacedOutputs.putAll(rhsFetchRewrite.replacedOutputs());
+        return new FetchRewrite(
+            allReplacedOutputs,
+            new NestedLoopJoin(
+                lhsFetchRewrite.newPlan(),
+                rhsFetchRewrite.newPlan(),
+                joinType,
+                joinCondition,
+                isFiltered,
+                topMostLeftRelation,
+                orderByWasPushedDown,
+                rewriteFilterOnOuterJoinToInnerJoinDone
+            )
         );
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -29,6 +29,8 @@ import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.FieldsVisitor;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
@@ -41,8 +43,10 @@ import io.crate.planner.PositionalOrderBy;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class Order extends ForwardingLogicalPlan {
@@ -93,7 +97,39 @@ public class Order extends ForwardingLogicalPlan {
         if (fetchRewrite == null) {
             return null;
         }
-        return new FetchRewrite(replaceSources(List.of(fetchRewrite.newPlan())));
+        LogicalPlan newSource = fetchRewrite.newPlan();
+        Order newOrderBy = new Order(newSource, orderBy);
+        Map<Symbol, Symbol> replacedOutputs = fetchRewrite.replacedOutputs();
+        if (newOrderBy.outputs.size() > newSource.outputs().size()) {
+            // This is the case if the `orderBy` contains computations on top of the source outputs.
+            // e.g. OrderBy [x + y] where the source provides [x, y]
+            // We need to extend replacedOutputs in this case because it must always contain entries for all outputs
+            LinkedHashMap<Symbol, Symbol> newReplacedOutputs = new LinkedHashMap<>(replacedOutputs);
+            FunctionCopyVisitor<Void> mapToFetchStubs = new FunctionCopyVisitor<>() {
+
+                @Override
+                protected Symbol visitSymbol(Symbol symbol, Void context) {
+                    return replacedOutputs.getOrDefault(symbol, symbol);
+                }
+
+                @Override
+                public Symbol visitFunction(Function func, Void context) {
+                    Symbol mappedFunc = replacedOutputs.get(func);
+                    if (mappedFunc == null) {
+                        return processAndMaybeCopy(func, context);
+                    } else {
+                        return mappedFunc;
+                    }
+                }
+            };
+            for (int i = newSource.outputs().size(); i < newOrderBy.outputs.size(); i++) {
+                Symbol extraOutput = newOrderBy.outputs.get(i);
+                newReplacedOutputs.put(extraOutput, extraOutput.accept(mapToFetchStubs, null));
+            }
+            return new FetchRewrite(newReplacedOutputs, newOrderBy);
+        } else {
+            return new FetchRewrite(replacedOutputs, newOrderBy);
+        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -71,7 +71,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
         List<Reference> fetchRefs = fetchRewrite.extractFetchRefs();
         Map<RelationName, FetchSource> fetchSourceByRelation = fetchRewrite.createFetchSources();
         return new Fetch(
-            limit.outputs(),
+            fetchRewrite.replacedOutputs(),
             fetchRefs,
             fetchSourceByRelation,
             limit.replaceSources(List.of(fetchRewrite.newPlan()))

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -22,48 +22,33 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import io.crate.analyze.relations.DocTableRelation;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.RefVisitor;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.planner.node.fetch.FetchSource;
-import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Fetch;
+import io.crate.planner.operators.FetchRewrite;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
-import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
-import io.crate.types.DataTypes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 public final class RewriteToQueryThenFetch implements Rule<Limit> {
 
-    private final Capture<Collect> collectCapture;
     private final Pattern<Limit> pattern;
 
     public RewriteToQueryThenFetch() {
-        this.collectCapture = new Capture<>();
-        this.pattern = typeOf(Limit.class)
-            .with(
-                source(),
-                typeOf(Collect.class)
-                    .with(c -> c.relation() instanceof DocTableRelation)
-                    .capturedAs(collectCapture)
-            );
+        this.pattern = typeOf(Limit.class);
     }
 
     @Override
@@ -76,45 +61,20 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx) {
-        Collect collect = captures.get(collectCapture);
-        DocTableRelation relation = (DocTableRelation) collect.relation();
-        Reference fetchRef = DocSysColumns.forTable(relation.relationName(), DocSysColumns.FETCHID);
-        if (collect.outputs().contains(fetchRef)) {
+        if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
-        ArrayList<Symbol> newOutputs = new ArrayList<>();
-        FetchSource fetchSource = new FetchSource();
-        ArrayList<Reference> allFetchRefs = new ArrayList<>();
-        for (Symbol output : collect.outputs()) {
-            if (Symbols.containsColumn(output, DocSysColumns.SCORE)) {
-                newOutputs.add(output);
-            } else if (!SymbolVisitors.any(Symbols.IS_COLUMN, output)) {
-                newOutputs.add(output);
-            } else {
-                RefVisitor.visitRefs(output, ref -> {
-                    fetchSource.addRefToFetch(ref);
-                    allFetchRefs.add(ref);
-                });
-            }
-        }
-        if (newOutputs.size() == collect.outputs().size()) {
+        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(Set.of());
+        if (fetchRewrite == null) {
             return null;
         }
-        newOutputs.add(0, fetchRef);
-        fetchSource.addFetchIdColumn(new InputColumn(0, DataTypes.LONG));
-        Collect newCollect = new Collect(
-            collect.preferSourceLookup(),
-            relation,
-            newOutputs,
-            collect.where(),
-            collect.numExpectedRows(),
-            collect.estimatedRowSize()
-        );
+        List<Reference> fetchRefs = fetchRewrite.extractFetchRefs();
+        Map<RelationName, FetchSource> fetchSourceByRelation = fetchRewrite.createFetchSources();
         return new Fetch(
-            collect.outputs(),
-            allFetchRefs,
-            Map.of(relation.relationName(), fetchSource),
-            limit.replaceSources(List.of(newCollect))
+            limit.outputs(),
+            fetchRefs,
+            fetchSourceByRelation,
+            limit.replaceSources(List.of(fetchRewrite.newPlan()))
         );
     }
 }

--- a/sql/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.testing.SymbolMatchers.isReference;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class FetchMarkerTest {
+
+    @Test
+    public void test_fetch_marker_streams_as_if_it_is_a_fetchId_reference() throws Exception {
+        RelationName relationName = new RelationName("doc", "tbl");
+        FetchMarker fetchMarker = new FetchMarker(relationName, List.of());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Symbols.toStream(fetchMarker, out);
+
+        StreamInput in = out.bytes().streamInput();
+        Symbol symbol = Symbols.fromStream(in);
+        assertThat(symbol, isReference(is(new ColumnIdent("_fetchid")), is(relationName), is(DataTypes.LONG)));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -155,7 +155,6 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
     public void testCrossJoinJoinUnordered() throws Exception {
         execute("create table employees (size float, name string) clustered by (size) into 1 shards");
         execute("create table offices (height float, name string) clustered by (height) into 1 shards");
-        ensureYellow();
         execute("insert into employees (size, name) values (1.5, 'Trillian')");
         execute("insert into offices (height, name) values (1.5, 'Hobbit House')");
         execute("refresh table employees, offices");

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -235,7 +235,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCollectAndMergePlan() throws Exception {
-        Merge merge = e.plan("select name from users where name = 'x' order by id limit 10");
+        QueryThenFetch qtf = e.plan("select name from users where name = 'x' order by id limit 10");
+        Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
         assertThat(collectPhase.where().toString(), is("(name = 'x')"));
 
@@ -298,7 +299,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCollectAndMergePlanPartitioned() throws Exception {
-        Merge merge = e.plan("select id, name, date from parted_pks where date > 0 and name = 'x' order by id limit 10");
+        QueryThenFetch qtf = e.plan("select id, name, date from parted_pks where date > 0 and name = 'x' order by id limit 10");
+        Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
 
         Set<String> indices = new HashSet<>();
@@ -318,7 +320,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCollectAndMergePlanFunction() throws Exception {
-        Merge merge = e.plan("select format('Hi, my name is %s', name), name from users where name = 'x' order by id limit 10");
+        QueryThenFetch qtf = e.plan("select format('Hi, my name is %s', name), name from users where name = 'x' order by id limit 10");
+        Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
 
         assertThat(collectPhase.where().toString(), is("(name = 'x')"));
@@ -481,7 +484,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testQTFPagingIsEnabledOnHighLimit() throws Exception {
-        Merge merge = e.plan("select name, date from users order by name limit 1000000");
+        QueryThenFetch qtf = e.plan("select name, date from users order by name limit 1000000");
+        Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
         assertThat(merge.mergePhase().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
         assertThat(collectPhase.nodePageSizeHint(), is(750000));

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -368,6 +368,21 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
+    @Test
+    public void test_limit_on_join_is_rewritten_to_query_then_fetch() {
+        LogicalPlan plan = plan("select * from t1, t2 limit 3");
+        assertThat(
+            plan,
+            isPlan(
+                "Fetch[a, x, i, b, y, i]\n" +
+                "  └ Limit[3;0]\n" +
+                "    └ NestedLoopJoin[CROSS]\n" +
+                "      ├ Collect[doc.t1 | [_fetchid] | true]\n" +
+                "      └ Collect[doc.t2 | [_fetchid] | true]"
+            )
+        );
+    }
+
     public static Matcher<LogicalPlan> isPlan(String expectedPlan) {
         return new FeatureMatcher<>(equalTo(expectedPlan), "same output", "output ") {
 

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -147,9 +147,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             "Limit[1;0]\n" +
             "  └ Rename[a, x] AS tt\n" +
             "    └ OrderBy[x DESC]\n" +
-            "      └ Limit[3;0]\n" +
-            "        └ OrderBy[a ASC]\n" +
-            "          └ Collect[doc.t1 | [a, x] | true]"));
+            "      └ Fetch[a, x]\n" +
+            "        └ Limit[3;0]\n" +
+            "          └ OrderBy[a ASC]\n" +
+            "            └ Collect[doc.t1 | [_fetchid, a] | true]"));
     }
 
     @Test
@@ -312,12 +313,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             "  └ HashJoin[(i = i)]\n" +
             "    ├ Rename[a, i] AS t1\n" +
             "    │  └ Filter[(a > '50')]\n" +
-            "    │    └ Limit[5;0]\n" +
-            "    │      └ OrderBy[a ASC]\n" +
-            "    │        └ Collect[doc.t1 | [a, i] | true]\n" +
+            "    │    └ Fetch[a, i]\n" +
+            "    │      └ Limit[5;0]\n" +
+            "    │        └ OrderBy[a ASC]\n" +
+            "    │          └ Collect[doc.t1 | [_fetchid, a] | true]\n" +
             "    └ Rename[b, i] AS t2\n" +
-            "      └ Collect[doc.t2 | [b, i] | ((b > '100') AND (b > '10'))]"
-        ));
+            "      └ Collect[doc.t2 | [b, i] | ((b > '100') AND (b > '10'))]"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

The approach taken is similar to how the fetch planning worked before its
removal (https://github.com/crate/crate/pull/9669) with 2 important
differences.

- The trigger is still a rule, and only the sub-tree where the rule matched
  will be rewritten.

- Instead of doing pointer chasing to get the `Reference` items, they're now
  bubbled up as part of the rewrite via a `FetchRewrite` result with
  `FetchStub` symbols.

Rough outline how it works:

A rule triggers on any `Limit` operator. The rule invokes
`source.rewriteFetch(usedOutputs)` to trigger a rewrite of the sub-tree.
`usedOutputs` is used the same as before, it indicates intermediately used
columns.

The result of `rewriteFetch` is a `FetchRewrite` that contains:

- The rewritten LogicalPlan operator
- `replacedOutputs`, which is a mapping from "previousOutput" to "what-the
  fetch operation needs to fetch to get the value for the original symbol".
  Semantically both keys and values of the `replacedOutputs` represent the
  `outputs` of an operator *before* the rewrite. The values contain `FetchStub`
  symbols which are used by `Fetch` to know what to fetch.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
