### PR TITLE
Add fast function lookup-by-signature support

### DIFF
--- a/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
@@ -25,6 +25,7 @@ package io.crate.plugin;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.CauseMatcher;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -98,9 +99,13 @@ public class PluginLoaderTest extends ESIntegTestCase {
                    is(new FunctionInfo( isEven, DataTypes.BOOLEAN)));
 
         // Also check that the built-in functions are not lost
-        FunctionIdent abs = new FunctionIdent("abs", Collections.singletonList(DataTypes.LONG));
-        assertThat(functions.getQualified(abs).info(),
-                   is(new FunctionInfo(abs, DataTypes.LONG)));
+        var abs = Signature.scalar(
+            "abs",
+            DataTypes.LONG.getTypeSignature(),
+            DataTypes.LONG.getTypeSignature()
+        );
+        assertThat(functions.getQualified(abs, List.of(DataTypes.LONG)).signature(),
+                   is(abs));
     }
 
     @Test

--- a/common/src/main/java/io/crate/types/TypeSignatureType.java
+++ b/common/src/main/java/io/crate/types/TypeSignatureType.java
@@ -23,37 +23,25 @@
 package io.crate.types;
 
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.List;
 
-final class ObjectParameterTypeSignature extends TypeSignature {
+public enum TypeSignatureType {
 
-    private final String parameterName;
+    TYPE_SIGNATURE(TypeSignature::new),
+    OBJECT_PARAMETER_TYPE_SIGNATURE(ObjectParameterTypeSignature::new);
 
-    public ObjectParameterTypeSignature(String parameterName,
-                                        TypeSignature typeSignature) {
-        super(typeSignature.getBaseTypeName(), typeSignature.getParameters());
-        this.parameterName = parameterName;
+    public static final List<TypeSignatureType> VALUES = List.of(values());
+
+    private final Writeable.Reader<TypeSignature> reader;
+
+    TypeSignatureType(Writeable.Reader<TypeSignature> reader) {
+        this.reader = reader;
     }
 
-    public ObjectParameterTypeSignature(StreamInput in) throws IOException {
-        super(in);
-        parameterName = in.readString();
-    }
-
-    public String parameterName() {
-        return parameterName;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeString(parameterName);
-    }
-
-    @Override
-    public TypeSignatureType type() {
-        return TypeSignatureType.OBJECT_PARAMETER_TYPE_SIGNATURE;
+    public TypeSignature newInstance(StreamInput in) throws IOException {
+        return reader.read(in);
     }
 }

--- a/enterprise/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/enterprise/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -30,6 +30,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
@@ -66,15 +67,23 @@ public class OffsetValueFunctions implements WindowFunction {
 
     private final OffsetDirection offsetDirection;
     private final FunctionInfo info;
+    private final Signature signature;
 
-    private OffsetValueFunctions(FunctionInfo info, OffsetDirection offsetDirection) {
+    private OffsetValueFunctions(FunctionInfo info, Signature signature, OffsetDirection offsetDirection) {
         this.info = info;
+        this.signature = signature;
         this.offsetDirection = offsetDirection;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override
@@ -123,12 +132,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LEAD_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.FORWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LEAD_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.FORWARD
+                )
         );
         module.register(
             Signature.window(
@@ -137,12 +149,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 DataTypes.INTEGER.getTypeSignature(),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LEAD_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.FORWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LEAD_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.FORWARD
+                )
         );
         module.register(
             Signature.window(
@@ -152,12 +167,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LEAD_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.FORWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LEAD_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.FORWARD
+                )
         );
 
         module.register(
@@ -166,12 +184,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LAG_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.BACKWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LAG_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.BACKWARD
+                )
         );
         module.register(
             Signature.window(
@@ -180,12 +201,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 DataTypes.INTEGER.getTypeSignature(),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LAG_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.BACKWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LAG_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.BACKWARD
+                )
         );
         module.register(
             Signature.window(
@@ -195,12 +219,15 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new OffsetValueFunctions(
-                new FunctionInfo(
-                    new FunctionIdent(LAG_NAME, args),
-                    args.get(0),
-                    FunctionInfo.Type.WINDOW),
-                OffsetDirection.BACKWARD)
+            (signature, args) ->
+                new OffsetValueFunctions(
+                    new FunctionInfo(
+                        new FunctionIdent(LAG_NAME, args),
+                        args.get(0),
+                        FunctionInfo.Type.WINDOW),
+                    signature,
+                    OffsetDirection.BACKWARD
+                )
         );
     }
 }

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -24,6 +24,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import org.elasticsearch.common.inject.Inject;
 import org.graalvm.polyglot.Context;
@@ -56,12 +57,13 @@ public class JavaScriptLanguage implements UDFLanguage {
         udfService.registerLanguage(this);
     }
 
-    public Scalar createFunctionImplementation(UserDefinedFunctionMetaData meta) throws ScriptException {
+    public Scalar createFunctionImplementation(UserDefinedFunctionMetaData meta,
+                                               Signature signature) throws ScriptException {
         FunctionInfo info = new FunctionInfo(
             new FunctionIdent(meta.schema(), meta.name(), meta.argumentTypes()),
             meta.returnType()
         );
-        return new JavaScriptUserDefinedFunction(info, meta.definition());
+        return new JavaScriptUserDefinedFunction(info, signature, meta.definition());
     }
 
     @Nullable

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -23,10 +23,12 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -35,10 +37,12 @@ import static io.crate.operation.language.JavaScriptLanguage.resolvePolyglotFunc
 public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final String script;
 
-    JavaScriptUserDefinedFunction(FunctionInfo info, String script) {
+    JavaScriptUserDefinedFunction(FunctionInfo info, Signature signature, String script) {
         this.info = info;
+        this.signature = signature;
         this.script = script;
     }
 
@@ -79,6 +83,12 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     private class CompiledFunction extends Scalar<Object, Object> {

--- a/sql/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
+++ b/sql/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
@@ -96,7 +96,7 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
         if (allLiterals && !Operators.LOGICAL_OPERATORS.contains(functionName)) {
             return isNull ? Literal.NULL : Literal.BOOLEAN_TRUE;
         }
-        return new Function(symbol.info(), newArgs);
+        return new Function(symbol.info(), symbol.signature(), newArgs);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -77,6 +77,7 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.ExpressionFormatter;
 import io.crate.sql.parser.SqlParser;
@@ -1109,6 +1110,7 @@ public class ExpressionAnalyzer {
             coordinatorTxnCtx.sessionContext().searchPath());
 
         FunctionInfo functionInfo = funcImpl.info();
+        Signature signature = funcImpl.signature();
         List<Symbol> castArguments = cast(arguments, functionInfo.ident().argumentTypes());
         Function newFunction;
         if (windowDefinition == null) {
@@ -1118,7 +1120,7 @@ public class ExpressionAnalyzer {
                 throw new UnsupportedOperationException(
                     "Only aggregate functions allow a FILTER clause");
             }
-            newFunction = new Function(functionInfo, castArguments, filter);
+            newFunction = new Function(functionInfo, signature, castArguments, filter);
         } else {
             if (functionInfo.type() != FunctionInfo.Type.WINDOW && functionInfo.type() != FunctionInfo.Type.AGGREGATE) {
                 throw new IllegalArgumentException(String.format(
@@ -1128,6 +1130,7 @@ public class ExpressionAnalyzer {
             }
             newFunction = new WindowFunction(
                 functionInfo,
+                signature,
                 castArguments,
                 filter,
                 windowDefinition);

--- a/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -37,17 +37,15 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.sys.SysShardsTableInfo;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.IntegerType;
 import io.crate.types.StringType;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,11 +79,15 @@ public class WriterProjection extends Projection {
     );
 
 
-    public static final Symbol DIRECTORY_TO_FILENAME = new Function(new FunctionInfo(
-        new FunctionIdent(FormatFunction.NAME, Arrays.<DataType>asList(StringType.INSTANCE,
-            StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE)),
-        StringType.INSTANCE),
-        Arrays.asList(Literal.of("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF)
+    public static final Symbol DIRECTORY_TO_FILENAME = new Function(
+        new FunctionInfo(
+            new FunctionIdent(
+                FormatFunction.NAME,
+                List.of(StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE)
+            ),
+            StringType.INSTANCE),
+        FormatFunction.SIGNATURE,
+        List.of(Literal.of("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF)
     );
 
     private final Symbol uri;

--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -170,7 +170,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
             return replacement;
         }
         ArrayList<Symbol> replacedFunctionArgs = getProcessedArgs(symbol.arguments(), sourceSymbols);
-        return new Function(symbol.info(), replacedFunctionArgs);
+        return new Function(symbol.info(), symbol.signature(), replacedFunctionArgs);
     }
 
     @Nullable
@@ -206,6 +206,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         }
         return new WindowFunction(
             windowFunction.info(),
+            windowFunction.signature(),
             replacedFunctionArgs,
             filterWithReplacedArgs,
             windowFunction.windowDefinition()

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -40,9 +40,6 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
     public static final String NAME = "arbitrary";
 
-    private final FunctionInfo info;
-    private final SizeEstimator<Object> partialEstimator;
-
     public static void register(AggregationImplModule mod) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             mod.register(
@@ -50,23 +47,38 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                     NAME,
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature()),
-                args -> new ArbitraryAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new ArbitraryAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            args.get(0),
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
 
-    ArbitraryAggregation(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+    private final SizeEstimator<Object> partialEstimator;
+
+    ArbitraryAggregation(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
         partialEstimator = SizeEstimatorFactory.create(partialType());
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -46,7 +46,6 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
     public static final String[] NAMES = new String[]{"avg", "mean"};
     public static final String NAME = NAMES[0];
-    private final FunctionInfo info;
 
     static {
         DataTypes.register(AverageStateType.ID, in -> AverageStateType.INSTANCE);
@@ -66,11 +65,15 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                         functionName,
                         supportedType.getTypeSignature(),
                         DataTypes.DOUBLE.getTypeSignature()),
-                    args -> new AverageAggregation(
-                        new FunctionInfo(
-                            new FunctionIdent(functionName, args),
-                            DataTypes.DOUBLE,
-                            FunctionInfo.Type.AGGREGATE))
+                    (signature, args) ->
+                        new AverageAggregation(
+                            new FunctionInfo(
+                                new FunctionIdent(functionName, args),
+                                DataTypes.DOUBLE,
+                                FunctionInfo.Type.AGGREGATE
+                            ),
+                            signature
+                        )
                 );
             }
         }
@@ -166,8 +169,12 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         }
     }
 
-    AverageAggregation(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    AverageAggregation(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
@@ -240,5 +247,11 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -53,10 +53,6 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
     private static final Object PRESENT = null;
 
     public static final String NAME = "collect_set";
-    private final SizeEstimator<Object> innerTypeEstimator;
-
-    private final FunctionInfo info;
-    private final DataType<?> partialReturnType;
 
     public static void register(AggregationImplModule mod) {
         for (DataType<?> supportedType : DataTypes.PRIMITIVE_TYPES) {
@@ -66,24 +62,40 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
                     NAME,
                     supportedType.getTypeSignature(),
                     returnType.getTypeSignature()),
-                args -> new CollectSetAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        returnType,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new CollectSetAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            returnType,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
 
-    private CollectSetAggregation(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+    private final DataType<?> partialReturnType;
+    private final SizeEstimator<Object> innerTypeEstimator;
+
+    private CollectSetAggregation(FunctionInfo info, Signature signature) {
         this.innerTypeEstimator = SizeEstimatorFactory.create(((ArrayType<?>) info.returnType()).innerType());
         this.info = info;
+        this.signature = signature;
         this.partialReturnType = UncheckedObjectType.INSTANCE;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -63,11 +63,15 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()),
-                args -> new GeometricMeanAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        DataTypes.DOUBLE,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new GeometricMeanAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            DataTypes.DOUBLE,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
@@ -184,9 +188,11 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    public GeometricMeanAggregation(FunctionInfo info) {
+    public GeometricMeanAggregation(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Nullable
@@ -256,5 +262,11 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
 
-    private static final String NAME = "percentile";
+    public static final String NAME = "percentile";
 
     static {
         DataTypes.register(TDigestStateType.ID, in -> TDigestStateType.INSTANCE);
@@ -54,11 +54,15 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     supportedType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()),
-                args -> new PercentileAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        DataTypes.DOUBLE,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new PercentileAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            DataTypes.DOUBLE,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
             mod.register(
                 Signature.aggregate(
@@ -67,24 +71,36 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                     DataTypes.DOUBLE_ARRAY.getTypeSignature()
                 ),
-                args -> new PercentileAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        DataTypes.DOUBLE_ARRAY,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new PercentileAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            DataTypes.DOUBLE_ARRAY,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    PercentileAggregation(FunctionInfo info) {
+    PercentileAggregation(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -61,11 +61,15 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()),
-                args -> new StandardDeviationAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        DataTypes.DOUBLE,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new StandardDeviationAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            DataTypes.DOUBLE,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
@@ -122,9 +126,17 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    public StandardDeviationAggregation(FunctionInfo functionInfo) {
+    public StandardDeviationAggregation(FunctionInfo functionInfo, Signature signature) {
         this.info = functionInfo;
+        this.signature = signature;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,14 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         DataTypes.STRING,
         FunctionInfo.Type.AGGREGATE
     );
+    public static final Signature SIGNATURE =
+        Signature.aggregate(
+            NAME,
+            DataTypes.STRING.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature()
+        );
+
 
     private static final int LIST_ENTRY_OVERHEAD = 32;
 
@@ -64,12 +73,8 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
     public static void register(AggregationImplModule mod) {
         mod.register(
-            Signature.aggregate(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()),
-            args -> new StringAgg()
+            SIGNATURE,
+            (signature, args) -> new StringAgg(signature)
         );
     }
 
@@ -137,6 +142,12 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         public void writeValueTo(StreamOutput out, StringAggState val) throws IOException {
             val.writeTo(out);
         }
+    }
+
+    private final Signature signature;
+
+    public StringAgg(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -236,5 +247,11 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -52,14 +52,16 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                 NAME,
                 DataTypes.FLOAT.getTypeSignature(),
                 DataTypes.FLOAT.getTypeSignature()),
-            args -> new SumAggregation<>(DataTypes.FLOAT, Float::sum, (n1, n2) -> n1 - n2)
+            (signature, args) ->
+                new SumAggregation<>(DataTypes.FLOAT, Float::sum, (n1, n2) -> n1 - n2, signature)
         );
         mod.register(
             Signature.aggregate(
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()),
-            args -> new SumAggregation<>(DataTypes.DOUBLE, Double::sum, (n1, n2) -> n1 - n2)
+            (signature, args) ->
+                new SumAggregation<>(DataTypes.DOUBLE, Double::sum, (n1, n2) -> n1 - n2, signature)
         );
 
         for (var supportedType : List.of(DataTypes.BYTE, DataTypes.SHORT, DataTypes.INTEGER, DataTypes.LONG)) {
@@ -68,12 +70,14 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature()),
-                args -> new SumAggregation<>(supportedType, DataTypes.LONG, add, sub)
+                (signature, args) ->
+                    new SumAggregation<>(supportedType, DataTypes.LONG, add, sub, signature)
             );
         }
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final BinaryOperator<T> addition;
     private final BinaryOperator<T> subtraction;
     private final DataType<T> returnType;
@@ -82,14 +86,16 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     @VisibleForTesting
     private SumAggregation(final DataType<T> returnType,
                            final BinaryOperator<T> addition,
-                           final BinaryOperator<T> subtraction) {
-        this(returnType, returnType, addition, subtraction);
+                           final BinaryOperator<T> subtraction,
+                           Signature signature) {
+        this(returnType, returnType, addition, subtraction, signature);
     }
 
     private SumAggregation(final DataType<?> inputType,
                            final DataType<T> returnType,
                            final BinaryOperator<T> addition,
-                           final BinaryOperator<T> subtraction) {
+                           final BinaryOperator<T> subtraction,
+                           Signature signature) {
         this.addition = addition;
         this.subtraction = subtraction;
         this.returnType = returnType;
@@ -107,6 +113,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
             returnType,
             FunctionInfo.Type.AGGREGATE
         );
+        this.signature = signature;
     }
 
     @Nullable
@@ -148,6 +155,12 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -61,11 +61,15 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()),
-                args -> new VarianceAggregation(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args),
-                        DataTypes.DOUBLE,
-                        FunctionInfo.Type.AGGREGATE))
+                (signature, args) ->
+                    new VarianceAggregation(
+                        new FunctionInfo(
+                            new FunctionIdent(NAME, args),
+                            DataTypes.DOUBLE,
+                            FunctionInfo.Type.AGGREGATE
+                        ),
+                        signature
+                    )
             );
         }
     }
@@ -122,11 +126,12 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    public VarianceAggregation(FunctionInfo info) {
+    public VarianceAggregation(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
-
 
     @Nullable
     @Override
@@ -196,5 +201,11 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.window;
 
+import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
 import io.crate.expression.scalar.arithmetic.IntervalTimestampArithmeticScalar;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -56,7 +57,12 @@ class ArithmeticOperatorsFactory {
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {
                     return new IntervalTimestampArithmeticScalar(
-                        "+", "add-interval", List.of(fstArgDataType, sndArgDataType), fstArgDataType);
+                        "+",
+                        ArithmeticFunctions.Names.ADD,
+                        List.of(fstArgDataType, sndArgDataType),
+                        fstArgDataType,
+                        IntervalTimestampArithmeticScalar.signatureFor(fstArgDataType, ArithmeticFunctions.Names.ADD)
+                    );
                 }
                 return ADD_LONG_FUNCTION;
             case DoubleType.ID:
@@ -80,7 +86,12 @@ class ArithmeticOperatorsFactory {
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {
                     return new IntervalTimestampArithmeticScalar(
-                        "-", "sub-interval", List.of(fstArgDataType, sndArgDataType), fstArgDataType);
+                        "-",
+                        ArithmeticFunctions.Names.SUBTRACT,
+                        List.of(fstArgDataType, sndArgDataType),
+                        fstArgDataType,
+                        IntervalTimestampArithmeticScalar.signatureFor(fstArgDataType, ArithmeticFunctions.Names.SUBTRACT)
+                    );
                 }
                 return SUB_LONG_FUNCTION;
             case DoubleType.ID:

--- a/sql/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
+++ b/sql/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
@@ -30,16 +30,32 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class RowNumberWindowFunction implements WindowFunction {
 
     private static final String NAME = "row_number";
 
-    private final FunctionInfo info;
+    public static void register(WindowFunctionModule module) {
+        module.register(
+            Signature.window(NAME, DataTypes.INTEGER.getTypeSignature()),
+            (signature, args) -> new RowNumberWindowFunction(
+                new FunctionInfo(
+                    new FunctionIdent(NAME, args),
+                    DataTypes.INTEGER,
+                    FunctionInfo.Type.WINDOW),
+                signature
+            )
+        );
+    }
 
-    private RowNumberWindowFunction(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private RowNumberWindowFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
@@ -55,14 +71,9 @@ public class RowNumberWindowFunction implements WindowFunction {
         return info;
     }
 
-    public static void register(WindowFunctionModule module) {
-        module.register(
-            Signature.window(NAME, DataTypes.INTEGER.getTypeSignature()),
-            args -> new RowNumberWindowFunction(
-                new FunctionInfo(
-                    new FunctionIdent(NAME, args),
-                    DataTypes.INTEGER,
-                    FunctionInfo.Type.WINDOW))
-        );
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/AbstractFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/AbstractFunctionModule.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public abstract class AbstractFunctionModule<T extends FunctionImplementation> extends AbstractModule {
 
@@ -50,27 +50,27 @@ public abstract class AbstractFunctionModule<T extends FunctionImplementation> e
     private MapBinder<FunctionName, List<FuncResolver>> implementationsBinder;
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     public void register(T impl) {
         functions.put(impl.info().ident(), impl);
     }
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     public void register(String name, FunctionResolver functionResolver) {
         register(new FunctionName(name), functionResolver);
     }
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     public void register(FunctionName qualifiedName, FunctionResolver functionResolver) {
         resolver.put(qualifiedName, functionResolver);
     }
 
-    public void register(Signature signature, Function<List<DataType>, FunctionImplementation> factory) {
+    public void register(Signature signature, BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
         List<FuncResolver> functions = functionImplementations.computeIfAbsent(
             signature.getName(),
             k -> new ArrayList<>());

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -31,6 +31,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +42,6 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
 
     public static final String NAME = "array_cat";
-    private final FunctionInfo functionInfo;
 
     public static FunctionInfo createInfo(List<DataType> types, String name) {
         ensureBothInnerTypesAreNotUndefined(types, name);
@@ -59,19 +59,33 @@ class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
                 parseTypeSignature("array(E)"),
                 parseTypeSignature("array(E)"),
                 parseTypeSignature("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
-            args ->
-                new ArrayCatFunction(ArrayCatFunction.createInfo(args, NAME))
+            )
+                .withTypeVariableConstraints(typeVariable("E")),
+            (signature, args) ->
+                new ArrayCatFunction(
+                    ArrayCatFunction.createInfo(args, NAME),
+                    signature
+                )
         );
     }
 
-    ArrayCatFunction(FunctionInfo functionInfo) {
+    private final FunctionInfo functionInfo;
+    private final Signature signature;
+
+    ArrayCatFunction(FunctionInfo functionInfo, Signature signature) {
         this.functionInfo = functionInfo;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return functionInfo;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -57,8 +57,12 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
                 parseTypeSignature("array(E)"),
                 parseTypeSignature("array(E)")
             ).withTypeVariableConstraints(typeVariable("E")),
-            argumentTypes ->
-                new ArrayDifferenceFunction(createInfo(argumentTypes), null)
+            (signature, argumentTypes) ->
+                new ArrayDifferenceFunction(
+                    createInfo(argumentTypes),
+                    signature,
+                    null
+                )
         );
     }
 
@@ -72,16 +76,26 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
     }
 
     private final FunctionInfo functionInfo;
+    private final Signature signature;
     private final Optional<Set<Object>> optionalSubtractSet;
 
-    private ArrayDifferenceFunction(FunctionInfo functionInfo, @Nullable Set<Object> subtractSet) {
+    private ArrayDifferenceFunction(FunctionInfo functionInfo,
+                                    Signature signature,
+                                    @Nullable Set<Object> subtractSet) {
         this.functionInfo = functionInfo;
+        this.signature = signature;
         optionalSubtractSet = Optional.ofNullable(subtractSet);
     }
 
     @Override
     public FunctionInfo info() {
         return functionInfo;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override
@@ -107,7 +121,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
                 subtractSet.add(innerType.value(element));
             }
         }
-        return new ArrayDifferenceFunction(this.functionInfo, subtractSet);
+        return new ArrayDifferenceFunction(this.functionInfo, signature, subtractSet);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -30,6 +30,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
@@ -39,7 +40,6 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 class ArrayLowerFunction extends Scalar<Integer, Object> {
 
     public static final String NAME = "array_lower";
-    private FunctionInfo functionInfo;
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -49,21 +49,33 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 ensureInnerTypeIsNotUndefined(argumentTypes, NAME);
                 return new ArrayLowerFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.INTEGER));
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.INTEGER),
+                    signature
+                );
             }
         );
     }
 
-    private ArrayLowerFunction(FunctionInfo functionInfo) {
+    private final FunctionInfo functionInfo;
+    private final Signature signature;
+
+    private ArrayLowerFunction(FunctionInfo functionInfo, Signature signature) {
         this.functionInfo = functionInfo;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return functionInfo;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -30,6 +30,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
@@ -40,7 +41,6 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
 
     public static final String ARRAY_UPPER = "array_upper";
     public static final String ARRAY_LENGTH = "array_length";
-    private FunctionInfo functionInfo;
 
     public static void register(ScalarFunctionModule module) {
         for (var name : List.of(ARRAY_UPPER, ARRAY_LENGTH)) {
@@ -51,22 +51,34 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E")),
-                argumentTypes -> {
+                (signature, argumentTypes) -> {
                     ensureInnerTypeIsNotUndefined(argumentTypes, name);
                     return new ArrayUpperFunction(
-                        new FunctionInfo(new FunctionIdent(name, argumentTypes), DataTypes.INTEGER));
+                        new FunctionInfo(new FunctionIdent(name, argumentTypes), DataTypes.INTEGER),
+                        signature
+                    );
                 }
             );
         }
     }
 
-    private ArrayUpperFunction(FunctionInfo functionInfo) {
+    private final FunctionInfo functionInfo;
+    private final Signature signature;
+
+    private ArrayUpperFunction(FunctionInfo functionInfo, Signature signature) {
         this.functionInfo = functionInfo;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return functionInfo;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -29,6 +29,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
@@ -37,7 +38,6 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
 
     public static final String NAME = "collection_avg";
-    private final FunctionInfo info;
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -46,15 +46,20 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
                 parseTypeSignature("array(E)"),
                 DataTypes.DOUBLE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new CollectionAverageFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.DOUBLE)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.DOUBLE),
+                    signature
                 )
         );
     }
 
-    private CollectionAverageFunction(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private CollectionAverageFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
@@ -79,5 +84,11 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -29,6 +29,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
@@ -37,7 +38,6 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 public class CollectionCountFunction extends Scalar<Long, List<Object>> {
 
     public static final String NAME = "collection_count";
-    private final FunctionInfo info;
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -46,15 +46,20 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
                 parseTypeSignature("array(E)"),
                 DataTypes.LONG.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new CollectionCountFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.LONG)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.LONG),
+                    signature
                 )
         );
     }
 
-    private CollectionCountFunction(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private CollectionCountFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
@@ -69,5 +74,11 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -33,6 +33,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 
 final class CurrentDatabaseFunction extends Scalar<String, Void> {
@@ -48,13 +49,25 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
                 FQN,
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> new CurrentDatabaseFunction()
+            (signature, args) -> new CurrentDatabaseFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public CurrentDatabaseFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -34,8 +34,9 @@ import io.crate.types.TimestampType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -45,9 +46,12 @@ public class DateFormatFunction extends Scalar<String, Object> {
     public static final String DEFAULT_FORMAT = "%Y-%m-%dT%H:%i:%s.%fZ";
 
     public static void register(ScalarFunctionModule module) {
-        Function<List<DataType>, FunctionImplementation> functionFactory = args -> new DateFormatFunction(
-            new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING)
-        );
+        BiFunction<Signature, List<DataType>, FunctionImplementation> functionFactory =
+            (signature, args) ->
+                new DateFormatFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING),
+                    signature
+                );
 
         List<DataType<?>> supportedTimestampTypes = List.of(
             DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP, DataTypes.LONG, DataTypes.STRING);
@@ -91,11 +95,12 @@ public class DateFormatFunction extends Scalar<String, Object> {
         }
     }
 
-    private FunctionInfo info;
+    private final FunctionInfo info;
+    private final Signature signature;
 
-
-    public DateFormatFunction(FunctionInfo info) {
+    public DateFormatFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
@@ -133,5 +138,11 @@ public class DateFormatFunction extends Scalar<String, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.rounding.DateTimeUnit;
 import org.elasticsearch.common.rounding.Rounding;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -72,8 +73,8 @@ public class DateTruncFunction extends Scalar<Long, Object> {
                     dataType.getTypeSignature(),
                     parseTypeSignature("text")
                 ),
-                argumentTypes ->
-                    new DateTruncFunction(info(argumentTypes))
+                (signature, argumentTypes) ->
+                    new DateTruncFunction(info(argumentTypes), signature)
             );
 
             // time zone aware variant
@@ -85,8 +86,8 @@ public class DateTruncFunction extends Scalar<Long, Object> {
                     dataType.getTypeSignature(),
                     parseTypeSignature("text")
                 ),
-                argumentTypes ->
-                    new DateTruncFunction(info(argumentTypes))
+                (signature, argumentTypes) ->
+                    new DateTruncFunction(info(argumentTypes), signature)
             );
         }
     }
