### PR TITLE
Use source lookup in fetch operations

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -332,8 +332,9 @@ public class Collect implements LogicalPlan {
                 replacedOutputs.put(output, output);
             } else {
                 Symbol outputWithFetchStub = RefReplacer.replaceRefs(output, ref -> {
-                    refsToFetch.add(ref);
-                    return new FetchStub(fetchMarker, ref);
+                    Reference sourceLookup = DocReferences.toSourceLookup(ref);
+                    refsToFetch.add(sourceLookup);
+                    return new FetchStub(fetchMarker, sourceLookup);
                 });
                 replacedOutputs.put(output, outputWithFetchStub);
             }

--- a/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -71,7 +71,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
             fetchRewrite.replacedOutputs(),
             Matchers.hasEntry(
                 isFunction("add", isReference("x"), isReference("x")),
-                isFunction("add", isFetchStub("x"), isFetchStub("x"))
+                isFunction("add", isFetchStub("_doc['x']"), isFetchStub("_doc['x']"))
             )
         );
         assertThat(List.copyOf(fetchRewrite.replacedOutputs().keySet()), is(eval.outputs()));
@@ -104,10 +104,10 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat(
             fetchRewrite.replacedOutputs(),
-            Matchers.hasEntry(isField("x", alias.relationName()), isFetchStub("x"))
+            Matchers.hasEntry(isField("x", alias.relationName()), isFetchStub("_doc['x']"))
         );
         assertThat(newRename.outputs(), contains(
-            isFetchMarker(alias.relationName(), contains(isReference("x"))))
+            isFetchMarker(alias.relationName(), contains(isReference("_doc['x']"))))
         );
 
         FetchStub fetchStub = (FetchStub) fetchRewrite.replacedOutputs().entrySet().iterator().next().getValue();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We used source lookups before the temporary fetch removal (https://github.com/crate/crate/pull/9669)
Current latest-nightly has a slight performance regression because it
doesn't use source lookups:

    # Results (server side duration in ms)
    V1: 4.1.4-6a9f8ebc5fefd63f666caa6f28e29b4b214ac7fc
    V2: 4.2.0-ac8af037f046b1a7c8a8167dea4d6381348e1c8a

    Q: select * from uservisits limit 10000
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      231.951 ±   14.242 |    201.630 |    235.172 |    238.319 |    403.620 |
    |   V2    |      267.224 ±   16.661 |    256.903 |    262.904 |    268.173 |    471.655 |
    mean:   +  14.13%
    median: +  11.14%

With this change:

    V1: 4.1.4-6a9f8ebc5fefd63f666caa6f28e29b4b214ac7fc
    V2: 4.2.0-7b5543f3871db75290e72c93ce7ba7486be42f3c

    Q: select * from uservisits limit 10000
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      230.902 ±   14.987 |    200.985 |    234.900 |    237.986 |    388.713 |
    |   V2    |      203.228 ±   11.706 |    197.643 |    200.649 |    202.306 |    409.048 |
    mean:   -  12.75%
    median: -  15.73%


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)