### PR TITLE
Optimize IS NOT NULL queries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,8 @@ None
 Changes
 =======
 
+- Optimized `<column> IS NOT NULL` queries.
+
 - Include the bundled version of ``OpenJDK`` (13.0.2+8) into the ``CrateDB``
   built. It means that ``CrateDB`` doesn't rely the ``JAVA_HOME`` of the host
   system any longer.

--- a/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -74,7 +74,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
         if (arg.equals(Literal.NULL)) {
             return Literal.of(true);
         } else if (arg.symbolType().isValueSymbol()) {
-            return Literal.of(((Input) arg).value() == null);
+            return Literal.of(((Input<?>) arg).value() == null);
         }
         return symbol;
     }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -69,12 +69,12 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     static final class ChildDocCollectorExpression extends LuceneCollectorExpression<Object> {
 
-        private final DataType returnType;
+        private final DataType<?> returnType;
         private final List<String> path;
         private SourceLookup sourceLookup;
         private LeafReaderContext context;
 
-        ChildDocCollectorExpression(DataType returnType, List<String> path) {
+        ChildDocCollectorExpression(DataType<?> returnType, List<String> path) {
             this.returnType = returnType;
             this.path = path;
         }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -92,24 +92,23 @@ public final class SourceLookup {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    static Object extractValue(final Map map, List<String> path, int pathStartIndex) {
+    static Object extractValue(final Map<?, ?> map, List<String> path, int pathStartIndex) {
         assert path instanceof RandomAccess : "path should support RandomAccess for fast index optimized loop";
-        Map m = map;
+        Map<?, ?> m = map;
         Object tmp = null;
         for (int i = pathStartIndex; i < path.size(); i++) {
             tmp = m.get(path.get(i));
             if (tmp instanceof Map) {
-                m = (Map) tmp;
+                m = (Map<?, ?>) tmp;
             } else if (tmp instanceof List) {
-                List list = (List) tmp;
+                List<?> list = (List<?>) tmp;
                 if (i + 1 == path.size()) {
                     return list;
                 }
-                List newList = new ArrayList(list.size());
+                ArrayList<Object> newList = new ArrayList<>(list.size());
                 for (Object o : list) {
                     if (o instanceof Map) {
-                        newList.add(extractValue((Map) o, path, i + 1));
+                        newList.add(extractValue((Map<?, ?>) o, path, i + 1));
                     } else {
                         newList.add(o);
                     }

--- a/sql/src/main/java/io/crate/lucene/NotQuery.java
+++ b/sql/src/main/java/io/crate/lucene/NotQuery.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.operator.LikeOperators;
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.predicate.IsNullPredicate;
+import io.crate.expression.scalar.Ignore3vlFunction;
+import io.crate.expression.scalar.conditional.CoalesceFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Reference;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+final class NotQuery implements FunctionToQuery {
+
+    private final SymbolToNotNullRangeQueryArgs INNER_VISITOR = new SymbolToNotNullRangeQueryArgs();
+    private final LuceneQueryBuilder.Visitor visitor;
+
+    public NotQuery(LuceneQueryBuilder.Visitor visitor) {
+        this.visitor = visitor;
+    }
+
+    private static class SymbolToNotNullContext {
+        private final HashSet<Reference> references = new HashSet<>();
+        boolean hasStrictThreeValuedLogicFunction = false;
+
+        void add(Reference symbol) {
+            references.add(symbol);
+        }
+
+        Set<Reference> references() {
+            return references;
+        }
+    }
+
+    private static class SymbolToNotNullRangeQueryArgs extends SymbolVisitor<SymbolToNotNullContext, Void> {
+
+        /**
+         * Three valued logic systems are defined in logic as systems in which there are 3 truth values: true,
+         * false and an indeterminate third value (in our case null is the third value).
+         * <p>
+         * This is a set of functions for which inputs evaluating to null needs to be explicitly included or
+         * excluded (in the case of 'not ...') in the boolean queries
+         */
+        private final Set<String> STRICT_3VL_FUNCTIONS =
+            Set.of(
+                AnyOperators.Names.EQ,
+                AnyOperators.Names.NEQ,
+                AnyOperators.Names.GTE,
+                AnyOperators.Names.GT,
+                AnyOperators.Names.LTE,
+                AnyOperators.Names.LT,
+                LikeOperators.ANY_LIKE,
+                LikeOperators.ANY_NOT_LIKE,
+                CoalesceFunction.NAME
+            );
+
+        @Override
+        public Void visitReference(Reference symbol, SymbolToNotNullContext context) {
+            context.add(symbol);
+            return null;
+        }
+
+        @Override
+        public Void visitFunction(Function function, SymbolToNotNullContext context) {
+            String functionName = function.info().ident().name();
+            if (Ignore3vlFunction.NAME.equals(functionName)) {
+                return null;
+            }
+            if (!STRICT_3VL_FUNCTIONS.contains(functionName)) {
+                for (Symbol arg : function.arguments()) {
+                    arg.accept(this, context);
+                }
+            } else {
+                context.hasStrictThreeValuedLogicFunction = true;
+            }
+            return null;
+        }
+    }
+
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        assert input != null : "function must not be null";
+        assert input.arguments().size() == 1 : "function's number of arguments must be 1";
+        /**
+         * not null -> null     -> no match
+         * not true -> false    -> no match
+         * not false -> true    -> match
+         */
+
+        // handles not true / not false
+        Symbol arg = input.arguments().get(0);
+        Query innerQuery = arg.accept(visitor, context);
+        Query notX = Queries.not(innerQuery);
+
+        // not x =  not x & x is not null
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(notX, BooleanClause.Occur.MUST);
+
+        SymbolToNotNullContext ctx = new SymbolToNotNullContext();
+        arg.accept(INNER_VISITOR, ctx);
+        for (Reference reference : ctx.references()) {
+            String columnName = reference.column().fqn();
+            MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+            if (fieldType == null) {
+                // probably an object column, fallback to genericFunctionFilter
+                return null;
+            }
+            if (reference.isNullable()) {
+                builder.add(ExistsQueryBuilder.newFilter(context.queryShardContext, columnName), BooleanClause.Occur.MUST);
+            }
+        }
+        if (ctx.hasStrictThreeValuedLogicFunction) {
+            FunctionInfo isNullInfo = IsNullPredicate.generateInfo(Collections.singletonList(arg.valueType()));
+            Function isNullFunction = new Function(isNullInfo, Collections.singletonList(arg));
+            builder.add(
+                Queries.not(LuceneQueryBuilder.genericFunctionFilter(isNullFunction, context)),
+                BooleanClause.Occur.MUST
+            );
+        }
+        return builder.build();
+    }
+}

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -382,10 +382,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testIsNullOnObjectArray() throws Exception {
-        Query query = convert("o_array IS NULL");
-        assertThat(query.toString(), is("+*:* -ConstantScore(_field_names:o_array)"));
-        query = convert("o_array IS NOT NULL");
-        assertThat(query, instanceOf(GenericFunctionQuery.class));
+        Query isNull = convert("o_array IS NULL");
+        assertThat(isNull.toString(), is("+*:* -ConstantScore(_field_names:o_array)"));
+        Query isNotNull = convert("o_array IS NOT NULL");
+        assertThat(isNotNull.toString(), is("ConstantScore(DocValuesFieldExistsQuery [field=o_array.xs])"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `_field_names` index also exists for object columns. So we can always
use `ExistsQueryBuilder.newFilter` for `NOT (<ref> IS NULL)` queries.

This significantly improves the performance:

    Q: select min(obj['x']) from tbl where obj is not null
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |        Q3 |        Max |
    |   V1    |     8134.572 ± 5422.497 |    294.628 |  11127.396 | 11463.783 |  12676.666 |
    |   V2    |       87.163 ±   17.929 |     51.363 |     80.865 |   100.901 |    107.858 |
    mean:   - 195.76%
    median: - 197.11%
    Likely significant


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)