@@ -98,21 +99,32 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
 
-    private FunctionInfo info;
-    private Rounding tzRounding;
+    private final FunctionInfo info;
+    private final Signature signature;
+    @Nullable
+    private final Rounding tzRounding;
 
-    DateTruncFunction(FunctionInfo info) {
-        this.info = info;
+    DateTruncFunction(FunctionInfo info, Signature signature) {
+        this(info, signature, null);
     }
 
-    private DateTruncFunction(FunctionInfo info, Rounding tzRounding) {
-        this(info);
+    private DateTruncFunction(FunctionInfo info,
+                              Signature signature,
+                              @Nullable Rounding tzRounding) {
+        this.info = info;
+        this.signature = signature;
         this.tzRounding = tzRounding;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override
@@ -134,7 +146,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
             timeZone = (String) ((Input<?>) arguments.get(1)).value();
         }
 
-        return new DateTruncFunction(this.info, rounding(interval, timeZone));
+        return new DateTruncFunction(this.info, signature, rounding(interval, timeZone));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/DoubleScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/DoubleScalar.java
@@ -27,9 +27,11 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.function.DoubleUnaryOperator;
 
 import static java.util.Collections.singletonList;
@@ -43,16 +45,29 @@ import static java.util.Collections.singletonList;
 public final class DoubleScalar extends Scalar<Double, Number> {
 
     private final FunctionInfo info;
+    @Nullable
+    private final Signature signature;
     private final DoubleUnaryOperator func;
 
     public DoubleScalar(String name, DataType inputType, DoubleUnaryOperator func) {
+        this(name, null, inputType, func);
+    }
+
+    public DoubleScalar(String name, Signature signature, DataType inputType, DoubleUnaryOperator func) {
         this.info = new FunctionInfo(new FunctionIdent(name, singletonList(inputType)), DataTypes.DOUBLE);
+        this.signature = signature;
         this.func = func;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -29,6 +29,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Locale;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
@@ -37,28 +38,36 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 public class FormatFunction extends Scalar<String, Object> {
 
     public static final String NAME = "format";
-    private FunctionInfo info;
+
+    public static final Signature SIGNATURE =
+        Signature.scalar(
+            NAME,
+            DataTypes.STRING.getTypeSignature(),
+            parseTypeSignature("E"),
+            DataTypes.STRING.getTypeSignature()
+        )
+            .withTypeVariableConstraints(typeVariableOfAnyType("E"))
+            .withVariableArity();
+
 
     public static void register(ScalarFunctionModule module) {
         module.register(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                parseTypeSignature("E"),
-                DataTypes.STRING.getTypeSignature()
-            )
-                .withTypeVariableConstraints(typeVariableOfAnyType("E"))
-                .withVariableArity(),
-            argumentTypes ->
+            SIGNATURE,
+            (signature, argumentTypes) ->
                 new FormatFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
+                    signature
                 )
 
         );
     }
 
-    private FormatFunction(FunctionInfo info) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private FormatFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @SafeVarargs
@@ -80,5 +89,11 @@ public class FormatFunction extends Scalar<String, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -30,6 +30,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 
 /**
@@ -57,8 +58,14 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
             ),
-            argumentTypes -> new Ignore3vlFunction()
+            (signature, argumentTypes) -> new Ignore3vlFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public Ignore3vlFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -74,5 +81,11 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
     @Override
     public FunctionInfo info() {
         return FUNCTION_INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -30,12 +30,12 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public final class PiFunction extends Scalar<Double, Object> {
 
     private static final String NAME = "pi";
-    private final FunctionInfo info;
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -43,11 +43,15 @@ public final class PiFunction extends Scalar<Double, Object> {
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            args -> new PiFunction()
+            (signature, args) -> new PiFunction(signature)
         );
     }
 
-    public PiFunction() {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    public PiFunction(Signature signature) {
+        this.signature = signature;
         info = new FunctionInfo(new FunctionIdent(NAME, List.of()), DataTypes.DOUBLE);
     }
 
@@ -60,5 +64,11 @@ public final class PiFunction extends Scalar<Double, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -90,7 +90,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public class ScalarFunctionModule extends AbstractModule {
 
@@ -103,7 +103,7 @@ public class ScalarFunctionModule extends AbstractModule {
     private MapBinder<FunctionName, List<FuncResolver>> implementationsBinder;
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     @Deprecated()
     public void register(FunctionImplementation impl) {
@@ -111,7 +111,7 @@ public class ScalarFunctionModule extends AbstractModule {
     }
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     @Deprecated()
     public void register(String name, FunctionResolver functionResolver) {
@@ -119,14 +119,14 @@ public class ScalarFunctionModule extends AbstractModule {
     }
 
     /**
-     * @deprecated Use {@link #register(Signature, Function)} instead.
+     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
      */
     @Deprecated()
     public void register(FunctionName qualifiedName, FunctionResolver functionResolver) {
         resolver.put(qualifiedName, functionResolver);
     }
 
-    public void register(Signature signature, Function<List<DataType>, FunctionImplementation> factory) {
+    public void register(Signature signature, BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
         List<FuncResolver> functions = functionImplementations.computeIfAbsent(
             signature.getName(),
             k -> new ArrayList<>());

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import io.crate.expression.AbstractFunctionModule;
 import io.crate.expression.scalar.arithmetic.AbsFunction;
 import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
 import io.crate.expression.scalar.arithmetic.ArrayFunction;
@@ -75,67 +76,12 @@ import io.crate.expression.scalar.systeminformation.VersionFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.scalar.timestamp.NowFunction;
 import io.crate.expression.scalar.timestamp.TimezoneFunction;
-import io.crate.metadata.FuncResolver;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionName;
-import io.crate.metadata.FunctionResolver;
-import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.inject.TypeLiteral;
-import org.elasticsearch.common.inject.multibindings.MapBinder;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-
-public class ScalarFunctionModule extends AbstractModule {
-
-    private Map<FunctionIdent, FunctionImplementation> functions = new HashMap<>();
-    private Map<FunctionName, FunctionResolver> resolver = new HashMap<>();
-    private MapBinder<FunctionIdent, FunctionImplementation> functionBinder;
-    private MapBinder<FunctionName, FunctionResolver> resolverBinder;
-
-    private HashMap<FunctionName, List<FuncResolver>> functionImplementations = new HashMap<>();
-    private MapBinder<FunctionName, List<FuncResolver>> implementationsBinder;
-
-    /**
-     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
-     */
-    @Deprecated()
-    public void register(FunctionImplementation impl) {
-        functions.put(impl.info().ident(), impl);
-    }
-
-    /**
-     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
-     */
-    @Deprecated()
-    public void register(String name, FunctionResolver functionResolver) {
-        register(new FunctionName(name), functionResolver);
-    }
-
-    /**
-     * @deprecated Use {@link #register(Signature, BiFunction)} instead.
-     */
-    @Deprecated()
-    public void register(FunctionName qualifiedName, FunctionResolver functionResolver) {
-        resolver.put(qualifiedName, functionResolver);
-    }
-
-    public void register(Signature signature, BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
-        List<FuncResolver> functions = functionImplementations.computeIfAbsent(
-            signature.getName(),
-            k -> new ArrayList<>());
-        functions.add(new FuncResolver(signature, factory));
-    }
-
+public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImplementation> {
 
     @Override
-    protected void configure() {
+    public void configureFunctions() {
         NegateFunctions.register(this);
         CollectionCountFunction.register(this);
         CollectionAverageFunction.register(this);
@@ -223,34 +169,5 @@ public class ScalarFunctionModule extends AbstractModule {
         CurrentDatabaseFunction.register(this);
         VersionFunction.register(this);
         ObjDescriptionFunction.register(this);
-
-        // bind all registered functions and resolver
-        // by doing it here instead of the register functions, plugins can also use the
-        // register functions in their onModule(...) hooks
-        functionBinder = MapBinder.newMapBinder(binder(), FunctionIdent.class, FunctionImplementation.class);
-        resolverBinder = MapBinder.newMapBinder(binder(), FunctionName.class, FunctionResolver.class);
-        for (Map.Entry<FunctionIdent, FunctionImplementation> entry : functions.entrySet()) {
-            functionBinder.addBinding(entry.getKey()).toInstance(entry.getValue());
-        }
-        for (Map.Entry<FunctionName, FunctionResolver> entry : resolver.entrySet()) {
-            resolverBinder.addBinding(entry.getKey()).toInstance(entry.getValue());
-        }
-
-        // clear registration maps
-        functions = null;
-        resolver = null;
-
-        // New signature registry
-        implementationsBinder = MapBinder.newMapBinder(
-            binder(),
-            new TypeLiteral<FunctionName>() {},
-            new TypeLiteral<List<FuncResolver>>() {});
-        for (Map.Entry<FunctionName, List<FuncResolver>> entry : functionImplementations.entrySet()) {
-            implementationsBinder.addBinding(entry.getKey()).toProvider(entry::getValue);
-        }
-
-        // clear registration maps
-        functionImplementations = null;
     }
-
 }

--- a/sql/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -40,17 +40,6 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
 
     private static final String NAME = "string_to_array";
 
-    private final FunctionInfo info;
-
-    private StringToArrayFunction(FunctionInfo info) {
-        this.info = info;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
-    }
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
@@ -59,9 +48,10 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringToArrayFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY),
+                    signature
                 )
         );
         module.register(
@@ -72,11 +62,31 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringToArrayFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY),
+                    signature
                 )
         );
+    }
+
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private StringToArrayFunction(FunctionInfo info, Signature signature) {
+        this.info = info;
+        this.signature = signature;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -31,16 +31,11 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class SubstrFunction extends Scalar<String, Object> {
 
     public static final String NAME = "substr";
-
-    private FunctionInfo info;
-
-    private SubstrFunction(FunctionInfo info) {
-        this.info = info;
-    }
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -50,9 +45,10 @@ public class SubstrFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new SubstrFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
+                    signature
                 )
         );
         module.register(
@@ -63,16 +59,31 @@ public class SubstrFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new SubstrFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING)
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
+                    signature
                 )
         );
