### PR TITLE
mergify: Add ignore_conflicts option to backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
     name: default
   - actions:
       backport:
+        ignore_conflicts: true
         branches:
           - '4.1'
     conditions:
@@ -22,6 +23,7 @@ pull_request_rules:
     name: backport 4.1
   - actions:
       backport:
+        ignore_conflicts: true
         branches:
           - '4.0'
     conditions:
@@ -30,6 +32,7 @@ pull_request_rules:
     name: backport 4.0
   - actions:
       backport:
+        ignore_conflicts: true
         branches:
           - '3.3'
     conditions:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Mergify otherwise no longer creates a PR for a backport if the backport has
conflicts.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)