### PR TITLE
Optimize memory footprint for upsert

### DIFF
--- a/sql/src/main/java/io/crate/execution/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/execution/TransportActionProvider.java
@@ -24,6 +24,7 @@ package io.crate.execution;
 
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
+import io.crate.execution.dml.upsert.TransportShardInsertAction;
 import io.crate.execution.dml.upsert.TransportShardUpsertAction;
 import io.crate.execution.dml.upsert.TransportShardUpdateAction;
 import io.crate.execution.engine.fetch.TransportFetchNodeAction;
@@ -56,6 +57,7 @@ public class TransportActionProvider {
 
     private final Provider<TransportShardUpsertAction> transportShardUpsertActionProvider;
     private final Provider<TransportShardUpdateAction> transportShardUpdateActionProvider;
+    private final Provider<TransportShardInsertAction> transportShardInsertActionProvider;
     private final Provider<TransportCreatePartitionsAction> transportBulkCreateIndicesActionProvider;
 
     private final Provider<TransportJobAction> transportJobInitActionProvider;
@@ -81,6 +83,7 @@ public class TransportActionProvider {
                                    Provider<TransportClusterUpdateSettingsAction> transportClusterUpdateSettingsActionProvider,
                                    Provider<TransportShardDeleteAction> transportShardDeleteActionProvider,
                                    Provider<TransportShardUpsertAction> transportShardUpsertActionProvider,
+                                   Provider<TransportShardInsertAction> transportShardInsertActionProvider,
                                    Provider<TransportShardUpdateAction> transportShardUpdateActionProvider,
                                    Provider<TransportKillAllNodeAction> transportKillAllNodeActionProvider,
                                    Provider<TransportJobAction> transportJobInitActionProvider,
@@ -100,6 +103,7 @@ public class TransportActionProvider {
         this.transportShardDeleteActionProvider = transportShardDeleteActionProvider;
         this.transportShardUpsertActionProvider = transportShardUpsertActionProvider;
         this.transportShardUpdateActionProvider = transportShardUpdateActionProvider;
+        this.transportShardInsertActionProvider = transportShardInsertActionProvider;
         this.transportKillAllNodeActionProvider = transportKillAllNodeActionProvider;
         this.transportFetchNodeActionProvider = transportFetchNodeActionProvider;
         this.transportCollectProfileNodeActionProvider = transportCollectProfileNodeActionProvider;
@@ -135,6 +139,10 @@ public class TransportActionProvider {
 
     public TransportShardUpdateAction transportShardUpdateAction() {
         return transportShardUpdateActionProvider.get();
+    }
+
+    public TransportShardInsertAction transportShardInsertAction() {
+        return transportShardInsertActionProvider.get();
     }
 
     public TransportShardDeleteAction transportShardDeleteAction() {

--- a/sql/src/main/java/io/crate/execution/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/execution/TransportActionProvider.java
@@ -25,6 +25,7 @@ package io.crate.execution;
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
 import io.crate.execution.dml.upsert.TransportShardUpsertAction;
+import io.crate.execution.dml.upsert.TransportShardUpdateAction;
 import io.crate.execution.engine.fetch.TransportFetchNodeAction;
 import io.crate.execution.engine.profile.TransportCollectProfileNodeAction;
 import io.crate.execution.jobs.kill.TransportKillAllNodeAction;
@@ -54,6 +55,7 @@ public class TransportActionProvider {
     private final Provider<TransportShardDeleteAction> transportShardDeleteActionProvider;
 
     private final Provider<TransportShardUpsertAction> transportShardUpsertActionProvider;
+    private final Provider<TransportShardUpdateAction> transportShardUpdateActionProvider;
     private final Provider<TransportCreatePartitionsAction> transportBulkCreateIndicesActionProvider;
 
     private final Provider<TransportJobAction> transportJobInitActionProvider;
@@ -79,6 +81,7 @@ public class TransportActionProvider {
                                    Provider<TransportClusterUpdateSettingsAction> transportClusterUpdateSettingsActionProvider,
                                    Provider<TransportShardDeleteAction> transportShardDeleteActionProvider,
                                    Provider<TransportShardUpsertAction> transportShardUpsertActionProvider,
+                                   Provider<TransportShardUpdateAction> transportShardUpdateActionProvider,
                                    Provider<TransportKillAllNodeAction> transportKillAllNodeActionProvider,
                                    Provider<TransportJobAction> transportJobInitActionProvider,
                                    Provider<TransportCreatePartitionsAction> transportBulkCreateIndicesActionProvider,
@@ -96,6 +99,7 @@ public class TransportActionProvider {
         this.transportClusterUpdateSettingsActionProvider = transportClusterUpdateSettingsActionProvider;
         this.transportShardDeleteActionProvider = transportShardDeleteActionProvider;
         this.transportShardUpsertActionProvider = transportShardUpsertActionProvider;
+        this.transportShardUpdateActionProvider = transportShardUpdateActionProvider;
         this.transportKillAllNodeActionProvider = transportKillAllNodeActionProvider;
         this.transportFetchNodeActionProvider = transportFetchNodeActionProvider;
         this.transportCollectProfileNodeActionProvider = transportCollectProfileNodeActionProvider;
@@ -127,6 +131,10 @@ public class TransportActionProvider {
 
     public TransportShardUpsertAction transportShardUpsertAction() {
         return transportShardUpsertActionProvider.get();
+    }
+
+    public TransportShardUpdateAction transportShardUpdateAction() {
+        return transportShardUpdateActionProvider.get();
     }
 
     public TransportShardDeleteAction transportShardDeleteAction() {

--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -23,6 +23,8 @@
 package io.crate.execution;
 
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
+import io.crate.execution.dml.upsert.TransportShardUpsertAction;
+import io.crate.execution.dml.upsert.TransportShardUpdateAction;
 import io.crate.statistics.TransportAnalyzeAction;
 import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
@@ -35,7 +37,6 @@ import io.crate.execution.ddl.tables.TransportRenameTableAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
-import io.crate.execution.dml.upsert.TransportShardUpsertAction;
 import io.crate.execution.engine.collect.stats.TransportNodeStatsAction;
 import io.crate.execution.engine.distribution.TransportDistributedResultAction;
 import io.crate.execution.engine.fetch.TransportFetchNodeAction;
@@ -60,6 +61,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportJobAction.class).asEagerSingleton();
         bind(TransportDistributedResultAction.class).asEagerSingleton();
         bind(TransportShardUpsertAction.class).asEagerSingleton();
+        bind(TransportShardUpdateAction.class).asEagerSingleton();
         bind(TransportShardDeleteAction.class).asEagerSingleton();
         bind(TransportFetchNodeAction.class).asEagerSingleton();
         bind(TransportDecommissionNodeAction.class).asEagerSingleton();

--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -23,6 +23,7 @@
 package io.crate.execution;
 
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
+import io.crate.execution.dml.upsert.TransportShardInsertAction;
 import io.crate.execution.dml.upsert.TransportShardUpsertAction;
 import io.crate.execution.dml.upsert.TransportShardUpdateAction;
 import io.crate.statistics.TransportAnalyzeAction;
@@ -62,6 +63,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportDistributedResultAction.class).asEagerSingleton();
         bind(TransportShardUpsertAction.class).asEagerSingleton();
         bind(TransportShardUpdateAction.class).asEagerSingleton();
+        bind(TransportShardInsertAction.class).asEagerSingleton();
         bind(TransportShardDeleteAction.class).asEagerSingleton();
         bind(TransportFetchNodeAction.class).asEagerSingleton();
         bind(TransportDecommissionNodeAction.class).asEagerSingleton();

--- a/sql/src/main/java/io/crate/execution/dml/ShardRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardRequest.java
@@ -77,13 +77,6 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
         jobId = new UUID(in.readLong(), in.readLong());
     }
 
-    protected void readItems(StreamInput in, int size) throws IOException {
-        items = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            items.add(readItem(in));
-        }
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -117,8 +110,6 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
                ", timeout=" + timeout +
                '}';
     }
-
-    protected abstract I readItem(StreamInput input) throws IOException;
 
     public abstract static class Item implements Writeable {
 

--- a/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -25,7 +25,6 @@ package io.crate.execution.dml;
 import com.carrotsearch.hppc.IntArrayList;
 import com.google.common.base.MoreObjects;
 import io.crate.Streamer;
-import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import org.elasticsearch.Version;
@@ -294,8 +293,8 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
             return successfulWrites.cardinality();
         }
 
-        public void markAsFailed(List<ShardUpsertRequest.Item> items) {
-            for (ShardUpsertRequest.Item item : items) {
+        public void markAsFailed(List<? extends ShardRequest.Item> items) {
+            for (ShardRequest.Item item : items) {
                 failureLocations.set(item.location());
             }
         }

--- a/sql/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.UUID;
 
 public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDeleteRequest.Item> {
@@ -64,15 +65,15 @@ public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDe
     public ShardDeleteRequest(StreamInput in) throws IOException {
         super(in);
         int numItems = in.readVInt();
-        readItems(in, numItems);
+        if (numItems > 0) {
+            items = new ArrayList<>(numItems);
+            for (int i = 0; i < numItems; i++) {
+                items.add(new ShardDeleteRequest.Item(in));
+            }
+        }
         if (in.readBoolean()) {
             skipFromLocation = in.readVInt();
         }
-    }
-
-    @Override
-    protected Item readItem(StreamInput input) throws IOException {
-        return new Item(input);
     }
 
     public static class Item extends ShardRequest.Item {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/AbstractShardWriteRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/AbstractShardWriteRequest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.common.collections.EnumSets;
+import io.crate.execution.dml.ShardRequest;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.settings.SessionSettings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.ShardId;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+
+public abstract class AbstractShardWriteRequest<T extends ShardRequest<T, I>, I extends ShardRequest.Item> extends ShardRequest<T, I> {
+
+    public enum Mode {
+        DUPLICATE_KEY_UPDATE_OR_FAIL,
+        DUPLICATE_KEY_OVERWRITE,
+        DUPLICATE_KEY_IGNORE,
+        CONTINUE_ON_ERROR,
+        VALIDATE_CONSTRAINTS
+    }
+
+    protected Set<Mode> modes;
+
+
+    protected AbstractShardWriteRequest(StreamInput in) throws IOException {
+        super(in);
+        this.modes = EnumSets.unpackFromInt(in.readVInt(), Mode.class);
+    }
+
+    protected AbstractShardWriteRequest(ShardId shardId, UUID jobId, EnumSet<Mode> modes) {
+        super(shardId, jobId);
+        this.modes = modes;
+
+    }
+
+    @Nullable
+    public abstract SessionSettings sessionSettings();
+
+    @Nullable
+    public abstract Symbol[] returnValues();
+
+    @Nullable
+    public abstract String[] updateColumns();
+
+
+    @Nullable
+    public abstract Reference[] insertColumns();
+
+    public Set<Mode> modes() {
+        return modes;
+    }
+
+    boolean continueOnError() {
+        return modes.contains(Mode.CONTINUE_ON_ERROR);
+    }
+
+    boolean validateConstraints() {
+        return modes.contains(Mode.VALIDATE_CONSTRAINTS);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(EnumSets.packToInt(modes));
+    }
+
+    /**
+     * A single update item.
+     */
+    public abstract static class Item extends ShardRequest.Item {
+
+        @Nullable
+        private BytesReference source;
+
+        protected Item(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                source = in.readBytesReference();
+            }
+        }
+
+        protected Item(String id,
+                    @Nullable Long version,
+                    @Nullable Long seqNo,
+                    @Nullable Long primaryTerm
+        ) {
+            super(id);
+            if (version != null) {
+                this.version = version;
+            }
+            if (seqNo != null) {
+                this.seqNo = seqNo;
+            }
+            if (primaryTerm != null) {
+                this.primaryTerm = primaryTerm;
+            }
+        }
+
+        @Nullable
+        public BytesReference source() {
+            return source;
+        }
+
+        public void source(BytesReference source) {
+            this.source = source;
+        }
+
+        boolean retryOnConflict() {
+            return seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO && version == Versions.MATCH_ANY;
+        }
+
+        @Nullable
+        abstract Symbol[] updateAssignments();
+
+        @Nullable
+        public abstract Object[] insertValues();
+
+
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            boolean sourceAvailable = source != null;
+            out.writeBoolean(sourceAvailable);
+            if (sourceAvailable) {
+                out.writeBytesReference(source);
+            }
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/AbstractTransportShardWriteAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/AbstractTransportShardWriteAction.java
@@ -1,0 +1,499 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.Constants;
+import io.crate.execution.ddl.SchemaUpdateClient;
+import io.crate.execution.dml.ShardResponse;
+import io.crate.execution.dml.TransportShardAction;
+import io.crate.execution.engine.collect.PKLookupOperation;
+import io.crate.execution.jobs.TasksService;
+import io.crate.expression.reference.Doc;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Functions;
+import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.engine.DocumentSourceMissingException;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.crate.exceptions.SQLExceptions.userFriendlyCrateExceptionTopOnly;
+
+/**
+ * Realizes Upserts of tables which either results in an Insert or an Update.
+ */
+public abstract class AbstractTransportShardWriteAction
+    <Request extends AbstractShardWriteRequest<Request, Item>, Item extends AbstractShardWriteRequest.Item>
+    extends TransportShardAction<Request, Item> {
+
+    private static final int MAX_RETRY_LIMIT = 100_000; // upper bound to prevent unlimited retries on unexpected states
+
+    private final Schemas schemas;
+    private final Functions functions;
+
+    public AbstractTransportShardWriteAction(String actionName,
+                                             ThreadPool threadPool,
+                                             ClusterService clusterService,
+                                             TransportService transportService,
+                                             SchemaUpdateClient schemaUpdateClient,
+                                             TasksService tasksService,
+                                             IndicesService indicesService,
+                                             ShardStateAction shardStateAction,
+                                             Functions functions,
+                                             Schemas schemas,
+                                             IndexNameExpressionResolver indexNameExpressionResolver,
+                                             Writeable.Reader<Request> reader
+
+    ) {
+        super(
+            actionName,
+            transportService,
+            indexNameExpressionResolver,
+            clusterService,
+            indicesService,
+            threadPool,
+            shardStateAction,
+            reader,
+            schemaUpdateClient
+        );
+        this.schemas = schemas;
+        this.functions = functions;
+        tasksService.addListener(this);
+    }
+
+    @Override
+    protected WritePrimaryResult<Request, ShardResponse> processRequestItems(IndexShard indexShard,
+                                                                             Request request,
+                                                                             AtomicBoolean killed) {
+        ShardResponse shardResponse = new ShardResponse(request.returnValues());
+        String indexName = request.index();
+        DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);
+        Reference[] insertColumns = request.insertColumns();
+        GeneratedColumns.Validation valueValidation = request.validateConstraints()
+            ? GeneratedColumns.Validation.VALUE_MATCH
+            : GeneratedColumns.Validation.NONE;
+        // Can be null
+        TransactionContext txnCtx = TransactionContext.of(request.sessionSettings());
+        // txnCtx is not needed for when insert is already string-based
+        InsertSourceGen insertSourceGen = insertColumns == null
+            ? null
+            : InsertSourceGen.of(txnCtx, functions, tableInfo, indexName, valueValidation, Arrays.asList(insertColumns));
+
+        UpdateSourceGen updateSourceGen = request.updateColumns() == null
+            ? null
+            : new UpdateSourceGen(functions,
+                                  txnCtx,
+                                  tableInfo,
+                                  request.updateColumns());
+
+        ReturnValueGen returnValueGen = request.returnValues() == null
+            ? null
+            : new ReturnValueGen(functions, txnCtx, tableInfo, request.returnValues());
+
+        Translog.Location translogLocation = null;
+        for (Item item : request.items()) {
+            int location = item.location();
+            if (killed.get()) {
+                // set failure on response and skip all next items.
+                // this way replica operation will be executed, but only items with a valid source (= was processed on primary)
+                // will be processed on the replica
+                shardResponse.failure(new InterruptedException());
+                break;
+            }
+            try {
+                IndexItemResponse indexItemResponse = indexItem(
+                    request,
+                    item,
+                    indexShard,
+                    updateSourceGen,
+                    insertSourceGen,
+                    returnValueGen
+                );
+                if (indexItemResponse != null) {
+                    if (indexItemResponse.translog != null) {
+                        shardResponse.add(location);
+                        translogLocation = indexItemResponse.translog;
+                    }
+                    if (indexItemResponse.returnValues != null) {
+                        shardResponse.addResultRows(indexItemResponse.returnValues);
+                    }
+                }
+            } catch (Exception e) {
+                if (retryPrimaryException(e)) {
+                    if (e instanceof RuntimeException) {
+                        throw (RuntimeException) e;
+                    }
+                    throw new RuntimeException(e);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Failed to execute upsert shardId={} id={} error={}", request.shardId(), item.id(), e);
+                }
+
+                // *mark* the item as failed by setting the source to null
+                // to prevent the replica operation from processing this concrete item
+                item.source(null);
+
+                if (!request.continueOnError()) {
+                    shardResponse.failure(e);
+                    break;
+                }
+                shardResponse.add(location,
+                    new ShardResponse.Failure(
+                        item.id(),
+                        userFriendlyCrateExceptionTopOnly(e),
+                        (e instanceof VersionConflictEngineException)));
+            }
+        }
+        return new WritePrimaryResult<>(request, shardResponse, translogLocation, null, indexShard);
+    }
+
+    @Override
+    protected WriteReplicaResult<Request> processRequestItemsOnReplica(IndexShard indexShard, Request request) throws IOException {
+        Translog.Location location = null;
+        for (Item item : request.items()) {
+            if (item.source() == null) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("[{} (R)] Document with id {}, has no source, primary operation must have failed",
+                        indexShard.shardId(), item.id());
+                }
+                continue;
+            }
+            SourceToParse sourceToParse = new SourceToParse(
+                indexShard.shardId().getIndexName(),
+                item.id(),
+                item.source(),
+                XContentType.JSON
+            );
+
+            Engine.IndexResult indexResult = indexShard.applyIndexOperationOnReplica(
+                item.seqNo(),
+                item.version(),
+                Translog.UNSET_AUTO_GENERATED_TIMESTAMP,
+                false,
+                sourceToParse
+            );
+            if (indexResult.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
+                // Even though the primary waits on all nodes to ack the mapping changes to the master
+                // (see MappingUpdatedAction.updateMappingOnMaster) we still need to protect against missing mappings
+                // and wait for them. The reason is concurrent requests. Request r1 which has new field f triggers a
+                // mapping update. Assume that that update is first applied on the primary, and only later on the replica
+                // (it’s happening concurrently). Request r2, which now arrives on the primary and which also has the new
+                // field f might see the updated mapping (on the primary), and will therefore proceed to be replicated
+                // to the replica. When it arrives on the replica, there’s no guarantee that the replica has already
+                // applied the new mapping, so there is no other option than to wait.
+                throw new TransportReplicationAction.RetryOnReplicaException(indexShard.shardId(),
+                    "Mappings are not available on the replica yet, triggered update: " + indexResult.getRequiredMappingUpdate());
+            }
+            location = indexResult.getTranslogLocation();
+        }
+        return new WriteReplicaResult<>(request, location, null, indexShard, logger);
+    }
+
+    @Nullable
+    private IndexItemResponse indexItem(Request request,
+                                        Item item,
+                                        IndexShard indexShard,
+                                        @Nullable UpdateSourceGen updateSourceGen,
+                                        @Nullable InsertSourceGen insertSourceGen,
+                                        @Nullable ReturnValueGen returnValueGen) throws Exception {
+        VersionConflictEngineException lastException = null;
+        boolean tryInsertFirst = item.insertValues() != null;
+        boolean isRetry;
+        for (int retryCount = 0; retryCount < MAX_RETRY_LIMIT; retryCount++) {
+            try {
+                isRetry = retryCount > 0;
+                if (tryInsertFirst) {
+                    return insert(request, item, indexShard, isRetry, returnValueGen, insertSourceGen);
+                } else {
+                    return update(item, indexShard, isRetry, returnValueGen, updateSourceGen);
+                }
+            } catch (VersionConflictEngineException e) {
+                lastException = e;
+                if (request.modes().contains(AbstractShardWriteRequest.Mode.DUPLICATE_KEY_IGNORE)) {
+                    // on conflict do nothing
+                    item.source(null);
+                    return null;
+                }
+                Symbol[] updateAssignments = item.updateAssignments();
+                if (updateAssignments != null && updateAssignments.length > 0) {
+                    if (tryInsertFirst) {
+                        // insert failed, document already exists, try update
+                        tryInsertFirst = false;
+                        continue;
+                    } else if (item.retryOnConflict()) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("[{}] VersionConflict, retrying operation for document id={}, version={} retryCount={}",
+                                indexShard.shardId(), item.id(), item.version(), retryCount);
+                        }
+                        continue;
+                    }
+                }
+                throw e;
+            }
+        }
+        logger.warn("[{}] VersionConflict for document id={}, version={} exceeded retry limit of {}, will stop retrying",
+            indexShard.shardId(), item.id(), item.version(), MAX_RETRY_LIMIT);
+        throw lastException;
+    }
+
+    static class IndexItemResponse {
+        @Nullable
+        final Translog.Location translog;
+        @Nullable
+        final Object[] returnValues;
+
+        IndexItemResponse(@Nullable Translog.Location translog, @Nullable Object[] returnValues) {
+            this.translog = translog;
+            this.returnValues = returnValues;
+        }
+    }
+
+    @VisibleForTesting
+    protected IndexItemResponse insert(Request request,
+                                       Item item,
+                                       IndexShard indexShard,
+                                       boolean isRetry,
+                                       @Nullable ReturnValueGen returnGen,
+                                       InsertSourceGen insertSourceGen) throws Exception {
+        assert insertSourceGen != null : "InsertSourceGen must not be null";
+        BytesReference rawSource;
+        Map<String, Object> source = null;
+        try {
+            // This optimizes for the case where the insert value is already string-based, so we can take directly
+            // the rawSource
+            if (insertSourceGen instanceof FromRawInsertSource) {
+                rawSource = insertSourceGen.generateSourceAndCheckConstraintsAsBytesReference(item.insertValues());
+            } else {
+                source = insertSourceGen.generateSourceAndCheckConstraints(item.insertValues());
+                rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+            }
+        } catch (IOException e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+        item.source(rawSource);
+
+        long version = request.modes().contains(AbstractShardWriteRequest.Mode.DUPLICATE_KEY_OVERWRITE) ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
+        long seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        long primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+
+        Engine.IndexResult indexResult = index(item, indexShard, isRetry, seqNo, primaryTerm, version);
+        Object[] returnvalues = null;
+        if (returnGen != null) {
+            // This optimizes for the case where the insert value is already string-based, so only parse the source
+            // when return values are requested
+            if (source == null) {
+                source = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    BytesReference.toBytes(rawSource)).map();
+            }
+            returnvalues = returnGen.generateReturnValues(
+                // return -1 as docId, the docId can only be retrieved by fetching the inserted document again, which
+                // we want to avoid. The docId is anyway just valid with the lifetime of a searcher and can change afterwards.
+                new Doc(
+                    -1,
+                    indexShard.shardId().getIndexName(),
+                    item.id(),
+                    indexResult.getVersion(),
+                    indexResult.getSeqNo(),
+                    indexResult.getTerm(),
+                    source,
+                    rawSource::utf8ToString
+                )
+            );
+        }
+        return new IndexItemResponse(indexResult.getTranslogLocation(), returnvalues);
+    }
+
+    protected IndexItemResponse update(Item item,
+                                       IndexShard indexShard,
+                                       boolean isRetry,
+                                       @Nullable ReturnValueGen returnGen,
+                                       UpdateSourceGen updateSourceGen) throws Exception {
+        assert updateSourceGen != null : "UpdateSourceGen must not be null";
+        Doc fetchedDoc = getDocument(indexShard, item.id(), item.version(), item.seqNo(), item.primaryTerm());
+        Map<String, Object> source = updateSourceGen.generateSource(
+            fetchedDoc,
+            item.updateAssignments(),
+            item.insertValues()
+        );
+        BytesReference rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        item.source(rawSource);
+        long seqNo = item.seqNo();
+        long primaryTerm = item.primaryTerm();
+        long version = Versions.MATCH_ANY;
+
+        Engine.IndexResult indexResult = index(item, indexShard, isRetry, seqNo, primaryTerm, version);
+        Object[] returnvalues = null;
+        if (returnGen != null) {
+            returnvalues = returnGen.generateReturnValues(
+                new Doc(
+                    fetchedDoc.docId(),
+                    fetchedDoc.getIndex(),
+                    fetchedDoc.getId(),
+                    indexResult.getVersion(),
+                    indexResult.getSeqNo(),
+                    indexResult.getTerm(),
+                    source,
+                    rawSource::utf8ToString
+                )
+            );
+        }
+        return new IndexItemResponse(indexResult.getTranslogLocation(), returnvalues);
+    }
+
+    private Engine.IndexResult index(Item item,
+                                     IndexShard indexShard,
+                                     boolean isRetry,
+                                     long seqNo,
+                                     long primaryTerm,
+                                     long version) throws Exception {
+        SourceToParse sourceToParse = new SourceToParse(
+            indexShard.shardId().getIndexName(),
+            item.id(),
+            item.source(),
+            XContentType.JSON
+        );
+
+        Engine.IndexResult indexResult = executeOnPrimaryHandlingMappingUpdate(
+            indexShard.shardId(),
+            () -> indexShard.applyIndexOperationOnPrimary(
+                version,
+                VersionType.INTERNAL,
+                sourceToParse,
+                seqNo,
+                primaryTerm,
+                Translog.UNSET_AUTO_GENERATED_TIMESTAMP,
+                isRetry
+            ),
+            e -> indexShard.getFailedIndexResult(e, Versions.MATCH_ANY)
+        );
+
+        switch (indexResult.getResultType()) {
+            case SUCCESS:
+                // update the seqNo and version on request for the replicas
+                if (logger.isTraceEnabled()) {
+                    logger.trace("SUCCESS - id={}, primary_term={}, seq_no={}",
+                                 item.id(),
+                                 primaryTerm,
+                                 indexResult.getSeqNo());
+                }
+                item.seqNo(indexResult.getSeqNo());
+                item.version(indexResult.getVersion());
+                return indexResult;
+
+            case FAILURE:
+                Exception failure = indexResult.getFailure();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("FAILURE - id={}, primary_term={}, seq_no={}",
+                                item.id(),
+                                primaryTerm,
+                                indexResult.getSeqNo());
+                }
+                assert failure != null : "Failure must not be null if resultType is FAILURE";
+                throw failure;
+
+            case MAPPING_UPDATE_REQUIRED:
+            default:
+                throw new AssertionError("IndexResult must either succeed or fail. Required mapping updates must have been handled.");
+        }
+    }
+
+    private static Doc getDocument(IndexShard indexShard, String id, long version, long seqNo, long primaryTerm) {
+        // when sequence versioning is used, this lookup will throw VersionConflictEngineException
+        Doc doc = PKLookupOperation.lookupDoc(indexShard, id, Versions.MATCH_ANY, VersionType.INTERNAL, seqNo, primaryTerm);
+        if (doc == null) {
+            throw new DocumentMissingException(indexShard.shardId(), Constants.DEFAULT_MAPPING_TYPE, id);
+        }
+        if (doc.getSource() == null) {
+            throw new DocumentSourceMissingException(indexShard.shardId(), Constants.DEFAULT_MAPPING_TYPE, id);
+        }
+        if (version != Versions.MATCH_ANY && version != doc.getVersion()) {
+            throw new VersionConflictEngineException(
+                indexShard.shardId(),
+                id,
+                "Requested version: " + version + " but got version: " + doc.getVersion());
+        }
+        return doc;
+    }
+
+    public static Collection<ColumnIdent> getNotUsedNonGeneratedColumns(Reference[] targetColumns,
+                                                                        DocTableInfo tableInfo) {
+        Set<String> targetColumnsSet = new HashSet<>();
+        Collection<ColumnIdent> columnsNotUsed = new ArrayList<>();
+
+        if (targetColumns != null) {
+            for (Reference targetColumn : targetColumns) {
+                targetColumnsSet.add(targetColumn.column().fqn());
+            }
+        }
+
+        for (Reference reference : tableInfo.columns()) {
+            if (!reference.isNullable() && !(reference instanceof GeneratedReference || reference.defaultExpression() != null)) {
+                if (!targetColumnsSet.contains(reference.column().fqn())) {
+                    columnsNotUsed.add(reference.column());
+                }
+            }
+        }
+        return columnsNotUsed;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
@@ -141,12 +141,10 @@ public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertReq
         private Object[] insertValues;
 
         public Item(String id,
-                    @Nullable Symbol[] updateAssignments,
                     @Nullable Object[] insertValues,
                     @Nullable Long version,
                     @Nullable Long seqNo,
-                    @Nullable Long primaryTerm,
-                    @Nullable Symbol[] returnValues
+                    @Nullable Long primaryTerm
         ) {
             super(id, version, seqNo, primaryTerm);
             if (version != null) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.Streamer;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Reference;
+import io.crate.metadata.settings.SessionSettings;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.ShardId;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+
+public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertRequest, ShardInsertRequest.Item> {
+
+    private SessionSettings sessionSettings;
+
+    /**
+     * List of references used on insert
+     */
+    private Reference[] insertColumns;
+
+    public ShardInsertRequest(ShardId shardId,
+                              UUID jobId,
+                              EnumSet<Mode> modes,
+                              SessionSettings sessionSettings,
+                              Reference[] insertColumns) {
+        super(shardId, jobId, modes);
+        this.sessionSettings = sessionSettings;
+        this.insertColumns = insertColumns;
+    }
+
+    public ShardInsertRequest(StreamInput in) throws IOException {
+        super(in);
+        int missingAssignmentsColumnsSize = in.readVInt();
+        Streamer[] insertValuesStreamer = null;
+        if (missingAssignmentsColumnsSize > 0) {
+            insertColumns = new Reference[missingAssignmentsColumnsSize];
+            for (int i = 0; i < missingAssignmentsColumnsSize; i++) {
+                insertColumns[i] = Reference.fromStream(in);
+            }
+            insertValuesStreamer = Symbols.streamerArray(List.of(insertColumns));
+        }
+
+        sessionSettings = new SessionSettings(in);
+        int numItems = in.readVInt();
+        items = new ArrayList<>(numItems);
+        for (int i = 0; i < numItems; i++) {
+            items.add(new ShardInsertRequest.Item(in, insertValuesStreamer));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        Streamer[] insertValuesStreamer = null;
+        if (insertColumns != null) {
+            out.writeVInt(insertColumns.length);
+            for (Reference reference : insertColumns) {
+                Reference.toStream(reference, out);
+            }
+            insertValuesStreamer = Symbols.streamerArray(List.of(insertColumns));
+        } else {
+            out.writeVInt(0);
+        }
+        sessionSettings.writeTo(out);
+
+        boolean allOn4_2 = out.getVersion().onOrAfter(Version.V_4_2_0);
+
+        out.writeVInt(items.size());
+        for (ShardInsertRequest.Item item : items) {
+            item.writeTo(out, insertValuesStreamer, allOn4_2);
+        }
+    }
+
+
+    @Nullable
+    @Override
+    public SessionSettings sessionSettings() {
+        return sessionSettings;
+    }
+
+    @Nullable
+    @Override
+    public Symbol[] returnValues() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String[] updateColumns() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Reference[] insertColumns() {
+        return insertColumns;
+    }
+
+    /**
+     * A single insert item.
+     */
+    public static class Item extends AbstractShardWriteRequest.Item {
+
+        /**
+         * List of objects used on insert
+         */
+        @Nullable
+        private Object[] insertValues;
+
+        public Item(String id,
+                    @Nullable Symbol[] updateAssignments,
+                    @Nullable Object[] insertValues,
+                    @Nullable Long version,
+                    @Nullable Long seqNo,
+                    @Nullable Long primaryTerm,
+                    @Nullable Symbol[] returnValues
+        ) {
+            super(id, version, seqNo, primaryTerm);
+            if (version != null) {
+                this.version = version;
+            }
+            if (seqNo != null) {
+                this.seqNo = seqNo;
+            }
+            if (primaryTerm != null) {
+                this.primaryTerm = primaryTerm;
+            }
+            this.insertValues = insertValues;
+        }
+
+        boolean retryOnConflict() {
+            return seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO && version == Versions.MATCH_ANY;
+        }
+
+        @Nullable
+        Symbol[] updateAssignments() {
+            return null;
+        }
+
+        @Nullable
+        public Object[] insertValues() {
+            return insertValues;
+        }
+
+        @Nullable
+        public Symbol[] returnValues() {
+            return null;
+        }
+
+        public Item(StreamInput in, @Nullable Streamer[] insertValueStreamers) throws IOException {
+            super(in);
+            int missingAssignmentsSize = in.readVInt();
+            if (missingAssignmentsSize > 0) {
+                assert insertValueStreamers != null : "streamers are required if reading insert values";
+                this.insertValues = new Object[missingAssignmentsSize];
+                for (int i = 0; i < missingAssignmentsSize; i++) {
+                    insertValues[i] = insertValueStreamers[i].readValueFrom(in);
+                }
+            }
+        }
+
+        public void writeTo(StreamOutput out, @Nullable Streamer[] insertValueStreamers, boolean allOn4_2) throws IOException {
+            super.writeTo(out);
+            if (insertValues != null) {
+                assert insertValueStreamers != null : "streamers are required to stream insert values";
+                out.writeVInt(insertValues.length);
+                for (int i = 0; i < insertValues.length; i++) {
+                    insertValueStreamers[i].writeValueTo(out, insertValues[i]);
+                }
+            } else {
+                out.writeVInt(0);
+            }
+        }
+    }
+
+
+    public static class Builder {
+
+        private final SessionSettings sessionSettings;
+        private final TimeValue timeout;
+        @Nullable
+        private final Reference[] insertColumns;
+        private final UUID jobId;
+        @Nullable
+        private final EnumSet<Mode> modes;
+
+        public Builder(SessionSettings sessionSettings,
+                       TimeValue timeout,
+                       boolean continueOnError,
+                       Reference[] insertColumns,
+                       UUID jobId,
+                       boolean validateGeneratedColumns,
+                       Mode... modes) {
+            this.sessionSettings = sessionSettings;
+            this.timeout = timeout;
+            this.insertColumns = insertColumns;
+            this.jobId = jobId;
+            this.modes = EnumSet.copyOf(List.of(modes));
+            if (validateGeneratedColumns) {
+                this.modes.add(Mode.VALIDATE_CONSTRAINTS);
+            }
+            if (continueOnError) {
+                this.modes.add(Mode.CONTINUE_ON_ERROR);
+            }
+        }
+
+        public ShardInsertRequest newRequest(ShardId shardId) {
+            return new ShardInsertRequest(
+                shardId,
+                jobId,
+                modes,
+                sessionSettings,
+                insertColumns
+            ).timeout(timeout);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardInsertRequest.java
@@ -42,7 +42,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
-public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertRequest, ShardInsertRequest.Item> {
+public class ShardInsertRequest extends ShardWriteRequest<ShardInsertRequest, ShardInsertRequest.Item> {
 
     private SessionSettings sessionSettings;
 
@@ -100,7 +100,7 @@ public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertReq
 
         out.writeVInt(items.size());
         for (ShardInsertRequest.Item item : items) {
-            item.writeTo(out, insertValuesStreamer, allOn4_2);
+            item.writeTo(out, insertValuesStreamer);
         }
     }
 
@@ -132,7 +132,7 @@ public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertReq
     /**
      * A single insert item.
      */
-    public static class Item extends AbstractShardWriteRequest.Item {
+    public static class Item extends ShardWriteRequest.Item {
 
         /**
          * List of objects used on insert
@@ -141,7 +141,7 @@ public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertReq
         private Object[] insertValues;
 
         public Item(String id,
-                    @Nullable Object[] insertValues,
+                    Object[] insertValues,
                     @Nullable Long version,
                     @Nullable Long seqNo,
                     @Nullable Long primaryTerm
@@ -190,7 +190,7 @@ public class ShardInsertRequest extends AbstractShardWriteRequest<ShardInsertReq
             }
         }
 
-        public void writeTo(StreamOutput out, @Nullable Streamer[] insertValueStreamers, boolean allOn4_2) throws IOException {
+        public void writeTo(StreamOutput out, @Nullable Streamer[] insertValueStreamers) throws IOException {
             super.writeTo(out);
             if (insertValues != null) {
                 assert insertValueStreamers != null : "streamers are required to stream insert values";

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpdateRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpdateRequest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Reference;
+import io.crate.metadata.settings.SessionSettings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+
+public final class ShardUpdateRequest extends AbstractShardWriteRequest<ShardUpdateRequest, ShardUpdateRequest.Item> {
+
+    /**
+     * List of column names used on update
+     */
+    private String[] updateColumns;
+
+    private SessionSettings sessionSettings;
+
+    @Nullable
+    private Symbol[] returnValues;
+
+    public ShardUpdateRequest(
+        ShardId shardId,
+        UUID jobId,
+        EnumSet<Mode> modes,
+        SessionSettings sessionSettings,
+        String[] updateColumns,
+        @Nullable Symbol[] returnValues
+    ) {
+        super(shardId, jobId, modes);
+        this.sessionSettings = sessionSettings;
+        this.updateColumns = updateColumns;
+        this.returnValues = returnValues;
+    }
+
+    public ShardUpdateRequest(StreamInput in) throws IOException {
+        super(in);
+        int assignmentsColumnsSize = in.readVInt();
+        if (assignmentsColumnsSize > 0) {
+            updateColumns = new String[assignmentsColumnsSize];
+            for (int i = 0; i < assignmentsColumnsSize; i++) {
+                updateColumns[i] = in.readString();
+            }
+        }
+        sessionSettings = new SessionSettings(in);
+        int numItems = in.readVInt();
+        items = new ArrayList<>(numItems);
+        for (int i = 0; i < numItems; i++) {
+            items.add(new ShardUpdateRequest.Item(in));
+        }
+        int returnValuesSize = in.readVInt();
+        if (returnValuesSize > 0) {
+            returnValues = new Symbol[returnValuesSize];
+            for (int i = 0; i < returnValuesSize; i++) {
+                returnValues[i] = Symbols.fromStream(in);
+            }
+        }
+    }
+
+    @Override
+    public SessionSettings sessionSettings() {
+        return sessionSettings;
+    }
+
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        // Stream References
+        if (updateColumns != null) {
+            out.writeVInt(updateColumns.length);
+            for (String column : updateColumns) {
+                out.writeString(column);
+            }
+        } else {
+            out.writeVInt(0);
+        }
+
+        sessionSettings.writeTo(out);
+
+        out.writeVInt(items.size());
+        for (ShardUpdateRequest.Item item : items) {
+            item.writeTo(out);
+        }
+        if (returnValues != null) {
+            out.writeVInt(returnValues.length);
+            for (Symbol returnValue : returnValues) {
+                Symbols.toStream(returnValue, out);
+            }
+        } else {
+            out.writeVInt(0);
+        }
+    }
+
+    @Override
+    @Nullable
+    public Symbol[] returnValues() {
+        return returnValues;
+    }
+
+    @Override
+    public String[] updateColumns() {
+        return updateColumns;
+    }
+
+    @Override
+    @Nullable
+    public Reference[] insertColumns() {
+        return null;
+    }
+
+    public static class Item extends AbstractShardWriteRequest.Item {
+
+        /**
+         * List of symbols used on update if document exist
+         */
+        @Nullable
+        private Symbol[] updateAssignments;
+
+
+        protected Item(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                int assignmentsSize = in.readVInt();
+                updateAssignments = new Symbol[assignmentsSize];
+                for (int i = 0; i < assignmentsSize; i++) {
+                    updateAssignments[i] = Symbols.fromStream(in);
+                }
+            }
+        }
+
+        public Item(String id,
+                    Symbol[] updateAssignments,
+                    @Nullable Long version,
+                    @Nullable Long seqNo,
+                    @Nullable Long primaryTerm
+        ) {
+            super(id, version, seqNo, primaryTerm);
+            this.updateAssignments = updateAssignments;
+        }
+
+        @Nullable
+        @Override
+        Symbol[] updateAssignments() {
+            return updateAssignments;
+        }
+
+        @Nullable
+        @Override
+        public Object[] insertValues() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            if (updateAssignments != null) {
+                out.writeBoolean(true);
+                out.writeVInt(updateAssignments.length);
+                for (Symbol updateAssignment : updateAssignments) {
+                    Symbols.toStream(updateAssignment, out);
+                }
+            } else {
+                out.writeBoolean(false);
+            }
+        }
+    }
+
+    public static class Builder {
+
+        private final SessionSettings sessionSettings;
+        private final TimeValue timeout;
+        private final String[] assignmentsColumns;
+        @Nullable
+        private final Symbol[] returnValues;
+        private final UUID jobId;
+        private final EnumSet<Mode> modes;
+
+        public Builder(SessionSettings sessionSettings,
+                       TimeValue timeout,
+                       boolean continueOnError,
+                       String[] assignmentsColumns,
+                       Symbol[] returnValues,
+                       UUID jobId,
+                       boolean validateGeneratedColumns,
+                       Mode... modes) {
+            this.sessionSettings = sessionSettings;
+            this.timeout = timeout;
+            this.assignmentsColumns = assignmentsColumns;
+            this.returnValues = returnValues;
+            this.jobId = jobId;
+            this.modes = EnumSet.copyOf(List.of(modes));
+            if (validateGeneratedColumns) {
+                this.modes.add(Mode.VALIDATE_CONSTRAINTS);
+            }
+            if (continueOnError) {
+                this.modes.add(Mode.CONTINUE_ON_ERROR);
+            }
+        }
+
+        public ShardUpdateRequest newRequest(ShardId shardId) {
+            return new ShardUpdateRequest(
+                shardId,
+                jobId,
+                modes,
+                sessionSettings,
+                assignmentsColumns,
+                returnValues
+            ).timeout(timeout);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpdateRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpdateRequest.java
@@ -38,7 +38,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
-public final class ShardUpdateRequest extends AbstractShardWriteRequest<ShardUpdateRequest, ShardUpdateRequest.Item> {
+public final class ShardUpdateRequest extends ShardWriteRequest<ShardUpdateRequest, ShardUpdateRequest.Item> {
 
     /**
      * List of column names used on update
@@ -140,7 +140,7 @@ public final class ShardUpdateRequest extends AbstractShardWriteRequest<ShardUpd
         return null;
     }
 
-    public static class Item extends AbstractShardWriteRequest.Item {
+    public static class Item extends ShardWriteRequest.Item {
 
         /**
          * List of symbols used on update if document exist

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -248,19 +248,12 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
         @Nullable
         private Object[] insertValues;
 
-        /**
-         * List of references or expressions to compute values for returning for update.
-         */
-        @Nullable
-        private Symbol[] returnValues;
-
         public Item(String id,
                     @Nullable Symbol[] updateAssignments,
                     @Nullable Object[] insertValues,
                     @Nullable Long version,
                     @Nullable Long seqNo,
-                    @Nullable Long primaryTerm,
-                    @Nullable Symbol[] returnValues
+                    @Nullable Long primaryTerm
                     ) {
             super(id);
             this.updateAssignments = updateAssignments;
@@ -274,7 +267,6 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                 this.primaryTerm = primaryTerm;
             }
             this.insertValues = insertValues;
-            this.returnValues = returnValues;
         }
 
         @Nullable
@@ -300,11 +292,6 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             return insertValues;
         }
 
-        @Nullable
-        public Symbol[] returnValues() {
-            return returnValues;
-        }
-
         public Item(StreamInput in, @Nullable Streamer[] insertValueStreamers) throws IOException {
             super(in);
             if (in.readBoolean()) {
@@ -324,15 +311,6 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             }
             if (in.readBoolean()) {
                 source = in.readBytesReference();
-            }
-            if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
-                int returnValueSize = in.readVInt();
-                if (returnValueSize > 0) {
-                    returnValues = new Symbol[returnValueSize];
-                    for (int i = 0; i < returnValueSize; i++) {
-                        returnValues[i] = Symbols.fromStream(in);
-                    }
-                }
             }
         }
 
@@ -362,16 +340,6 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             out.writeBoolean(sourceAvailable);
             if (sourceAvailable) {
                 out.writeBytesReference(source);
-            }
-            if (allOn4_2) {
-                if (returnValues != null) {
-                    out.writeVInt(returnValues.length);
-                    for (Symbol returnValue : returnValues) {
-                        Symbols.toStream(returnValue, out);
-                    }
-                } else {
-                    out.writeVInt(0);
-                }
             }
         }
     }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -28,7 +28,6 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.settings.SessionSettings;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -189,9 +188,6 @@ public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertReq
      */
     public static class Item extends AbstractShardWriteRequest.Item {
 
-        @Nullable
-        private BytesReference source;
-
         /**
          * List of symbols used on update if document exist
          */
@@ -233,15 +229,6 @@ public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertReq
             this.returnValues = returnValues;
         }
 
-        @Nullable
-        public BytesReference source() {
-            return source;
-        }
-
-        public void source(BytesReference source) {
-            this.source = source;
-        }
-
         boolean retryOnConflict() {
             return seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO && version == Versions.MATCH_ANY;
         }
@@ -278,9 +265,6 @@ public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertReq
                     insertValues[i] = insertValueStreamers[i].readValueFrom(in);
                 }
             }
-            if (in.readBoolean()) {
-                source = in.readBytesReference();
-            }
             if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
                 int returnValueSize = in.readVInt();
                 if (returnValueSize > 0) {
@@ -312,12 +296,6 @@ public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertReq
                 }
             } else {
                 out.writeVInt(0);
-            }
-
-            boolean sourceAvailable = source != null;
-            out.writeBoolean(sourceAvailable);
-            if (sourceAvailable) {
-                out.writeBytesReference(source);
             }
             if (allOn4_2) {
                 if (returnValues != null) {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -42,7 +42,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
-public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertRequest, ShardUpsertRequest.Item> {
+public class ShardUpsertRequest extends ShardWriteRequest<ShardUpsertRequest, ShardUpsertRequest.Item> {
 
     private SessionSettings sessionSettings;
 
@@ -186,7 +186,7 @@ public class ShardUpsertRequest extends AbstractShardWriteRequest<ShardUpsertReq
     /**
      * A single update item.
      */
-    public static class Item extends AbstractShardWriteRequest.Item {
+    public static class Item extends ShardWriteRequest.Item {
 
         /**
          * List of symbols used on update if document exist

--- a/sql/src/main/java/io/crate/execution/dml/upsert/ShardWriteRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/ShardWriteRequest.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import java.util.UUID;
 
 
-public abstract class AbstractShardWriteRequest<T extends ShardRequest<T, I>, I extends ShardRequest.Item> extends ShardRequest<T, I> {
+public abstract class ShardWriteRequest<T extends ShardRequest<T, I>, I extends ShardRequest.Item> extends ShardRequest<T, I> {
 
     public enum Mode {
         DUPLICATE_KEY_UPDATE_OR_FAIL,
@@ -54,12 +54,12 @@ public abstract class AbstractShardWriteRequest<T extends ShardRequest<T, I>, I 
     protected Set<Mode> modes;
 
 
-    protected AbstractShardWriteRequest(StreamInput in) throws IOException {
+    protected ShardWriteRequest(StreamInput in) throws IOException {
         super(in);
         this.modes = EnumSets.unpackFromInt(in.readVInt(), Mode.class);
     }
 
-    protected AbstractShardWriteRequest(ShardId shardId, UUID jobId, EnumSet<Mode> modes) {
+    protected ShardWriteRequest(ShardId shardId, UUID jobId, EnumSet<Mode> modes) {
         super(shardId, jobId);
         this.modes = modes;
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardInsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardInsertAction.java
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 
 @Singleton
 public class TransportShardInsertAction extends
-    AbstractTransportShardWriteAction<ShardInsertRequest, ShardInsertRequest.Item> {
+        TransportShardWriteAction<ShardInsertRequest, ShardInsertRequest.Item> {
 
     private static final String ACTION_NAME = "internal:crate:sql/data/insert";
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardInsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardInsertAction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dml.upsert;
+
+import io.crate.execution.ddl.SchemaUpdateClient;
+import io.crate.execution.jobs.TasksService;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Schemas;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportShardInsertAction extends
+    AbstractTransportShardWriteAction<ShardInsertRequest, ShardInsertRequest.Item> {
+
+    private static final String ACTION_NAME = "internal:crate:sql/data/insert";
+
+    @Inject
+    public TransportShardInsertAction(ThreadPool threadPool,
+                                      ClusterService clusterService,
+                                      TransportService transportService,
+                                      SchemaUpdateClient schemaUpdateClient,
+                                      TasksService tasksService,
+                                      IndicesService indicesService,
+                                      ShardStateAction shardStateAction,
+                                      Functions functions,
+                                      Schemas schemas,
+                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(
+            ACTION_NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            schemaUpdateClient,
+            tasksService,
+            indicesService,
+            shardStateAction,
+            functions,
+            schemas,
+            indexNameExpressionResolver,
+            ShardInsertRequest::new
+        );
+    }
+}

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpdateAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpdateAction.java
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 
 @Singleton
 public final class TransportShardUpdateAction extends
-    AbstractTransportShardWriteAction<ShardUpdateRequest, ShardUpdateRequest.Item> {
+        TransportShardWriteAction<ShardUpdateRequest, ShardUpdateRequest.Item> {
 
     private static final String ACTION_NAME = "internal:crate:sql/data/update";
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpdateAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpdateAction.java
@@ -30,16 +30,19 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportShardUpsertAction extends AbstractTransportShardWriteAction<ShardUpsertRequest, ShardUpsertRequest.Item> {
+@Singleton
+public final class TransportShardUpdateAction extends
+    AbstractTransportShardWriteAction<ShardUpdateRequest, ShardUpdateRequest.Item> {
 
-    private static final String ACTION_NAME = "internal:crate:sql/data/write";
+    private static final String ACTION_NAME = "internal:crate:sql/data/update";
 
     @Inject
-    public TransportShardUpsertAction(ThreadPool threadPool,
+    public TransportShardUpdateAction(ThreadPool threadPool,
                                       ClusterService clusterService,
                                       TransportService transportService,
                                       SchemaUpdateClient schemaUpdateClient,
@@ -61,7 +64,7 @@ public class TransportShardUpsertAction extends AbstractTransportShardWriteActio
             functions,
             schemas,
             indexNameExpressionResolver,
-            ShardUpsertRequest::new
+            ShardUpdateRequest::new
         );
     }
 }

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -27,7 +27,7 @@ import io.crate.Constants;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.execution.engine.collect.PKLookupOperation;
 import io.crate.execution.jobs.TasksService;
 import io.crate.expression.reference.Doc;
@@ -266,7 +266,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 }
             } catch (VersionConflictEngineException e) {
                 lastException = e;
-                if (request.duplicateKeyAction() == DuplicateKeyAction.IGNORE) {
+                if (request.properties().contains(Properties.DUPLICATE_KEY_IGNORE)) {
                     // on conflict do nothing
                     item.source(null);
                     return null;
@@ -329,7 +329,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         }
         item.source(rawSource);
 
-        long version = request.duplicateKeyAction() == DuplicateKeyAction.OVERWRITE ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
+        long version = request.properties().contains(Properties.DUPLICATE_KEY_OVERWRITE) ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
         long seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
         long primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -34,7 +34,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportShardUpsertAction extends AbstractTransportShardWriteAction<ShardUpsertRequest, ShardUpsertRequest.Item> {
+public class TransportShardUpsertAction extends TransportShardWriteAction<ShardUpsertRequest, ShardUpsertRequest.Item> {
 
     private static final String ACTION_NAME = "internal:crate:sql/data/write";
 

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardWriteAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardWriteAction.java
@@ -81,8 +81,8 @@ import static io.crate.exceptions.SQLExceptions.userFriendlyCrateExceptionTopOnl
 /**
  * Realizes Upserts of tables which either results in an Insert or an Update.
  */
-public abstract class AbstractTransportShardWriteAction
-    <Request extends AbstractShardWriteRequest<Request, Item>, Item extends AbstractShardWriteRequest.Item>
+public abstract class TransportShardWriteAction
+    <Request extends ShardWriteRequest<Request, Item>, Item extends ShardWriteRequest.Item>
     extends TransportShardAction<Request, Item> {
 
     private static final int MAX_RETRY_LIMIT = 100_000; // upper bound to prevent unlimited retries on unexpected states
@@ -90,18 +90,18 @@ public abstract class AbstractTransportShardWriteAction
     private final Schemas schemas;
     private final Functions functions;
 
-    public AbstractTransportShardWriteAction(String actionName,
-                                             ThreadPool threadPool,
-                                             ClusterService clusterService,
-                                             TransportService transportService,
-                                             SchemaUpdateClient schemaUpdateClient,
-                                             TasksService tasksService,
-                                             IndicesService indicesService,
-                                             ShardStateAction shardStateAction,
-                                             Functions functions,
-                                             Schemas schemas,
-                                             IndexNameExpressionResolver indexNameExpressionResolver,
-                                             Writeable.Reader<Request> reader
+    public TransportShardWriteAction(String actionName,
+                                     ThreadPool threadPool,
+                                     ClusterService clusterService,
+                                     TransportService transportService,
+                                     SchemaUpdateClient schemaUpdateClient,
+                                     TasksService tasksService,
+                                     IndicesService indicesService,
+                                     ShardStateAction shardStateAction,
+                                     Functions functions,
+                                     Schemas schemas,
+                                     IndexNameExpressionResolver indexNameExpressionResolver,
+                                     Writeable.Reader<Request> reader
 
     ) {
         super(
@@ -268,7 +268,7 @@ public abstract class AbstractTransportShardWriteAction
                 }
             } catch (VersionConflictEngineException e) {
                 lastException = e;
-                if (request.modes().contains(AbstractShardWriteRequest.Mode.DUPLICATE_KEY_IGNORE)) {
+                if (request.modes().contains(ShardWriteRequest.Mode.DUPLICATE_KEY_IGNORE)) {
                     // on conflict do nothing
                     item.source(null);
                     return null;
@@ -331,7 +331,7 @@ public abstract class AbstractTransportShardWriteAction
         }
         item.source(rawSource);
 
-        long version = request.modes().contains(AbstractShardWriteRequest.Mode.DUPLICATE_KEY_OVERWRITE) ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
+        long version = request.modes().contains(ShardWriteRequest.Mode.DUPLICATE_KEY_OVERWRITE) ? Versions.MATCH_ANY : Versions.MATCH_DELETED;
         long seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
         long primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -29,7 +29,7 @@ import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.TransportActionProvider;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
@@ -102,13 +102,14 @@ public class ColumnIndexWriterProjector implements Projector {
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            ignoreDuplicateKeys ? DuplicateKeyAction.IGNORE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
             returnValueOrNull,
             jobId,
-            true);
+            true,
+            ignoreDuplicateKeys ? Properties.DUPLICATE_KEY_IGNORE : Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            );
 
         InputRow insertValues = new InputRow(insertInputs);
         Function<String, ShardUpsertRequest.Item> itemFactory =

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -31,7 +31,7 @@ import io.crate.execution.TransportActionProvider;
 import io.crate.execution.dml.ShardRequest;
 import io.crate.execution.dml.upsert.ShardInsertRequest;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
+import io.crate.execution.dml.upsert.ShardWriteRequest.Mode;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -118,8 +118,8 @@ public class ColumnIndexWriterProjector implements Projector {
                                               insertValues.materialize(),
                                               null,
                                               null,
-                                              null,
-                                              returnValueOrNull);
+                                              null
+                                              );
 
         var upsertResultContext = returnValues.isEmpty() ? UpsertResultContext.forRowCount() : UpsertResultContext.forResultRows();
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -29,7 +29,7 @@ import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.TransportActionProvider;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
+import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
@@ -108,7 +108,7 @@ public class ColumnIndexWriterProjector implements Projector {
             returnValueOrNull,
             jobId,
             true,
-            ignoreDuplicateKeys ? Properties.DUPLICATE_KEY_IGNORE : Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ignoreDuplicateKeys ? Mode.DUPLICATE_KEY_IGNORE : Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             );
 
         InputRow insertValues = new InputRow(insertInputs);
@@ -118,8 +118,8 @@ public class ColumnIndexWriterProjector implements Projector {
                                               insertValues.materialize(),
                                               null,
                                               null,
-                                              null
-                                              );
+                                              null,
+                                              returnValueOrNull);
 
         var upsertResultContext = returnValues.isEmpty() ? UpsertResultContext.forRowCount() : UpsertResultContext.forResultRows();
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -27,7 +27,7 @@ import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
+import io.crate.execution.dml.upsert.ShardWriteRequest.Mode;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -27,8 +27,8 @@ import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
+import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
@@ -109,11 +109,11 @@ public class IndexWriterProjector implements Projector {
             null,
             jobId,
             false,
-            overwriteDuplicates ? Properties.DUPLICATE_KEY_OVERWRITE : Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            overwriteDuplicates ? Mode.DUPLICATE_KEY_OVERWRITE : Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             );
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
+            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -28,7 +28,7 @@ import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
@@ -103,13 +103,14 @@ public class IndexWriterProjector implements Projector {
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            overwriteDuplicates ? DuplicateKeyAction.OVERWRITE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
             new Reference[]{rawSourceReference},
             null,
             jobId,
-            false);
+            false,
+            overwriteDuplicates ? Properties.DUPLICATE_KEY_OVERWRITE : Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            );
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
             id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -113,7 +113,7 @@ public class IndexWriterProjector implements Projector {
             );
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);
+            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -526,14 +526,14 @@ public class ProjectionToProjectorVisitor
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             context.txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             projection.assignmentsColumns(),
             null,
             projection.returnValues(),
             context.jobId,
-            true
-        );
+            true,
+            ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            );
 
         return new ShardDMLExecutor<>(
             ShardDMLExecutor.DEFAULT_BULK_SIZE,

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -548,8 +548,7 @@ public class ProjectionToProjectorVisitor
                                               null,
                                               projection.requiredVersion(),
                                               null,
-                                              null,
-                                              projection.returnValues()),
+                                              null),
             transportActionProvider.transportShardUpsertAction()::execute,
             collector);
     }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.Iterables;
 
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest;
+import io.crate.execution.dml.upsert.ShardWriteRequest;
 import io.crate.execution.dml.upsert.ShardUpdateRequest;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -525,14 +525,14 @@ public class ProjectionToProjectorVisitor
         Collector<ShardResponse, A, Iterable<Row>> collector) {
 
         ShardUpdateRequest.Builder builder = new ShardUpdateRequest.Builder(
-            context.txnCtx.sessionSettings(),
-            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            false,
-            projection.assignmentsColumns(),
-            projection.returnValues(),
-            context.jobId,
-            true,
-            AbstractShardWriteRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
+                context.txnCtx.sessionSettings(),
+                ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
+                false,
+                projection.assignmentsColumns(),
+                projection.returnValues(),
+                context.jobId,
+                true,
+                ShardWriteRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             );
 
         return new ShardDMLExecutor<>(

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -27,7 +27,7 @@ import io.crate.analyze.where.DocKeys;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dml.ShardRequestExecutor;
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest;
+import io.crate.execution.dml.upsert.ShardWriteRequest;
 import io.crate.execution.dml.upsert.ShardUpdateRequest;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
 import io.crate.expression.symbol.Assignments;
@@ -111,14 +111,14 @@ public final class UpdateById implements Plan {
         ClusterService clusterService = dependencies.clusterService();
         CoordinatorTxnCtx txnCtx = plannerContext.transactionContext();
         ShardUpdateRequest.Builder requestBuilder = new ShardUpdateRequest.Builder(
-            txnCtx.sessionSettings(),
-            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(clusterService.state().metaData().settings()),
-            true,
-            assignments.targetNames(),
-            returnValues,
-            plannerContext.jobId(),
-            false,
-            AbstractShardWriteRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
+                txnCtx.sessionSettings(),
+                ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(clusterService.state().metaData().settings()),
+                true,
+                assignments.targetNames(),
+                returnValues,
+                plannerContext.jobId(),
+                false,
+                ShardWriteRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             );
 
         UpdateRequests updateRequests = new UpdateRequests(requestBuilder, table, assignments);

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -168,8 +168,8 @@ public final class UpdateById implements Plan {
                                                                        null,
                                                                        version,
                                                                        seqNo,
-                                                                       primaryTerm,
-                                                                       request.getReturnValues());
+                                                                       primaryTerm
+                                                                       );
             request.add(location, item);
         }
     }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -112,13 +112,13 @@ public final class UpdateById implements Plan {
         ShardUpsertRequest.Builder requestBuilder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(clusterService.state().metaData().settings()),
-            ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             assignments.targetNames(),
             null, // missing assignments are for INSERT .. ON DUPLICATE KEY UPDATE
             returnValues,
             plannerContext.jobId(),
-            false
+            false,
+            ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
         );
         UpdateRequests updateRequests = new UpdateRequests(requestBuilder, table, assignments);
         return new ShardRequestExecutor<>(

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -231,15 +231,15 @@ public class InsertFromValues implements LogicalPlan {
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             plannerContext.transactionContext().sessionSettings(),
             BULK_REQUEST_TIMEOUT_SETTING.setting().get(dependencies.settings()),
-            writerProjection.isIgnoreDuplicateKeys()
-                ? ShardUpsertRequest.DuplicateKeyAction.IGNORE
-                : ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
             rows.size() > 1, // continueOnErrors
             updateColumnNames,
             writerProjection.allTargetColumns().toArray(new Reference[0]),
             returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[0]),
             plannerContext.jobId(),
-            false);
+            false,
+            writerProjection.isIgnoreDuplicateKeys()
+                ? ShardUpsertRequest.Properties.DUPLICATE_KEY_IGNORE
+                : ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL);
 
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
@@ -346,15 +346,16 @@ public class InsertFromValues implements LogicalPlan {
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             plannerContext.transactionContext().sessionSettings(),
             BULK_REQUEST_TIMEOUT_SETTING.setting().get(dependencies.settings()),
-            writerProjection.isIgnoreDuplicateKeys()
-                ? ShardUpsertRequest.DuplicateKeyAction.IGNORE
-                : ShardUpsertRequest.DuplicateKeyAction.UPDATE_OR_FAIL,
+
             true, // continueOnErrors
             updateColumnNames,
             writerProjection.allTargetColumns().toArray(new Reference[0]),
             null,
             plannerContext.jobId(),
-            true);
+            true,
+            writerProjection.isIgnoreDuplicateKeys()
+                ? ShardUpsertRequest.Properties.DUPLICATE_KEY_IGNORE
+                : ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL);
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
         HashMap<String, InsertSourceFromCells> validatorsCache = new HashMap<>();

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -238,8 +238,8 @@ public class InsertFromValues implements LogicalPlan {
             plannerContext.jobId(),
             false,
             writerProjection.isIgnoreDuplicateKeys()
-                ? ShardUpsertRequest.Properties.DUPLICATE_KEY_IGNORE
-                : ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL);
+                ? ShardUpsertRequest.Mode.DUPLICATE_KEY_IGNORE
+                : ShardUpsertRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL);
 
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
@@ -354,8 +354,8 @@ public class InsertFromValues implements LogicalPlan {
             plannerContext.jobId(),
             true,
             writerProjection.isIgnoreDuplicateKeys()
-                ? ShardUpsertRequest.Properties.DUPLICATE_KEY_IGNORE
-                : ShardUpsertRequest.Properties.DUPLICATE_KEY_UPDATE_OR_FAIL);
+                ? ShardUpsertRequest.Mode.DUPLICATE_KEY_IGNORE
+                : ShardUpsertRequest.Mode.DUPLICATE_KEY_UPDATE_OR_FAIL);
         var shardedRequests = new ShardedRequests<>(builder::newRequest);
 
         HashMap<String, InsertSourceFromCells> validatorsCache = new HashMap<>();
@@ -454,7 +454,7 @@ public class InsertFromValues implements LogicalPlan {
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null);
+                null, null, null, this.writerProjection.returnValues().toArray(new Symbol[0]));
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -454,7 +454,7 @@ public class InsertFromValues implements LogicalPlan {
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null, this.writerProjection.returnValues().toArray(new Symbol[0]));
+                null, null, null);
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkRequestExecutor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkRequestExecutor.java
@@ -26,7 +26,7 @@ import io.crate.execution.dml.ShardResponse;
 import org.elasticsearch.action.ActionListener;
 
 @FunctionalInterface
-public interface BulkRequestExecutor<Request extends ShardRequest> {
+public interface BulkRequestExecutor<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item> {
 
-    void execute(Request request, ActionListener<ShardResponse> listener);
+    void execute(TReq request, ActionListener<ShardResponse> listener);
 }

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
-import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
+import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
@@ -69,21 +69,22 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         UUID jobId = UUID.randomUUID();
         Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
-            TimeValue.timeValueSeconds(30),
-            false,
-            assignmentColumns,
-            missingAssignmentColumns,
-            null,
-            jobId,
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
+                TimeValue.timeValueSeconds(30),
+                false,
+                assignmentColumns,
+                missingAssignmentColumns,
+                null,
+                jobId,
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
 
         request.add(123, new ShardUpsertRequest.Item(
             "99",
             null,
             new Object[]{99, "Marvin"},
+            null,
             null,
             null,
             null));
@@ -93,6 +94,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
+            null,
             null));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
