### PR TITLE
Use BlockBasedRamAccounting for projections

### DIFF
--- a/dex/src/main/java/io/crate/breaker/BlockBasedRamAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/BlockBasedRamAccounting.java
@@ -52,9 +52,13 @@ public final class BlockBasedRamAccounting implements RamAccounting {
      * Scale the block size that is eagerly allocated depending on the circuit breakers current limit and the shards
      * on the node.
      */
-    public static int calculateBlockSizeInBytes(long breakerLimit, int shardsUsedOnNode) {
+    public static int blockSizeInBytesPerShard(long breakerLimit, int shardsUsedOnNode) {
         int blockSize = Math.min((int) (breakerLimit * BREAKER_LIMIT_PERCENTAGE), MAX_BLOCK_SIZE_IN_BYTES);
         return blockSize / Math.max(shardsUsedOnNode, 1);
+    }
+
+    public static int blockSizeInBytes(long breakerLimit) {
+        return Math.min((int) (breakerLimit * BREAKER_LIMIT_PERCENTAGE), MAX_BLOCK_SIZE_IN_BYTES);
     }
 
     public BlockBasedRamAccounting(LongConsumer reserveMemory, int blockSizeInBytes) {

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -698,7 +698,7 @@ public class JobSetup {
                 projections,
                 phase.jobId(),
                 context.txnCtx(),
-                ramAccounting,          // some projectors may account ram concurrently, e.g. fetch
+                ramAccountingForMerge,
                 memoryManager,
                 projectorFactory
             );
@@ -846,7 +846,7 @@ public class JobSetup {
                 phase.projections(),
                 phase.jobId(),
                 context.txnCtx(),
-                concurrentRamAccounting,          // some projectors may account ram concurrently, e.g. fetch
+                ramAccountingOfOperation,
                 memoryManager,
                 projectorFactory
             );
@@ -920,7 +920,7 @@ public class JobSetup {
                 phase.projections(),
                 phase.jobId(),
                 context.txnCtx(),
-                ramAccounting,          // some projectors may account ram concurrently, e.g. fetch
+                ramAccountingOfOperation,
                 memoryManager,
                 projectorFactory
             );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Using `ConcurrentRamAccounting` directly has a large performance overhead.
See https://github.com/crate/crate/pull/9830


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)