### PR TITLE
Fix ordering on IP columns and scalar functions

### DIFF
--- a/common/src/main/java/io/crate/types/BooleanType.java
+++ b/common/src/main/java/io/crate/types/BooleanType.java
@@ -97,7 +97,7 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
 
     @Override
     public int compare(Boolean val1, Boolean val2) {
-        return nullSafeCompareValueTo(val1, val2, Boolean::compare);
+        return Boolean.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/ByteType.java
+++ b/common/src/main/java/io/crate/types/ByteType.java
@@ -72,7 +72,7 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
 
     @Override
     public int compare(Byte val1, Byte val2) {
-        return nullSafeCompareValueTo(val1, val2, Byte::compare);
+        return Byte.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/DataType.java
+++ b/common/src/main/java/io/crate/types/DataType.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable, Comparator<T> {
@@ -118,19 +117,6 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
             return false;
         }
         return possibleConversions.contains(other.id());
-    }
-
-    static <T> int nullSafeCompareValueTo(T val1, T val2, Comparator<T> cmp) {
-        if (val1 == null) {
-            if (val2 == null) {
-                return 0;
-            }
-            return -1;
-        }
-        if (val2 == null) {
-            return 1;
-        }
-        return Objects.compare(val1, val2, cmp);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/DoubleType.java
+++ b/common/src/main/java/io/crate/types/DoubleType.java
@@ -73,7 +73,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
     @Override
     public int compare(Double val1, Double val2) {
-        return nullSafeCompareValueTo(val1, val2, Double::compare);
+        return Double.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/FloatType.java
+++ b/common/src/main/java/io/crate/types/FloatType.java
@@ -77,7 +77,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
 
     @Override
     public int compare(Float val1, Float val2) {
-        return nullSafeCompareValueTo(val1, val2, Float::compare);
+        return Float.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/IntegerType.java
+++ b/common/src/main/java/io/crate/types/IntegerType.java
@@ -78,7 +78,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
 
     @Override
     public int compare(Integer val1, Integer val2) {
-        return nullSafeCompareValueTo(val1, val2, Integer::compare);
+        return Integer.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/IntervalType.java
+++ b/common/src/main/java/io/crate/types/IntervalType.java
@@ -31,7 +31,6 @@ import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Locale;
 
 public class IntervalType extends DataType<Period> implements FixedWidthType, Streamer<Period> {
@@ -101,8 +100,9 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
         throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Cannot convert %s to interval", value));
     }
 
+    @Override
     public int compare(Period p1, Period p2) {
-        return nullSafeCompareValueTo(p1.toStandardDuration(), p2.toStandardDuration(), Comparator.naturalOrder());
+        return p1.toStandardDuration().compareTo(p2.toStandardDuration());
 
     }
 

--- a/common/src/main/java/io/crate/types/LongType.java
+++ b/common/src/main/java/io/crate/types/LongType.java
@@ -70,7 +70,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
 
     @Override
     public int compare(Long val1, Long val2) {
-        return nullSafeCompareValueTo(val1, val2, Long::compare);
+        return Long.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/ShortType.java
+++ b/common/src/main/java/io/crate/types/ShortType.java
@@ -77,7 +77,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
 
     @Override
     public int compare(Short val1, Short val2) {
-        return nullSafeCompareValueTo(val1, val2, Short::compare);
+        return Short.compare(val1, val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/StringType.java
+++ b/common/src/main/java/io/crate/types/StringType.java
@@ -21,13 +21,7 @@
 
 package io.crate.types;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Comparator;
-
+import io.crate.Streamer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -35,7 +29,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
 
 public class StringType extends DataType<String> implements Streamer<String> {
 
@@ -108,7 +106,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
 
     @Override
     public int compare(String val1, String val2) {
-        return Comparator.<String>nullsFirst(Comparator.naturalOrder()).compare(val1, val2);
+        return val1.compareTo(val2);
     }
 
     @Override

--- a/common/src/main/java/io/crate/types/TimestampType.java
+++ b/common/src/main/java/io/crate/types/TimestampType.java
@@ -115,7 +115,7 @@ public final class TimestampType extends DataType<Long>
 
     @Override
     public int compare(Long val1, Long val2) {
-        return nullSafeCompareValueTo(val1, val2, Long::compare);
+        return Long.compare(val1, val2);
     }
 
     @Override

--- a/common/src/test/java/io/crate/types/DataTypesTest.java
+++ b/common/src/test/java/io/crate/types/DataTypesTest.java
@@ -21,19 +21,18 @@
 
 package io.crate.types;
 
-import static io.crate.types.DataTypes.compareTypesById;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNot.not;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.junit.Test;
-
-import io.crate.test.integration.CrateUnitTest;
+import static io.crate.types.DataTypes.compareTypesById;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 
 public class DataTypesTest extends CrateUnitTest {
@@ -331,6 +330,10 @@ public class DataTypesTest extends CrateUnitTest {
     }
 
     private static void assertCompareValueTo(DataType dt, Object val1, Object val2, int expected) {
-        assertThat(dt.compare(dt.value(val1), dt.value(val2)), is(expected));
+        if (val1 == null || val2 == null) {
+            assertThat(Comparator.nullsFirst(dt).compare(dt.value(val1), dt.value(val2)), is(expected));
+        } else {
+            assertThat(dt.compare(dt.value(val1), dt.value(val2)), is(expected));
+        }
     }
 }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,4 +163,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to incorrect ordering of a result sets if
+  using ``ORDER BY`` on a column of type ``IP`` or on a scalar function.

--- a/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
@@ -34,6 +34,7 @@ import io.crate.types.DataType;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,7 +115,7 @@ public final class GeneratedColumns<T> {
 
             //noinspection unchecked
             DataType<Object> dataType = (DataType<Object>) ref.valueType();
-            if (dataType.compare(dataType.value(generatedValue), dataType.value(providedValue)) != 0) {
+            if (Comparator.nullsFirst(dataType).compare(dataType.value(generatedValue), dataType.value(providedValue)) != 0) {
                 throw new IllegalArgumentException(
                     "Given value " + providedValue +
                     " for generated column " + ref.column() +

--- a/sql/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Literal.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -192,7 +193,7 @@ public class Literal<T> extends Symbol implements Input<T>, Comparable<Literal<T
         Literal<?> literal = (Literal<?>) obj;
         if (valueType().equals(literal.valueType())) {
             DataType type = valueType();
-            return type.compare(value, literal.value) == 0;
+            return Comparator.nullsFirst(type).compare(value, literal.value) == 0;
         }
         return false;
     }

--- a/sql/src/test/java/io/crate/integrationtests/OrderByITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OrderByITest.java
@@ -35,16 +35,21 @@ public class OrderByITest extends SQLTransportIntegrationTest {
         execute("create table t1 (" +
                 "  ipp ip" +
                 ")");
-        ensureYellow();
         execute("insert into t1 (ipp) values (?)", new Object[][]{
             {"127.0.0.1"},
             {null},
             {"10.0.0.1"},
+            {"10.200.1.100"},
+            {"10.220.1.120"},
+            {"10.220.1.20"}
         });
         execute("refresh table t1");
         execute("select ipp from t1 order by ipp");
         assertThat(TestingHelpers.printedTable(response.rows()), Is.is(
             "10.0.0.1\n" +
+            "10.200.1.100\n" +
+            "10.220.1.120\n" +
+            "10.220.1.20\n" +
             "127.0.0.1\n" +
             "NULL\n"));
 
@@ -52,6 +57,9 @@ public class OrderByITest extends SQLTransportIntegrationTest {
         assertThat(TestingHelpers.printedTable(response.rows()), Is.is(
             "NULL\n" +
             "127.0.0.1\n" +
+            "10.220.1.20\n" +
+            "10.220.1.120\n" +
+            "10.200.1.100\n" +
             "10.0.0.1\n"));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
@@ -157,7 +157,13 @@ public class SelectOrderByIntegrationTest extends SQLTransportIntegrationTest {
         refresh();
 
         execute("select str from t1 order by upper(str) limit 5");
-        assertNull(response.rows()[0][0]);
+        assertThat(printedTable(response.rows()), is(
+            "a\n" +
+            "b\n" +
+            "NULL\n" +
+            "NULL\n" +
+            "NULL\n"
+        ));
 
         execute("select i from t1 order by ln(i)");
         assertThat(response.rows()[0][0], is(2));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

All the `DataType.compare` implementations had baked in `null` handling.
This broke the `NULLS FIRST` / `NULLS LAST` handling.

For example, the query:

    select name from t order by substr(name, 1, 1) nulls last

Returned nulls first.

If columns of type IP were sorted on Lucene level, it used a binary
doc-value based sorting, which has a different ordering than the text
based alphanumeric ordering that is used for IP types in other places in
the pipeline. This switches IP types to use the `InputFieldComparator`.
This may slow down the sorting, but it is necessary to ensure consistent
ordering.

Fixes https://github.com/crate/crate/issues/9842


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)