@@ -100,7 +102,8 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             null,
             2L,
             1L,
-            5L));
+            5L,
+            null));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
@@ -118,15 +121,15 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         UUID jobId = UUID.randomUUID();
         Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
-            TimeValue.timeValueSeconds(30),
-            false,
-            assignmentColumns,
-            missingAssignmentColumns,
-            null,
-            jobId,
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
+                TimeValue.timeValueSeconds(30),
+                false,
+                assignmentColumns,
+                missingAssignmentColumns,
+                null,
+                jobId,
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
 
         request.add(123, new ShardUpsertRequest.Item(
@@ -135,21 +138,24 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            new Symbol[0]));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            new Symbol[0]));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L));
+            5L,
+            new Symbol[0]));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -86,13 +86,11 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
             null));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
-            null,
             null,
             null,
             null));
@@ -102,8 +100,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             null,
             2L,
             1L,
-            5L,
-            null));
+            5L));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
@@ -138,24 +135,21 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L,
-            new Symbol[0]));
+            5L));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
-import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
@@ -71,15 +71,14 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             assignmentColumns,
             missingAssignmentColumns,
             null,
             jobId,
-            false
-        ).newRequest(shardId);
-        request.validateConstraints(false);
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ).newRequest(shardId);
 
         request.add(123, new ShardUpsertRequest.Item(
             "99",
@@ -124,15 +123,14 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             assignmentColumns,
             missingAssignmentColumns,
             null,
             jobId,
-            false
-        ).newRequest(shardId);
-        request.validateConstraints(false);
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ).newRequest(shardId);
 
         request.add(123, new ShardUpsertRequest.Item(
             "99",

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -86,13 +86,11 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
             null));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
