### PR TITLE
Use netty IntObjectHashMap insteaf hppc in HashJoin

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
@@ -22,13 +22,13 @@
 
 package io.crate.execution.engine.join;
 
-import com.carrotsearch.hppc.IntObjectHashMap;
 import io.crate.data.BatchIterator;
 import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.UnsafeArrayRow;
 import io.crate.data.join.CombinedRow;
 import io.crate.data.join.JoinBatchIterator;
+import io.netty.util.collection.IntObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -164,8 +164,7 @@ public class HashInnerJoinBatchIterator extends JoinBatchIterator<Row, Row, Row>
 
     private void recreateBuffer() {
         blockSize = calculateBlockSize.getAsInt();
-        buffer.release();
-        buffer.ensureCapacity(blockSize);
+        buffer.clear();
         numberOfRowsInBuffer = 0;
 
         // A batch is not guaranteed to deliver PAGE_SIZE number of rows. It could be more or less.
@@ -227,7 +226,6 @@ public class HashInnerJoinBatchIterator extends JoinBatchIterator<Row, Row, Row>
         numberOfRowsInBuffer++;
     }
 
-    @SuppressWarnings("unchecked")
     private boolean findMatchingRows() {
         while (leftMatchingRowsIterator.hasNext()) {
             leftRow.cells(leftMatchingRowsIterator.next());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    Q: select * from articles inner join colors on articles.id = colors.id order by articles.id limit 1000
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       49.473 ±   72.379 |     33.304 |     37.293 |     41.099 |    970.946 |
    |   V2    |       35.414 ±    2.910 |     32.405 |     34.196 |     36.455 |     49.801 |
    mean:   -  33.12%
    median: -   8.66%
    Likely significant


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
