### PR TITLE
Early return if no global checkpoint listeners

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
@@ -194,7 +194,10 @@ public class GlobalCheckpointListeners implements Closeable {
     private void notifyListeners(final long globalCheckpoint, final IndexShardClosedException e) {
         assert Thread.holdsLock(this) : Thread.currentThread();
         assertNotification(globalCheckpoint, e);
-
+        // early return if there are no listeners
+        if (listeners.isEmpty()) {
+            return;
+        }
         final Map<GlobalCheckpointListener, Tuple<Long, ScheduledFuture<?>>> listenersToNotify;
         if (globalCheckpoint != UNASSIGNED_SEQ_NO) {
             listenersToNotify =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Port of https://github.com/elastic/elasticsearch/pull/53036/commits/5b3e1a0fba668ed4e914b280ee3fe284c94b5329


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)