-            null,
             null,
             null,
             null));
@@ -102,8 +100,8 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             null,
             2L,
             1L,
-            5L,
-            null));
+            5L
+            ));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
@@ -138,24 +136,21 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L,
-            new Symbol[0]));
+            5L));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
+import io.crate.execution.dml.upsert.ShardWriteRequest.Mode;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -184,7 +184,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 false,
                 Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -206,7 +206,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 false,
                 Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -248,7 +248,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 false,
                 Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -270,7 +270,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 false,
                 Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -25,7 +25,7 @@ package io.crate.execution.dml.upsert;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
+import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
 import io.crate.execution.jobs.TasksService;
 import io.crate.metadata.Functions;
 import io.crate.metadata.PartitionName;
@@ -110,7 +110,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                                  ShardStateAction shardStateAction,
                                                  Functions functions,
                                                  Schemas schemas,
-                                                 IndexNameExpressionResolver indexNameExpressionResolver) {
+                                                 IndexNameExpressionResolver indexNameExpressionResolver
+        ) {
             super(threadPool, clusterService, transportService, schemaUpdateClient,
                 tasksService, indicesService, shardStateAction, functions, schemas, indexNameExpressionResolver);
         }
@@ -173,17 +174,17 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            DUMMY_SESSION_INFO,
-            TimeValue.timeValueSeconds(30),
-            false,
-            null,
-            new Reference[]{ID_REF},
-            null,
-            UUID.randomUUID(),
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                DUMMY_SESSION_INFO,
+                TimeValue.timeValueSeconds(30),
+                false,
+                null,
+                new Reference[]{ID_REF},
+                null,
+                UUID.randomUUID(),
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -195,17 +196,17 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            DUMMY_SESSION_INFO,
-            TimeValue.timeValueSeconds(30),
-            true,
-            null,
-            new Reference[]{ID_REF},
-            null,
-            UUID.randomUUID(),
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                DUMMY_SESSION_INFO,
+                TimeValue.timeValueSeconds(30),
+                true,
+                null,
+                new Reference[]{ID_REF},
+                null,
+                UUID.randomUUID(),
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -237,17 +238,17 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            DUMMY_SESSION_INFO,
-            TimeValue.timeValueSeconds(30),
-            false,
-            null,
-            new Reference[]{ID_REF},
-            null,
-            UUID.randomUUID(),
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                DUMMY_SESSION_INFO,
+                TimeValue.timeValueSeconds(30),
+                false,
+                null,
+                new Reference[]{ID_REF},
+                null,
+                UUID.randomUUID(),
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -259,17 +260,17 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            DUMMY_SESSION_INFO,
-            TimeValue.timeValueSeconds(30),
-            false,
-            null,
-            new Reference[]{ID_REF},
-            null,
-            UUID.randomUUID(),
-            false,
-            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+                DUMMY_SESSION_INFO,
+                TimeValue.timeValueSeconds(30),
+                false,
+                null,
+                new Reference[]{ID_REF},
+                null,
+                UUID.randomUUID(),
+                false,
+                Mode.DUPLICATE_KEY_UPDATE_OR_FAIL
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -25,7 +25,7 @@ package io.crate.execution.dml.upsert;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
-import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.Properties;
 import io.crate.execution.jobs.TasksService;
 import io.crate.metadata.Functions;
 import io.crate.metadata.PartitionName;
