### PR TITLE
Allow the definition of check constraints in ALTER ADD COLUMN statements

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.expressions.TableReferenceResolver;
@@ -591,12 +592,17 @@ public class AnalyzedTableElements<T> {
         return sb.toString();
     }
 
-    public void addCheckConstraint(RelationName relationName, CheckConstraint check) {
+    public void addCheckConstraint(RelationName relationName, CheckConstraint<?> check) {
         addCheckConstraint(relationName.fqn(), check.columnName(), check.name(), check.expressionStr());
     }
 
-    public void addCheckColumnConstraint(RelationName relationName, CheckColumnConstraint check) {
+    public void addCheckColumnConstraint(RelationName relationName, CheckColumnConstraint<?> check) {
         addCheckConstraint(relationName.fqn(), check.columnName(), check.name(), check.expressionStr());
+    }
+
+    @VisibleForTesting
+    Map<String, String> getCheckConstraints() {
+        return Map.copyOf(checkConstraints);
     }
 
     public boolean hasGeneratedColumns() {

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -99,7 +99,7 @@ public final class CreateTableStatementAnalyzer {
             .collect(Collectors.toList());
         tableElementsWithExpressions.addAll(analyzedCheckConstraints);
         analyzedCreateTable.tableElements().addAll(analyzedCheckConstraints);
-        analyzedCheckConstraints.forEach(c -> analyzedTableElements.addCheckConstraint(relationName, (CheckConstraint) c));
+        analyzedCheckConstraints.forEach(c -> analyzedTableElements.addCheckConstraint(relationName, (CheckConstraint<Symbol>) c));
         AnalyzedTableElements<Symbol> analyzedTableElementsWithExpressions = TableElementsAnalyzer.analyze(
             tableElementsWithExpressions, relationName, null, false);
         return new AnalyzedCreateTable(

--- a/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -48,16 +48,20 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
         this.relationName = relationName;
     }
 
-    @Override
-    public Reference resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
-        List<String> parts = qualifiedName.getParts();
-        ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);
-        if (parts.size() != 1) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+    public static ColumnIdent columnIdent(QualifiedName qualifiedName, @Nullable List<String> path) {
+        List<String> qualifiedNameParts = qualifiedName.getParts();
+        if (qualifiedNameParts.size() != 1) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
                 "Column reference \"%s\" has too many parts. " +
                 "A column must not have a schema or a table here.", qualifiedName));
         }
+        return new ColumnIdent(qualifiedNameParts.get(qualifiedNameParts.size() - 1), path);
+    }
 
+    @Override
+    public Reference resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+        ColumnIdent columnIdent = columnIdent(qualifiedName, path);
         for (Reference reference : tableReferences) {
             if (reference.column().equals(columnIdent)) {
                 if (reference instanceof GeneratedReference) {

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -357,6 +357,16 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void test_alter_table_add_column_succedds_because_check_constaint_refers_to_self_columns() {
+        execute("create table t (id integer primary key, qty integer constraint check_1 check (qty > 0))");
+        execute("alter table t add column bazinga integer constraint bazinga_check check(bazinga <> 42)");
+        execute("insert into t(id, qty, bazinga) values(0, 1, 100)");
+        expectedException.expectMessage(containsString(
+            "SQLParseException: Failed CONSTRAINT bazinga_check CHECK (\"bazinga\" <> 42) and values {qty=1, id=0, bazinga=42}"));
+        execute("insert into t(id, qty, bazinga) values(0, 1, 42)");
+    }
+
+    @Test
     public void testAlterTable() throws Exception {
         execute("create table test (col1 int) with (number_of_replicas='0-all')");
         ensureYellow();


### PR DESCRIPTION
With the caveat that such check constraints can only refer to the column
being defined, to not invalidate existing data.