+    }
+
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    private SubstrFunction(FunctionInfo info, Signature signature) {
+        this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -26,6 +26,9 @@ import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
+
+import javax.annotation.Nullable;
 
 
 /**
@@ -36,16 +39,31 @@ import io.crate.metadata.Scalar;
 public final class TripleScalar<R, T> extends Scalar<R, T> {
 
     private final FunctionInfo info;
+    @Nullable
+    private final Signature signature;
     private final ThreeParametersFunction<T, T, T, R> func;
 
     public TripleScalar(FunctionInfo info, ThreeParametersFunction<T, T, T, R> func) {
+        this(info, null, func);
+    }
+
+    public TripleScalar(FunctionInfo info,
+                        @Nullable Signature signature,
+                        ThreeParametersFunction<T, T, T, R> func) {
         this.info = info;
+        this.signature = signature;
         this.func = func;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -27,8 +27,10 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
@@ -42,19 +44,42 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
 
     private final FunctionInfo info;
     private final Function<T, R> func;
+    @Nullable
+    private final Signature signature;
 
     public UnaryScalar(FunctionIdent functionIdent, DataType<?> returnType, Function<T, R> func) {
-        this.info = new FunctionInfo(functionIdent, returnType);
-        this.func = func;
+        this(functionIdent, null, returnType, func);
     }
 
     public UnaryScalar(String name, DataType<?> argType, DataType<?> returnType, Function<T, R> func) {
         this(new FunctionIdent(name, List.of(argType)), returnType, func);
     }
 
+    public UnaryScalar(String name,
+                       Signature signature,
+                       DataType<?> argType, DataType<?> returnType,
+                       Function<T, R> func) {
+        this(new FunctionIdent(name, List.of(argType)), signature, returnType, func);
+    }
+
+    public UnaryScalar(FunctionIdent functionIdent,
+                       @Nullable Signature signature,
+                       DataType<?> returnType,
+                       Function<T, R> func) {
+        this.info = new FunctionInfo(functionIdent, returnType);
+        this.signature = signature;
+        this.func = func;
+    }
+
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -37,10 +37,11 @@ public final class AbsFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                args -> {
+                (signature, args) -> {
                     DataType<?> argType = args.get(0);
                     return new UnaryScalar<>(
                         NAME,
+                        signature,
                         argType,
                         argType,
                         x -> argType.value(Math.abs(((Number) x).doubleValue()))

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -27,8 +27,10 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.BinaryOperator;
@@ -37,17 +39,34 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
 
     private final BinaryOperator<T> func;
     private final FunctionInfo info;
+    @Nullable
+    private final Signature signature;
     private final DataType<T> type;
 
     public BinaryScalar(BinaryOperator<T> func, String name, DataType<T> type, Set<FunctionInfo.Feature> feature) {
+        this(func, name, null, type, feature);
+    }
+
+    public BinaryScalar(BinaryOperator<T> func,
+                        String name,
+                        @Nullable Signature signature,
+                        DataType<T> type,
+                        Set<FunctionInfo.Feature> feature) {
         this.func = func;
         this.info = new FunctionInfo(new FunctionIdent(name, Arrays.asList(type, type)), type, FunctionInfo.Type.SCALAR, feature);
+        this.signature = signature;
         this.type = type;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -41,12 +41,13 @@ public final class CeilFunction {
             for (var name : List.of(CEIL, CEILING)) {
                 module.register(
                     scalar(name, typeSignature, typeSignature),
-                    argumentTypes -> {
+                    (signature, argumentTypes) -> {
                         DataType<?> argType = argumentTypes.get(0);
                         DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
                         assert returnType != null : "Could not get integral type of " + argType;
                         return new UnaryScalar<>(
                             name,
+                            signature,
                             argType,
                             returnType,
                             x -> returnType.value(Math.ceil(((Number) x).doubleValue()))

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -38,10 +38,11 @@ public class ExpFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                argumentTypes -> {
+                (signature, argumentTypes) -> {
                     DataType<?> argType = argumentTypes.get(0);
                     return new UnaryScalar<>(
                         NAME,
+                        signature,
                         argType,
                         argType,
                         x -> argType.value(Math.exp(((Number) x).doubleValue()))

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -37,12 +37,13 @@ public final class FloorFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                argumentTypes -> {
+                (signature, argumentTypes) -> {
                     DataType<?> argType = argumentTypes.get(0);
                     DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
                     assert returnType != null : "Could not get integral type of " + argType;
                     return new UnaryScalar<>(
                         NAME,
+                        signature,
                         argType,
                         returnType,
                         x -> returnType.value(Math.floor(((Number) x).doubleValue()))

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
@@ -32,6 +32,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.joda.time.Period;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -45,7 +46,8 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
             ),
-            args -> new IntervalArithmeticScalar("+", ArithmeticFunctions.Names.ADD)
+            (signature, args) ->
+                new IntervalArithmeticScalar("+", ArithmeticFunctions.Names.ADD, signature)
         );
         module.register(
             Signature.scalar(
@@ -54,19 +56,22 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
             ),
-            args -> new IntervalArithmeticScalar("-", ArithmeticFunctions.Names.SUBTRACT)
+            (signature, args) ->
+                new IntervalArithmeticScalar("-", ArithmeticFunctions.Names.SUBTRACT, signature)
         );
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final BiFunction<Period, Period, Period> operation;
 
-    IntervalArithmeticScalar(String operator, String name) {
+    IntervalArithmeticScalar(String operator, String name, Signature signature) {
         info = new FunctionInfo(
             new FunctionIdent(
                 name,
                 List.of(DataTypes.INTERVAL, DataTypes.INTERVAL)),
             DataTypes.INTERVAL);
+        this.signature = signature;
 
         switch (operator) {
             case "+":
@@ -85,6 +90,12 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
     @Override
     public FunctionInfo info() {
         return this.info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -27,10 +27,10 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.types.DataType;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
+import javax.annotation.Nullable;
 
 import static io.crate.metadata.functions.Signature.scalar;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -38,8 +38,6 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 public abstract class LogFunction extends Scalar<Number, Number> {
 
     public static final String NAME = "log";
-    private static final List<DataType> ALLOWED_TYPES = DataTypes.NUMERIC_PRIMITIVE_TYPES;
-    protected final FunctionInfo info;
 
     public static void register(ScalarFunctionModule module) {
         LogBaseFunction.registerLogBaseFunctions(module);
@@ -47,9 +45,23 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         LnFunction.registerLnFunctions(module);
     }
 
+    protected final FunctionInfo info;
+    protected final Signature signature;
+
+    LogFunction(FunctionInfo info, Signature signature) {
+        this.info = info;
+        this.signature = signature;
+    }
+
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     /**
@@ -67,10 +79,6 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         return result;
     }
 
-    LogFunction(FunctionInfo info) {
-        this.info = info;
-    }
-
     static class LogBaseFunction extends LogFunction {
 
         static void registerLogBaseFunctions(ScalarFunctionModule module) {
@@ -81,16 +89,17 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
                     parseTypeSignature("double precision")),
-                args -> new LogBaseFunction(
+                (signature, args) -> new LogBaseFunction(
                     new FunctionInfo(
                         new FunctionIdent(NAME, args), DataTypes.DOUBLE
-                    )
+                    ),
+                    signature
                 )
             );
         }
 
-        LogBaseFunction(FunctionInfo info) {
-            super(info);
+        LogBaseFunction(FunctionInfo info, Signature signature) {
+            super(info, signature);
         }
 
         @Override
@@ -123,14 +132,15 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
                 ),
-                args -> new Log10Function(
-                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE)
+                (signature, args) -> new Log10Function(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE),
+                    signature
                 )
             );
         }
 
-        Log10Function(FunctionInfo info) {
-            super(info);
+        Log10Function(FunctionInfo info, Signature signature) {
+            super(info, signature);
         }
 
         @Override
@@ -159,16 +169,17 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
                 ),
-                args -> new LnFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE)
+                (signature, args) -> new LnFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE),
+                    signature
                 )
             );
         }
 
         public static final String NAME = "ln";
 
-        LnFunction(FunctionInfo info) {
-            super(info);
+        LnFunction(FunctionInfo info, Signature signature) {
+            super(info, signature);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -41,9 +41,9 @@ public final class NegateFunctions {
                 parseTypeSignature("double precision")
             )
                 .withForbiddenCoercion(),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Double, Double>(NAME, dataType, dataType, x -> x * -1);
+                return new UnaryScalar<Double, Double>(NAME, signature, dataType, dataType, x -> x * -1);
             }
         );
         module.register(
@@ -53,9 +53,9 @@ public final class NegateFunctions {
                 parseTypeSignature("float")
             )
                 .withForbiddenCoercion(),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Float, Float>(NAME, dataType, dataType, x -> x * -1);
+                return new UnaryScalar<Float, Float>(NAME, signature, dataType, dataType, x -> x * -1);
             }
         );
         module.register(
@@ -65,9 +65,9 @@ public final class NegateFunctions {
                 parseTypeSignature("integer")
             )
                 .withForbiddenCoercion(),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Integer, Integer>(NAME, dataType, dataType, x -> x * -1);
+                return new UnaryScalar<Integer, Integer>(NAME, signature, dataType, dataType, x -> x * -1);
             }
         );
         module.register(
@@ -77,9 +77,9 @@ public final class NegateFunctions {
                 parseTypeSignature("bigint")
             )
                 .withForbiddenCoercion(),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Long, Long>(NAME, dataType, dataType, x -> x * -1);
+                return new UnaryScalar<Long, Long>(NAME, signature, dataType, dataType, x -> x * -1);
             }
         );
         module.register(
@@ -89,9 +89,9 @@ public final class NegateFunctions {
                 parseTypeSignature("smallint")
             )
                 .withForbiddenCoercion(),
-            argumentTypes -> {
+            (signature, argumentTypes) -> {
                 DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Short, Short>(NAME, dataType, dataType, x -> (short) (x * -1));
+                return new UnaryScalar<Short, Short>(NAME, signature, dataType, dataType, x -> (short) (x * -1));
             }
         );
     }

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -24,19 +24,29 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class RadiansDegreesFunctions {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
-            scalar("radians", parseTypeSignature("double precision"), parseTypeSignature("double precision")),
-            args -> new UnaryScalar<>("radians", args.get(0), args.get(0), Math::toRadians));
+            scalar(
+                "radians",
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            (signature, args) ->
+                new UnaryScalar<>("radians", signature, args.get(0), args.get(0), Math::toRadians));
 
         module.register(
-            scalar("degrees", parseTypeSignature("double precision"), parseTypeSignature("double precision")),
-            args -> new UnaryScalar<>("degrees", args.get(0), args.get(0), Math::toDegrees));
+            scalar(
+                "degrees",
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            (signature, args) ->
+                new UnaryScalar<>("degrees", signature, args.get(0), args.get(0), Math::toDegrees));
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -30,13 +30,14 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Random;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class RandomFunction extends Scalar<Double, Void> {
 
@@ -46,13 +47,18 @@ public class RandomFunction extends Scalar<Double, Void> {
         new FunctionIdent(NAME, Collections.emptyList()), DataTypes.DOUBLE,
         FunctionInfo.Type.SCALAR, FunctionInfo.NO_FEATURES);
 
-    private final Random random = new Random();
-
     public static void register(ScalarFunctionModule module) {
         module.register(
-            scalar(NAME, parseTypeSignature("double precision")),
-            args -> new RandomFunction()
+            scalar(NAME, DataTypes.DOUBLE.getTypeSignature()),
+            (signature, args) -> new RandomFunction(signature)
         );
+    }
+
+    private final Signature signature;
+    private final Random random = new Random();
+
+    public RandomFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -67,6 +73,12 @@ public class RandomFunction extends Scalar<Double, Void> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -37,16 +37,26 @@ public final class RoundFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                argumentTypes -> {
+                (signature, argumentTypes) -> {
                     DataType<?> argType = argumentTypes.get(0);
                     DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
                     assert returnType != null : "Could not get integral type of " + argType;
                     if (returnType.equals(DataTypes.INTEGER)) {
                         return new UnaryScalar<>(
-                            NAME, argType, returnType, x -> Math.round(((Number) x).floatValue()));
+                            NAME,
+                            signature,
+                            argType,
+                            returnType,
+                            x -> Math.round(((Number) x).floatValue())
+                        );
                     } else {
                         return new UnaryScalar<>(
-                            NAME, argType, returnType, x -> Math.round(((Number) x).doubleValue()));
+                            NAME,
+                            signature,
+                            argType,
+                            returnType,
+                            x -> Math.round(((Number) x).doubleValue())
+                        );
                     }
                 }
             );

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -37,8 +37,8 @@ public final class SquareRootFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                argumentTypes ->
-                    new DoubleScalar(NAME, argumentTypes.get(0), SquareRootFunction::sqrt)
+                (signature, argumentTypes) ->
+                    new DoubleScalar(NAME, signature, argumentTypes.get(0), SquareRootFunction::sqrt)
             );
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -26,13 +26,13 @@ import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionInfo;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 
 import java.util.function.DoubleUnaryOperator;
 
 import static io.crate.metadata.functions.Signature.scalar;
 import static io.crate.types.DataTypes.NUMERIC_PRIMITIVE_TYPES;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class TrigonometricFunctions {
 
@@ -51,10 +51,16 @@ public final class TrigonometricFunctions {
                     "atan2",
                     inputType.getTypeSignature(),
                     inputType.getTypeSignature(),
-                    parseTypeSignature("double precision")
+                    DataTypes.DOUBLE.getTypeSignature()
                 ),
-                argumentTypes ->
-                    new BinaryScalar<>(Math::atan2, "atan2", DoubleType.INSTANCE, FunctionInfo.DETERMINISTIC_ONLY)
+                (signature, argumentTypes) ->
+                    new BinaryScalar<>(
+                        Math::atan2,
+                        "atan2",
+                        signature,
+                        DoubleType.INSTANCE,
+                        FunctionInfo.DETERMINISTIC_ONLY
+                    )
             );
         }
     }
@@ -65,10 +71,10 @@ public final class TrigonometricFunctions {
                 scalar(
                     name,
                     inputType.getTypeSignature(),
-                    parseTypeSignature("double precision")
+                    DataTypes.DOUBLE.getTypeSignature()
                 ),
-                argumentTypes ->
-                    new DoubleScalar(name, inputType, func)
+                (signature, argumentTypes) ->
+                    new DoubleScalar(name, signature, inputType, func)
             );
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -28,9 +28,11 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
@@ -55,12 +57,18 @@ public final class TruncFunction {
                     type.getTypeSignature(),
                     returnType.getTypeSignature()
                 ),
-                argumentTypes ->
-                    new UnaryScalar<Number, Number>(NAME, type, returnType, n -> {
-                        double val = n.doubleValue();
-                        Function<Double, Double> f = val >= 0 ? Math::floor : Math::ceil;
-                        return (Number) returnType.value(f.apply(val));
-                    })
+                (signature, argumentTypes) ->
+                    new UnaryScalar<Number, Number>(
+                        NAME,
+                        signature,
+                        type,
+                        returnType,
+                        n -> {
+                            double val = n.doubleValue();
+                            Function<Double, Double> f = val >= 0 ? Math::floor : Math::ceil;
+                            return (Number) returnType.value(f.apply(val));
+                        }
+                    )
             );
 
         }
@@ -76,7 +84,7 @@ public final class TruncFunction {
         );
     }
 
-    private static Scalar<Number, Number> createTruncWithMode(List<DataType> argumentTypes) {
+    private static Scalar<Number, Number> createTruncWithMode(Signature signature, List<DataType> argumentTypes) {
         return new Scalar<>() {
 
             FunctionInfo info = new FunctionInfo(new FunctionIdent(
@@ -85,6 +93,12 @@ public final class TruncFunction {
             @Override
             public FunctionInfo info() {
                 return info;
+            }
+
+            @Nullable
+            @Override
+            public Signature signature() {
+                return signature;
             }
 
             @Override

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -29,6 +29,8 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
+import javax.annotation.Nullable;
+
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -43,20 +45,29 @@ public class CoalesceFunction extends Scalar<Object, Object> {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            args -> new CoalesceFunction(FunctionInfo.of(NAME, args, args.get(0)))
+            (signature, args) ->
+                new CoalesceFunction(FunctionInfo.of(NAME, args, args.get(0)), signature)
         );
     }
 
     public static final String NAME = "coalesce";
     private final FunctionInfo info;
+    private final Signature signature;
 
-    private CoalesceFunction(FunctionInfo info) {
+    private CoalesceFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
@@ -26,20 +26,30 @@ import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 
 abstract class ConditionalCompareFunction extends Scalar<Object, Object> implements Comparator<Object> {
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    ConditionalCompareFunction(FunctionInfo info) {
+    ConditionalCompareFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
@@ -35,8 +35,8 @@ public class GreatestFunction extends ConditionalCompareFunction {
 
     private static final String NAME = "greatest";
 
-    private GreatestFunction(FunctionInfo info) {
-        super(info);
+    private GreatestFunction(FunctionInfo info, Signature signature) {
+        super(info, signature);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -55,7 +55,8 @@ public class GreatestFunction extends ConditionalCompareFunction {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            args -> new GreatestFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)))
+            (signature, args) ->
+                new GreatestFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -30,6 +30,8 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
+
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -61,7 +63,8 @@ public class IfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new IfFunction(FunctionInfo.of(NAME, args, args.get(1)))
+            (signature, args) ->
+                new IfFunction(FunctionInfo.of(NAME, args, args.get(1)), signature)
         );
         // if (condition, result, default)
         module.register(
@@ -72,21 +75,30 @@ public class IfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new IfFunction(FunctionInfo.of(NAME, args, args.get(1)))
+            (signature, args) ->
+                new IfFunction(FunctionInfo.of(NAME, args, args.get(1)), signature)
         );
     }
 
     public static final String NAME = "if";
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    private IfFunction(FunctionInfo info) {
+    private IfFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
@@ -35,8 +35,8 @@ public class LeastFunction extends ConditionalCompareFunction {
 
     private static final String NAME = "least";
 
-    private LeastFunction(FunctionInfo info) {
-        super(info);
+    private LeastFunction(FunctionInfo info, Signature signature) {
+        super(info, signature);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -55,7 +55,8 @@ public class LeastFunction extends ConditionalCompareFunction {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            args -> new LeastFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)))
+            (signature, args) ->
+                new LeastFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -29,6 +29,8 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
+import javax.annotation.Nullable;
+
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.DataTypes.tryFindNotNullType;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -43,20 +45,29 @@ public class NullIfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> new NullIfFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)))
+            (signature, args) ->
+                new NullIfFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
         );
     }
 
     public static final String NAME = "nullif";
-    private FunctionInfo info;
+    private final FunctionInfo info;
+    private final Signature signature;
 
-    private NullIfFunction(FunctionInfo info) {
+    private NullIfFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class CoordinateFunction {
 
@@ -41,8 +40,8 @@ public final class CoordinateFunction {
     private static void register(ScalarFunctionModule module, String name, Function<Object, Double> func) {
         for (DataType<?> inputType : SUPPORTED_INPUT_TYPES) {
             module.register(
-                scalar(name, inputType.getTypeSignature(), parseTypeSignature("double precision")),
-                args -> new UnaryScalar<>(name, inputType, DataTypes.DOUBLE, func)
+                scalar(name, inputType.getTypeSignature(), DataTypes.DOUBLE.getTypeSignature()),
+                (signature, args) -> new UnaryScalar<>(name, signature, inputType, DataTypes.DOUBLE, func)
             );
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -32,7 +32,6 @@ import org.locationtech.spatial4j.shape.Point;
 import java.util.List;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class GeoHashFunction {
 
@@ -45,10 +44,16 @@ public final class GeoHashFunction {
                 scalar(
                     "geohash",
                     inputType.getTypeSignature(),
-                    parseTypeSignature("text")
+                    DataTypes.STRING.getTypeSignature()
                 ),
-                args ->
-                    new UnaryScalar<>("geohash", inputType, DataTypes.STRING, GeoHashFunction::getGeoHash)
+                (signature, args) ->
+                    new UnaryScalar<>(
+                        "geohash",
+                        signature,
+                        inputType,
+                        DataTypes.STRING,
+                        GeoHashFunction::getGeoHash
+                    )
             );
         }
     }

--- a/sql/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -32,16 +32,17 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.locationtech.spatial4j.shape.Shape;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class IntersectsFunction extends Scalar<Boolean, Object> {
 
@@ -70,18 +71,21 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
                         NAME,
                         type1.getTypeSignature(),
                         type2.getTypeSignature(),
-                        parseTypeSignature("boolean")
+                        DataTypes.BOOLEAN.getTypeSignature()
                         ),
-                    args -> new IntersectsFunction(info(type1, type2))
+                    (signature, args) ->
+                        new IntersectsFunction(info(type1, type2), signature)
                 );
             }
         }
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    public IntersectsFunction(FunctionInfo functionInfo) {
+    public IntersectsFunction(FunctionInfo functionInfo, Signature signature) {
         this.info = functionInfo;
+        this.signature = signature;
     }
 
     @Override
@@ -103,6 +107,12 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override
@@ -131,7 +141,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
         }
 
         if (literalConverted) {
-            return new Function(SHAPE_INFO, Arrays.asList(left, right));
+            return new Function(SHAPE_INFO, signature, Arrays.asList(left, right));
         }
 
         return symbol;

--- a/sql/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -29,12 +29,15 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.metadata.settings.session.SessionSetting;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataTypes;
+
+import javax.annotation.Nullable;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class CurrentSettingFunction extends Scalar<String, Object> {
 
@@ -45,38 +48,48 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
         module.register(
             scalar(
                 FQN,
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new CurrentSettingFunction(
-                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0))
+                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0)),
+                    signature
                 )
         );
 
         module.register(
             scalar(
                 FQN,
-                parseTypeSignature("text"),
-                parseTypeSignature("boolean"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new CurrentSettingFunction(
-                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0))
+                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0)),
+                    signature
                 )
         );
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    CurrentSettingFunction(FunctionInfo info) {
+    CurrentSettingFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -32,13 +32,14 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class PgBackendPidFunction extends Scalar<Integer, Void> {
 
@@ -54,9 +55,15 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
-            scalar(FQN, parseTypeSignature("integer")),
-            args -> new PgBackendPidFunction()
+            scalar(FQN, DataTypes.INTEGER.getTypeSignature()),
+            (signature, args) -> new PgBackendPidFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public PgBackendPidFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -68,6 +75,12 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -31,16 +31,24 @@ import io.crate.types.DataTypes;
 
 import static io.crate.auth.user.User.CRATE_USER;
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class PgGetUserByIdFunction {
 
     public static void register(ScalarFunctionModule module) {
         var name = new FunctionName(PgCatalogSchemaInfo.NAME, "pg_get_userbyid");
         module.register(
-            scalar(name, parseTypeSignature("integer"), parseTypeSignature("text")),
-            args ->
-                new UnaryScalar<>(new FunctionIdent(name, args), DataTypes.STRING, id -> CRATE_USER.name())
+            scalar(
+                name,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            (signature, args) ->
+                new UnaryScalar<>(
+                    new FunctionIdent(name, args),
+                    signature,
+                    DataTypes.STRING,
+                    id -> CRATE_USER.name()
+                )
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -36,8 +36,6 @@ import io.crate.types.DataTypes;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public class RegexpReplaceFunction extends Scalar<String, Object> {
 
     public static final String NAME = "regexp_replace";
@@ -46,38 +44,58 @@ public class RegexpReplaceFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new RegexpReplaceFunction(new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING))
+            (signature, args) ->
+                new RegexpReplaceFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING),
+                    signature
+                )
         );
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new RegexpReplaceFunction(new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING))
+            (signature, args) ->
+                new RegexpReplaceFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.STRING),
+                    signature
+                )
         );
     }
 
-    private FunctionInfo info;
-    private RegexMatcher regexMatcher;
+    private final FunctionInfo info;
+    private final Signature signature;
+    @Nullable
+    private final RegexMatcher regexMatcher;
 
-    private RegexpReplaceFunction(FunctionInfo info) {
+    private RegexpReplaceFunction(FunctionInfo info, Signature signature) {
+        this(info, signature, null);
+    }
+
+    private RegexpReplaceFunction(FunctionInfo info, Signature signature, RegexMatcher regexMatcher) {
         this.info = info;
+        this.signature = signature;
+        this.regexMatcher = regexMatcher;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override
@@ -121,7 +139,7 @@ public class RegexpReplaceFunction extends Scalar<String, Object> {
                 Symbol flagsSymbol = arguments.get(3);
                 if (flagsSymbol instanceof Input) {
                     String flags = (String) ((Input) flagsSymbol).value();
-                    regexMatcher = new RegexMatcher(pattern, flags);
+                    return new RegexpReplaceFunction(info, signature, new RegexMatcher(pattern, flags));
                 }
             }
         }

--- a/sql/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -27,19 +27,17 @@ import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public final class AsciiFunction {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 "ascii",
-                parseTypeSignature("text"),
-                parseTypeSignature("integer")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
             ),
-            args ->
-                new UnaryScalar<>("ascii", args.get(0), DataTypes.INTEGER, AsciiFunction::ascii)
+            (signature, args) ->
+                new UnaryScalar<>("ascii", signature, args.get(0), DataTypes.INTEGER, AsciiFunction::ascii)
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -36,30 +36,40 @@ import java.util.Locale;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public class EncodeDecodeFunction {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 "encode",
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new BinaryScalar<>(new Encode(), "encode", DataTypes.STRING, FunctionInfo.DETERMINISTIC_ONLY)
+            (signature, args) ->
+                new BinaryScalar<>(
+                    new Encode(),
+                    "encode",
+                    signature,
+                    DataTypes.STRING,
+                    FunctionInfo.DETERMINISTIC_ONLY
+                )
         );
         module.register(
             Signature.scalar(
                 "decode",
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new BinaryScalar<>(new Decode(), "decode", DataTypes.STRING, FunctionInfo.DETERMINISTIC_ONLY)
+            (signature, args) ->
+                new BinaryScalar<>(
+                    new Decode(),
+                    "decode",
+                    signature,
+                    DataTypes.STRING,
+                    FunctionInfo.DETERMINISTIC_ONLY
+                )
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -35,8 +35,6 @@ import java.security.MessageDigest;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public final class HashFunctions {
 
     public static void register(ScalarFunctionModule module) {
@@ -48,11 +46,11 @@ public final class HashFunctions {
         module.register(
             Signature.scalar(
                 name,
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
-                new UnaryScalar<>(name, DataTypes.STRING, DataTypes.STRING, func)
+            (signature, args) ->
+                new UnaryScalar<>(name, signature, DataTypes.STRING, DataTypes.STRING, func)
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -27,19 +27,23 @@ import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public final class InitCapFunction {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 "initcap",
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new UnaryScalar<>("initcap", DataTypes.STRING, DataTypes.STRING, InitCapFunction::toCapital)
+            (signature, args) ->
+                new UnaryScalar<>(
+                    "initcap",
+                    signature,
+                    DataTypes.STRING,
+                    DataTypes.STRING,
+                    InitCapFunction::toCapital
+                )
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -30,8 +30,6 @@ import io.crate.types.DataTypes;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public final class LengthFunction {
 
     public static void register(ScalarFunctionModule module) {
@@ -45,10 +43,10 @@ public final class LengthFunction {
         module.register(
             Signature.scalar(
                 name,
-                parseTypeSignature("text"),
-                parseTypeSignature("integer")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> new UnaryScalar<>(name, DataTypes.STRING, DataTypes.INTEGER, func)
+            (signature, args) -> new UnaryScalar<>(name, signature, DataTypes.STRING, DataTypes.INTEGER, func)
         );
     }
 

--- a/sql/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -28,8 +28,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.sql.Identifiers;
 import io.crate.types.DataTypes;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 
 public final class QuoteIdentFunction {
 
@@ -37,11 +35,17 @@ public final class QuoteIdentFunction {
         module.register(
             Signature.scalar(
                 "quote_ident",
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
-                new UnaryScalar<>("quote_ident", DataTypes.STRING, DataTypes.STRING, Identifiers::quoteIfNeeded)
+            (signature, args) ->
+                new UnaryScalar<>(
+                    "quote_ident",
+                    signature,
+                    DataTypes.STRING,
+                    DataTypes.STRING,
+                    Identifiers::quoteIfNeeded
+                )
         );
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -32,8 +32,6 @@ import org.elasticsearch.common.Strings;
 
 import java.util.List;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 
 public final class ReplaceFunction {
 
@@ -43,16 +41,17 @@ public final class ReplaceFunction {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args -> new TripleScalar<>(
+            (signature, args) -> new TripleScalar<>(
                 new FunctionInfo(
                     new FunctionIdent(NAME, List.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)),
                     DataTypes.STRING
                 ),
+                signature,
                 Strings::replace)
         );
     }

--- a/sql/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -29,20 +29,19 @@ import io.crate.types.DataTypes;
 
 import java.util.Locale;
 
-import static io.crate.types.TypeSignature.parseTypeSignature;
-
 public final class StringCaseFunction {
 
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 "upper",
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
+            (signature, args) ->
                 new UnaryScalar<String, String>(
                     "upper",
+                    signature,
                     DataTypes.STRING,
                     DataTypes.STRING,
                     val -> val.toUpperCase(Locale.ENGLISH)
@@ -51,12 +50,13 @@ public final class StringCaseFunction {
         module.register(
             Signature.scalar(
                 "lower",
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            args ->
+            (signature, args) ->
                 new UnaryScalar<String, String>(
                     "lower",
+                    signature,
                     DataTypes.STRING,
                     DataTypes.STRING,
                     val -> val.toLowerCase(Locale.ENGLISH)

--- a/sql/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -31,11 +31,10 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
-
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class StringLeftRightFunction extends Scalar<String, Object> {
 
@@ -43,38 +42,48 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 "left",
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
-                new StringLeftRightFunction("left", StringLeftRightFunction::left)
+            (signature, args) ->
+                new StringLeftRightFunction("left", signature, StringLeftRightFunction::left)
         );
         module.register(
             Signature.scalar(
                 "right",
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
-                new StringLeftRightFunction("right", StringLeftRightFunction::right)
+            (signature, args) ->
+                new StringLeftRightFunction("right", signature, StringLeftRightFunction::right)
         );
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final BiFunction<String, Integer, String> func;
 
-    private StringLeftRightFunction(String funcName, BiFunction<String, Integer, String> func) {
+    private StringLeftRightFunction(String funcName,
+                                    Signature signature,
+                                    BiFunction<String, Integer, String> func) {
         info = new FunctionInfo(new FunctionIdent(funcName,
                                                   List.of(DataTypes.STRING, DataTypes.INTEGER)),
                                 DataTypes.STRING);
+        this.signature = signature;
         this.func = func;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -32,9 +32,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Locale;
-
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class StringPaddingFunction extends Scalar<String, Object> {
 
@@ -48,13 +47,14 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 LNAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringPaddingFunction(
                     new FunctionInfo(new FunctionIdent(LNAME, argumentTypes), DataTypes.STRING),
+                    signature,
                     StringPaddingFunction::lpad
                 )
         );
@@ -62,14 +62,15 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 LNAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringPaddingFunction(
                     new FunctionInfo(new FunctionIdent(LNAME, argumentTypes), DataTypes.STRING),
+                    signature,
                     StringPaddingFunction::lpad
                 )
         );
@@ -77,13 +78,14 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 RNAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringPaddingFunction(
                     new FunctionInfo(new FunctionIdent(RNAME, argumentTypes), DataTypes.STRING),
+                    signature,
                     StringPaddingFunction::rpad
                 )
         );
@@ -91,30 +93,41 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 RNAME,
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new StringPaddingFunction(
                     new FunctionInfo(new FunctionIdent(RNAME, argumentTypes), DataTypes.STRING),
+                    signature,
                     StringPaddingFunction::rpad
                 )
         );
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final ThreeParametersFunction<char[], Integer, char[], String> func;
 
-    private StringPaddingFunction(FunctionInfo info, ThreeParametersFunction<char[], Integer, char[], String> func) {
+    private StringPaddingFunction(FunctionInfo info,
+                                  Signature signature,
+                                  ThreeParametersFunction<char[], Integer, char[], String> func) {
         this.info = info;
+        this.signature = signature;
         this.func = func;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -31,9 +31,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
-
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class StringRepeatFunction extends Scalar<String, Object> {
 
@@ -49,12 +48,18 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
         module.register(
             Signature.scalar(
                 "repeat",
-                parseTypeSignature("text"),
-                parseTypeSignature("integer"),
-                parseTypeSignature("text")
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
             ),
-            argumentTypes -> new StringRepeatFunction()
+            (signature, argumentTypes) -> new StringRepeatFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public StringRepeatFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -76,5 +81,11 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -59,13 +59,25 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
                 FQN,
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> new CurrentSchemaFunction()
+            (signature, args) -> new CurrentSchemaFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public CurrentSchemaFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -34,6 +34,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,13 +57,25 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> new CurrentSchemasFunction()
+            (signature, args) -> new CurrentSchemasFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public CurrentSchemasFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -34,13 +34,13 @@ import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public final class ObjDescriptionFunction extends Scalar<String, Object> {
 
     private static final String NAME = "obj_description";
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
-    private final FunctionInfo info;
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -54,11 +54,15 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
         );
     }
 
-    public ObjDescriptionFunction(List<DataType> argumentTypes) {
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    public ObjDescriptionFunction(Signature signature, List<DataType> argumentTypes) {
         info = new FunctionInfo(
             new FunctionIdent(FQN, argumentTypes),
             DataTypes.STRING
         );
+        this.signature = signature;
     }
 
     @SafeVarargs
@@ -71,5 +75,11 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -33,6 +33,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 
 public class PgGetExpr extends Scalar<String, Object> {
@@ -48,8 +49,14 @@ public class PgGetExpr extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> new PgGetExpr()
+            (signature, args) -> new PgGetExpr(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public PgGetExpr(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -62,5 +69,11 @@ public class PgGetExpr extends Scalar<String, Object> {
         return new FunctionInfo(
             new FunctionIdent(FQN, Arrays.asList(DataTypes.STRING, DataTypes.INTEGER)),
             DataTypes.STRING);
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -33,6 +33,8 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
+
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -48,26 +50,35 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature()
             )
                 .withTypeVariableConstraints(typeVariable("E")),
-            argumentTypes ->
+            (signature, argumentTypes) ->
                 new PgTypeofFunction(
                     new FunctionInfo(new FunctionIdent(FQNAME, argumentTypes),
-                                     DataTypes.STRING)
+                                     DataTypes.STRING),
+                    signature
                 )
         );
 
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
     private final String type;
 
-    private PgTypeofFunction(FunctionInfo info) {
+    private PgTypeofFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
         type = this.info.ident().argumentTypes().get(0).getName();
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @SafeVarargs

--- a/sql/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -35,6 +35,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Locale;
 
@@ -54,7 +55,7 @@ public class VersionFunction extends Scalar<String, Void> {
                 FQN,
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> new VersionFunction()
+            (signature, args) -> new VersionFunction(signature)
         );
 
     }
@@ -89,6 +90,12 @@ public class VersionFunction extends Scalar<String, Void> {
 
     private static final String VERSION = formatVersion();
 
+    private final Signature signature;
+
+    public VersionFunction(Signature signature) {
+        this.signature = signature;
+    }
+
     @Override
     public String evaluate(TransactionContext txnCtx, Input<Void>... args) {
         return VERSION;
@@ -97,5 +104,11 @@ public class VersionFunction extends Scalar<String, Void> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -31,12 +31,11 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class CurrentTimestampFunction extends Scalar<Long, Integer> {
 
@@ -53,13 +52,18 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("integer"),
-                parseTypeSignature("timestamp with time zone")
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
-            args -> new CurrentTimestampFunction()
+            (signature, args) -> new CurrentTimestampFunction(signature)
         );
     }
 
+    private final Signature signature;
+
+    public CurrentTimestampFunction(Signature signature) {
+        this.signature = signature;
+    }
 
     @Override
     @SafeVarargs
@@ -99,5 +103,11 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -31,9 +31,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
-
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class NowFunction extends Scalar<Long, Object> {
 
@@ -48,10 +47,16 @@ public final class NowFunction extends Scalar<Long, Object> {
         module.register(
             Signature.scalar(
                 NAME,
-                parseTypeSignature("timestamp with time zone")
+                DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
-            args -> new NowFunction()
+            (signature, args) -> new NowFunction(signature)
         );
+    }
+
+    private final Signature signature;
+
+    public NowFunction(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
@@ -63,5 +68,11 @@ public final class NowFunction extends Scalar<Long, Object> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -31,6 +31,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -50,8 +51,11 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMPZ.getTypeSignature(),
                 DataTypes.TIMESTAMP.getTypeSignature()
             ),
-            argumentTypes ->
-                new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMP))
+            (signature, argumentTypes) ->
+                new TimezoneFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMP),
+                    signature
+                )
         );
         module.register(
             Signature.scalar(
@@ -60,8 +64,11 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMP.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
-            argumentTypes ->
-                new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ))
+            (signature, argumentTypes) ->
+                new TimezoneFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ),
+                    signature
+                )
         );
         module.register(
             Signature.scalar(
@@ -70,20 +77,31 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
-            argumentTypes ->
-                new TimezoneFunction(new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ))
+            (signature, argumentTypes) ->
+                new TimezoneFunction(
+                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.TIMESTAMPZ),
+                    signature
+                )
         );
     }
 
     private final FunctionInfo info;
+    private final Signature signature;
 
-    private TimezoneFunction(FunctionInfo info) {
+    private TimezoneFunction(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return info;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -35,7 +35,7 @@ import java.util.List;
 public enum AggregateMode {
     ITER_PARTIAL {
         @Override
-        public DataType returnType(AggregationFunction function) {
+        public DataType returnType(AggregationFunction<?, ?> function) {
             return function.partialType();
         }
 
@@ -49,7 +49,7 @@ public enum AggregateMode {
 
     private static final List<AggregateMode> VALUES = ImmutableList.copyOf(values());
 
-    public DataType returnType(AggregationFunction function) {
+    public DataType returnType(AggregationFunction<?, ?> function) {
         return function.info().returnType();
     }
 

--- a/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -80,7 +80,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         changed |= filter != newFilter;
 
         if (changed) {
-            return new Function(func.info(), newArgs, newFilter);
+            return new Function(func.info(), func.signature(), newArgs, newFilter);
         }
         return func;
     }
@@ -101,7 +101,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (arg1 == newArg1 && arg2 == newArg2 && filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), List.of(newArg1, newArg2), newFilter);
+        return new Function(func.info(), func.signature(), List.of(newArg1, newArg2), newFilter);
     }
 
     private Function zeroArg(Function func, C context) {
@@ -116,7 +116,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), List.of(), newFilter);
+        return new Function(func.info(), func.signature(), List.of(), newFilter);
     }
 
     private Function oneArg(Function func, C context) {
@@ -130,7 +130,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (arg == newArg && filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), List.of(newArg), newFilter);
+        return new Function(func.info(), func.signature(), List.of(newArg), newFilter);
     }
 
     @Nullable
@@ -151,6 +151,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         Function processedFunction = processAndMaybeCopy(windowFunction, context);
         return new WindowFunction(
             processedFunction.info(),
+            processedFunction.signature(),
             processedFunction.arguments(),
             processNullable(windowFunction.filter(), context),
             windowFunction.windowDefinition().map(s -> s.accept(this, context))

--- a/sql/src/main/java/io/crate/expression/symbol/WindowFunction.java
+++ b/sql/src/main/java/io/crate/expression/symbol/WindowFunction.java
@@ -29,6 +29,7 @@ import io.crate.analyze.WindowFrameDefinition;
 import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.functions.Signature;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -53,7 +54,15 @@ public class WindowFunction extends Function {
                           List<Symbol> arguments,
                           @Nullable Symbol filter,
                           WindowDefinition windowDefinition) {
-        super(info, arguments, filter);
+        this(info, null, arguments, filter, windowDefinition);
+    }
+
+    public WindowFunction(FunctionInfo info,
+                          Signature signature,
+                          List<Symbol> arguments,
+                          @Nullable Symbol filter,
+                          WindowDefinition windowDefinition) {
+        super(info, signature, arguments, filter);
         assert info.type() == WINDOW || info.type() == AGGREGATE :
             "only window and aggregate functions are allowed to be modelled over a window";
         this.windowDefinition = windowDefinition;

--- a/sql/src/main/java/io/crate/expression/udf/UDFLanguage.java
+++ b/sql/src/main/java/io/crate/expression/udf/UDFLanguage.java
@@ -23,6 +23,7 @@
 package io.crate.expression.udf;
 
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 
 import javax.annotation.Nullable;
 import javax.script.ScriptException;
@@ -46,7 +47,7 @@ public interface UDFLanguage {
      * @return the function implementation
      * @throws ScriptException if the implementation cannot be created
      */
-    Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData) throws ScriptException;
+    Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData, Signature signature) throws ScriptException;
 
     /**
      * Validate the function code provided by the meta data.

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -404,6 +404,7 @@ public class LuceneQueryBuilder {
                     if (ref.column().equals(DocSysColumns.UID)) {
                         return new Function(
                             function.info(),
+                            function.signature(),
                             ImmutableList.of(DocSysColumns.forTable(ref.ident().tableIdent(), DocSysColumns.ID), right)
                         );
                     } else {

--- a/sql/src/main/java/io/crate/metadata/FuncResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FuncResolver.java
@@ -26,15 +26,15 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public class FuncResolver {
 
     private final Signature signature;
-    private final Function<List<DataType>, FunctionImplementation> factory;
+    private final BiFunction<Signature, List<DataType>, FunctionImplementation> factory;
 
     public FuncResolver(Signature signature,
-                        Function<List<DataType>, FunctionImplementation> factory) {
+                        BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
         this.signature = signature;
         this.factory = factory;
     }
@@ -43,7 +43,7 @@ public class FuncResolver {
         return signature;
     }
 
-    public Function<List<DataType>, FunctionImplementation> getFactory() {
+    public BiFunction<Signature, List<DataType>, FunctionImplementation> getFactory() {
         return factory;
     }
 

--- a/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -23,6 +23,7 @@ package io.crate.metadata;
 
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.functions.Signature;
 
 import javax.annotation.Nullable;
 
@@ -35,6 +36,17 @@ public interface FunctionImplementation {
      * Provides meta information about this function implementation.
      */
     FunctionInfo info();
