### PR TITLE
Add rewriteToFetch to Eval, Rename and HashJoin

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchResponse.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/NodeFetchResponse.java
@@ -35,6 +35,7 @@ import org.elasticsearch.transport.TransportResponse;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Objects;
 
 public class NodeFetchResponse extends TransportResponse {
 
@@ -58,7 +59,7 @@ public class NodeFetchResponse extends TransportResponse {
             fetched = new IntObjectHashMap<>(numReaders);
             for (int i = 0; i < numReaders; i++) {
                 int readerId = in.readVInt();
-                StreamBucket bucket = new StreamBucket(in, streamers.get(readerId));
+                StreamBucket bucket = new StreamBucket(in, Objects.requireNonNull(streamers.get(readerId), "streamers must exist for readerId=" + readerId));
                 fetched.put(readerId, bucket);
             }
         } else {

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -254,7 +254,8 @@ public class JobSetup {
         try {
             return innerPreparer.process(phase, context);
         } catch (Throwable t) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            IllegalArgumentException e = new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
                 "Couldn't create executionContexts from%n" +
                 "NodeOperations: %s%n" +
                 "Leafs: %s%n" +
@@ -265,6 +266,8 @@ public class JobSetup {
                 context.opCtx.targetToSourceMap,
                 t.getClass().getSimpleName() + ": " + t.getMessage()),
                 t);
+            e.setStackTrace(t.getStackTrace());
+            throw e;
         }
     }
 

--- a/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -31,12 +31,11 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 
 import java.util.List;
 import java.util.Locale;
@@ -93,6 +92,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
 
     @Override
     protected Input<?> visitSymbol(Symbol symbol, C context) {
-        throw new UnsupportedOperationException(Symbols.format("Can't handle Symbol %s", symbol));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ENGLISH, "Can't handle Symbol [%s: %s]", symbol.getClass().getSimpleName(), symbol));
     }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/FetchMarker.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FetchMarker.java
