### PR TITLE
Avoid tuple construction to parse xContent to Map

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -210,7 +210,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         }
         Objects.requireNonNull(xContentType);
         try {
-            mappings.put(type, XContentHelper.convertToJson(source, false, false, xContentType));
+            mappings.put(type, XContentHelper.convertToJson(source, xContentType));
             return this;
         } catch (IOException e) {
             throw new UncheckedIOException("failed to convert to json", e);

--- a/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -260,7 +260,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
     public PutMappingRequest source(BytesReference mappingSource, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         try {
-            this.source = XContentHelper.convertToJson(mappingSource, false, false, xContentType);
+            this.source = XContentHelper.convertToJson(mappingSource, xContentType);
             return this;
         } catch (IOException e) {
             throw new UncheckedIOException("failed to convert source to json", e);

--- a/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -229,7 +229,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
     public PutIndexTemplateRequest mapping(String type, BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         try {
-            mappings.put(type, XContentHelper.convertToJson(source, false, false, xContentType));
+            mappings.put(type, XContentHelper.convertToJson(source, xContentType));
             return this;
         } catch (IOException e) {
             throw new UncheckedIOException("failed to convert source to json", e);

--- a/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -28,9 +28,11 @@ import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 
+import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -89,27 +91,42 @@ public class XContentHelper {
         return convertToMap(bytes, ordered, null);
     }
 
+    public static Map<String, Object> toMap(BytesReference bytes, XContentType xContentType) {
+        try (InputStream inputStream = getUncompressedInputStream(bytes)) {
+            XContentParser parser = xContentType.xContent().createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                inputStream
+            );
+            return parser.map();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static InputStream getUncompressedInputStream(BytesReference bytes) throws IOException {
+        Compressor compressor = CompressorFactory.compressor(bytes);
+        if (compressor == null) {
+            return bytes.streamInput();
+        }
+        InputStream compressedStreamInput = compressor.streamInput(bytes.streamInput());
+        if (compressedStreamInput.markSupported()) {
+            return compressedStreamInput;
+        } else {
+            return new BufferedInputStream(compressedStreamInput);
+        }
+    }
+
     /**
-     * Converts the given bytes into a map that is optionally ordered. The provided {@link XContentType} must be non-null.
+     * Converts the given bytes into a map that is optionally ordered.
      */
-    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered, XContentType xContentType)
+    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered, @Nullable XContentType xContentType)
         throws ElasticsearchParseException {
         try {
             final XContentType contentType;
-            InputStream input;
-            Compressor compressor = CompressorFactory.compressor(bytes);
-            if (compressor != null) {
-                InputStream compressedStreamInput = compressor.streamInput(bytes.streamInput());
-                if (compressedStreamInput.markSupported() == false) {
-                    compressedStreamInput = new BufferedInputStream(compressedStreamInput);
-                }
-                input = compressedStreamInput;
-            } else {
-                input = bytes.streamInput();
-            }
-            contentType = xContentType != null ? xContentType : XContentFactory.xContentType(input);
-            try (InputStream stream = input) {
-                return new Tuple<>(Objects.requireNonNull(contentType), convertToMap(XContentFactory.xContent(contentType), stream, ordered));
+            try (InputStream input = getUncompressedInputStream(bytes)) {
+                contentType = xContentType != null ? xContentType : XContentFactory.xContentType(input);
+                return new Tuple<>(Objects.requireNonNull(contentType), convertToMap(XContentFactory.xContent(contentType), input, ordered));
             }
         } catch (IOException e) {
             throw new ElasticsearchParseException("Failed to parse content to map", e);

--- a/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/es/es-server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -162,36 +162,20 @@ public class XContentHelper {
         }
     }
 
-    @Deprecated
-    public static String convertToJson(BytesReference bytes, boolean reformatJson) throws IOException {
-        return convertToJson(bytes, reformatJson, false);
-    }
 
-    @Deprecated
-    public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint) throws IOException {
-        return convertToJson(bytes, reformatJson, prettyPrint, XContentFactory.xContentType(bytes.toBytesRef().bytes));
-    }
-
-    public static String convertToJson(BytesReference bytes, boolean reformatJson, XContentType xContentType) throws IOException {
-        return convertToJson(bytes, reformatJson, false, xContentType);
-    }
-
-    public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint, XContentType xContentType)
-        throws IOException {
+    public static String convertToJson(BytesReference bytes, XContentType xContentType) throws IOException {
         Objects.requireNonNull(xContentType);
-        if (xContentType == XContentType.JSON && !reformatJson) {
+        if (xContentType == XContentType.JSON) {
             return bytes.utf8ToString();
         }
-
         // It is safe to use EMPTY here because this never uses namedObject
         try (InputStream stream = bytes.streamInput();
-             XContentParser parser = XContentFactory.xContent(xContentType).createParser(NamedXContentRegistry.EMPTY,
-                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION, stream)) {
+             XContentParser parser = XContentFactory.xContent(xContentType).createParser(
+                 NamedXContentRegistry.EMPTY,
+                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                 stream)) {
             parser.nextToken();
             XContentBuilder builder = XContentFactory.jsonBuilder();
-            if (prettyPrint) {
-                builder.prettyPrint();
-            }
             builder.copyCurrentStructure(parser);
             return Strings.toString(builder);
         }

--- a/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParser.java
+++ b/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParser.java
@@ -80,7 +80,7 @@ public final class SQLRequestParser {
         } catch (Exception e) {
             String sSource = "_na_";
             try {
-                sSource = XContentHelper.convertToJson(source, false, XContentType.JSON);
+                sSource = XContentHelper.convertToJson(source, XContentType.JSON);
             } catch (Throwable e1) {
                 // ignore
             }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
@@ -105,7 +105,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         }
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         builder.map(mapping);
-        return XContentHelper.convertToJson(BytesReference.bytes(builder), false, false, XContentType.JSON);
+        return XContentHelper.convertToJson(BytesReference.bytes(builder), XContentType.JSON);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSource.java
@@ -63,7 +63,7 @@ public final class GeneratedColsFromRawInsertSource implements InsertSourceGen {
     @Override
     public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
         String rawSource = (String) values[0];
-        Map<String, Object> source = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
+        Map<String, Object> source = XContentHelper.toMap(new BytesArray(rawSource), XContentType.JSON);
         mixinDefaults(source, defaults);
         for (int i = 0; i < expressions.size(); i++) {
             expressions.get(i).setNextRow(source);

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -40,6 +40,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.PKAndVersion;
 import org.apache.lucene.index.Term;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -64,8 +65,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 
 public final class PKLookupOperation {
 
@@ -146,7 +145,7 @@ public final class PKLookupOperation {
                 docIdAndVersion.version,
                 docIdAndVersion.seqNo,
                 docIdAndVersion.primaryTerm,
-                convertToMap(visitor.source(), false, XContentType.JSON).v2(),
+                XContentHelper.toMap(visitor.source(), XContentType.JSON),
                 () -> visitor.source().utf8ToString()
             );
         }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -73,14 +73,10 @@ public final class SourceLookup {
         return fieldsVisitor.source();
     }
 
-    private Map<String, Object> loadSource() {
-        ensureDocVisited();
-        return XContentHelper.convertToMap(fieldsVisitor.source(), false, XContentType.JSON).v2();
-    }
-
     private void ensureSourceParsed() {
         if (source == null) {
-            source = loadSource();
+            ensureDocVisited();
+            source = XContentHelper.toMap(fieldsVisitor.source(), XContentType.JSON);
         }
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/file/LineContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/file/LineContext.java
@@ -56,7 +56,7 @@ public class LineContext {
         if (parsedSource == null) {
             if (rawSource != null) {
                 try {
-                    parsedSource = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
+                    parsedSource = XContentHelper.toMap(new BytesArray(rawSource), XContentType.JSON);
                 } catch (ElasticsearchParseException | NotXContentException e) {
                     throw new RuntimeException("JSON parser error: " + e.getMessage(), e);
                 }

--- a/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
@@ -92,12 +92,11 @@ public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTem
                 .settings(settings);
             try {
                 for (ObjectObjectCursor<String, CompressedXContent> cursor : templateMetaData.getMappings()) {
-                    var mappingSource = XContentHelper.convertToMap(
-                        cursor.value.compressedReference(), false, XContentType.JSON).v2();
+                    var mappingSource = XContentHelper.toMap(cursor.value.compressedReference(), XContentType.JSON);
 
                     Object defaultMapping = mappingSource.get("default");
-                    if (defaultMapping instanceof Map && ((Map) defaultMapping).containsKey("_all")) {
-                        Map mapping = (Map) defaultMapping;
+                    if (defaultMapping instanceof Map && ((Map<?, ?>) defaultMapping).containsKey("_all")) {
+                        Map<?, ?> mapping = (Map<?, ?>) defaultMapping;
 
                         // Support for `_all` was removed (in favour of `copy_to`.
                         // We never utilized this but always set `_all: {enabled: false}` if you created a table using SQL in earlier version, so we can safely drop it.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)