+
+    /**
+     * Return the declared signature for this implementation.
+     * This should be favoured over {@link #info()}.
+     *
+     * @return  NULL for functions using the old registry
+     */
+    @Nullable
+    default Signature signature() {
+        return null;
+    }
 
     /**
      * Normalize a symbol into a simplified form.

--- a/sql/src/main/java/io/crate/metadata/FunctionName.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionName.java
@@ -46,7 +46,7 @@ public final class FunctionName implements Comparable<FunctionName>, Writeable {
         this(null, name);
     }
 
-    FunctionName(StreamInput in) throws IOException {
+    public FunctionName(StreamInput in) throws IOException {
         schema = in.readOptionalString();
         name = in.readString();
     }

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -173,22 +174,27 @@ public class Functions {
      */
     @Nullable
     private FunctionImplementation getBuiltin(FunctionName functionName, List<DataType> dataTypes) {
-        // Try new signature registry first
-        FunctionImplementation impl = resolveFunctionBySignature(
-            functionName,
-            dataTypes,
-            SearchPath.pathWithPGCatalogAndDoc(),
-            functionImplementations::get
-        );
-        if (impl != null) {
-            return impl;
-        }
-
         FunctionResolver resolver = functionResolvers.get(functionName);
         if (resolver == null) {
             return null;
         }
         return resolver.getForTypes(dataTypes);
+    }
+
+    @Nullable
+    private FunctionImplementation get(Signature signature,
+                                       List<DataType> actualArgumentTypes,
+                                       Function<FunctionName, List<FuncResolver>> lookupFunction) {
+        var candidates = lookupFunction.apply(signature.getName());
+        if (candidates == null) {
+            return null;
+        }
+        for (var candidate : candidates) {
+            if (candidate.getSignature().equals(signature)) {
+                return candidate.getFactory().apply(signature, actualArgumentTypes);
+            }
+        }
+        return null;
     }
 
     /**
@@ -204,11 +210,10 @@ public class Functions {
                                                     List<? extends FuncArg> argumentsTypes,
                                                     SearchPath searchPath) {
         // V2
-        FunctionImplementation impl = resolveFunctionBySignature(
+        FunctionImplementation impl = resolveBuiltInFunctionBySignature(
             functionName,
             Lists2.map(argumentsTypes, FuncArg::valueType),
-            searchPath,
-            functionImplementations::get
+            searchPath
         );
         if (impl != null) {
             return impl;
@@ -222,10 +227,18 @@ public class Functions {
     }
 
     @Nullable
-    private FunctionImplementation resolveFunctionBySignature(FunctionName name,
-                                                              List<DataType> arguments,
-                                                              SearchPath searchPath,
-                                                              Function<FunctionName, List<FuncResolver>> lookupFunction) {
+    public FunctionImplementation resolveBuiltInFunctionBySignature(FunctionName name,
+                                                                     List<DataType> arguments,
+                                                                     SearchPath searchPath) {
+        return resolveFunctionBySignature(name, arguments, searchPath, functionImplementations::get);
+    }
+
+
+    @Nullable
+    private static FunctionImplementation resolveFunctionBySignature(FunctionName name,
+                                                                     List<DataType> arguments,
+                                                                     SearchPath searchPath,
+                                                                     Function<FunctionName, List<FuncResolver>> lookupFunction) {
         var candidates = lookupFunction.apply(name);
         if (candidates == null && name.schema() == null) {
             for (String pathSchema : searchPath) {
@@ -237,27 +250,33 @@ public class Functions {
             }
         }
         if (candidates != null) {
+            assert candidates.stream().allMatch(f -> f.getSignature().getBindingInfo() != null) :
+                "Resolving/Matching of signatures can only be done with non-null signature's binding info";
+
+            @SuppressWarnings("ConstantConditions")
             // First lets try exact candidates, no generic type variables, no coercion allowed.
             var exactCandidates = candidates.stream()
-                .filter(function -> function.getSignature().getTypeVariableConstraints().isEmpty())
+                .filter(function -> function.getSignature().getBindingInfo().getTypeVariableConstraints().isEmpty())
                 .collect(Collectors.toList());
             var match = matchFunctionCandidates(exactCandidates, arguments, false);
             if (match != null) {
                 return match;
             }
 
+            @SuppressWarnings("ConstantConditions")
             // Second, try candidates with generic type variables, still no coercion allowed.
             var genericCandidates = candidates.stream()
-                .filter(function -> !function.getSignature().getTypeVariableConstraints().isEmpty())
+                .filter(function -> !function.getSignature().getBindingInfo().getTypeVariableConstraints().isEmpty())
                 .collect(Collectors.toList());
             match = matchFunctionCandidates(genericCandidates, arguments, false);
             if (match != null) {
                 return match;
             }
 
+            @SuppressWarnings("ConstantConditions")
             // Last, try all candidates which allow coercion.
             var candidatesAllowingCoercion = candidates.stream()
-                .filter(function -> function.getSignature().isCoercionAllowed())
+                .filter(function -> function.getSignature().getBindingInfo().isCoercionAllowed())
                 .collect(Collectors.toList());
             return matchFunctionCandidates(candidatesAllowingCoercion, arguments, true);
         }
@@ -362,6 +381,9 @@ public class Functions {
     }
 
     /**
+     * @deprecated Superseded by {@link #getQualified(Signature, List)}.
+     *             This method gets removed once all functions use the signature based registry.
+     *
      * Returns the function implementation for the given function ident.
      * First look up function in built-ins then fallback to user-defined functions.
      *
@@ -373,6 +395,23 @@ public class Functions {
         FunctionImplementation impl = getBuiltin(ident.fqnName(), ident.argumentTypes());
         if (impl == null) {
             impl = getUserDefined(ident.fqnName(), ident.argumentTypes());
+        }
+        return impl;
+    }
+
+    /**
+     * Returns the function implementation for the given function signature.
+     * First look up function in built-ins then fallback to user-defined functions.
+     *
+     * @param signature The function signature.
+     * @return The function implementation.
+     * @throws UnsupportedOperationException if no implementation is found.
+     */
+    public FunctionImplementation getQualified(Signature signature,
+                                               List<DataType> actualArgumentTypes) throws UnsupportedOperationException {
+        FunctionImplementation impl = get(signature, actualArgumentTypes, functionImplementations::get);
+        if (impl == null) {
+            impl = get(signature, actualArgumentTypes, udfFunctionImplementations::get);
         }
         return impl;
     }