@@ -175,14 +175,14 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false
-        ).newRequest(shardId);
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
@@ -197,14 +197,14 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false
-        ).newRequest(shardId);
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
@@ -239,14 +239,14 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false
-        ).newRequest(shardId);
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
+            ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
@@ -261,13 +261,13 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             DUMMY_SESSION_INFO,
             TimeValue.timeValueSeconds(30),
-            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},
             null,
             UUID.randomUUID(),
-            false
+            false,
+            Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
         ).newRequest(shardId);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -183,7 +183,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -205,7 +205,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -247,7 +247,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
             ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -269,7 +269,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             false,
             Properties.DUPLICATE_KEY_UPDATE_OR_FAIL
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -25,7 +25,7 @@ package io.crate.execution.dml.upsert;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
-import io.crate.execution.dml.upsert.AbstractShardWriteRequest.Mode;
+import io.crate.execution.dml.upsert.ShardWriteRequest.Mode;
 import io.crate.execution.jobs.TasksService;
 import io.crate.metadata.Functions;
 import io.crate.metadata.PartitionName;

--- a/sql/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
@@ -34,10 +34,6 @@ import static org.hamcrest.Matchers.is;
 public class BulkShardCreationLimiterTest extends CrateUnitTest {
 
     private static class DummyShardRequest extends ShardRequest<DummyShardRequest, DummyRequestItem> {
-        @Override
-        protected DummyRequestItem readItem(StreamInput input) throws IOException {
-            return null;
-        }
     }
 
     private static class DummyRequestItem extends ShardRequest.Item {

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -277,7 +277,8 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                         throw new RuntimeException(e);
                     }
                 }
