### PR TITLE
Fix OFFSET application for UNION with ORDER BY

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,5 +163,8 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused a ``OFFSET`` as part of a ``UNION`` to be applied
+  incorrectly.
+
 - Fixed an issue that could lead to incorrect ordering of a result sets if
   using ``ORDER BY`` on a column of type ``IP`` or on a scalar function.

--- a/sql/src/main/java/io/crate/planner/Merge.java
+++ b/sql/src/main/java/io/crate/planner/Merge.java
@@ -128,11 +128,8 @@ public class Merge implements ExecutionPlan, ResultDescription {
             subExecutionPlan.addProjection(projection);
         }
         if (topN != null) {
-            subExecutionPlan.addProjection(topN, TopN.NO_LIMIT, 0, null);
+            subExecutionPlan.addProjection(topN, TopN.NO_LIMIT, 0, resultDescription.orderBy());
         }
-        // resultDescription.orderBy can be ignored here because it is only relevant to do a sorted merge
-        // (of a pre-sorted result)
-        // In this case there is only one node/bucket which is already correctly sorted
         return subExecutionPlan;
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -91,12 +91,16 @@ public class Union implements LogicalPlan {
             : null;
 
         ExecutionPlan left = lhs.build(
-            plannerContext, projectionBuilder, limit + offset, offset, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
         ExecutionPlan right = rhs.build(
-            plannerContext, projectionBuilder, limit + offset, offset, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
 
-        left = addMergeIfNeeded(left, plannerContext);
-        right = addMergeIfNeeded(right, plannerContext);
+        if (left.resultDescription().hasRemainingLimitOrOffset()) {
+            left = Merge.ensureOnHandler(left, plannerContext);
+        }
+        if (right.resultDescription().hasRemainingLimitOrOffset()) {
+            right = Merge.ensureOnHandler(right, plannerContext);
+        }
 
         ResultDescription leftResultDesc = left.resultDescription();
         ResultDescription rightResultDesc = right.resultDescription();
@@ -194,22 +198,5 @@ public class Union implements LogicalPlan {
     @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitUnion(this, context);
-    }
-
-    /**
-     * Wraps the plan inside a Merge plan if limit or offset need to be applied.
-     */
-    private static ExecutionPlan addMergeIfNeeded(ExecutionPlan plan, PlannerContext plannerContext) {
-        ResultDescription resultDescription = plan.resultDescription();
-        if (resultDescription.hasRemainingLimitOrOffset()) {
-            // Do a merge because we have to apply a limit/offset projection
-            //
-            // Note: Currently, this is performed on the handler node. It would be possible to
-            // do this on another involved node instead but we don't do that for now because
-            // the Merge of the union itself is always performed on the handler. So the
-            // performance gain would be small.
-            return Merge.ensureOnHandler(plan, plannerContext);
-        }
-        return plan;
     }
 }

--- a/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -29,6 +29,7 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.LogicalPlannerTest;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -91,7 +92,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan, instanceOf(UnionExecutionPlan.class));
         UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
         assertThat(unionExecutionPlan.mergePhase().numInputs(), is(2));
-        assertThat(unionExecutionPlan.orderBy(), is(nullValue()));
+        assertThat(unionExecutionPlan.orderBy(), Matchers.notNullValue());
         assertThat(unionExecutionPlan.mergePhase().projections(), contains(
             instanceOf(TopNProjection.class)
         ));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The logical plan was correct, but the offset of the Limit operator was
passed down too far.

    Limit[100;1]                          // Due to the offset application below, OFFSET 2 was already applied *before* the LIMIT operator
      └ Union[id, num]                    // passed down (limit + offset) as limit BUT also offset (1)
        ├ OrderBy[max(num) AS num ASC]    // Resulted in a OrderedTopN with limit 101, offset 1
        │  └ Eval[id, max(num) AS num]
        │    └ GroupHashAggregate[id | max(num)]
        │      └ Rename[id, num] AS t
        │        └ TableFunction[unnest | [col1, col2] | true]
        └ OrderBy[max(num) AS num ASC]    // Same as above
          └ Eval[id, max(num) AS num]
            └ GroupHashAggregate[id | max(num)]
              └ Rename[id, num] AS t
                └ TableFunction[unnest | [col1, col2] | true]

Fixes https://github.com/crate/crate/issues/9854

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)