### PR TITLE
Add support for selecting most specific function 

### DIFF
--- a/common/src/main/java/io/crate/types/ArrayType.java
+++ b/common/src/main/java/io/crate/types/ArrayType.java
@@ -102,7 +102,7 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Override
     public Precedence precedence() {
-        return Precedence.ArrayType;
+        return Precedence.ARRAY;
     }
 
     public final DataType<T> innerType() {

--- a/common/src/main/java/io/crate/types/BooleanType.java
+++ b/common/src/main/java/io/crate/types/BooleanType.java
@@ -51,7 +51,7 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
 
     @Override
     public Precedence precedence() {
-        return Precedence.BooleanType;
+        return Precedence.BOOLEAN;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/ByteType.java
+++ b/common/src/main/java/io/crate/types/ByteType.java
@@ -42,7 +42,7 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
 
     @Override
     public Precedence precedence() {
-        return Precedence.ByteType;
+        return Precedence.BYTE;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/DataType.java
+++ b/common/src/main/java/io/crate/types/DataType.java
@@ -46,26 +46,28 @@ public abstract class DataType<T> implements Comparable, Writeable {
      *
      */
     public enum Precedence {
-        NotSupportedType,
-        UndefinedType,
-        LiteralType,
-        StringType,
-        ByteType,
-        BooleanType,
-        ShortType,
-        IntegerType,
-        IntervalType,
-        LongType,
-        FloatType,
-        DoubleType,
-        ArrayType,
-        SetType,
-        TableType,
-        GeoPointType,
-        ObjectType,
-        UncheckedObjectType,
-        GeoShapeType,
-        Custom
+        NOT_SUPPORTED,
+        UNDEFINED,
+        LITERAL,
+        STRING,
+        BYTE,
+        BOOLEAN,
+        SHORT,
+        INTEGER,
+        INTERVAL,
+        TIMESTAMP_WITH_TIME_ZONE,
+        TIMESTAMP,
+        LONG,
+        FLOAT,
+        DOUBLE,
+        ARRAY,
+        SET,
+        TABLE,
+        GEO_POINT,
+        OBJECT,
+        UNCHECKED_OBJECT,
+        GEO_SHAPE,
+        CUSTOM
     }
 
     public abstract int id();

--- a/common/src/main/java/io/crate/types/DoubleType.java
+++ b/common/src/main/java/io/crate/types/DoubleType.java
@@ -44,7 +44,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
     @Override
     public Precedence precedence() {
-        return Precedence.DoubleType;
+        return Precedence.DOUBLE;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/FloatType.java
+++ b/common/src/main/java/io/crate/types/FloatType.java
@@ -44,7 +44,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
 
     @Override
     public Precedence precedence() {
-        return Precedence.FloatType;
+        return Precedence.FLOAT;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/GeoPointType.java
+++ b/common/src/main/java/io/crate/types/GeoPointType.java
@@ -52,7 +52,7 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
 
     @Override
     public Precedence precedence() {
-        return Precedence.GeoPointType;
+        return Precedence.GEO_POINT;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/GeoShapeType.java
+++ b/common/src/main/java/io/crate/types/GeoShapeType.java
@@ -48,7 +48,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
 
     @Override
     public Precedence precedence() {
-        return Precedence.GeoShapeType;
+        return Precedence.GEO_SHAPE;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/IntegerType.java
+++ b/common/src/main/java/io/crate/types/IntegerType.java
@@ -44,7 +44,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
 
     @Override
     public Precedence precedence() {
-        return Precedence.IntegerType;
+        return Precedence.INTEGER;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/IntervalType.java
+++ b/common/src/main/java/io/crate/types/IntervalType.java
@@ -71,7 +71,7 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
 
     @Override
     public Precedence precedence() {
-        return Precedence.IntervalType;
+        return Precedence.INTERVAL;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/LongType.java
+++ b/common/src/main/java/io/crate/types/LongType.java
@@ -41,7 +41,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
 
     @Override
     public Precedence precedence() {
-        return Precedence.LongType;
+        return Precedence.LONG;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/NotSupportedType.java
+++ b/common/src/main/java/io/crate/types/NotSupportedType.java
@@ -43,7 +43,7 @@ public class NotSupportedType extends DataType<Void> {
 
     @Override
     public Precedence precedence() {
-        return Precedence.NotSupportedType;
+        return Precedence.NOT_SUPPORTED;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/ObjectType.java
+++ b/common/src/main/java/io/crate/types/ObjectType.java
@@ -113,7 +113,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     @Override
     public Precedence precedence() {
-        return Precedence.ObjectType;
+        return Precedence.OBJECT;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/RowType.java
+++ b/common/src/main/java/io/crate/types/RowType.java
@@ -129,7 +129,7 @@ public final class RowType extends DataType<Row> implements Streamer<Row> {
 
     @Override
     public Precedence precedence() {
-        return Precedence.TableType;
+        return Precedence.TABLE;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/ShortType.java
+++ b/common/src/main/java/io/crate/types/ShortType.java
@@ -44,7 +44,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
 
     @Override
     public Precedence precedence() {
-        return Precedence.ShortType;
+        return Precedence.SHORT;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/StringType.java
+++ b/common/src/main/java/io/crate/types/StringType.java
@@ -54,7 +54,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
 
     @Override
     public Precedence precedence() {
-        return Precedence.StringType;
+        return Precedence.STRING;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -50,21 +50,25 @@ public final class TimestampType extends DataType<Long>
     public static final TimestampType INSTANCE_WITH_TZ = new TimestampType(
         ID_WITH_TZ,
         "timestamp with time zone",
-        TimestampType::parseTimestamp);
+        TimestampType::parseTimestamp,
+        Precedence.TIMESTAMP_WITH_TIME_ZONE);
 
     public static final TimestampType INSTANCE_WITHOUT_TZ = new TimestampType(
         ID_WITHOUT_TZ,
         "timestamp without time zone",
-        TimestampType::parseTimestampIgnoreTimeZone);
+        TimestampType::parseTimestampIgnoreTimeZone,
+        Precedence.TIMESTAMP);
 
     private final int id;
     private final String name;
     private final Function<String, Long> parse;
+    private final Precedence precedence;
 
-    private TimestampType(int id, String name, Function<String, Long> parse) {
+    private TimestampType(int id, String name, Function<String, Long> parse, Precedence precedence) {
         this.id = id;
         this.name = name;
         this.parse = parse;
+        this.precedence = precedence;
     }
 
     @Override
@@ -79,7 +83,7 @@ public final class TimestampType extends DataType<Long>
 
     @Override
     public Precedence precedence() {
-        return Precedence.LongType;
+        return precedence;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/UncheckedObjectType.java
+++ b/common/src/main/java/io/crate/types/UncheckedObjectType.java
@@ -56,7 +56,7 @@ public class UncheckedObjectType extends DataType<Map<Object, Object>> implement
 
     @Override
     public Precedence precedence() {
-        return Precedence.UncheckedObjectType;
+        return Precedence.UNCHECKED_OBJECT;
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/UndefinedType.java
+++ b/common/src/main/java/io/crate/types/UndefinedType.java
@@ -43,7 +43,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
 
     @Override
     public Precedence precedence() {
-        return Precedence.UndefinedType;
+        return Precedence.UNDEFINED;
     }
 
     @Override

--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -232,7 +232,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -113,7 +113,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -197,7 +197,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -134,7 +134,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
         @Override
         public Precedence precedence() {
-            return Precedence.UndefinedType;
+            return Precedence.UNDEFINED;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -73,7 +73,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -105,7 +105,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
@@ -54,7 +54,7 @@ class TDigestStateType extends DataType<TDigestState> implements Streamer<TDiges
 
     @Override
     public Precedence precedence() {
-        return Precedence.Custom;
+        return Precedence.CUSTOM;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -74,7 +74,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
         @Override
         public Precedence precedence() {
-            return Precedence.Custom;
+            return Precedence.CUSTOM;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -42,26 +42,24 @@ public abstract class ConcatFunction extends Scalar<String, String> {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
-            Signature.builder()
-                .name(NAME)
-                .kind(FunctionInfo.Type.SCALAR)
-                .argumentTypes(parseTypeSignature("text"), parseTypeSignature("text"))
-                .returnType(parseTypeSignature("text"))
-                .setVariableArity(false)
-                .build(),
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
             args -> new StringConcatFunction(
                 new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
             )
         );
 
         module.register(
-            Signature.builder()
-                .name(NAME)
-                .kind(FunctionInfo.Type.SCALAR)
-                .argumentTypes(parseTypeSignature("text"))
-                .returnType(parseTypeSignature("text"))
-                .setVariableArity(true)
-                .build(),
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            )
+                .withVariableArity(),
             args -> new GenericConcatFunction(
                 new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
             )
@@ -69,14 +67,13 @@ public abstract class ConcatFunction extends Scalar<String, String> {
 
         // concat(array[], array[]) -> same as `array_cat(...)`
         module.register(
-            Signature.builder()
-                .name(NAME)
-                .kind(FunctionInfo.Type.SCALAR)
-                .typeVariableConstraints(typeVariable("E"))
-                .argumentTypes(parseTypeSignature("array(E)"), parseTypeSignature("array(E)"))
-                .returnType(parseTypeSignature("array(E)"))
-                .setVariableArity(false)
-                .build(),
+            Signature.scalar(
+                NAME,
+                parseTypeSignature("array(E)"),
+                parseTypeSignature("array(E)"),
+                parseTypeSignature("array(E)")
+            )
+                .withTypeVariableConstraints(typeVariable("E")),
             args -> new ArrayCatFunction(ArrayCatFunction.createInfo(args, NAME))
         );
     }
@@ -103,7 +100,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         return Literal.ofUnchecked(functionInfo.returnType(), evaluate(txnCtx, inputs));
     }
 
-    private static class StringConcatFunction extends ConcatFunction {
+    static class StringConcatFunction extends ConcatFunction {
 
         StringConcatFunction(FunctionInfo functionInfo) {
             super(functionInfo);

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -75,22 +75,18 @@ public abstract class LogFunction extends Scalar<Number, Number> {
 
         static void registerLogBaseFunctions(ScalarFunctionModule module) {
             // log(valueType, baseType) : double
-            for (DataType<?> baseType : ALLOWED_TYPES) {
-                for (DataType<?> valueType : ALLOWED_TYPES) {
-                    module.register(
-                        scalar(
-                            NAME,
-                            valueType.getTypeSignature(),
-                            baseType.getTypeSignature(),
-                            parseTypeSignature("double precision")),
-                        args -> new LogBaseFunction(
-                            new FunctionInfo(
-                                new FunctionIdent(NAME, List.of(valueType, baseType)), DataTypes.DOUBLE
-                            )
-                        )
-                    );
-                }
-            }
+            module.register(
+                scalar(
+                    NAME,
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    parseTypeSignature("double precision")),
+                args -> new LogBaseFunction(
+                    new FunctionInfo(
+                        new FunctionIdent(NAME, args), DataTypes.DOUBLE
+                    )
+                )
+            );
         }
 
         LogBaseFunction(FunctionInfo info) {
@@ -120,15 +116,17 @@ public abstract class LogFunction extends Scalar<Number, Number> {
     static class Log10Function extends LogFunction {
 
         static void registerLog10Functions(ScalarFunctionModule module) {
-            // log(dataType) : double
-            for (DataType<?> dt : ALLOWED_TYPES) {
-                module.register(
-                    scalar(NAME, dt.getTypeSignature(), parseTypeSignature("double precision")),
-                    args -> new Log10Function(
-                        new FunctionInfo(new FunctionIdent(NAME, List.of(dt)), DataTypes.DOUBLE)
-                    )
-                );
-            }
+            // log(double) : double
+            module.register(
+                scalar(
+                    NAME,
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                args -> new Log10Function(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE)
+                )
+            );
         }
 
         Log10Function(FunctionInfo info) {
@@ -154,15 +152,17 @@ public abstract class LogFunction extends Scalar<Number, Number> {
     public static class LnFunction extends Log10Function {
 
         static void registerLnFunctions(ScalarFunctionModule module) {
-            // ln(dataType) : double
-            for (DataType<?> dt : ALLOWED_TYPES) {
-                module.register(
-                    scalar(LnFunction.NAME, dt.getTypeSignature(), parseTypeSignature("double precision")),
-                    args -> new LnFunction(
-                        new FunctionInfo(new FunctionIdent(NAME, List.of(dt)), DataTypes.DOUBLE)
-                    )
-                );
-            }
+            // ln(double) : double
+            module.register(
+                scalar(
+                    LnFunction.NAME,
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                args -> new LnFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE)
+                )
+            );
         }
 
         public static final String NAME = "ln";

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 
 public final class TruncFunction {
@@ -64,17 +63,17 @@ public final class TruncFunction {
                     })
             );
 
-            // trunc(number, mode)
-            module.register(
-                scalar(
-                    NAME,
-                    type.getTypeSignature(),
-                    parseTypeSignature("integer"),
-                    returnType.getTypeSignature()
-                ),
-                TruncFunction::createTruncWithMode
-            );
         }
+        // trunc(number, mode)
+        module.register(
+            scalar(
+                NAME,
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            TruncFunction::createTruncWithMode
+        );
     }
 
     private static Scalar<Number, Number> createTruncWithMode(List<DataType> argumentTypes) {

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -37,8 +37,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public class TimezoneFunction extends Scalar<Long, Object> {
 
     public static final String NAME = "timezone";
@@ -48,9 +46,9 @@ public class TimezoneFunction extends Scalar<Long, Object> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("timestamp with time zone"),
-                parseTypeSignature("timestamp without time zone")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.TIMESTAMPZ.getTypeSignature(),
+                DataTypes.TIMESTAMP.getTypeSignature()
             ),
             argumentTypes ->
                 new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMP))
@@ -58,9 +56,9 @@ public class TimezoneFunction extends Scalar<Long, Object> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("timestamp without time zone"),
-                parseTypeSignature("timestamp with time zone")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.TIMESTAMP.getTypeSignature(),
+                DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
             argumentTypes ->
                 new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ))
@@ -68,9 +66,9 @@ public class TimezoneFunction extends Scalar<Long, Object> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("bigint"),
-                parseTypeSignature("timestamp with time zone")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
             argumentTypes ->
                 new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ))

--- a/sql/src/main/java/io/crate/metadata/FuncResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FuncResolver.java
@@ -28,7 +28,7 @@ import io.crate.types.DataType;
 import java.util.List;
 import java.util.function.Function;
 
-public class FuncResolver implements Function<List<DataType>, FunctionImplementation> {
+public class FuncResolver {
 
     private final Signature signature;
     private final Function<List<DataType>, FunctionImplementation> factory;
@@ -43,9 +43,8 @@ public class FuncResolver implements Function<List<DataType>, FunctionImplementa
         return signature;
     }
 
-    @Override
-    public FunctionImplementation apply(List<DataType> dataTypes) {
-        return factory.apply(dataTypes);
+    public Function<List<DataType>, FunctionImplementation> getFactory() {
+        return factory;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -21,11 +21,13 @@
 
 package io.crate.expression.scalar;
 
+import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
@@ -100,5 +102,11 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluate() throws Exception {
         assertEvaluate("concat([1], [2::integer, 3::integer])", List.of(1L, 2L, 3L));
+    }
+
+    @Test
+    public void test_two_string_arguments_result_in_special_scalar() {
+        var func = getFunction(ConcatFunction.NAME, List.of(DataTypes.STRING, DataTypes.STRING));
+        assertThat(func, instanceOf(ConcatFunction.StringConcatFunction.class));
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -43,7 +43,7 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWrongType() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `char`");
         assertEvaluate("abs('foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -44,7 +44,7 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testInvalidType() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `char`");
         assertEvaluate("round('foo')", null);
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -48,7 +48,7 @@ public class SquareRootFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testInvalidType() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `char`");
         assertEvaluate("sqrt('foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -304,9 +304,9 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testStyles() throws Exception {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(bar+cast(\"select\" as long)+1+1+1+1+1+1)))");
         assertThat(nestedFn.toString(Style.QUALIFIED),
-            is("abs(sqrt(ln((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1))))"));
+            is("abs(sqrt(ln(cast((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1) AS double precision))))"));
         assertThat(nestedFn.toString(Style.UNQUALIFIED),
-            is("abs(sqrt(ln((((((((bar + cast(\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1))))"));
+            is("abs(sqrt(ln(cast((((((((bar + cast(\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1) AS double precision))))"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/sql/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import io.crate.expression.symbol.FuncArg;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.functions.Signature;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+import static org.hamcrest.Matchers.contains;
+
+public class FunctionsTest extends CrateUnitTest {
+
+    private Map<FunctionName, List<FuncResolver>> implementations = new HashMap<>();
+
+    private void register(Signature signature, Function<List<DataType>, FunctionImplementation> factory) {
+        List<FuncResolver> functions = implementations.computeIfAbsent(
+            signature.getName(),
+            k -> new ArrayList<>());
+        functions.add(new FuncResolver(signature, factory));
+    }
+
+    private Functions createFunctions() {
+        return new Functions(Collections.emptyMap(), Collections.emptyMap(), implementations);
+    }
+
+    private FunctionImplementation resolve(String functionName,
+                                           List<? extends FuncArg> arguments) {
+        return createFunctions().get(null, functionName, arguments, SearchPath.pathWithPGCatalogAndDoc());
+    }
+
+    @Test
+    public void test_function_name_doesnt_exists() {
+        var functions = createFunctions();
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: does_not_exists()");
+        functions.get(null, "does_not_exists", Collections.emptyList(), SearchPath.pathWithPGCatalogAndDoc());
+    }
+
+    @Test
+    public void test_signature_matches_exact() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.STRING)
+        );
+        var impl = resolve("foo", List.of(Literal.of("hoschi")));
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.STRING));
+    }
+
+    @Test
+    public void test_signature_matches_with_coercion() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+        var impl = resolve("foo", List.of(Literal.of(1L)));
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.INTEGER));
+    }
+
+    @Test
+    public void test_signature_matches_with_coercion_and_precedence() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.DOUBLE)
+        );
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+
+        var impl = resolve("foo", List.of(Literal.of(1L)));
+
+        // integer is more specific than double
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.INTEGER));
+    }
+
+    @Test
+    public void test_multiple_signature_matches_with_same_return_type_results_in_first_selected() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+        register(
+            Signature.scalar(
+                "foo",
+                parseTypeSignature("array(E)"),
+                DataTypes.INTEGER.getTypeSignature()
+            ).withTypeVariableConstraints(typeVariable("E")),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+
+        var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.STRING));
+    }
+
+    @Test
+    public void test_multiple_signature_matches_with_undefined_arguments_only_result_in_first_selected() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+        register(
+            Signature.scalar(
+                "foo",
+                parseTypeSignature("array(E)"),
+                parseTypeSignature("array(E)")
+            ).withTypeVariableConstraints(typeVariable("E")),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.UNDEFINED)
+        );
+
+        var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.STRING));
+    }
+}

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -454,7 +454,11 @@ public class SQLTransportExecutor {
                 return elements;
             }
             case "char":
-                return Byte.valueOf(resultSet.getString(columnIndex));
+                String strValue = resultSet.getString(columnIndex);
+                if (strValue == null) {
+                    return null;
+                }
+                return Byte.valueOf(strValue);
             case "byte":
                 value = resultSet.getByte(columnIndex);
                 break;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If given argument types won’t result in an exact match of a registered function signature, multiple signatures may match with allowed coercion.
Till now, the first matching signature is used which may be wrong as this relies on the order of signature registrations.

Hereby we introduce a logic to select the most specific one based on type precedence, the signature with the lowest precedence of the types will be used.
If that fails it will fallback to select just the first one if all signatures defines the same return type. All signatures are then semantically the same, so it shouldn’t matter which one to choose.
To be deterministic, the first one is chosen.

The last fallback happens when all given types are undefined but multiple matching candidates still exists after trying to select the most specific one.
This case currently only happens for `concat(null, null)`, it matches both:

	`concat(text, text):text`
	`concat(array(E), array(E)):array(E)`

because an `undefined` type is convertible to `text` and `array(E)`.

In that case we also just select the first matching as the `concat(text, text)` was registered first and is the expected one (`concat(null, null)` must return an empty string).
Maybe we can come up with a better solution for that eventually.

This is again heavily inspired by Presto.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