-                for (TransportShardUpsertAction action : internalCluster().getInstances(TransportShardUpsertAction.class)) {
+                for (TransportShardUpsertAction action : internalCluster().getInstances(
+                        TransportShardUpsertAction.class)) {
                     try {
                         Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
                         assertThat(operations.size(), is(0));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This draft adds a dedicated  `ShardUpdateRequest` for the `update-by-id` and `update-by-query` usecase. The request classes can now be optimised based on the suggestions from https://github.com/crate/crate/issues/9810. Necessary streamers are generated on demand and common request properties are handled as enum and streamed efficiently. This PoC serves only as a foundation for feedback and discussion and can be further extended if we decide to go forward with it and needs more work.

Implementation:
- Introduced `AbstractTransportShardWriteAction` and `AbstractShardWriteRequest` to hold the business logic 
- Added  `TransportShardUpdateAction` and `ShardUpdateRequest` for the update usecase
- Adapted the code for `update-by-id` and `update-by-query` 
- Added  `TransportShardUpsertAction` to serve all other usecases for now


Pro's:
- Business logic is not duplicated 
- Request classes can be specific to the usecase with a smaller memory footprint
- BwC should not be a problem to add to the current approach

Con's:
- Additional inheritance/boilerplate code
- Each usecase will need to have an own action registered (insert, update, update with return values etc.)

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