@@ -43,9 +43,13 @@ public final class FetchMarker extends Symbol {
     private final Reference fetchId;
 
     public FetchMarker(RelationName relationName, List<Reference> fetchRefs) {
+        this(relationName, fetchRefs, DocSysColumns.forTable(relationName, DocSysColumns.FETCHID));
+    }
+
+    public FetchMarker(RelationName relationName, List<Reference> fetchRefs, Reference fetchId) {
         this.relationName = relationName;
         this.fetchRefs = fetchRefs;
-        this.fetchId = DocSysColumns.forTable(relationName, DocSysColumns.FETCHID);
+        this.fetchId = fetchId;
     }
 
     public List<Reference> fetchRefs() {
@@ -77,6 +81,9 @@ public final class FetchMarker extends Symbol {
 
     @Override
     public String toString(Style style) {
+        if (relationName.schema() == null) {
+            return relationName + "." + fetchId.toString(style);
+        }
         return fetchId.toString(style);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/MapBackedSymbolReplacer.java
+++ b/sql/src/main/java/io/crate/planner/operators/MapBackedSymbolReplacer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.FunctionCopyVisitor;
+import io.crate.expression.symbol.Symbol;
+
+import java.util.Map;
+
+public final class MapBackedSymbolReplacer extends FunctionCopyVisitor<Map<Symbol, Symbol>> {
+
+    private static final MapBackedSymbolReplacer INSTANCE = new MapBackedSymbolReplacer();
+
+    private MapBackedSymbolReplacer() {
+    }
+
+    public static Symbol convert(Symbol symbol, Map<Symbol, Symbol> replacements) {
+        return symbol.accept(INSTANCE, replacements);
+    }
+
+    @Override
+    protected Symbol visitSymbol(Symbol symbol, Map<Symbol, Symbol> map) {
+        return map.getOrDefault(symbol, symbol);
+    }
+
+    @Override
+    public Symbol visitFunction(Function func, Map<Symbol, Symbol> map) {
+        Symbol mappedFunc = map.get(func);
+        if (mappedFunc == null) {
+            return processAndMaybeCopy(func, map);
+        } else {
+            return mappedFunc;
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
@@ -21,29 +21,26 @@
  */
 package io.crate.execution.engine.fetch;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
-import static org.hamcrest.Matchers.is;
-
-import java.util.List;
-import java.util.Map;
-
 import com.carrotsearch.hppc.IntObjectHashMap;
-
-import org.junit.Test;
-
 import io.crate.data.ArrayBucket;
 import io.crate.data.Bucket;
 import io.crate.data.RowN;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.planner.node.fetch.FetchSource;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
+import static org.hamcrest.Matchers.is;
 
 public class FetchRowsTest extends CrateDummyClusterServiceUnitTest {
 
@@ -73,7 +70,7 @@ public class FetchRowsTest extends CrateDummyClusterServiceUnitTest {
             CoordinatorTxnCtx.systemTransactionContext(),
             e.functions(),
             fetchSources,
-            List.<Symbol>of(
+            List.of(
                 new FetchReference(new InputColumn(0, DataTypes.LONG), x),
                 new FetchReference(new InputColumn(1, DataTypes.LONG), y),
                 new InputColumn(2, DataTypes.INTEGER)

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -323,7 +323,8 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testPrintFetchRefs() throws Exception {
         Symbol field = sqlExpressions.asSymbol("bar");
         assertThat(field, isReference("bar"));
-        FetchReference fetchRef = new FetchReference(new InputColumn(0, field.valueType()), ((Reference) field));
+        Reference ref = (Reference) field;
+        FetchReference fetchRef = new FetchReference(new InputColumn(0, field.valueType()), ref);
         assertPrint(fetchRef, "FETCH(INPUT(0), doc.formatter.bar)");
     }
 

--- a/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.Function;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.testing.SymbolMatchers.isFetchStub;
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isReference;
+import static org.hamcrest.Matchers.is;
+
+public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_fetch_rewrite_on_eval_removes_eval_and_extends_replaced_outputs() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+
+        DocTableInfo tableInfo = e.resolveTableInfo("tbl");
+        var x = e.asSymbol("x");
+        var relation = new DocTableRelation(tableInfo);
+        var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var eval = new Eval(collect, List.of(Function.of("add", List.of(x, x), DataTypes.INTEGER)));
+
+        FetchRewrite fetchRewrite = eval.rewriteToFetch(List.of());
+        assertThat(fetchRewrite, Matchers.notNullValue());
+        assertThat(fetchRewrite.newPlan(), isPlan("Collect[doc.tbl | [_fetchid] | true]"));
+        assertThat(
+            fetchRewrite.replacedOutputs(),
+            Matchers.hasEntry(
+                isFunction("add", isReference("x"), isReference("x")),
+                isFunction("add", isFetchStub("x"), isFetchStub("x"))
+            )
+        );
+        assertThat(List.copyOf(fetchRewrite.replacedOutputs().keySet()), is(eval.outputs()));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -23,9 +23,16 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AliasedAnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.FetchMarker;
+import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -35,9 +42,12 @@ import org.junit.Test;
 import java.util.List;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.testing.SymbolMatchers.isFetchMarker;
 import static io.crate.testing.SymbolMatchers.isFetchStub;
+import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isReference;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
@@ -65,5 +75,46 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
             )
         );
         assertThat(List.copyOf(fetchRewrite.replacedOutputs().keySet()), is(eval.outputs()));
+    }
+
+    @Test
+    public void test_fetchrewrite_on_rename_puts_fetch_marker_into_alias_scope() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+        DocTableInfo tableInfo = e.resolveTableInfo("tbl");
+        Reference x = (Reference) e.asSymbol("x");
+        var relation = new DocTableRelation(tableInfo);
+        var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
+        var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        Symbol t1X = alias.getField(x.column(), Operation.READ);
+        assertThat(t1X, Matchers.notNullValue());
+        var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
+
+        FetchRewrite fetchRewrite = rename.rewriteToFetch(List.of());
+        assertThat(fetchRewrite, Matchers.notNullValue());
+        LogicalPlan newRename = fetchRewrite.newPlan();
+        assertThat(newRename, isPlan(
+            "Rename[t1._fetchid] AS t1\n" +
+            "  └ Collect[doc.tbl | [_fetchid] | true]"));
+        assertThat(
+            "fetchRewrite replacedOutputs.keySet() must always match the outputs of the operator prior to the rewrite",
+            List.copyOf(fetchRewrite.replacedOutputs().keySet()),
+            is(rename.outputs())
+        );
+        assertThat(
+            fetchRewrite.replacedOutputs(),
+            Matchers.hasEntry(isField("x", alias.relationName()), isFetchStub("x"))
+        );
+        assertThat(newRename.outputs(), contains(
+            isFetchMarker(alias.relationName(), contains(isReference("x"))))
+        );
+
+        FetchStub fetchStub = (FetchStub) fetchRewrite.replacedOutputs().entrySet().iterator().next().getValue();
+        assertThat(
+            "FetchStub fetchMarker must be changed to the aliased marker",
+            fetchStub.fetchMarker(),
+            Matchers.sameInstance(newRename.outputs().get(0))
+        );
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -383,6 +383,21 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
+    @Test
+    public void test_limit_on_hash_join_is_rewritten_to_query_then_fetch() {
+        LogicalPlan plan = plan("select * from t1 inner join t2 on t1.a = t2.b limit 3");
+        assertThat(
+            plan,
+            isPlan(
+                "Fetch[a, x, i, b, y, i]\n" +
+                "  └ Limit[3;0]\n" +
+                "    └ HashJoin[(a = b)]\n" +
+                "      ├ Collect[doc.t1 | [_fetchid, a] | true]\n" +
+                "      └ Collect[doc.t2 | [_fetchid, b] | true]"
+            )
+        );
+    }
+
     public static Matcher<LogicalPlan> isPlan(String expectedPlan) {
         return new FeatureMatcher<>(equalTo(expectedPlan), "same output", "output ") {
 

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -25,6 +25,7 @@ package io.crate.testing;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.AliasSymbol;
+import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
@@ -92,6 +93,14 @@ public class SymbolMatchers {
             instanceOf(ScopedSymbol.class),
             withFeature(x -> ((ScopedSymbol) x).column().sqlFqn(), "", equalTo(expectedName)),
             withFeature(x -> ((ScopedSymbol) x).relation(), "", equalTo(relation))
+        );
+    }
+
+    public static Matcher<Symbol> isFetchMarker(RelationName relation, Matcher<Iterable<? extends Symbol>> refsMatcher) {
+        return allOf(
+            instanceOf(FetchMarker.class),
+            withFeature(x -> ((FetchMarker) x).relationName(), "", equalTo(relation)),
+            withFeature(x -> ((FetchMarker) x).fetchRefs(), "", refsMatcher)
         );
     }
 

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.FetchReference;
+import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
@@ -73,6 +74,13 @@ public class SymbolMatchers {
     public static Matcher<Symbol> isInputColumn(final Integer index) {
         return both(Matchers.<Symbol>instanceOf(InputColumn.class))
             .and(withFeature(s -> ((InputColumn) s).index(), "index", equalTo(index)));
+    }
+
+    public static Matcher<Symbol> isFetchStub(String columnName) {
+        return allOf(
+            instanceOf(FetchStub.class),
+            withFeature(x -> ((FetchStub) x).ref(), "", isReference(columnName))
+        );
     }
 
     public static Matcher<Symbol> isField(final String expectedName) {


### PR DESCRIPTION
## 

With this we should have the same kind of execution plans we had before https://github.com/crate/crate/pull/9669

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)