### PR TITLE
Fix testConcurrentFunctionRegistering

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -105,7 +104,7 @@ public class Functions {
             .removeIf(
                 function ->
                     schema.equals(function.getKey().schema())
-                    && !Objects.equals(functions.get(function.getKey()), function.getValue()));
+                    && functions.get(function.getKey()) == null);
         udfFunctionImplementations.putAll(functions);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Reverted the modification in `Functions#registerUdfFunctionImplementationsForSchema`
introduced by #9808

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
