### PR TITLE
Avoid HashMap creation for CSV to JSON conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test-output/
 
 # eclipse files
 bin/
+.jdt.ls/
 
 # Python files
 __pycache__/

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
@@ -43,7 +43,7 @@ public class LineParser {
     public void readFirstLine(URI currentUri, FileUriCollectPhase.InputFormat inputFormat, BufferedReader currentReader) throws IOException {
         if (isInputCsv(inputFormat, currentUri)) {
             csvLineParser = new CSVLineParser();
-            csvLineParser.parseHeader(currentReader);
+            csvLineParser.parseHeader(currentReader.readLine());
             inputType = InputType.CSV;
         } else {
             inputType = InputType.JSON;

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
@@ -28,10 +28,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
 
-public class LineProcessor {
+public final class LineProcessor {
 
-    private LineContext lineContext = new LineContext();
-    private LineParser lineParser = new LineParser();
+    private final LineContext lineContext = new LineContext();
+    private final LineParser lineParser = new LineParser();
 
     public void startCollect(Iterable<LineCollectorExpression<?>> collectorExpressions) {
         for (LineCollectorExpression<?> collectorExpression : collectorExpressions) {

--- a/sql/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -13,72 +13,65 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CSVLineParserTest {
 
-    private CSVLineParser subjectUnderTest;
+    private CSVLineParser csvParser;
     private byte[] result;
 
     @Before
     public void setup(){
-        subjectUnderTest = new CSVLineParser();
+        csvParser = new CSVLineParser();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenEmptyHeader_thenThrowsException() throws IOException {
         String header = "\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        csvParser.parse("GER,Germany\n");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenDuplicateKey_thenThrowsException() throws IOException {
         String header = "Code,Country,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result =subjectUnderTest.parse("GER,Germany,Another\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany,Another\n");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenMissingKey_thenThrowsException() throws IOException {
         String header = "Code,\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenExtraValue_thenIgnoresTheKeyWithoutValue() throws IOException {
         String header = "Code,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        subjectUnderTest.parse("GER,Germany,Berlin\n");
+        csvParser.parseHeader(header);
+        csvParser.parse("GER,Germany,Berlin\n");
     }
 
     @Test
     public void parse_givenExtraKey_thenIgnoresTheKeyWithoutValue() throws IOException {
         String header = "Code,Country,Another\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenCSVInput_thenParsesToMap() throws IOException {
         String header = "Code,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenEmptyRow_thenParsesToEmptyJson() throws IOException {
         String header = "Code,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("");
 
         assertThat(result, is("{}".getBytes(StandardCharsets.UTF_8)));
     }
@@ -86,70 +79,63 @@ public class CSVLineParserTest {
     @Test
     public void parse_givenEmptyRowWithCommas_thenParsesAsEmptyStrings() throws IOException {
         String header ="Code,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse(",");
+        csvParser.parseHeader(header);
+        result = csvParser.parse(",");
 
-        assertThat(result, is("{\"Country\":\"\",\"Code\":\"\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"\",\"Country\":\"\"}"));
     }
 
     @Test
     public void parse_givenEscapedComma_thenParsesLineCorrectly() throws IOException {
         String header = "Code,\"Coun, try\"\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
 
-        assertThat(result, is("{\"Coun, try\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Coun, try\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenRowWithMissingValue_thenTheValueIsAssignedToKeyAsAnEmptyString() throws IOException {
         String header = "Code,Country,City\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,,Berlin\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,,Berlin\n");
 
-        assertThat(result, is("{\"Country\":\"\",\"City\":\"Berlin\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"\",\"City\":\"Berlin\"}"));
     }
 
     @Test
     public void parse_givenTrailingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code ,Country  \n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenTrailingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code ,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER        ,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER        ,Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenPrecedingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "         Code,         Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 
     @Test
     public void parse_givenPrecedingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code,Country\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
-        subjectUnderTest.parseHeader(bufferedReader);
-        result = subjectUnderTest.parse("GER,               Germany\n");
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,               Germany\n");
 
-        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

measureCsvParser_new  avgt   25  16.427 ± 0.211  us/op
measureCsvParser_old  avgt   25  21.636 ± 0.156  us/op

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)