### PR TITLE
Update estimated row size of Collect after prune or fetch rewrite

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -91,12 +91,12 @@ public class Collect implements LogicalPlan {
 
     WhereClause where;
 
-    public static LogicalPlan create(AbstractTableRelation<?> relation,
-                                     List<Symbol> toCollect,
-                                     WhereClause where,
-                                     Set<PlanHint> hints,
-                                     TableStats tableStats,
-                                     Row params) {
+    public static Collect create(AbstractTableRelation<?> relation,
+                                 List<Symbol> toCollect,
+                                 WhereClause where,
+                                 Set<PlanHint> hints,
+                                 TableStats tableStats,
+                                 Row params) {
         Stats stats = tableStats.getStats(relation.tableInfo().ident());
         return new Collect(
             hints.contains(PlanHint.PREFER_SOURCE_LOOKUP),
@@ -288,7 +288,7 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         ArrayList<Symbol> newOutputs = new ArrayList<>();
         for (Symbol output : outputs) {
             if (outputsToKeep.contains(output)) {
@@ -298,19 +298,20 @@ public class Collect implements LogicalPlan {
         if (newOutputs.equals(outputs)) {
             return this;
         }
+        Stats stats = tableStats.getStats(relation.relationName());
         return new Collect(
             preferSourceLookup,
             relation,
             newOutputs,
             where,
             numExpectedRows,
-            estimatedRowSize
+            stats.estimateSizeForColumns(newOutputs)
         );
     }
 
     @Nullable
     @Override
-    public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+    public FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
         if (!(tableInfo instanceof DocTableInfo)) {
             return null;
         }
@@ -341,6 +342,7 @@ public class Collect implements LogicalPlan {
             return null;
         }
         newOutputs.add(0, fetchMarker);
+        Stats stats = tableStats.getStats(relation.relationName());
         return new FetchRewrite(
             replacedOutputs,
             new Collect(
@@ -349,7 +351,7 @@ public class Collect implements LogicalPlan {
                 newOutputs,
                 where,
                 numExpectedRows,
-                estimatedRowSize
+                stats.estimateSizeForColumns(newOutputs)
             )
         );
     }

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -42,6 +42,7 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.CountPlan;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -141,7 +142,7 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         return this;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Eval.java
+++ b/sql/src/main/java/io/crate/planner/operators/Eval.java
@@ -33,6 +33,7 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -92,8 +93,8 @@ public final class Eval extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, outputsToKeep);
         if (source == newSource) {
             return this;
         }
@@ -102,8 +103,8 @@ public final class Eval extends ForwardingLogicalPlan {
 
     @Nullable
     @Override
-    public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
-        FetchRewrite fetchRewrite = source.rewriteToFetch(usedColumns);
+    public FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
+        FetchRewrite fetchRewrite = source.rewriteToFetch(tableStats, usedColumns);
         if (fetchRewrite == null) {
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/sql/src/main/java/io/crate/planner/operators/Fetch.java
@@ -38,6 +38,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ReaderAllocations;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.fetch.FetchSource;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -98,7 +99,7 @@ public final class Fetch extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         return this;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -90,10 +91,10 @@ public final class Filter extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         LinkedHashSet<Symbol> toKeep = new LinkedHashSet<>(outputsToKeep);
         SymbolVisitors.intersection(query, source.outputs(), toKeep::add);
-        LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (newSource == source) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
+import io.crate.statistics.TableStats;
 
 import java.util.Collection;
 import java.util.List;
@@ -47,8 +48,8 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, outputsToKeep);
         if (newSource == source) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -40,6 +40,7 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.dql.Collect;
+import io.crate.statistics.TableStats;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -167,7 +168,7 @@ public class Get implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         ArrayList<Symbol> newOutputs = new ArrayList<>();
         boolean excludedAny = false;
         for (Symbol output : outputs) {

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -229,7 +229,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         HashSet<Symbol> toKeep = new HashSet<>();
         // We cannot prune groupKeys, even if they are not used in the outputs, because it would change the result semantically
         for (Symbol groupKey : groupKeys) {
@@ -242,7 +242,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         for (Function newAggregate : newAggregates) {
             SymbolVisitors.intersection(newAggregate, source.outputs(), toKeep::add);
         }
-        LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (newSource == source && aggregates.size() == newAggregates.size()) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -42,6 +42,7 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -145,7 +146,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         ArrayList<Function> newAggregates = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, aggregates, newAggregates::add);
@@ -154,7 +155,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         for (Function newAggregate : newAggregates) {
             SymbolVisitors.intersection(newAggregate, source.outputs(), toKeep::add);
         }
-        LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (source == newSource && newAggregates == aggregates) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -114,8 +115,8 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        LogicalPlan newSource = source.pruneOutputsExcept(source.outputs());
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, source.outputs());
         if (newSource == source) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -69,6 +69,7 @@ import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataType;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
@@ -784,7 +785,7 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         return this;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -36,6 +36,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -147,7 +148,7 @@ public interface LogicalPlan extends Plan {
      *  That allows implementations to do a cheap identity check to avoid LogicalPlan re-creations themselves.
      * </p>
      */
-    LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep);
+    LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep);
 
     /**
      * Rewrite an operator and its children to utilize a "query-then-fetch" approach.
@@ -181,10 +182,9 @@ public interface LogicalPlan extends Plan {
      * @param usedColumns The columns that the ancestor operators use intermediately to produce their result.
      *                    For example, a `Filter (x > 10)` uses `x > 10`, a `Order [a ASC]` uses `a`.
      *                    An operator that uses *all* of its sources outputs to produce a result should return `null`
-     *                    to indicate that there is no reason to use query-then-fetch.
      */
     @Nullable
-    default FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+    default FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
         return null;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -222,7 +222,7 @@ public class LogicalPlanner {
             plannerContext.params());
         LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
         return fetchOptimizer.optimize(
-            optimizedPlan.pruneOutputsExcept(relation.outputs()),
+            optimizedPlan.pruneOutputsExcept(tableStats, relation.outputs()),
             tableStats,
             coordinatorTxnCtx
         );

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -47,6 +47,7 @@ import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
+import io.crate.statistics.TableStats;
 import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
@@ -257,7 +258,7 @@ public class NestedLoopJoin implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         ArrayList<Symbol> lhsToKeep = new ArrayList<>();
         ArrayList<Symbol> rhsToKeep = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
@@ -268,8 +269,8 @@ public class NestedLoopJoin implements LogicalPlan {
             SymbolVisitors.intersection(joinCondition, lhs.outputs(), lhsToKeep::add);
             SymbolVisitors.intersection(joinCondition, rhs.outputs(), rhsToKeep::add);
         }
-        LogicalPlan newLhs = lhs.pruneOutputsExcept(lhsToKeep);
-        LogicalPlan newRhs = rhs.pruneOutputsExcept(rhsToKeep);
+        LogicalPlan newLhs = lhs.pruneOutputsExcept(tableStats, lhsToKeep);
+        LogicalPlan newRhs = rhs.pruneOutputsExcept(tableStats, rhsToKeep);
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
@@ -287,7 +288,7 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Nullable
     @Override
-    public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+    public FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
         ArrayList<Symbol> usedFromLeft = new ArrayList<>();
         ArrayList<Symbol> usedFromRight = new ArrayList<>();
         for (Symbol usedColumn : usedColumns) {
@@ -298,11 +299,11 @@ public class NestedLoopJoin implements LogicalPlan {
             SymbolVisitors.intersection(joinCondition, lhs.outputs(), usedFromLeft::add);
             SymbolVisitors.intersection(joinCondition, rhs.outputs(), usedFromRight::add);
         }
-        FetchRewrite lhsFetchRewrite = lhs.rewriteToFetch(usedFromLeft);
+        FetchRewrite lhsFetchRewrite = lhs.rewriteToFetch(tableStats, usedFromLeft);
         if (lhsFetchRewrite == null) {
             return null;
         }
-        FetchRewrite rhsFetchRewrite = rhs.rewriteToFetch(usedFromRight);
+        FetchRewrite rhsFetchRewrite = rhs.rewriteToFetch(tableStats, usedFromRight);
         if (rhsFetchRewrite == null) {
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/sql/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -104,7 +105,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         HashSet<Symbol> toKeep = new HashSet<>();
         LinkedHashSet<Symbol> newStandalone = new LinkedHashSet<>();
         LinkedHashSet<Function> newTableFunctions = new LinkedHashSet<>();
@@ -116,7 +117,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
             SymbolVisitors.intersection(newTableFunction, source.outputs(), toKeep::add);
         }
         toKeep.addAll(newStandalone);
-        LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (newSource == source) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/sql/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -40,6 +40,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.dql.Collect;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -131,7 +132,7 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         if (outputsToKeep.containsAll(toCollect)) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -41,6 +41,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
 import io.crate.planner.UnionExecutionPlan;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -150,7 +151,7 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         IntArrayList outputIndicesToKeep = new IntArrayList();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, outputs, s -> {
@@ -167,8 +168,8 @@ public class Union implements LogicalPlan {
             toKeepFromRhs.add(rhs.outputs().get(cursor.value));
             newOutputs.add(outputs.get(cursor.value));
         }
-        LogicalPlan newLhs = lhs.pruneOutputsExcept(toKeepFromLhs);
-        LogicalPlan newRhs = rhs.pruneOutputsExcept(toKeepFromRhs);
+        LogicalPlan newLhs = lhs.pruneOutputsExcept(tableStats, toKeepFromLhs);
+        LogicalPlan newRhs = rhs.pruneOutputsExcept(tableStats, toKeepFromRhs);
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/sql/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -43,6 +43,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.DistributionType;
+import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -106,7 +107,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
     }
 
     @Override
-    public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         HashSet<Symbol> toKeep = new HashSet<>();
         ArrayList<WindowFunction> newWindowFunctions = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
@@ -116,7 +117,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         for (WindowFunction newWindowFunction : newWindowFunctions) {
             SymbolVisitors.intersection(newWindowFunction, source.outputs(), toKeep::add);
         }
-        LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
+        LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (newSource == source) {
             return this;
         }

--- a/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -64,7 +64,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
-        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(Set.of());
+        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(tableStats, Set.of());
         if (fetchRewrite == null) {
             return null;
         }

--- a/sql/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.data.Row;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+
+public class CollectTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_prune_output_of_collect_updates_estimated_row_size() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (x int, y int)")
+            .build();
+        TableStats tableStats = new TableStats();
+        Symbol x = e.asSymbol("x");
+        Collect collect = Collect.create(
+            new DocTableRelation(e.resolveTableInfo("t")),
+            List.of(x, e.asSymbol("y")),
+            WhereClause.MATCH_ALL,
+            Set.of(),
+            tableStats,
+            Row.EMPTY
+        );
+        assertThat(collect.estimatedRowSize(), is(DataTypes.INTEGER.fixedSize() * 2L));
+        LogicalPlan prunedCollect = collect.pruneOutputsExcept(tableStats, List.of(x));
+        assertThat(prunedCollect.estimatedRowSize(), is((long) DataTypes.INTEGER.fixedSize()));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -25,7 +25,6 @@ package io.crate.planner.operators;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AliasedAnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
-import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
@@ -33,6 +32,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -64,7 +64,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(collect, List.of(Function.of("add", List.of(x, x), DataTypes.INTEGER)));
 
-        FetchRewrite fetchRewrite = eval.rewriteToFetch(List.of());
+        FetchRewrite fetchRewrite = eval.rewriteToFetch(new TableStats(), List.of());
         assertThat(fetchRewrite, Matchers.notNullValue());
         assertThat(fetchRewrite.newPlan(), isPlan("Collect[doc.tbl | [_fetchid] | true]"));
         assertThat(
@@ -91,7 +91,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         assertThat(t1X, Matchers.notNullValue());
         var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
 
-        FetchRewrite fetchRewrite = rename.rewriteToFetch(List.of());
+        FetchRewrite fetchRewrite = rename.rewriteToFetch(new TableStats(), List.of());
         assertThat(fetchRewrite, Matchers.notNullValue());
         LogicalPlan newRename = fetchRewrite.newPlan();
         assertThat(newRename, isPlan(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Column pruning or fetch rewrite reduces the size of a row. That should
be reflected.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)