@@ -584,11 +623,11 @@ public class Functions {
 
         private final Signature declaredSignature;
         private final Signature boundSignature;
-        private final Function<List<DataType>, FunctionImplementation> factory;
+        private final BiFunction<Signature, List<DataType>, FunctionImplementation> factory;
 
         public ApplicableFunction(Signature declaredSignature,
                                   Signature boundSignature,
-                                  Function<List<DataType>, FunctionImplementation> factory) {
+                                  BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
             this.declaredSignature = declaredSignature;
             this.boundSignature = boundSignature;
             this.factory = factory;
@@ -604,7 +643,10 @@ public class Functions {
 
         @Override
         public FunctionImplementation get() {
-            return factory.apply(Lists2.map(boundSignature.getArgumentTypes(), TypeSignature::createType));
+            return factory.apply(
+                declaredSignature,
+                Lists2.map(boundSignature.getArgumentTypes(), TypeSignature::createType)
+            );
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/sql/src/main/java/io/crate/metadata/functions/Signature.java
@@ -26,18 +26,25 @@ import io.crate.common.collections.Lists2;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.types.TypeSignature;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-public final class Signature {
+public final class Signature implements Writeable {
 
     /**
      * See {@link #aggregate(FunctionName, TypeSignature...)}
      */
     public static Signature aggregate(String name, TypeSignature... types) {
-        return scalar(new FunctionName(null, name), types);
+        return aggregate(new FunctionName(null, name), types);
     }
 
     /**
@@ -128,10 +135,11 @@ public final class Signature {
             kind = signature.getKind();
             argumentTypes = signature.getArgumentTypes();
             returnType = signature.getReturnType();
-            typeVariableConstraints = signature.getTypeVariableConstraints();
-            variableArityGroup = signature.getVariableArityGroup();
-            variableArity = signature.isVariableArity();
-            allowCoercion = signature.isCoercionAllowed();
+            assert signature.getBindingInfo() != null : "Expecting the signature's binding info to be not null";
+            typeVariableConstraints = signature.getBindingInfo().getTypeVariableConstraints();
+            variableArityGroup = signature.getBindingInfo().getVariableArityGroup();
+            variableArity = signature.getBindingInfo().isVariableArity();
+            allowCoercion = signature.getBindingInfo().isCoercionAllowed();
         }
 
         public Builder name(String name) {
@@ -208,10 +216,8 @@ public final class Signature {
     private final FunctionInfo.Type kind;
     private final List<TypeSignature> argumentTypes;
     private final TypeSignature returnType;
-    private final List<TypeVariableConstraint> typeVariableConstraints;
-    private final List<TypeSignature> variableArityGroup;
-    private final boolean variableArity;
-    private final boolean allowCoercion;
+    @Nullable
+    private final SignatureBindingInfo bindingInfo;
 
     private Signature(FunctionName name,
                       FunctionInfo.Type kind,
@@ -224,11 +230,25 @@ public final class Signature {
         this.name = name;
         this.kind = kind;
         this.argumentTypes = argumentTypes;
-        this.typeVariableConstraints = typeVariableConstraints;
         this.returnType = returnType;
-        this.variableArityGroup = variableArityGroup;
-        this.variableArity = variableArity;
-        this.allowCoercion = allowCoercion;
+        this.bindingInfo = new SignatureBindingInfo(
+            typeVariableConstraints,
+            variableArityGroup,
+            variableArity,
+            allowCoercion
+        );
+    }
+
+    public Signature(StreamInput in) throws IOException {
+        name = new FunctionName(in);
+        kind = FunctionInfo.Type.values()[in.readVInt()];
+        int argsSize = in.readVInt();
+        argumentTypes = new ArrayList<>(argsSize);
+        for (int i = 0; i < argsSize; i++) {
+            argumentTypes.add(TypeSignature.fromStream(in));
+        }
+        returnType = TypeSignature.fromStream(in);
+        bindingInfo = null;
     }
 
     public Signature withTypeVariableConstraints(TypeVariableConstraint... typeVariableConstraints) {
@@ -269,25 +289,48 @@ public final class Signature {
         return returnType;
     }
 
-    public List<TypeVariableConstraint> getTypeVariableConstraints() {
-        return typeVariableConstraints;
+    @Nullable
+    public SignatureBindingInfo getBindingInfo() {
+        return bindingInfo;
     }
 
-    public List<TypeSignature> getVariableArityGroup() {
-        return variableArityGroup;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        name.writeTo(out);
+        out.writeVInt(kind.ordinal());
+        out.writeVInt(argumentTypes.size());
+        for (TypeSignature typeSignature : argumentTypes) {
+            TypeSignature.toStream(typeSignature, out);
+        }
+        TypeSignature.toStream(returnType, out);
     }
 
-    public boolean isVariableArity() {
-        return variableArity;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Signature signature = (Signature) o;
+        return name.equals(signature.name) &&
+               kind == signature.kind &&
+               argumentTypes.equals(signature.argumentTypes) &&
+               returnType.equals(signature.returnType);
     }
 
-    public boolean isCoercionAllowed() {
-        return allowCoercion;
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, kind, argumentTypes, returnType);
     }
 
     @Override
     public String toString() {
-        List<String> allConstraints = Lists2.map(typeVariableConstraints, TypeVariableConstraint::toString);
+        List<String> allConstraints = List.of();
+        if (bindingInfo != null) {
+            allConstraints = Lists2.map(bindingInfo.getTypeVariableConstraints(), TypeVariableConstraint::toString);
+        }
 
         return name + (allConstraints.isEmpty() ? "" : "<" + String.join(",", allConstraints) + ">") +
                "(" + Lists2.joinOn(",", argumentTypes, TypeSignature::toString) + "):" + returnType;

--- a/sql/src/main/java/io/crate/metadata/functions/SignatureBindingInfo.java
+++ b/sql/src/main/java/io/crate/metadata/functions/SignatureBindingInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.types.TypeSignature;
+
+import java.util.List;
+
+/**
+ * Containing {@link Signature} properties which are only required for signature binding/matching.
+ * It won't be streamed and all properties won't be taken into account when resolving a function by signature.
+ */
+public class SignatureBindingInfo {
+
+    private final List<TypeVariableConstraint> typeVariableConstraints;
+    private final List<TypeSignature> variableArityGroup;
+    private final boolean variableArity;
+    private final boolean allowCoercion;
+
+    public SignatureBindingInfo(List<TypeVariableConstraint> typeVariableConstraints,
+                                List<TypeSignature> variableArityGroup,
+                                boolean variableArity,
+                                boolean allowCoercion) {
+        this.typeVariableConstraints = typeVariableConstraints;
+        this.variableArityGroup = variableArityGroup;
+        this.variableArity = variableArity;
+        this.allowCoercion = allowCoercion;
+    }
+
+    public List<TypeVariableConstraint> getTypeVariableConstraints() {
+        return typeVariableConstraints;
+    }
+
+    public List<TypeSignature> getVariableArityGroup() {
+        return variableArityGroup;
+    }
+
+    public boolean isVariableArity() {
+        return variableArity;
+    }
+
+    public boolean isCoercionAllowed() {
+        return allowCoercion;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
+++ b/sql/src/main/java/io/crate/metadata/functions/TypeVariableConstraint.java
@@ -22,9 +22,14 @@
 
 package io.crate.metadata.functions;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
 import java.util.Objects;
 
-public class TypeVariableConstraint {
+public class TypeVariableConstraint implements Writeable {
 
     public static TypeVariableConstraint typeVariable(String name) {
         return new TypeVariableConstraint(name, false);
@@ -42,12 +47,23 @@ public class TypeVariableConstraint {
         this.anyAllowed = anyAllowed;
     }
 
+    public TypeVariableConstraint(StreamInput in) throws IOException {
+        name = in.readString();
+        anyAllowed = in.readBoolean();
+    }
+
     public String getName() {
         return name;
     }
 
     public boolean isAnyAllowed() {
         return anyAllowed;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeBoolean(anyAllowed);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
@@ -65,6 +65,7 @@ public class GroupProjectionTest extends CrateUnitTest {
         List<Aggregation> aggregations = Collections.singletonList(
             new Aggregation(
                 CountAggregation.COUNT_STAR_FUNCTION,
+                CountAggregation.COUNT_STAR_SIGNATURE,
                 CountAggregation.COUNT_STAR_FUNCTION.returnType(),
                 Collections.emptyList()
             )

--- a/sql/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -30,9 +30,9 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.expression.symbol.WindowFunctionContext;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -141,6 +141,11 @@ public class WindowAggProjectionSerialisationTest {
 
     private FunctionImplementation getSumFunction() {
         return functions.getQualified(
-            new FunctionIdent(SumAggregation.NAME, List.of(DataTypes.FLOAT)));
+            Signature.aggregate(
+                SumAggregation.NAME,
+                DataTypes.FLOAT.getTypeSignature(),
+                DataTypes.FLOAT.getTypeSignature()),
+            List.of(DataTypes.FLOAT)
+        );
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -49,7 +49,9 @@ public class ArrayAggTest extends AggregationTest {
     @Test
     public void test_array_agg_return_type_is_array_of_argument_type() {
         DataType<?> returnType = functions.getQualified(
-            new FunctionIdent(ArrayAgg.NAME, List.of(DataTypes.LONG))).info().returnType();
+            ArrayAgg.SIGNATURE,
+            List.of(DataTypes.LONG)
+        ).info().returnType();
         assertThat(returnType, Matchers.is(new ArrayType<>(DataTypes.LONG)));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -22,13 +22,19 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.junit.Test;
+
+import java.util.List;
 
 public class MaximumAggregationTest extends AggregationTest {
 
@@ -38,7 +44,10 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionImplementation max = functions.getQualified(new FunctionIdent("max", ImmutableList.of(DataTypes.INTEGER)));
+        FunctionImplementation max = functions.getQualified(
+            Signature.aggregate("max", DataTypes.INTEGER.getTypeSignature(), DataTypes.INTEGER.getTypeSignature()),
+            List.of(DataTypes.INTEGER)
+        );
         assertEquals(DataTypes.INTEGER, max.info().returnType());
     }
 

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -24,11 +24,14 @@ package io.crate.execution.engine.aggregation.impl;
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.junit.Test;
+
+import java.util.List;
 
 public class MinimumAggregationTest extends AggregationTest {
 
@@ -38,7 +41,10 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionImplementation min = functions.getQualified(new FunctionIdent("min", ImmutableList.of(DataTypes.INTEGER)));
+        FunctionImplementation min = functions.getQualified(
+            Signature.aggregate("min", DataTypes.INTEGER.getTypeSignature(), DataTypes.INTEGER.getTypeSignature()),
+            List.of(DataTypes.INTEGER)
+        );
         assertEquals(DataTypes.INTEGER, min.info().returnType());
     }
 

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
-import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -43,16 +43,12 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class PercentileAggregationTest extends AggregationTest {
 
-    private static final String NAME = "percentile";
-
     private Object execSingleFractionPercentile(DataType<?> valueType, Object[][] rows) throws Exception {
-        String name = "percentile";
-        return executeAggregation(name, valueType, rows, List.of(valueType, DataTypes.DOUBLE));
+        return executeAggregation(PercentileAggregation.NAME, valueType, rows, List.of(valueType, DataTypes.DOUBLE));
     }
 
     private Object execArrayFractionPercentile(DataType<?> valueType, Object[][] rows) throws Exception {
-        String name = "percentile";
-        return executeAggregation(name, valueType, rows, List.of(valueType, DataTypes.DOUBLE_ARRAY));
+        return executeAggregation(PercentileAggregation.NAME, valueType, rows, List.of(valueType, DataTypes.DOUBLE_ARRAY));
     }
 
     private PercentileAggregation singleArgPercentile;
@@ -61,9 +57,23 @@ public class PercentileAggregationTest extends AggregationTest {
     @Before
     public void initFunctions() throws Exception {
         singleArgPercentile = (PercentileAggregation) functions.getQualified(
-            new FunctionIdent(NAME, Arrays.asList(DataTypes.DOUBLE, DataTypes.DOUBLE)));
+            Signature.aggregate(
+                PercentileAggregation.NAME,
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE)
+        );
         arraysPercentile = (PercentileAggregation) functions.getQualified(
-            new FunctionIdent(NAME, Arrays.asList(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY)));
+            Signature.aggregate(
+                PercentileAggregation.NAME,
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature()
+            ),
+            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY)
+        );
     }
 
     @Test
@@ -188,7 +198,14 @@ public class PercentileAggregationTest extends AggregationTest {
     @Test
     public void testSingleItemFractionsArgumentResultsInArrayResult() {
         AggregationFunction impl = (AggregationFunction<?, ?>) functions.getQualified(
-            new FunctionIdent(NAME, Arrays.asList(DataTypes.LONG, DataTypes.DOUBLE_ARRAY)));
+            Signature.aggregate(
+                PercentileAggregation.NAME,
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature()
+            ),
+            List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY)
+        );
 
         RamAccounting ramAccounting = RamAccounting.NO_ACCOUNTING;
         Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -67,7 +67,7 @@ public class StringAggTest extends AggregationTest {
 
     @Test
     public void testMergeOf2States() throws Exception {
-        var stringAgg = new StringAgg();
+        var stringAgg = new StringAgg(StringAgg.SIGNATURE);
         var state1 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("a"), Literal.of(","));
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("b"), Literal.of(";"));

--- a/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -90,8 +90,10 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
 
         inExpr = new InputCollectExpression(0);
-        CountAggregation aggregation = ((CountAggregation) getFunctions().getQualified(
-            new FunctionIdent(CountAggregation.NAME, Collections.emptyList())));
+        CountAggregation aggregation = (CountAggregation) getFunctions().getQualified(
+            CountAggregation.COUNT_STAR_SIGNATURE,
+            Collections.emptyList()
+        );
         aggregationContexts = Collections.singletonList(new AggregationContext(aggregation, () -> true));
     }
 

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -60,6 +60,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
@@ -90,6 +91,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
     private ProjectionToProjectorVisitor visitor;
     private FunctionInfo countInfo;
     private FunctionInfo avgInfo;
+    private Signature avgSignature;
     private Functions functions;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
@@ -119,6 +121,11 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         avgInfo = new FunctionInfo(
             new FunctionIdent(AverageAggregation.NAME, Collections.singletonList(DataTypes.INTEGER)),
             DataTypes.DOUBLE);
+        avgSignature = Signature.aggregate(
+            "avg",
+            DataTypes.INTEGER.getTypeSignature(),
+            DataTypes.DOUBLE.getTypeSignature()
+        );
     }
 
     @Test
@@ -168,10 +175,12 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         AggregationProjection projection = new AggregationProjection(Arrays.asList(
             new Aggregation(
                 avgInfo,
+                avgSignature,
                 avgInfo.returnType(),
                 Collections.singletonList(new InputColumn(1))),
             new Aggregation(
                 countInfo,
+                CountAggregation.SIGNATURE,
                 countInfo.returnType(),
                 Collections.singletonList(new InputColumn(0)))
         ), RowGranularity.SHARD, AggregateMode.ITER_FINAL);
@@ -203,10 +212,12 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         List<Aggregation> aggregations = Arrays.asList(
             new Aggregation(
                 avgInfo,
+                avgSignature,
                 avgInfo.returnType(),
                 Collections.singletonList(new InputColumn(1))),
             new Aggregation(
                 countInfo,
+                CountAggregation.SIGNATURE,
                 countInfo.returnType(),
                 Collections.singletonList(new InputColumn(0)))
         );

--- a/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -138,7 +138,15 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
         var argsCtx = inputFactory.ctxForRefs(txnCtx, referenceResolver);
         argsCtx.add(windowFunctionSymbol.arguments());
 
-        FunctionImplementation impl = functions.getQualified(windowFunctionSymbol.info().ident());
+        var ident = windowFunctionSymbol.info().ident();
+        var signature = windowFunctionSymbol.signature();
+        FunctionImplementation impl;
+        if (signature == null) {
+            impl = functions.getQualified(ident);
+        } else {
+            impl = functions.getQualified(signature, ident.argumentTypes());
+        }
+
         assert impl instanceof WindowFunction || impl instanceof AggregationFunction: "Got " + impl + " but expected a window function";
         WindowFunction windowFunctionImpl;
         if (impl instanceof AggregationFunction) {

--- a/sql/src/test/java/io/crate/expression/AbstractFunctionModuleTest.java
+++ b/sql/src/test/java/io/crate/expression/AbstractFunctionModuleTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression;
+
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.functions.Signature;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+public class AbstractFunctionModuleTest extends CrateUnitTest {
+
+    AbstractFunctionModule<FunctionImplementation> module = new AbstractFunctionModule<>() {
+        @Override
+        public void configureFunctions() {
+        }
+    };
+
+    @Test
+    public void test_registering_function_with_same_signature_raises_an_error() {
+        var signature = Signature.scalar(
+            "foo",
+            DataTypes.INTEGER.getTypeSignature(),
+            DataTypes.INTEGER.getTypeSignature()
+        );
+
+        module.register(signature, (s, args) -> () -> null);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("A function already exists for signature");
+        module.register(signature, (s, args) -> () -> null);
+    }
+
+
+    @Test
+    public void test_registering_function_with_signature_only_differ_in_binding_info_raises_an_error() {
+        var signature = Signature.scalar(
+            "foo",
+            DataTypes.INTEGER.getTypeSignature(),
+            DataTypes.INTEGER.getTypeSignature()
+        );
+        module.register(signature, (s, args) -> () -> null);
+
+        var signature2 = Signature.scalar(
+            "foo",
+            DataTypes.INTEGER.getTypeSignature(),
+            DataTypes.INTEGER.getTypeSignature()
+        ).withVariableArity();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("A function already exists for signature");
+        module.register(signature2, (s, args) -> () -> null);
+    }
+}

--- a/sql/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -78,8 +78,8 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         Function avgX = (Function) expressions.asSymbol("avg(x)");
 
         List<Symbol> aggregations = Arrays.asList(
-            new Aggregation(countX.info(), countX.info().returnType(), Arrays.asList(new InputColumn(0))),
-            new Aggregation(avgX.info(), countX.info().returnType(), Arrays.asList(new InputColumn(0)))
+            new Aggregation(countX.info(), countX.signature(), countX.info().returnType(), Arrays.asList(new InputColumn(0))),
+            new Aggregation(avgX.info(), avgX.signature(), countX.info().returnType(), Arrays.asList(new InputColumn(0)))
         );
 
         InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);
@@ -142,10 +142,11 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         Function countX = (Function) expressions.asSymbol("count(x)");
 
         // values: [ count(in(0)) ]
-        List<Aggregation> values = Arrays.asList(new Aggregation(
+        List<Aggregation> values = List.of(new Aggregation(
             countX.info(),
+            countX.signature(),
             countX.valueType(),
-            Arrays.<Symbol>asList(new InputColumn(0))
+            List.of(new InputColumn(0))
         ));
 
         InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -140,8 +140,15 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             return;
         }
         Function function = (Function) functionSymbol;
-        FunctionImplementation impl = functions.getQualified(function.info().ident());
-        assertThat(impl, Matchers.notNullValue());
+        var ident = function.info().ident();
+        var signature = function.signature();
+        FunctionImplementation impl;
+        if (signature == null) {
+            impl = functions.getQualified(ident);
+        } else {
+            impl = functions.getQualified(signature, ident.argumentTypes());
+        }
+        assertThat("Function implementation not found using full qualified lookup", impl, Matchers.notNullValue());
 
         Symbol normalized = sqlExpressions.normalize(function);
         assertThat(
@@ -190,7 +197,16 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             }
             return literal;
         });
-        Scalar scalar = (Scalar) functions.getQualified(function.info().ident());
+        var ident = function.info().ident();
+        var signature = function.signature();
+        Scalar scalar;
+        if (signature == null) {
+            scalar = (Scalar) functions.getQualified(ident);
+        } else {
+            scalar = (Scalar) functions.getQualified(signature, ident.argumentTypes());
+        }
+        assertThat("Function implementation not found using full qualified lookup", scalar, Matchers.notNullValue());
+
         AssertMax1ValueCallInput[] arguments = new AssertMax1ValueCallInput[function.arguments().size()];
         InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         for (int i = 0; i < function.arguments().size(); i++) {
@@ -236,7 +252,15 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         assertThat("function expression was normalized, compile would not be hit", functionSymbol, not(instanceOf(Literal.class)));
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.getQualified(function.info().ident());
+        var ident = function.info().ident();
+        var signature = function.signature();
+        Scalar scalar;
+        if (signature == null) {
+            scalar = (Scalar) functions.getQualified(ident);
+        } else {
+            scalar = (Scalar) functions.getQualified(signature, ident.argumentTypes());
+        }
+        assertThat("Function implementation not found using full qualified lookup", scalar, Matchers.notNullValue());
 
         Scalar compiled = scalar.compile(function.arguments());
         assertThat(compiled, matcher.apply(scalar));

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -28,7 +28,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
 import io.crate.geo.GeoJSONUtils;
-import io.crate.metadata.FunctionIdent;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -218,11 +217,11 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         var returnType = ObjectType.builder()
             .setInnerType("field", DataTypes.STRING)
             .build();
-        var ident = new FunctionIdent(
-            CastFunctionResolver.castFuncName(ObjectType.untyped()),
-            List.of(ObjectType.untyped(), returnType));
+        var info = CastFunctionResolver.functionInfo(
+            List.of(ObjectType.untyped(), returnType), returnType, false);
+        var signature = CastFunctionResolver.createSignature(info);
 
-        var functionImpl = functions.getQualified(ident);
+        var functionImpl = functions.getQualified(signature, List.of(ObjectType.untyped(), returnType));
         assertThat(functionImpl.info().returnType(), is(returnType));
     }
 }

--- a/sql/src/test/java/io/crate/expression/symbol/AggregationTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/AggregationTest.java
@@ -39,6 +39,7 @@ public class AggregationTest extends CrateUnitTest {
     public void test_serialization_with_filter() throws Exception {
         Aggregation actual = new Aggregation(
             CountAggregation.COUNT_STAR_FUNCTION,
+            CountAggregation.COUNT_STAR_SIGNATURE,
             CountAggregation.COUNT_STAR_FUNCTION.returnType(),
             List.of(),
             Literal.BOOLEAN_FALSE
@@ -57,6 +58,7 @@ public class AggregationTest extends CrateUnitTest {
     public void test_serialization_with_filter_before_version_4_1_0() throws Exception {
         Aggregation actual = new Aggregation(
             CountAggregation.COUNT_STAR_FUNCTION,
+            CountAggregation.COUNT_STAR_SIGNATURE,
             CountAggregation.COUNT_STAR_FUNCTION.returnType(),
             List.of()
         );

--- a/sql/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -78,6 +78,7 @@ public class FunctionTest extends CrateUnitTest {
                 FunctionInfo.Type.SCALAR,
                 randomFeatures()
             ),
+            null,
             List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN)),
             Literal.of(true)
         );

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.symbol.format;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.expression.scalar.FormatFunction;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.FetchReference;

--- a/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -27,6 +27,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
 
@@ -42,12 +43,13 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
     static final UDFLanguage DUMMY_LANG = new UDFLanguage() {
         @Override
-        public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData) throws ScriptException {
+        public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData,
+                                                   Signature signature) throws ScriptException {
             FunctionInfo info = new FunctionInfo(
                 new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()),
                 metaData.returnType()
             );
-            return new DummyFunction(info);
+            return new DummyFunction(info, signature);
         }
 
         @Nullable
@@ -66,15 +68,23 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
         public static final Integer RESULT = -42;
 
-        private FunctionInfo info;
+        private final FunctionInfo info;
+        private final Signature signature;
 
-        DummyFunction(FunctionInfo info) {
+        DummyFunction(FunctionInfo info, Signature signature) {
             this.info = info;
+            this.signature = signature;
         }
 
         @Override
         public FunctionInfo info() {
             return info;
+        }
+
+        @Nullable
+        @Override
+        public Signature signature() {
+            return signature;
         }
 
         @Override

--- a/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -35,12 +35,14 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.script.ScriptException;
 import java.util.List;
 import java.util.Locale;
@@ -59,16 +61,25 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
     public static class DummyFunction<InputType> extends Scalar<String, InputType>  {
 
         private final FunctionInfo info;
+        private final Signature signature;
         private final UserDefinedFunctionMetaData metaData;
 
-        private DummyFunction(UserDefinedFunctionMetaData metaData) {
+        private DummyFunction(UserDefinedFunctionMetaData metaData,
+                              Signature signature) {
             this.info = new FunctionInfo(new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()), DataTypes.STRING);
+            this.signature = signature;
             this.metaData = metaData;
         }
 
         @Override
         public FunctionInfo info() {
             return info;
+        }
+
+        @Nullable
+        @Override
+        public Signature signature() {
+            return signature;
         }
 
         @Override
@@ -81,8 +92,9 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
     public static class DummyLang implements UDFLanguage {
 
         @Override
-        public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData) throws ScriptException {
-            return new DummyFunction<>(metaData);
+        public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData,
+                                                   Signature signature) throws ScriptException {
+            return new DummyFunction<>(metaData, signature);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/sql/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -45,7 +45,8 @@ public class FunctionsTest extends CrateUnitTest {
 
     private Map<FunctionName, List<FuncResolver>> implementations = new HashMap<>();
 
-    private void register(Signature signature, Function<List<DataType>, FunctionImplementation> factory) {
+    private void register(Signature signature,
+                          BiFunction<Signature, List<DataType>, FunctionImplementation> factory) {
         List<FuncResolver> functions = implementations.computeIfAbsent(
             signature.getName(),
             k -> new ArrayList<>());
@@ -78,7 +79,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.STRING)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.STRING)
         );
         var impl = resolve("foo", List.of(Literal.of("hoschi")));
         assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.STRING));
@@ -92,7 +94,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
         var impl = resolve("foo", List.of(Literal.of(1L)));
         assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.INTEGER));
@@ -106,7 +109,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.DOUBLE)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.DOUBLE)
         );
         register(
             Signature.scalar(
@@ -114,7 +118,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
 
         var impl = resolve("foo", List.of(Literal.of(1L)));
@@ -131,7 +136,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
         register(
             Signature.scalar(
@@ -139,7 +145,8 @@ public class FunctionsTest extends CrateUnitTest {
                 parseTypeSignature("array(E)"),
                 DataTypes.INTEGER.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -154,7 +161,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
         register(
             Signature.scalar(
@@ -162,7 +170,8 @@ public class FunctionsTest extends CrateUnitTest {
                 parseTypeSignature("array(E)"),
                 parseTypeSignature("array(E)")
             ).withTypeVariableConstraints(typeVariable("E")),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.UNDEFINED)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.UNDEFINED)
         );
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -178,7 +187,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
         register(
             Signature.scalar(
@@ -187,7 +197,8 @@ public class FunctionsTest extends CrateUnitTest {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+            (signature, args) ->
+                () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
         );
 
         var impl = resolve("foo", List.of(Literal.of(1), Literal.of(1L)));

--- a/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -34,6 +34,7 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -60,7 +61,8 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
         udfService = new UserDefinedFunctionService(clusterService, functions);
         udfService.registerLanguage(new UDFLanguage() {
             @Override
-            public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData) throws ScriptException {
+            public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData,
+                                                       Signature signature) throws ScriptException {
                 String error = validate(metaData);
                 if (error != null) {
                     throw new ScriptException("this is not Burlesque");
@@ -75,6 +77,12 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
                     @Override
                     public FunctionInfo info() {
                         return info;
+                    }
+
+                    @Nullable
+                    @Override
+                    public Signature signature() {
+                        return signature;
                     }
                 };
             }

--- a/sql/src/test/java/io/crate/metadata/functions/SignatureTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/SignatureTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.functions;
+
+import io.crate.metadata.FunctionInfo;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SignatureTest {
+
+    @Test
+    public void test_streaming_of_signature_and_type_signatures() throws Exception {
+        var objectType = ObjectType.builder()
+            .setInnerType("x", DataTypes.INTEGER)
+            .build();
+
+        var signature = Signature.builder()
+            .name("foo")
+            .kind(FunctionInfo.Type.SCALAR)
+            .argumentTypes(
+                parseTypeSignature("E"),
+                DataTypes.INTEGER.getTypeSignature(),
+                objectType.getTypeSignature()
+            )
+            .returnType(DataTypes.BIGINT_ARRAY.getTypeSignature())
+            .variableArityGroup(
+                List.of(
+                    DataTypes.INTEGER.getTypeSignature(),
+                    objectType.getTypeSignature()
+                )
+            )
+            .typeVariableConstraints(typeVariable("E"))
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        signature.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        var signature2 = new Signature(in);
+
+        assertThat(signature2, equalTo(signature));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -35,6 +35,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.SearchPath;
 import io.crate.test.integration.CrateUnitTest;
@@ -83,6 +84,13 @@ public abstract class AggregationTest extends CrateUnitTest {
             inputs = new InputCollectExpression[0];
         }
         AggregationFunction impl = (AggregationFunction) functions.getQualified(fi);
+        if (impl == null) {
+            impl = (AggregationFunction) functions.resolveBuiltInFunctionBySignature(
+                new FunctionName(null, name),
+                argumentTypes,
+                SearchPath.pathWithPGCatalogAndDoc()
+            );
+        }
         List<Object> states = new ArrayList<>();
         Version minNodeVersion = randomBoolean()
             ? Version.CURRENT
@@ -114,7 +122,7 @@ public abstract class AggregationTest extends CrateUnitTest {
         AggregationFunction function =
             (AggregationFunction) functions.get(null, functionName, arguments, SearchPath.pathWithPGCatalogAndDoc());
         return function.normalizeSymbol(
-            new Function(function.info(), arguments),
+            new Function(function.info(), function.signature(), arguments),
             new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -49,14 +49,14 @@ import java.util.UUID;
 import static org.hamcrest.core.Is.is;
 
 public class MergeNodeTest extends CrateUnitTest {
-
-
+    
     @Test
     public void testSerialization() throws Exception {
         List<Symbol> keys = Collections.singletonList(new InputColumn(0, DataTypes.STRING));
         List<Aggregation> aggregations = Collections.singletonList(
             new Aggregation(
                 CountAggregation.COUNT_STAR_FUNCTION,
+                CountAggregation.COUNT_STAR_SIGNATURE,
                 CountAggregation.COUNT_STAR_FUNCTION.returnType(),
                 Collections.emptyList()
             )

--- a/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -162,6 +162,7 @@ public class UpdateSettingsPlanTest extends CrateUnitTest {
     public void test_array_is_implicitly_converted_to_comma_separated_string() {
         var idsArray = new io.crate.expression.symbol.Function(
             ArrayFunction.createInfo(List.of(DataTypes.STRING, DataTypes.STRING)),
+            ArrayFunction.SIGNATURE,
             List.of(Literal.of("id1"), Literal.of("id2"))
         );
         Assignment<Symbol> assignment = new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), idsArray);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add support to lookup a function directly by its declared signature.
Before that, looking up a function which uses the signature based
registry, resulted in a full expensive signature match logic.
This improvement may fix related existing performance regressions.

Function implementations must carry the signature and also the signature
must be streamable in order for this to work.

We carry now both, a `FunctionIdent` and a `Signature` all through the
code base to be able to still support the old registry to migrate
all functions iterative.
Eventually the `FunctionInfo` (and `FunctionIdent`) should be replaced
by a `Signature` after all functions are migrated.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
