### PR TITLE
Fix NPE with COPY TO .. WHERE pk_column = ...

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,4 +57,5 @@ None
 Fixes
 =====
 
-None
+- Fixed an issue that caused a ``NullPointerException`` if using ``COPY TO``
+  with a ``WHERE`` clause with filters on primary key columns.

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -199,6 +199,7 @@ public final class PKLookupOperation {
                                                pkAndVersion.version(),
                                                pkAndVersion.seqNo(),
                                                pkAndVersion.primaryTerm()))
+                .filter(Objects::nonNull)
                 .map(resultToRow);
 
             Projectors projectors = new Projectors(

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -490,8 +490,11 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         execute("refresh table t1");
 
         String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
-        SQLResponse response = execute("copy t1 where id = 1 to DIRECTORY ?", new Object[]{uriTemplate});
-        assertThat(response.rowCount(), is(1L));
+        SQLResponse respNoMatch = execute("copy t1 where id = 2 to DIRECTORY ?", new Object[]{uriTemplate});
+        assertThat(respNoMatch.rowCount(), is(0L));
+
+        SQLResponse respMatch = execute("copy t1 where id = 1 to DIRECTORY ?", new Object[]{uriTemplate});
+        assertThat(respMatch.rowCount(), is(1L));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If a condition doesn't match, a NPE occurred.

This is currently not happening on master because there the `PKLookup`
isn't used anymore for COPY.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)