### PR TITLE
Drop guava dependecy from sql-parser.

### DIFF
--- a/sql-parser/build.gradle
+++ b/sql-parser/build.gradle
@@ -13,12 +13,11 @@ configurations {
 }
 
 dependencies {
-    implementation project(':shared')
     antlr4 "org.antlr:antlr4:${versions.antlr}"
-    compile "org.antlr:antlr4-runtime:${versions.antlr}"
+    implementation "org.antlr:antlr4-runtime:${versions.antlr}"
 
-    compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
-    compile "com.google.guava:guava:${versions.guava}"
+    implementation project(':shared')
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
 
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
     testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"

--- a/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -22,8 +22,6 @@
 
 package io.crate.sql;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.util.function.Predicate;
 
 public class Literals {
@@ -40,7 +38,6 @@ public class Literals {
         return EPSILON + "'" + literal + "'";
     }
 
-    @VisibleForTesting
     static String escapeStringLiteral(String literal) {
         return literal.replace("'", "''");
     }

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -22,7 +22,7 @@
 
 package io.crate.sql;
 
-import com.google.common.collect.Iterables;
+import io.crate.common.collections.Lists2;
 import io.crate.sql.tree.AliasedRelation;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.Assignment;
@@ -375,7 +375,7 @@ public final class SqlFormatter {
                     }
                 } else {
                     builder.append(' ');
-                    Iterables.getOnlyElement(node.getFrom()).accept(this, indent);
+                    Lists2.getOnlyElement(node.getFrom()).accept(this, indent);
                 }
             }
 
@@ -478,7 +478,7 @@ public final class SqlFormatter {
                 }
             } else {
                 builder.append(' ');
-                Iterables.getOnlyElement(node.getSelectItems()).accept(this, indent);
+                Lists2.getOnlyElement(node.getSelectItems()).accept(this, indent);
             }
 
             builder.append('\n');

--- a/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
@@ -21,11 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
 import io.crate.common.collections.Lists2;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -93,36 +93,34 @@ public class AddColumnDefinition<T> extends TableElement<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AddColumnDefinition that = (AddColumnDefinition) o;
-
-        if (!name.equals(that.name)) return false;
-        if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
-            that.generatedExpression != null) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        return constraints.equals(that.constraints);
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AddColumnDefinition<?> that = (AddColumnDefinition<?>) o;
+        return generated == that.generated &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(generatedExpression, that.generatedExpression) &&
+               Objects.equals(type, that.type) &&
+               Objects.equals(constraints, that.constraints);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + (generatedExpression != null ? generatedExpression.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + constraints.hashCode();
-        return result;
+        return Objects.hash(name, generatedExpression, generated, type, constraints);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("generatedExpression", generatedExpression)
-            .add("type", type)
-            .add("constraints", constraints)
-            .toString();
+        return "AddColumnDefinition{" +
+               "name=" + name +
+               ", generatedExpression=" + generatedExpression +
+               ", generated=" + generated +
+               ", type=" + type +
+               ", constraints=" + constraints +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
@@ -21,24 +21,20 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-
 import java.util.List;
+import java.util.Objects;
 
-public class AliasedRelation
-    extends Relation {
+import static java.util.Objects.requireNonNull;
+
+public class AliasedRelation extends Relation {
+
     private final Relation relation;
     private final String alias;
     private final List<String> columnNames;
 
     public AliasedRelation(Relation relation, String alias, List<String> columnNames) {
-        Preconditions.checkNotNull(relation, "relation is null");
-        Preconditions.checkNotNull(alias, "alias is null");
-        Preconditions.checkNotNull(columnNames, "columnNames is null");
-
-        this.relation = relation;
-        this.alias = alias;
+        this.relation = requireNonNull(relation, "relation is null");
+        this.alias = requireNonNull(alias, "alias is null");
         this.columnNames = columnNames;
     }
 
@@ -60,16 +56,6 @@ public class AliasedRelation
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("relation", relation)
-            .add("alias", alias)
-            .add("columnNames", columnNames)
-            .omitNullValues()
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -77,28 +63,23 @@ public class AliasedRelation
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         AliasedRelation that = (AliasedRelation) o;
-
-        if (!alias.equals(that.alias)) {
-            return false;
-        }
-        if (!columnNames.equals(that.columnNames)) {
-            return false;
-        }
-        if (!relation.equals(that.relation)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(relation, that.relation) &&
+               Objects.equals(alias, that.alias) &&
+               Objects.equals(columnNames, that.columnNames);
     }
 
     @Override
     public int hashCode() {
-        int result = relation.hashCode();
-        result = 31 * result + alias.hashCode();
-        result = 31 * result + (columnNames != null ? columnNames.hashCode() : 0);
-        return result;
+        return Objects.hash(relation, alias, columnNames);
     }
 
+    @Override
+    public String toString() {
+        return "AliasedRelation{" +
+               "relation=" + relation +
+               ", alias='" + alias + '\'' +
+               ", columnNames=" + columnNames +
+               '}';
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
@@ -21,8 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
-
+import java.util.Objects;
 import java.util.Optional;
 
 public class AllColumns extends SelectItem {
@@ -34,8 +33,7 @@ public class AllColumns extends SelectItem {
     }
 
     public AllColumns(QualifiedName prefix) {
-        Preconditions.checkNotNull(prefix, "prefix is null");
-        this.prefix = Optional.of(prefix);
+        this.prefix = Optional.ofNullable(prefix);
     }
 
     public Optional<QualifiedName> getPrefix() {
@@ -55,27 +53,17 @@ public class AllColumns extends SelectItem {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         AllColumns that = (AllColumns) o;
-
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(prefix, that.prefix);
     }
 
     @Override
     public int hashCode() {
-        return prefix != null ? prefix.hashCode() : 0;
+        return Objects.hash(prefix);
     }
 
     @Override
     public String toString() {
-        if (prefix.isPresent()) {
-            return prefix.get() + ".*";
-        }
-
-        return "*";
+        return prefix.map(qualifiedName -> qualifiedName + ".*").orElse("*");
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
@@ -21,10 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class AlterTable<T> extends Statement {
@@ -36,7 +34,7 @@ public class AlterTable<T> extends Statement {
     public AlterTable(Table<T> table, GenericProperties<T> genericProperties) {
         this.table = table;
         this.genericProperties = genericProperties;
-        this.resetProperties = ImmutableList.of();
+        this.resetProperties = List.of();
     }
 
     public AlterTable(Table<T> table, List<String> resetProperties) {
@@ -77,29 +75,30 @@ public class AlterTable<T> extends Statement {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("properties", genericProperties).toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AlterTable that = (AlterTable) o;
-
-        if (!genericProperties.equals(that.genericProperties)) return false;
-        if (!table.equals(that.table)) return false;
-
-        return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterTable<?> that = (AlterTable<?>) o;
+        return Objects.equals(table, that.table) &&
+               Objects.equals(genericProperties, that.genericProperties) &&
+               Objects.equals(resetProperties, that.resetProperties);
     }
 
     @Override
     public int hashCode() {
-        int result = table.hashCode();
-        result = 31 * result + genericProperties.hashCode();
-        return result;
+        return Objects.hash(table, genericProperties, resetProperties);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterTable{" +
+               "table=" + table +
+               ", genericProperties=" + genericProperties +
+               ", resetProperties=" + resetProperties +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableAddColumn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableAddColumn.java
@@ -21,7 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
 public class AlterTableAddColumn<T> extends Statement {
 
@@ -43,29 +43,28 @@ public class AlterTableAddColumn<T> extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof AlterTableAddColumn)) return false;
-
-        AlterTableAddColumn that = (AlterTableAddColumn) o;
-
-        if (!table.equals(that.table)) return false;
-        if (!addColumnDefinition.equals(that.addColumnDefinition)) return false;
-
-        return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterTableAddColumn<?> that = (AlterTableAddColumn<?>) o;
+        return Objects.equals(table, that.table) &&
+               Objects.equals(addColumnDefinition, that.addColumnDefinition);
     }
 
     @Override
     public int hashCode() {
-        int result = addColumnDefinition.hashCode();
-        result = 31 * result + table.hashCode();
-        return result;
+        return Objects.hash(table, addColumnDefinition);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("element", addColumnDefinition).toString();
+        return "AlterTableAddColumn{" +
+               "table=" + table +
+               ", addColumnDefinition=" + addColumnDefinition +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableOpenClose.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableOpenClose.java
@@ -22,7 +22,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
 public class AlterTableOpenClose<T> extends Statement {
 
@@ -35,7 +35,6 @@ public class AlterTableOpenClose<T> extends Statement {
         this.blob = blob;
         this.openTable = openTable;
     }
-
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
@@ -55,32 +54,30 @@ public class AlterTableOpenClose<T> extends Statement {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("blob", blob)
-            .add("open table", openTable).toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AlterTableOpenClose that = (AlterTableOpenClose) o;
-
-        if (!blob == that.blob) return false;
-        if (!openTable == that.openTable) return false;
-        if (!table.equals(that.table)) return false;
-
-        return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterTableOpenClose<?> that = (AlterTableOpenClose<?>) o;
+        return blob == that.blob &&
+               openTable == that.openTable &&
+               Objects.equals(table, that.table);
     }
 
     @Override
     public int hashCode() {
-        int result = table.hashCode();
-        result = 31 * result + (blob ? 1 : 0);
-        result = 31 * result + Boolean.hashCode(openTable);
-        return result;
+        return Objects.hash(table, blob, openTable);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterTableOpenClose{" +
+               "table=" + table +
+               ", blob=" + blob +
+               ", open table=" + openTable +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
@@ -22,7 +22,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
 public class AlterTableRename<T> extends Statement {
 
@@ -35,7 +35,6 @@ public class AlterTableRename<T> extends Statement {
         this.blob = blob;
         this.newName = newName;
     }
-
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
@@ -55,32 +54,30 @@ public class AlterTableRename<T> extends Statement {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("blob", blob)
-            .add("new name", newName).toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AlterTableRename that = (AlterTableRename) o;
-
-        if (!blob == that.blob) return false;
-        if (!newName.equals(that.newName)) return false;
-        if (!table.equals(that.table)) return false;
-
-        return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterTableRename<?> that = (AlterTableRename<?>) o;
+        return blob == that.blob &&
+               Objects.equals(table, that.table) &&
+               Objects.equals(newName, that.newName);
     }
 
     @Override
     public int hashCode() {
-        int result = table.hashCode();
-        result = 31 * result + (blob ? 1 : 0);
-        result = 31 * result + newName.hashCode();
-        return result;
+        return Objects.hash(table, blob, newName);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterTableRename{" +
+               "table=" + table +
+               ", blob=" + blob +
+               ", new name=" + newName +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
@@ -22,9 +22,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.function.Function;
 
 public class AlterUser<T> extends Statement {
@@ -51,26 +49,28 @@ public class AlterUser<T> extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AlterUser alterUser = (AlterUser) o;
-
-        if (!properties.equals(alterUser.properties)) return false;
-        return name.equals(alterUser.name);
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterUser<?> alterUser = (AlterUser<?>) o;
+        return Objects.equals(properties, alterUser.properties) &&
+               Objects.equals(name, alterUser.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, properties);
+        return Objects.hash(properties, name);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("properties", properties)
-            .toString();
+        return "AlterUser{" +
+               "properties=" + properties +
+               ", name='" + name + '\'' +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Assignment.java
@@ -21,14 +21,14 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import io.crate.common.collections.Lists2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 public class Assignment<T> extends Node {
 
@@ -44,9 +44,7 @@ public class Assignment<T> extends Node {
      * VALUE, VALUE, ...   -> two or more items in expressions list
      */
     public Assignment(T columnName, List<T> expressions) {
-        Preconditions.checkNotNull(columnName, "columnname is null");
-        Preconditions.checkNotNull(expressions, "expression is null");
-        this.columnName = columnName;
+        this.columnName = requireNonNull(columnName, "columnName is null");
         this.expressions = expressions;
     }
 
@@ -55,10 +53,8 @@ public class Assignment<T> extends Node {
      * only single expression is allowed on right side of assignment
      */
     public Assignment(T columnName, T expression) {
-        Preconditions.checkNotNull(columnName, "columnname is null");
-        Preconditions.checkNotNull(expression, "expression is null");
-        this.columnName = columnName;
-        this.expressions = Collections.singletonList(expression);
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.expressions = Collections.singletonList(requireNonNull(expression, "expression is null"));
     }
 
     public T columnName() {
@@ -78,30 +74,29 @@ public class Assignment<T> extends Node {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(columnName, expressions);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Assignment<?> that = (Assignment<?>) o;
+        return Objects.equals(columnName, that.columnName) &&
+               Objects.equals(expressions, that.expressions);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnName, expressions);
+    }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("column", columnName)
-            .add("expressions", expressions)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Assignment that = (Assignment) o;
-
-        if (!columnName.equals(that.columnName)) return false;
-        if (!expressions.equals(that.expressions)) return false;
-
-        return true;
+        return "Assignment{" +
+               "column=" + columnName +
+               ", expressions=" + expressions +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/BetweenPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/BetweenPredicate.java
@@ -21,7 +21,9 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class BetweenPredicate
     extends Expression {
@@ -30,13 +32,9 @@ public class BetweenPredicate
     private final Expression max;
 
     public BetweenPredicate(Expression value, Expression min, Expression max) {
-        Preconditions.checkNotNull(value, "value is null");
-        Preconditions.checkNotNull(min, "min is null");
-        Preconditions.checkNotNull(max, "max is null");
-
-        this.value = value;
-        this.min = min;
-        this.max = max;
+        this.value = requireNonNull(value, "value is null");
+        this.min = requireNonNull(min, "min is null");
+        this.max = requireNonNull(max, "max is null");
     }
 
     public Expression getValue() {
@@ -64,27 +62,14 @@ public class BetweenPredicate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         BetweenPredicate that = (BetweenPredicate) o;
-
-        if (!max.equals(that.max)) {
-            return false;
-        }
-        if (!min.equals(that.min)) {
-            return false;
-        }
-        if (!value.equals(that.value)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(value, that.value) &&
+               Objects.equals(min, that.min) &&
+               Objects.equals(max, that.max);
     }
 
     @Override
     public int hashCode() {
-        int result = value.hashCode();
-        result = 31 * result + min.hashCode();
-        result = 31 * result + max.hashCode();
-        return result;
+        return Objects.hash(value, min, max);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/BooleanLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/BooleanLiteral.java
@@ -21,9 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class BooleanLiteral extends Literal {
+
     public static final BooleanLiteral TRUE_LITERAL = new BooleanLiteral(true);
     public static final BooleanLiteral FALSE_LITERAL = new BooleanLiteral(false);
 
@@ -43,19 +44,19 @@ public class BooleanLiteral extends Literal {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(value);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BooleanLiteral that = (BooleanLiteral) o;
+        return value == that.value;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        final BooleanLiteral other = (BooleanLiteral) obj;
-        return Objects.equal(this.value, other.value);
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Cast.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Cast.java
@@ -21,17 +21,13 @@
 
 package io.crate.sql.tree;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
-public class Cast
-    extends Expression {
+public class Cast extends Expression {
     private final Expression expression;
     private final ColumnType type;
 
     public Cast(Expression expression, ColumnType type) {
-        checkNotNull(expression, "expression is null");
-        checkNotNull(type, "type is null");
-
         this.expression = expression;
         this.type = type;
     }
@@ -57,23 +53,13 @@ public class Cast
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         Cast cast = (Cast) o;
-
-        if (!expression.equals(cast.expression)) {
-            return false;
-        }
-        if (!type.equals(cast.type)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(expression, cast.expression) &&
+               Objects.equals(type, cast.type);
     }
 
     @Override
     public int hashCode() {
-        int result = expression.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
+        return Objects.hash(expression, type);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
@@ -21,9 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -51,28 +49,29 @@ public final class ClusteredBy<T> extends Node {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(column, numberOfShards);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClusteredBy<?> that = (ClusteredBy<?>) o;
+        return Objects.equals(column, that.column) &&
+               Objects.equals(numberOfShards, that.numberOfShards);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ClusteredBy that = (ClusteredBy) o;
-
-        if (!numberOfShards.equals(that.numberOfShards)) return false;
-        if (!column.equals(that.column)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(column, numberOfShards);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("column", column)
-            .add("number of shards", numberOfShards).toString();
+        return "ClusteredBy{" +
+               "column=" + column +
+               ", number of shards=" + numberOfShards +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
@@ -21,12 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.crate.common.collections.Lists2;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -113,37 +112,37 @@ public class ColumnDefinition<T> extends TableElement<T> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(ident, defaultExpression, generatedExpression, type, constraints);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnDefinition<?> that = (ColumnDefinition<?>) o;
+        return generated == that.generated &&
+               Objects.equals(ident, that.ident) &&
+               Objects.equals(defaultExpression, that.defaultExpression) &&
+               Objects.equals(generatedExpression, that.generatedExpression) &&
+               Objects.equals(type, that.type) &&
+               Objects.equals(constraints, that.constraints);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ColumnDefinition that = (ColumnDefinition) o;
-
-        if (!ident.equals(that.ident)) return false;
-        if (defaultExpression != null ? !defaultExpression.equals(that.defaultExpression) :
-            that.defaultExpression != null) return false;
-        if (generatedExpression != null ? !generatedExpression.equals(that.generatedExpression) :
-            that.generatedExpression != null) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        return constraints.equals(that.constraints);
-
+    public int hashCode() {
+        return Objects.hash(ident, defaultExpression, generatedExpression, generated, type, constraints);
     }
-
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("ident", ident)
-            .add("defaultExpression", defaultExpression)
-            .add("generatedExpression", generatedExpression)
-            .add("type", type)
-            .add("constraints", constraints)
-            .toString();
+        return "ColumnDefinition{" +
+               "ident='" + ident + '\'' +
+               ", defaultExpression=" + defaultExpression +
+               ", generatedExpression=" + generatedExpression +
+               ", generated=" + generated +
+               ", type=" + type +
+               ", constraints=" + constraints +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
@@ -22,8 +22,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -57,9 +55,13 @@ public class ColumnStorageDefinition<T> extends ColumnConstraint<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ColumnStorageDefinition that = (ColumnStorageDefinition) o;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnStorageDefinition<?> that = (ColumnStorageDefinition<?>) o;
         return Objects.equals(properties, that.properties);
     }
 
@@ -70,8 +72,8 @@ public class ColumnStorageDefinition<T> extends ColumnConstraint<T> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("properties", properties)
-            .toString();
+        return "ColumnStorageDefinition{" +
+               "properties=" + properties +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ComparisonExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ComparisonExpression.java
@@ -21,10 +21,12 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class ComparisonExpression
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class ComparisonExpression extends Expression {
+
     public enum Type {
         EQUAL("="),
         NOT_EQUAL("<>"),
@@ -56,13 +58,9 @@ public class ComparisonExpression
     private final Expression right;
 
     public ComparisonExpression(Type type, Expression left, Expression right) {
-        Preconditions.checkNotNull(type, "type is null");
-        Preconditions.checkNotNull(left, "left is null");
-        Preconditions.checkNotNull(right, "right is null");
-
         this.type = type;
-        this.left = left;
-        this.right = right;
+        this.left = requireNonNull(left, "left is null");
+        this.right = requireNonNull(right, "right is null");
     }
 
     public Type getType() {
@@ -90,28 +88,14 @@ public class ComparisonExpression
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         ComparisonExpression that = (ComparisonExpression) o;
-
-        if (!left.equals(that.left)) {
-            return false;
-        }
-        if (!right.equals(that.right)) {
-            return false;
-        }
-        if (type != that.type) {
-            return false;
-        }
-
-        return true;
+        return type == that.type &&
+               Objects.equals(left, that.left) &&
+               Objects.equals(right, that.right);
     }
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + left.hashCode();
-        result = 31 * result + right.hashCode();
-        return result;
+        return Objects.hash(type, left, right);
     }
 }
-

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
@@ -21,8 +21,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
@@ -89,10 +87,11 @@ public class CreateBlobTable<T> extends Statement {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("clusteredBy", clusteredBy)
-            .add("properties", genericProperties).toString();
+        return "CreateBlobTable{" +
+               "name=" + name +
+               ", clusteredBy=" + clusteredBy +
+               ", properties=" + genericProperties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateRepository.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateRepository.java
@@ -21,8 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class CreateRepository<T> extends Statement {
 
@@ -51,28 +50,31 @@ public class CreateRepository<T> extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(repository, type, properties);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CreateRepository<?> that = (CreateRepository<?>) o;
+        return Objects.equals(repository, that.repository) &&
+               Objects.equals(type, that.type) &&
+               Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        CreateRepository that = (CreateRepository) obj;
-        if (!repository.equals(that.repository)) return false;
-        if (!type.equals(that.type)) return false;
-        if (!properties.equals(that.properties)) return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(repository, type, properties);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("repository", repository)
-            .add("type", type)
-            .add("properties", properties).toString();
+        return "CreateRepository{" +
+               "repository=" + repository +
+               ", type=" + type +
+               ", properties=" + properties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateUser.java
@@ -22,8 +22,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class CreateUser<T> extends Statement {
 
@@ -43,28 +42,31 @@ public class CreateUser<T> extends Statement {
         return properties;
     }
 
+
     @Override
-    public int hashCode() {
-        return Objects.hashCode(name, properties);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CreateUser<?> that = (CreateUser<?>) o;
+        return Objects.equals(name, that.name) &&
+               Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        CreateUser that = (CreateUser)obj;
-        if (!name.equals(that.name)) return false;
-        if (!properties.equals(that.properties)) return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(name, properties);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("properties", properties)
-            .toString();
+        return "CreateUser{" +
+               "name='" + name + '\'' +
+               ", properties=" + properties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/CurrentTime.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CurrentTime.java
@@ -22,9 +22,8 @@
 package io.crate.sql.tree;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CurrentTime extends Expression {
 
@@ -42,7 +41,6 @@ public class CurrentTime extends Expression {
     }
 
     public CurrentTime(Type type, @Nullable Integer precision) {
-        checkNotNull(type, "type is null");
         this.type = type;
         this.precision = Optional.ofNullable(precision);
     }
@@ -68,23 +66,13 @@ public class CurrentTime extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         CurrentTime that = (CurrentTime) o;
-
-        if (!precision.equals(that.precision)) {
-            return false;
-        }
-        if (type != that.type) {
-            return false;
-        }
-
-        return true;
+        return type == that.type &&
+               Objects.equals(precision, that.precision);
     }
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + precision.hashCode();
-        return result;
+        return Objects.hash(type, precision);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Delete.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Delete.java
@@ -21,11 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-
+import java.util.Objects;
 import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class Delete extends Statement {
 
@@ -33,8 +32,7 @@ public class Delete extends Statement {
     private final Optional<Expression> where;
 
     public Delete(Relation relation, Optional<Expression> where) {
-        Preconditions.checkNotNull(relation, "relation is null");
-        this.relation = relation;
+        this.relation = requireNonNull(relation, "relation is null");
         this.where = where;
     }
 
@@ -51,31 +49,29 @@ public class Delete extends Statement {
         return visitor.visitDelete(this, context);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Delete delete = (Delete) o;
+        return Objects.equals(relation, delete.relation) &&
+               Objects.equals(where, delete.where);
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(relation, where);
+        return Objects.hash(relation, where);
     }
-
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("relation", relation)
-            .add("where", where)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Delete delete = (Delete) o;
-
-        if (relation != null ? !relation.equals(delete.relation) : delete.relation != null) return false;
-        if (where != null ? !where.equals(delete.where) : delete.where != null) return false;
-
-        return true;
+        return "Delete{" +
+               "relation=" + relation +
+               ", where=" + where +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
@@ -21,15 +21,14 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import static java.util.Objects.requireNonNull;
 
-public class DoubleLiteral
-    extends Literal {
+public class DoubleLiteral extends Literal {
+
     private final double value;
 
     public DoubleLiteral(String value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = Double.parseDouble(value);
+        this.value = Double.parseDouble(requireNonNull(value, "value is null"));
     }
 
     public double getValue() {
@@ -49,14 +48,8 @@ public class DoubleLiteral
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         DoubleLiteral that = (DoubleLiteral) o;
-
-        if (Double.compare(that.value, value) != 0) {
-            return false;
-        }
-
-        return true;
+        return Double.compare(that.value, value) == 0;
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropBlobTable.java
@@ -21,8 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+
+import java.util.Objects;
 
 public class DropBlobTable<T> extends Statement {
 
@@ -39,21 +39,13 @@ public class DropBlobTable<T> extends Statement {
         return ignoreNonExistentTable;
     }
 
-    public Table table() {
+    public Table<T> table() {
         return table;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitDropBlobTable(this, context);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("ignoreNonExistentTable", ignoreNonExistentTable)
-            .toString();
     }
 
     @Override
@@ -64,17 +56,21 @@ public class DropBlobTable<T> extends Statement {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        DropBlobTable that = (DropBlobTable) o;
-        if (this.ignoreNonExistentTable != that.ignoreNonExistentTable) {
-            return false;
-        }
-        return table.equals(that.table);
-
+        DropBlobTable<?> that = (DropBlobTable<?>) o;
+        return ignoreNonExistentTable == that.ignoreNonExistentTable &&
+               Objects.equals(table, that.table);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(table, ignoreNonExistentTable);
+        return Objects.hash(table, ignoreNonExistentTable);
+    }
+
+    @Override
+    public String toString() {
+        return "DropBlobTable{" +
+               "table=" + table +
+               ", ignoreNonExistentTable=" + ignoreNonExistentTable +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropSnapshot.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropSnapshot.java
@@ -21,8 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class DropSnapshot extends Statement {
 
@@ -37,22 +36,27 @@ public class DropSnapshot extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(name);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DropSnapshot that = (DropSnapshot) o;
+        return Objects.equals(name, that.name);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-        return name.equals(((DropSnapshot) obj).name);
+    public int hashCode() {
+        return Objects.hash(name);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .toString();
+        return "DropSnapshot{" +
+               "name=" + name +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
@@ -21,8 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+
+import java.util.Objects;
 
 public class DropTable<T> extends Statement {
 
@@ -48,31 +48,28 @@ public class DropTable<T> extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(table, dropIfExists);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DropTable that = (DropTable) obj;
-        if (this.dropIfExists != that.dropIfExists) {
-            return false;
-        }
-        return table.equals(that.table);
-
+        DropTable<?> dropTable = (DropTable<?>) o;
+        return dropIfExists == dropTable.dropIfExists &&
+               Objects.equals(table, dropTable.table);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("dropIfExists", dropIfExists)
-            .toString();
+        return "DropTable{" +
+               "table=" + table +
+               ", dropIfExists=" + dropIfExists +
+               '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(table, dropIfExists);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropUser.java
@@ -22,7 +22,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
 public class DropUser extends Statement {
 
@@ -43,27 +43,29 @@ public class DropUser extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return 31 * name.hashCode() + (ifExists ? 1 : 0);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DropUser dropUser = (DropUser) o;
+        return ifExists == dropUser.ifExists &&
+               Objects.equals(name, dropUser.name);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        DropUser that = (DropUser)obj;
-        if (!name.equals(that.name)) return false;
-        if (ifExists != that.ifExists) return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(name, ifExists);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("ifExists", ifExists)
-            .toString();
+        return "DropUser{" +
+               "name='" + name + '\'' +
+               ", ifExists=" + ifExists +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Except.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Except.java
@@ -21,9 +21,9 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class Except extends SetOperation {
 
@@ -31,8 +31,8 @@ public class Except extends SetOperation {
     private final Relation right;
 
     public Except(Relation left, Relation right) {
-        this.left = Preconditions.checkNotNull(left, "relation must not be null");
-        this.right = Preconditions.checkNotNull(right, "relation must not be null");
+        this.left = requireNonNull(left, "relation must not be null");
+        this.right = requireNonNull(right, "relation must not be null");
     }
 
     public Relation getLeft() {
@@ -49,27 +49,28 @@ public class Except extends SetOperation {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("left", left)
-            .add("right", right)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Except o = (Except) obj;
-        return Objects.equal(left, o.left) && Objects.equal(right, o.right);
+        Except except = (Except) o;
+        return Objects.equals(left, except.left) &&
+               Objects.equals(right, except.right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(left, right);
+        return Objects.hash(left, right);
+    }
+
+    @Override
+    public String toString() {
+        return "Except{" +
+               "left=" + left +
+               ", right=" + right +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ExistsPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ExistsPredicate.java
@@ -21,15 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class ExistsPredicate
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class ExistsPredicate extends Expression {
+
     private final Query subquery;
 
     public ExistsPredicate(Query subquery) {
-        Preconditions.checkNotNull(subquery, "subquery is null");
-        this.subquery = subquery;
+        this.subquery = requireNonNull(subquery, "subquery is null");
     }
 
     public Query getSubquery() {
@@ -49,18 +50,12 @@ public class ExistsPredicate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         ExistsPredicate that = (ExistsPredicate) o;
-
-        if (!subquery.equals(that.subquery)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(subquery, that.subquery);
     }
 
     @Override
     public int hashCode() {
-        return subquery.hashCode();
+        return Objects.hash(subquery);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Explain.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Explain.java
@@ -21,18 +21,17 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
-public class Explain
-    extends Statement {
+public class Explain extends Statement {
+
     private final Statement statement;
     private final boolean analyze;
 
     public Explain(Statement statement, boolean analyze) {
-        this.statement = checkNotNull(statement, "statement is null");
+        this.statement = requireNonNull(statement, "statement is null");
         this.analyze = analyze;
     }
 
@@ -50,26 +49,28 @@ public class Explain
     }
 
     @Override
-    public int hashCode() {
-        return statement.hashCode();
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Explain explain = (Explain) o;
+        return analyze == explain.analyze &&
+               Objects.equals(statement, explain.statement);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if ((obj == null) || (getClass() != obj.getClass())) {
-            return false;
-        }
-        Explain o = (Explain) obj;
-        return Objects.equal(statement, o.statement);
+    public int hashCode() {
+        return Objects.hash(statement, analyze);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("statement", statement)
-            .toString();
+        return "Explain{" +
+               "statement=" + statement +
+               ", analyze=" + analyze +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
@@ -23,8 +23,9 @@ package io.crate.sql.tree;
 
 import javax.annotation.concurrent.Immutable;
 import java.util.Locale;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class Extract extends Expression {
@@ -53,9 +54,8 @@ public class Extract extends Expression {
     }
 
     public Extract(Expression expression, StringLiteral field) {
-        checkNotNull(expression, "expression is null");
         // field: ident is converted to StringLiteral in SqlBase.g
-        this.expression = expression;
+        this.expression = requireNonNull(expression, "expression is null");
         this.field = Field.valueOf(field.getValue().toUpperCase(Locale.ENGLISH));
     }
 
@@ -80,23 +80,13 @@ public class Extract extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        Extract that = (Extract) o;
-
-        if (!expression.equals(that.expression)) {
-            return false;
-        }
-        if (!field.equals(that.field)) {
-            return false;
-        }
-
-        return true;
+        Extract extract = (Extract) o;
+        return Objects.equals(expression, extract.expression) &&
+               field == extract.field;
     }
 
     @Override
     public int hashCode() {
-        int result = expression.hashCode();
-        result = 31 * result + field.hashCode();
-        return result;
+        return Objects.hash(expression, field);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -21,12 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -49,7 +47,7 @@ import java.util.function.Function;
  */
 public class GenericProperties<T> extends Node {
 
-    private static final GenericProperties<?> EMPTY = new GenericProperties<>(ImmutableMap.of());
+    private static final GenericProperties<?> EMPTY = new GenericProperties<>(Map.of());
 
     public static <T> GenericProperties<T> empty() {
         return (GenericProperties<T>) EMPTY;
@@ -100,20 +98,20 @@ public class GenericProperties<T> extends Node {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(properties);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GenericProperties<?> that = (GenericProperties<?>) o;
+        return Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        GenericProperties that = (GenericProperties) o;
-
-        if (!properties.equals(that.properties)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(properties);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
@@ -21,8 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * A key-value entry mapping a string to a list of <code>Expression</code>s.
@@ -54,29 +53,29 @@ public class GenericProperty<T> extends AnalyzerElement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(key, value);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GenericProperty<?> that = (GenericProperty<?>) o;
+        return Objects.equals(key, that.key) &&
+               Objects.equals(value, that.value);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        GenericProperty that = (GenericProperty) o;
-
-        if (!key.equals(that.key)) return false;
-        if (!value.equals(that.value)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(key, value);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("key", key)
-            .add("value", value)
-            .toString();
+        return "GenericProperty{" +
+               "key='" + key + '\'' +
+               ", value=" + value +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/IfExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IfExpression.java
@@ -21,23 +21,23 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * IF(v1,v2[,v3]): CASE WHEN v1 THEN v2 [ELSE v3] END
  */
 public class IfExpression extends Expression {
+
     private final Expression condition;
     private final Expression trueValue;
     private final Optional<Expression> falseValue;
 
     public IfExpression(Expression condition, Expression trueValue, Optional<Expression> falseValue) {
-        this.condition = checkNotNull(condition, "condition is null");
-        this.trueValue = checkNotNull(trueValue, "trueValue is null");
+        this.condition = requireNonNull(condition, "condition is null");
+        this.trueValue = requireNonNull(trueValue, "trueValue is null");
         this.falseValue = falseValue;
     }
 
@@ -59,21 +59,21 @@ public class IfExpression extends Expression {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        IfExpression o = (IfExpression) obj;
-        return Objects.equal(condition, o.condition) &&
-               Objects.equal(trueValue, o.trueValue) &&
-               Objects.equal(falseValue, o.falseValue);
+        IfExpression that = (IfExpression) o;
+        return Objects.equals(condition, that.condition) &&
+               Objects.equals(trueValue, that.trueValue) &&
+               Objects.equals(falseValue, that.falseValue);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(condition, trueValue, falseValue);
+        return Objects.hash(condition, trueValue, falseValue);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
@@ -21,9 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -52,29 +50,29 @@ public class IndexColumnConstraint<T> extends ColumnConstraint<T> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(indexMethod, properties);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexColumnConstraint<?> that = (IndexColumnConstraint<?>) o;
+        return Objects.equals(indexMethod, that.indexMethod) &&
+               Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        IndexColumnConstraint that = (IndexColumnConstraint) o;
-
-        if (!indexMethod.equals(that.indexMethod)) return false;
-        if (!properties.equals(that.properties)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(indexMethod, properties);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("method", indexMethod)
-            .add("properties", properties)
-            .toString();
+        return "IndexColumnConstraint{" +
+               "method='" + indexMethod + '\'' +
+               ", properties=" + properties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
@@ -21,11 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -60,33 +59,33 @@ public class IndexDefinition<T> extends TableElement<T> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(ident, method, columns, properties);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexDefinition<?> that = (IndexDefinition<?>) o;
+        return Objects.equals(ident, that.ident) &&
+               Objects.equals(method, that.method) &&
+               Objects.equals(columns, that.columns) &&
+               Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        IndexDefinition that = (IndexDefinition) o;
-
-        if (!columns.equals(that.columns)) return false;
-        if (!ident.equals(that.ident)) return false;
-        if (!method.equals(that.method)) return false;
-        if (!properties.equals(that.properties)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(ident, method, columns, properties);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("ident", ident)
-            .add("method", method)
-            .add("columns", columns)
-            .add("properties", properties)
-            .toString();
+        return "IndexDefinition{" +
+               "ident='" + ident + '\'' +
+               ", method='" + method + '\'' +
+               ", columns=" + columns +
+               ", properties=" + properties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -21,11 +21,9 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public final class Insert<T> extends Statement {
 
@@ -47,7 +45,7 @@ public final class Insert<T> extends Statement {
         this.returning = returning;
     }
 
-    public Table table() {
+    public Table<T> table() {
         return table;
     }
 
@@ -68,11 +66,6 @@ public final class Insert<T> extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(table, columns, insertSource, returning);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -81,20 +74,27 @@ public final class Insert<T> extends Statement {
             return false;
         }
         Insert<?> insert = (Insert<?>) o;
-        return table.equals(insert.table) &&
-               columns.equals(insert.columns) &&
-               insertSource.equals(insert.insertSource) &&
-               returning.equals(insert.returning);
+        return Objects.equals(table, insert.table) &&
+               Objects.equals(duplicateKeyContext, insert.duplicateKeyContext) &&
+               Objects.equals(columns, insert.columns) &&
+               Objects.equals(insertSource, insert.insertSource) &&
+               Objects.equals(returning, insert.returning);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(table, duplicateKeyContext, columns, insertSource, returning);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("columns", columns)
-            .add("insertSource", insertSource)
-            .add("returning", returning)
-            .toString();
+        return "Insert{" +
+               "table=" + table +
+               ", duplicateKeyContext=" + duplicateKeyContext +
+               ", columns=" + columns +
+               ", insertSource=" + insertSource +
+               ", returning=" + returning +
+               '}';
     }
 
     @Override
@@ -139,6 +139,34 @@ public final class Insert<T> extends Statement {
 
         public List<String> getConstraintColumns() {
             return constraintColumns;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DuplicateKeyContext<?> that = (DuplicateKeyContext<?>) o;
+            return type == that.type &&
+                   Objects.equals(onDuplicateKeyAssignments, that.onDuplicateKeyAssignments) &&
+                   Objects.equals(constraintColumns, that.constraintColumns);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, onDuplicateKeyAssignments, constraintColumns);
+        }
+
+        @Override
+        public String toString() {
+            return "DuplicateKeyContext{" +
+                   "type=" + type +
+                   ", onDuplicateKeyAssignments=" + onDuplicateKeyAssignments +
+                   ", constraintColumns=" + constraintColumns +
+                   '}';
         }
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
@@ -21,9 +21,9 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class Intersect extends SetOperation {
 
@@ -31,8 +31,8 @@ public class Intersect extends SetOperation {
     private final Relation right;
 
     public Intersect(Relation left, Relation right) {
-        this.left = Preconditions.checkNotNull(left, "relation must not be null");
-        this.right = Preconditions.checkNotNull(right, "relation must not be null");
+        this.left = requireNonNull(left, "relation must not be null");
+        this.right = requireNonNull(right, "relation must not be null");
     }
 
     public Relation getLeft() {
@@ -49,27 +49,28 @@ public class Intersect extends SetOperation {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("left", left)
-            .add("right", right)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Intersect o = (Intersect) obj;
-        return Objects.equal(left, o.left) && Objects.equal(right, o.right);
+        Intersect intersect = (Intersect) o;
+        return Objects.equals(left, intersect.left) &&
+               Objects.equals(right, intersect.right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(left, right);
+        return Objects.hash(left, right);
+    }
+
+    @Override
+    public String toString() {
+        return "Intersect{" +
+               "left=" + left +
+               ", right=" + right +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/IsNotNullPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IsNotNullPredicate.java
@@ -21,15 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class IsNotNullPredicate
     extends Expression {
     private final Expression value;
 
     public IsNotNullPredicate(Expression value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = value;
+        this.value = requireNonNull(value, "value is null");
     }
 
     public Expression getValue() {
@@ -49,18 +50,12 @@ public class IsNotNullPredicate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         IsNotNullPredicate that = (IsNotNullPredicate) o;
-
-        if (!value.equals(that.value)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/IsNullPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IsNullPredicate.java
@@ -21,15 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class IsNullPredicate
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class IsNullPredicate extends Expression {
+
     private final Expression value;
 
     public IsNullPredicate(Expression value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = value;
+        this.value = requireNonNull(value, "value is null");
     }
 
     public Expression getValue() {
@@ -49,18 +50,12 @@ public class IsNullPredicate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         IsNullPredicate that = (IsNullPredicate) o;
-
-        if (!value.equals(that.value)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Join.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Join.java
@@ -21,26 +21,27 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class Join extends Relation {
+
     public Join(Type type, Relation left, Relation right, Optional<JoinCriteria> criteria) {
-        checkNotNull(left, "left is null");
-        checkNotNull(right, "right is null");
         if (type.equals(Type.CROSS)) {
-            checkArgument(!criteria.isPresent(), "Cross join cannot have join criteria");
+            if (criteria.isPresent()) {
+                throw new IllegalArgumentException("Cross join cannot have join criteria");
+            }
         } else {
-            checkArgument(criteria.isPresent(), "No join criteria specified");
+            if (criteria.isEmpty()) {
+                throw new IllegalArgumentException("No join criteria specified");
+            }
         }
 
         this.type = type;
-        this.left = left;
-        this.right = right;
+        this.left = requireNonNull(left, "left is null");
+        this.right = requireNonNull(right, "right is null");
         this.criteria = criteria;
     }
 
@@ -75,17 +76,6 @@ public class Join extends Relation {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("type", type)
-            .add("left", left)
-            .add("right", right)
-            .add("criteria", criteria)
-            .omitNullValues()
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -93,31 +83,25 @@ public class Join extends Relation {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         Join join = (Join) o;
-
-        if (criteria != null ? !criteria.equals(join.criteria) : join.criteria != null) {
-            return false;
-        }
-        if (!left.equals(join.left)) {
-            return false;
-        }
-        if (!right.equals(join.right)) {
-            return false;
-        }
-        if (type != join.type) {
-            return false;
-        }
-
-        return true;
+        return type == join.type &&
+               Objects.equals(left, join.left) &&
+               Objects.equals(right, join.right) &&
+               Objects.equals(criteria, join.criteria);
     }
 
     @Override
     public int hashCode() {
-        int result = type != null ? type.hashCode() : 0;
-        result = 31 * result + left.hashCode();
-        result = 31 * result + right.hashCode();
-        result = 31 * result + (criteria != null ? criteria.hashCode() : 0);
-        return result;
+        return Objects.hash(type, left, right, criteria);
+    }
+
+    @Override
+    public String toString() {
+        return "Join{" +
+               "type=" + type +
+               ", left=" + left +
+               ", right=" + right +
+               ", criteria=" + criteria +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/JoinOn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/JoinOn.java
@@ -21,17 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
-public class JoinOn
-    extends JoinCriteria {
+public class JoinOn extends JoinCriteria {
+
     private final Expression expression;
 
     public JoinOn(Expression expression) {
-        this.expression = checkNotNull(expression, "expression is null");
+        this.expression = requireNonNull(expression, "expression is null");
     }
 
     public Expression getExpression() {
@@ -39,26 +38,26 @@ public class JoinOn
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JoinOn o = (JoinOn) obj;
-        return Objects.equal(expression, o.expression);
+        JoinOn joinOn = (JoinOn) o;
+        return Objects.equals(expression, joinOn.expression);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(expression);
+        return Objects.hash(expression);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .addValue(expression)
-            .toString();
+        return "JoinOn{" +
+               "expression=" + expression +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/JoinUsing.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/JoinUsing.java
@@ -21,19 +21,12 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-public class JoinUsing
-    extends JoinCriteria {
+public class JoinUsing extends JoinCriteria {
 
     private static QualifiedName extendQualifiedName(QualifiedName name, String ext) {
         List<String> parts = new ArrayList<>(name.getParts().size() + 1);
@@ -43,8 +36,9 @@ public class JoinUsing
     }
 
     public static Expression toExpression(QualifiedName left, QualifiedName right, List<String> columns) {
-        checkNotNull(columns, "columns is null");
-        checkArgument(false == columns.isEmpty(), "columns is empty");
+        if (columns.isEmpty()) {
+            throw new IllegalArgumentException("columns must not be empty");
+        }
         List<ComparisonExpression> comp = columns.stream()
             .map(col -> new ComparisonExpression(
                 ComparisonExpression.Type.EQUAL,
@@ -75,9 +69,10 @@ public class JoinUsing
     private final List<String> columns;
 
     public JoinUsing(List<String> columns) {
-        checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "columns is empty");
-        this.columns = ImmutableList.copyOf(columns);
+        if (columns.isEmpty()) {
+            throw new IllegalArgumentException("columns must not be empty");
+        }
+        this.columns = List.copyOf(columns);
     }
 
     public List<String> getColumns() {
@@ -85,26 +80,26 @@ public class JoinUsing
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JoinUsing o = (JoinUsing) obj;
-        return Objects.equal(columns, o.columns);
+        JoinUsing joinUsing = (JoinUsing) o;
+        return Objects.equals(columns, joinUsing.columns);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(columns);
+        return Objects.hash(columns);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .addValue(columns)
-            .toString();
+        return "JoinUsing{" +
+               "columns=" + columns +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/LikePredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/LikePredicate.java
@@ -21,21 +21,21 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class LikePredicate
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class LikePredicate extends Expression {
+
     private final Expression value;
     private final Expression pattern;
     private final Expression escape;
     private final boolean ignoreCase;
 
     public LikePredicate(Expression value, Expression pattern, Expression escape, boolean ignoreCase) {
-        Preconditions.checkNotNull(value, "value is null");
-        Preconditions.checkNotNull(pattern, "pattern is null");
 
-        this.value = value;
-        this.pattern = pattern;
+        this.value = requireNonNull(value, "value is null");
+        this.pattern = requireNonNull(pattern, "pattern is null");
         this.escape = escape;
         this.ignoreCase = ignoreCase;
     }
@@ -69,30 +69,15 @@ public class LikePredicate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         LikePredicate that = (LikePredicate) o;
-
-        if (escape != null ? !escape.equals(that.escape) : that.escape != null) {
-            return false;
-        }
-        if (!pattern.equals(that.pattern)) {
-            return false;
-        }
-        if (!value.equals(that.value)) {
-            return false;
-        }
-        if (ignoreCase != that.ignoreCase) {
-            return false;
-        }
-        return true;
+        return ignoreCase == that.ignoreCase &&
+               Objects.equals(value, that.value) &&
+               Objects.equals(pattern, that.pattern) &&
+               Objects.equals(escape, that.escape);
     }
 
     @Override
     public int hashCode() {
-        int result = value.hashCode();
-        result = 31 * result + pattern.hashCode();
-        result = 31 * result + (escape != null ? escape.hashCode() : 0);
-        result = 31 * result + (ignoreCase ? 1 : 0);
-        return result;
+        return Objects.hash(value, pattern, escape, ignoreCase);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/LogicalBinaryExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/LogicalBinaryExpression.java
@@ -21,10 +21,12 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class LogicalBinaryExpression
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class LogicalBinaryExpression extends Expression {
+
     public enum Type {
         AND, OR
     }
@@ -34,13 +36,9 @@ public class LogicalBinaryExpression
     private final Expression right;
 
     public LogicalBinaryExpression(Type type, Expression left, Expression right) {
-        Preconditions.checkNotNull(type, "type is null");
-        Preconditions.checkNotNull(left, "left is null");
-        Preconditions.checkNotNull(right, "right is null");
-
         this.type = type;
-        this.left = left;
-        this.right = right;
+        this.left = requireNonNull(left, "left is null");
+        this.right = requireNonNull(right, "right is null");
     }
 
     public Type getType() {
@@ -68,27 +66,14 @@ public class LogicalBinaryExpression
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         LogicalBinaryExpression that = (LogicalBinaryExpression) o;
-
-        if (!left.equals(that.left)) {
-            return false;
-        }
-        if (!right.equals(that.right)) {
-            return false;
-        }
-        if (type != that.type) {
-            return false;
-        }
-
-        return true;
+        return type == that.type &&
+               Objects.equals(left, that.left) &&
+               Objects.equals(right, that.right);
     }
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + left.hashCode();
-        result = 31 * result + right.hashCode();
-        return result;
+        return Objects.hash(type, left, right);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
@@ -21,15 +21,14 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import static java.util.Objects.requireNonNull;
 
-public class LongLiteral
-    extends Literal {
+public class LongLiteral extends Literal {
+
     private final long value;
 
     public LongLiteral(String value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = Long.parseLong(value);
+        this.value = Long.parseLong(requireNonNull(value, "value is null"));
     }
 
     public long getValue() {
@@ -49,14 +48,8 @@ public class LongLiteral
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         LongLiteral that = (LongLiteral) o;
-
-        if (value != that.value) {
-            return false;
-        }
-
-        return true;
+        return value == that.value;
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
@@ -21,11 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class MatchPredicate extends Expression {
 
@@ -38,10 +38,11 @@ public class MatchPredicate extends Expression {
                           Expression value,
                           @Nullable String matchType,
                           GenericProperties<Expression> properties) {
-        Preconditions.checkArgument(idents.size() > 0, "at least one ident must be given");
-        Preconditions.checkNotNull(value, "query_term is null");
+        if (idents.isEmpty()) {
+            throw new IllegalArgumentException("at least one ident must be given");
+        }
         this.idents = idents;
-        this.value = value;
+        this.value = requireNonNull(value, "query_term is null");
         this.matchType = matchType;
         this.properties = properties;
     }
@@ -64,11 +65,6 @@ public class MatchPredicate extends Expression {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(idents, value, matchType, properties);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -76,21 +72,17 @@ public class MatchPredicate extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         MatchPredicate that = (MatchPredicate) o;
-
-        if (!idents.equals(that.idents)) return false;
-        if (!value.equals(that.value)) return false;
-        if (matchType != null && that.matchType == null || matchType == null && that.matchType != null) {
-            return false;
-        } else if (matchType != null && !matchType.equals(that.matchType)) {
-            return false;
-        }
-        if (!properties.equals(that.properties)) return false;
-
-        return true;
+        return Objects.equals(idents, that.idents) &&
+               Objects.equals(value, that.value) &&
+               Objects.equals(properties, that.properties) &&
+               Objects.equals(matchType, that.matchType);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(idents, value, properties, matchType);
+    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
@@ -21,11 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 public class MatchPredicateColumnIdent extends Expression {
 
@@ -35,11 +32,13 @@ public class MatchPredicateColumnIdent extends Expression {
     public MatchPredicateColumnIdent(Expression ident, @Nullable Expression boost) {
         this.ident = ident;
         if (boost != null) {
-            Preconditions.checkArgument(
-                boost instanceof LongLiteral || boost instanceof DoubleLiteral || boost instanceof ParameterExpression,
-                "'boost' value must be a numeric literal or a parameter expression");
+            if (!(boost instanceof LongLiteral ||
+                  boost instanceof DoubleLiteral ||
+                  boost instanceof ParameterExpression)) {
+                throw new IllegalArgumentException("'boost' value must be a numeric literal or a parameter expression");
+            }
         }
-        this.boost = MoreObjects.firstNonNull(boost, NullLiteral.INSTANCE);
+        this.boost = boost == null ? NullLiteral.INSTANCE : boost;
     }
 
     public Expression columnIdent() {
@@ -51,11 +50,6 @@ public class MatchPredicateColumnIdent extends Expression {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(ident, boost);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -63,17 +57,14 @@ public class MatchPredicateColumnIdent extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         MatchPredicateColumnIdent that = (MatchPredicateColumnIdent) o;
+        return Objects.equals(ident, that.ident) &&
+               Objects.equals(boost, that.boost);
+    }
 
-        if (!ident.equals(that.ident)) {
-            return false;
-        }
-        if (!boost.equals(that.boost)) {
-            return false;
-        }
-
-        return true;
+    @Override
+    public int hashCode() {
+        return Objects.hash(ident, boost);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/NaturalJoin.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/NaturalJoin.java
@@ -21,10 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+public class NaturalJoin extends JoinCriteria {
 
-public class NaturalJoin
-    extends JoinCriteria {
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -40,6 +38,6 @@ public class NaturalJoin
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).toString();
+        return "NaturalJoin{}";
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/NotExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/NotExpression.java
@@ -21,24 +21,20 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class NotExpression
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class NotExpression extends Expression {
+
     private final Expression value;
 
     public NotExpression(Expression value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = value;
+        this.value = requireNonNull(value, "value is null");
     }
 
     public Expression getValue() {
         return value;
-    }
-
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitNotExpression(this, context);
     }
 
     @Override
@@ -49,18 +45,17 @@ public class NotExpression
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         NotExpression that = (NotExpression) o;
-
-        if (!value.equals(that.value)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitNotExpression(this, context);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/OptimizeStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/OptimizeStatement.java
@@ -22,10 +22,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
 import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class OptimizeStatement<T> extends Statement {
@@ -47,35 +47,36 @@ public class OptimizeStatement<T> extends Statement {
     }
 
     public <U> OptimizeStatement<U> map(Function<? super T, ? extends U> mapper) {
-        return new OptimizeStatement(
+        return new OptimizeStatement<>(
             Lists2.map(tables, x -> x.map(mapper)),
             properties.map(mapper)
         );
     }
 
     @Override
-    public int hashCode() {
-        int result = tables.hashCode();
-        result = 31 * result + properties.hashCode();
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OptimizeStatement<?> that = (OptimizeStatement<?>) o;
+        return Objects.equals(tables, that.tables) &&
+               Objects.equals(properties, that.properties);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        OptimizeStatement that = (OptimizeStatement) o;
-
-        return tables.equals(that.tables) && properties.equals(that.properties);
+    public int hashCode() {
+        return Objects.hash(tables, properties);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", tables)
-            .add("properties", properties)
-            .toString();
+        return "OptimizeStatement{" +
+               "tables=" + tables +
+               ", properties=" + properties +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
@@ -21,11 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -42,25 +41,27 @@ public class PrimaryKeyConstraint<T> extends TableElement<T> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(columns);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PrimaryKeyConstraint<?> that = (PrimaryKeyConstraint<?>) o;
+        return Objects.equals(columns, that.columns);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PrimaryKeyConstraint that = (PrimaryKeyConstraint) o;
-
-        if (!columns.equals(that.columns)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(columns);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("columns", columns).toString();
+        return "PrimaryKeyConstraint{" +
+               "columns=" + columns +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Query.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Query.java
@@ -21,31 +21,24 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class Query extends Statement {
+
     private final QueryBody queryBody;
     private final List<SortItem> orderBy;
     private final Optional<Expression> limit;
     private final Optional<Expression> offset;
 
-    public Query(
-        QueryBody queryBody,
-        List<SortItem> orderBy,
-        Optional<Expression> limit,
-        Optional<Expression> offset) {
-        checkNotNull(queryBody, "queryBody is null");
-        checkNotNull(orderBy, "orderBy is null");
-        checkNotNull(limit, "limit is null");
-        checkNotNull(offset, "offset is null");
-
-        this.queryBody = queryBody;
+    public Query(QueryBody queryBody,
+                 List<SortItem> orderBy,
+                 Optional<Expression> limit,
+                 Optional<Expression> offset) {
+        this.queryBody = requireNonNull(queryBody, "queryBody is null");
         this.orderBy = orderBy;
         this.limit = limit;
         this.offset = offset;
@@ -73,33 +66,32 @@ public class Query extends Statement {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("queryBody", queryBody)
-            .add("orderBy", orderBy)
-            .add("limit", limit)
-            .add("offset", offset)
-            .omitNullValues()
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Query o = (Query) obj;
-        return Objects.equal(queryBody, o.queryBody) &&
-               Objects.equal(orderBy, o.orderBy) &&
-               Objects.equal(limit, o.limit) &&
-               Objects.equal(offset, o.offset);
+        Query query = (Query) o;
+        return Objects.equals(queryBody, query.queryBody) &&
+               Objects.equals(orderBy, query.orderBy) &&
+               Objects.equals(limit, query.limit) &&
+               Objects.equals(offset, query.offset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(queryBody, orderBy, limit, offset);
+        return Objects.hash(queryBody, orderBy, limit, offset);
+    }
+
+    @Override
+    public String toString() {
+        return "Query{" +
+               "queryBody=" + queryBody +
+               ", orderBy=" + orderBy +
+               ", limit=" + limit +
+               ", offset=" + offset +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
@@ -26,9 +26,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class QuerySpecification extends QueryBody {
+
     private final Select select;
     private final List<Relation> from;
     private final Optional<Expression> where;
@@ -39,25 +40,16 @@ public class QuerySpecification extends QueryBody {
     private final Optional<Expression> offset;
     private final Map<String, Window> windows;
 
-    public QuerySpecification(
-        Select select,
-        List<Relation> from,
-        Optional<Expression> where,
-        List<Expression> groupBy,
-        Optional<Expression> having,
-        Map<String, Window> windows,
-        List<SortItem> orderBy,
-        Optional<Expression> limit,
-        Optional<Expression> offset) {
-        checkNotNull(select, "select is null");
-        checkNotNull(where, "where is null");
-        checkNotNull(groupBy, "groupBy is null");
-        checkNotNull(having, "having is null");
-        checkNotNull(orderBy, "orderBy is null");
-        checkNotNull(limit, "limit is null");
-        checkNotNull(offset, "offset is null");
-
-        this.select = select;
+    public QuerySpecification(Select select,
+                              List<Relation> from,
+                              Optional<Expression> where,
+                              List<Expression> groupBy,
+                              Optional<Expression> having,
+                              Map<String, Window> windows,
+                              List<SortItem> orderBy,
+                              Optional<Expression> limit,
+                              Optional<Expression> offset) {
+        this.select = requireNonNull(select, "select is null");
         this.from = from;
         this.where = where;
         this.groupBy = groupBy;
@@ -110,21 +102,6 @@ public class QuerySpecification extends QueryBody {
     }
 
     @Override
-    public String toString() {
-        return "QuerySpecification{" +
-               "select=" + select +
-               ", from=" + from +
-               ", where=" + where +
-               ", groupBy=" + groupBy +
-               ", having=" + having +
-               ", orderBy=" + orderBy +
-               ", limit=" + limit +
-               ", offset=" + offset +
-               ", windows=" + windows +
-               '}';
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -147,5 +124,20 @@ public class QuerySpecification extends QueryBody {
     @Override
     public int hashCode() {
         return Objects.hash(select, from, where, groupBy, having, orderBy, limit, offset, windows);
+    }
+
+    @Override
+    public String toString() {
+        return "QuerySpecification{" +
+               "select=" + select +
+               ", from=" + from +
+               ", where=" + where +
+               ", groupBy=" + groupBy +
+               ", having=" + having +
+               ", orderBy=" + orderBy +
+               ", limit=" + limit +
+               ", offset=" + offset +
+               ", windows=" + windows +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/QueryUtil.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QueryUtil.java
@@ -21,21 +21,20 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.ArrayList;
 import java.util.List;
 
 public class QueryUtil {
 
     public static Select selectList(Expression... expressions) {
-        ImmutableList.Builder<SelectItem> items = ImmutableList.builder();
+        ArrayList<SelectItem> items = new ArrayList<>();
         for (Expression expression : expressions) {
             items.add(new SingleColumn(expression));
         }
-        return new Select(false, items.build());
+        return new Select(false, items);
     }
 
     public static List<Relation> table(QualifiedName name) {
-        return ImmutableList.<Relation>of(new Table(name));
+        return List.of(new Table<>(name));
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/RefreshStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RefreshStatement.java
@@ -21,10 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import java.util.List;
+import java.util.Objects;
 
 public class RefreshStatement<T> extends Statement {
 
@@ -39,27 +37,27 @@ public class RefreshStatement<T> extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(tables);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RefreshStatement<?> that = (RefreshStatement<?>) o;
+        return Objects.equals(tables, that.tables);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        RefreshStatement that = (RefreshStatement) o;
-
-        if (!tables.equals(that.tables)) return false;
-
-        return true;
+    public int hashCode() {
+        return Objects.hash(tables);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", tables)
-            .toString();
+        return "RefreshStatement{" +
+               "tables=" + tables +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ResetStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ResetStatement.java
@@ -21,11 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class ResetStatement<T> extends Statement {
@@ -47,27 +46,27 @@ public class ResetStatement<T> extends Statement {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResetStatement<?> that = (ResetStatement<?>) o;
+        return Objects.equals(columns, that.columns);
+    }
+
+    @Override
     public int hashCode() {
-        return Objects.hashCode(columns);
+        return Objects.hash(columns);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("columns", columns)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ResetStatement update = (ResetStatement) o;
-
-        if (!columns.equals(update.columns)) return false;
-
-        return true;
+        return "ResetStatement{" +
+               "columns=" + columns +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/Select.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Select.java
@@ -21,13 +21,12 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-public class Select
-    extends Node {
+public class Select extends Node {
+
     private final boolean distinct;
     private final List<SelectItem> selectItems;
 
@@ -50,15 +49,6 @@ public class Select
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("distinct", distinct)
-            .add("selectItems", selectItems)
-            .omitNullValues()
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -66,23 +56,21 @@ public class Select
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         Select select = (Select) o;
-
-        if (distinct != select.distinct) {
-            return false;
-        }
-        if (!selectItems.equals(select.selectItems)) {
-            return false;
-        }
-
-        return true;
+        return distinct == select.distinct &&
+               Objects.equals(selectItems, select.selectItems);
     }
 
     @Override
     public int hashCode() {
-        int result = (distinct ? 1 : 0);
-        result = 31 * result + selectItems.hashCode();
-        return result;
+        return Objects.hash(distinct, selectItems);
+    }
+
+    @Override
+    public String toString() {
+        return "Select{" +
+               "distinct=" + distinct +
+               ", selectItems=" + selectItems +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
@@ -21,13 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import io.crate.common.collections.Lists2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class SetStatement<T> extends Statement {
@@ -49,14 +47,12 @@ public class SetStatement<T> extends Statement {
     }
 
     public SetStatement(Scope scope, SettingType settingType, List<Assignment<T>> assignments) {
-        Preconditions.checkNotNull(assignments, "assignments are null");
         this.scope = scope;
         this.settingType = settingType;
         this.assignments = assignments;
     }
 
     public SetStatement(Scope scope, Assignment<T> assignment) {
-        Preconditions.checkNotNull(assignment, "assignment is null");
         this.scope = scope;
         this.settingType = SettingType.TRANSIENT;
         this.assignments = Collections.singletonList(assignment);
@@ -75,11 +71,6 @@ public class SetStatement<T> extends Statement {
     }
 
 
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(scope, assignments, settingType);
-    }
-
     public <U> SetStatement<U> map(Function<? super T, ? extends U> mapper) {
         return new SetStatement<>(
             scope,
@@ -89,26 +80,31 @@ public class SetStatement<T> extends Statement {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("scope", scope)
-            .add("assignments", assignments)
-            .add("settingType", settingType)
-            .toString();
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SetStatement<?> that = (SetStatement<?>) o;
+        return scope == that.scope &&
+               settingType == that.settingType &&
+               Objects.equals(assignments, that.assignments);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public int hashCode() {
+        return Objects.hash(scope, settingType, assignments);
+    }
 
-        SetStatement update = (SetStatement) o;
-
-        if (!scope.equals(update.scope)) return false;
-        if (!assignments.equals(update.assignments)) return false;
-        if (!settingType.equals(update.settingType)) return false;
-
-        return true;
+    @Override
+    public String toString() {
+        return "SetStatement{" +
+               "scope=" + scope +
+               ", assignments=" + assignments +
+               ", settingType=" + settingType +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
@@ -21,13 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class ShowColumns extends Statement {
 
@@ -42,7 +40,7 @@ public class ShowColumns extends Statement {
                        @Nullable QualifiedName schema,
                        Optional<Expression> where,
                        @Nullable String likePattern) {
-        this.table = checkNotNull(table, "table is null");
+        this.table = requireNonNull(table, "table is null");
         this.schema = schema;
         this.likePattern = likePattern;
         this.where = where;
@@ -72,32 +70,32 @@ public class ShowColumns extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(table, schema, likePattern);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ShowColumns that = (ShowColumns) o;
+        return Objects.equals(table, that.table) &&
+               Objects.equals(schema, that.schema) &&
+               Objects.equals(likePattern, that.likePattern) &&
+               Objects.equals(where, that.where);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if ((obj == null) || (getClass() != obj.getClass())) {
-            return false;
-        }
-        ShowColumns o = (ShowColumns) obj;
-        return Objects.equal(table, o.table) &&
-            Objects.equal(schema, o.schema) &&
-            Objects.equal(likePattern, o.likePattern) &&
-            Objects.equal(where, o.where);
+    public int hashCode() {
+        return Objects.hash(table, schema, likePattern, where);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .add("schema", schema)
-            .add("pattern", likePattern)
-            .add("where", where)
-            .toString();
+        return "ShowColumns{" +
+               "table=" + table +
+               ", schema=" + schema +
+               ", pattern='" + likePattern + '\'' +
+               ", where=" + where +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowCreateTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowCreateTable.java
@@ -21,8 +21,7 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
+import java.util.Objects;
 import java.util.function.Function;
 
 public class ShowCreateTable<T> extends Statement {
@@ -40,25 +39,26 @@ public class ShowCreateTable<T> extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ShowCreateTable that = (ShowCreateTable) o;
-
-        return table.equals(that.table);
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ShowCreateTable<?> that = (ShowCreateTable<?>) o;
+        return Objects.equals(table, that.table);
     }
 
     @Override
     public int hashCode() {
-        return table.hashCode();
+        return Objects.hash(table);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("table", table)
-            .toString();
+        return "ShowCreateTable{" +
+               "table=" + table +
+               '}';
     }
 
     public Table<T> table() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
@@ -21,8 +21,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,11 +53,15 @@ public class ShowSchemas extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ShowSchemas that = (ShowSchemas) o;
         return Objects.equals(likePattern, that.likePattern) &&
-            Objects.equals(whereExpression, that.whereExpression);
+               Objects.equals(whereExpression, that.whereExpression);
     }
 
     @Override
@@ -69,10 +71,9 @@ public class ShowSchemas extends Statement {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("likePattern", likePattern)
-            .add("whereExpression", whereExpression)
-            .toString();
+        return "ShowSchemas{" +
+               "likePattern='" + likePattern + '\'' +
+               ", whereExpression=" + whereExpression +
+               '}';
     }
-
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
@@ -21,10 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.Optional;
 
 public class ShowTables extends Statement {
@@ -63,31 +61,31 @@ public class ShowTables extends Statement {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(schema, whereExpression, likePattern);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ShowTables that = (ShowTables) o;
+        return Objects.equals(schema, that.schema) &&
+               Objects.equals(likePattern, that.likePattern) &&
+               Objects.equals(whereExpression, that.whereExpression);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if ((obj == null) || (getClass() != obj.getClass())) {
-            return false;
-        }
-        ShowTables o = (ShowTables) obj;
-        return Objects.equal(schema, o.schema) &&
-            Objects.equal(likePattern, o.likePattern) &&
-            Objects.equal(whereExpression, o.whereExpression);
+    public int hashCode() {
+        return Objects.hash(schema, likePattern, whereExpression);
     }
+
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("schema", schema)
-            .add("likePattern", likePattern)
-            .add("whereExpression", whereExpression.toString())
-            .toString();
+        return "ShowTables{" +
+               "schema=" + schema +
+               ", likePattern='" + likePattern + '\'' +
+               ", whereExpression=" + whereExpression +
+               '}';
     }
-
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SimpleCaseExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SimpleCaseExpression.java
@@ -21,20 +21,20 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-public class SimpleCaseExpression
-    extends Expression {
+import static java.util.Objects.requireNonNull;
+
+public class SimpleCaseExpression extends Expression {
+
     private final Expression operand;
     private final List<WhenClause> whenClauses;
     private final Expression defaultValue;
 
     public SimpleCaseExpression(Expression operand, List<WhenClause> whenClauses, Expression defaultValue) {
-        Preconditions.checkNotNull(operand, "operand is null");
-        this.operand = operand;
+        this.operand = requireNonNull(operand, "operand is null");
         this.whenClauses = Collections.unmodifiableList(whenClauses);
         this.defaultValue = defaultValue;
     }
@@ -64,27 +64,14 @@ public class SimpleCaseExpression
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         SimpleCaseExpression that = (SimpleCaseExpression) o;
-
-        if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null) {
-            return false;
-        }
-        if (!operand.equals(that.operand)) {
-            return false;
-        }
-        if (!whenClauses.equals(that.whenClauses)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(operand, that.operand) &&
+               Objects.equals(whenClauses, that.whenClauses) &&
+               Objects.equals(defaultValue, that.defaultValue);
     }
 
     @Override
     public int hashCode() {
-        int result = operand.hashCode();
-        result = 31 * result + whenClauses.hashCode();
-        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
-        return result;
+        return Objects.hash(operand, whenClauses, defaultValue);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
@@ -21,19 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-
 import javax.annotation.Nullable;
+import java.util.Objects;
 
-public class SingleColumn
-    extends SelectItem {
+public class SingleColumn extends SelectItem {
+
     @Nullable
-    private String alias;
-    private Expression expression;
+    private final String alias;
+    private final Expression expression;
 
     public SingleColumn(Expression expression, @Nullable String alias) {
-        Preconditions.checkNotNull(expression, "expression is null");
         this.expression = expression;
         this.alias = alias;
     }
@@ -52,20 +49,21 @@ public class SingleColumn
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final SingleColumn other = (SingleColumn) obj;
-        return Objects.equal(this.alias, other.alias) && Objects.equal(this.expression, other.expression);
+        SingleColumn that = (SingleColumn) o;
+        return Objects.equals(alias, that.alias) &&
+               Objects.equals(expression, that.expression);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(alias, expression);
+        return Objects.hash(alias, expression);
     }
 
     public String toString() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/SortItem.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SortItem.java
@@ -21,10 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
-public class SortItem
-    extends Node {
+public class SortItem extends Node {
+
     public enum Ordering {
         ASCENDING, DESCENDING
     }
@@ -61,15 +61,6 @@ public class SortItem
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("sortKey", sortKey)
-            .add("ordering", ordering)
-            .add("nullOrdering", nullOrdering)
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -77,28 +68,23 @@ public class SortItem
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         SortItem sortItem = (SortItem) o;
-
-        if (nullOrdering != sortItem.nullOrdering) {
-            return false;
-        }
-        if (ordering != sortItem.ordering) {
-            return false;
-        }
-        if (!sortKey.equals(sortItem.sortKey)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(sortKey, sortItem.sortKey) &&
+               ordering == sortItem.ordering &&
+               nullOrdering == sortItem.nullOrdering;
     }
 
     @Override
     public int hashCode() {
-        int result = sortKey.hashCode();
-        result = 31 * result + (ordering != null ? ordering.hashCode() : 0);
-        result = 31 * result + (nullOrdering != null ? nullOrdering.hashCode() : 0);
-        return result;
+        return Objects.hash(sortKey, ordering, nullOrdering);
     }
 
+    @Override
+    public String toString() {
+        return "SortItem{" +
+               "sortKey=" + sortKey +
+               ", ordering=" + ordering +
+               ", nullOrdering=" + nullOrdering +
+               '}';
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/StringLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/StringLiteral.java
@@ -21,15 +21,16 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
-public class StringLiteral
-    extends Literal {
+import static java.util.Objects.requireNonNull;
+
+public class StringLiteral extends Literal {
+
     private final String value;
 
     public StringLiteral(String value) {
-        Preconditions.checkNotNull(value, "value is null");
-        this.value = value;
+        this.value = requireNonNull(value, "value is null");
     }
 
     public String getValue() {
@@ -49,18 +50,12 @@ public class StringLiteral
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         StringLiteral that = (StringLiteral) o;
-
-        if (!value.equals(that.value)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Table.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Table.java
@@ -21,11 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 import io.crate.common.collections.Lists2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class Table<T> extends QueryBody {
@@ -41,7 +40,7 @@ public class Table<T> extends QueryBody {
     public Table(QualifiedName name, boolean excludePartitions) {
         this.name = name;
         this.excludePartitions = excludePartitions;
-        this.partitionProperties = ImmutableList.of();
+        this.partitionProperties = List.of();
     }
 
     public Table(QualifiedName name, List<Assignment<T>> partitionProperties) {
@@ -76,31 +75,29 @@ public class Table<T> extends QueryBody {
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("only", excludePartitions)
-            .addValue(name)
-            .add("partitionProperties", partitionProperties)
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Table)) return false;
-
-        Table that = (Table) o;
-
-        if (!name.equals(that.name)) return false;
-        if (!partitionProperties.equals(that.partitionProperties)) return false;
-
-        return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Table<?> table = (Table<?>) o;
+        return Objects.equals(name, table.name) &&
+               Objects.equals(partitionProperties, table.partitionProperties);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + partitionProperties.hashCode();
-        return result;
+        return Objects.hash(name, partitionProperties);
+    }
+
+    @Override
+    public String toString() {
+        return "Table{" +
+               "only=" + excludePartitions +
+               ", " + name +
+               ", partitionProperties=" + partitionProperties +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/TableFunction.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/TableFunction.java
@@ -22,8 +22,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.Objects;
 
 public class TableFunction extends QueryBody {
@@ -44,8 +42,12 @@ public class TableFunction extends QueryBody {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         TableFunction that = (TableFunction) o;
         return Objects.equals(functionCall, that.functionCall);
     }
@@ -57,9 +59,9 @@ public class TableFunction extends QueryBody {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("functionCall", functionCall)
-            .toString();
+        return "TableFunction{" +
+               "functionCall=" + functionCall +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/TableSubquery.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/TableSubquery.java
@@ -21,10 +21,10 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
-public class TableSubquery
-    extends QueryBody {
+public class TableSubquery extends QueryBody {
+
     private final Query query;
 
     public TableSubquery(Query query) {
@@ -41,13 +41,6 @@ public class TableSubquery
     }
 
     @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .addValue(query)
-            .toString();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -55,18 +48,19 @@ public class TableSubquery
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        TableSubquery tableSubquery = (TableSubquery) o;
-
-        if (!query.equals(tableSubquery.query)) {
-            return false;
-        }
-
-        return true;
+        TableSubquery that = (TableSubquery) o;
+        return Objects.equals(query, that.query);
     }
 
     @Override
     public int hashCode() {
-        return query.hashCode();
+        return Objects.hash(query);
+    }
+
+    @Override
+    public String toString() {
+        return "TableSubquery{" +
+               "query=" + query +
+               '}';
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/TryCast.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/TryCast.java
@@ -22,16 +22,13 @@
 
 package io.crate.sql.tree;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 public class TryCast extends Expression {
     private final Expression expression;
     private final ColumnType type;
 
     public TryCast(Expression expression, ColumnType type) {
-        checkNotNull(expression, "expression is null");
-        checkNotNull(type, "type is null");
-
         this.expression = expression;
         this.type = type;
     }
@@ -57,23 +54,13 @@ public class TryCast extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        TryCast cast = (TryCast) o;
-
-        if (!expression.equals(cast.expression)) {
-            return false;
-        }
-        if (!type.equals(cast.type)) {
-            return false;
-        }
-
-        return true;
+        TryCast tryCast = (TryCast) o;
+        return Objects.equals(expression, tryCast.expression) &&
+               Objects.equals(type, tryCast.type);
     }
 
     @Override
     public int hashCode() {
-        int result = expression.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
+        return Objects.hash(expression, type);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Union.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Union.java
@@ -21,9 +21,9 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 public class Union extends SetOperation {
 
@@ -32,8 +32,8 @@ public class Union extends SetOperation {
     private final boolean isDistinct;
 
     public Union(Relation left, Relation right, boolean isDistinct) {
-        this.left = Preconditions.checkNotNull(left, "relation must not be null");
-        this.right = Preconditions.checkNotNull(right, "relation must not be null");
+        this.left = requireNonNull(left, "relation must not be null");
+        this.right = requireNonNull(right, "relation must not be null");
         this.isDistinct = isDistinct;
     }
 
@@ -56,29 +56,29 @@ public class Union extends SetOperation {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("left", left)
-            .add("right", right)
-            .add("isDistinct", isDistinct)
-            .toString();
+        return "Union{" +
+               "left=" + left +
+               ", right=" + right +
+               ", isDistinct=" + isDistinct +
+               '}';
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Union o = (Union) obj;
-        return Objects.equal(left, o.left) &&
-               Objects.equal(right, o.right) &&
-               Objects.equal(isDistinct, o.isDistinct);
+        Union union = (Union) o;
+        return isDistinct == union.isDistinct &&
+               Objects.equals(left, union.left) &&
+               Objects.equals(right, union.right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(left, right, isDistinct);
+        return Objects.hash(left, right, isDistinct);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Update.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Update.java
@@ -21,12 +21,11 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class Update extends Statement {
 
@@ -39,9 +38,7 @@ public class Update extends Statement {
                   List<Assignment<Expression>> assignments,
                   Optional<Expression> where,
                   List<SelectItem> returning) {
-        Preconditions.checkNotNull(relation, "relation is null");
-        Preconditions.checkNotNull(assignments, "assignments are null");
-        this.relation = relation;
+        this.relation = requireNonNull(relation, "relation is null");
         this.assignments = assignments;
         this.where = where;
         this.returning = returning;
@@ -64,33 +61,33 @@ public class Update extends Statement {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Update update = (Update) o;
+        return Objects.equals(relation, update.relation) &&
+               Objects.equals(assignments, update.assignments) &&
+               Objects.equals(where, update.where) &&
+               Objects.equals(returning, update.returning);
+    }
+
+    @Override
     public int hashCode() {
-        return Objects.hashCode(relation, assignments, where, returning);
+        return Objects.hash(relation, assignments, where, returning);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("relation", relation)
-            .add("assignments", assignments)
-            .add("where", where)
-            .add("returning", returning)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Update update = (Update) o;
-
-        if (!assignments.equals(update.assignments)) return false;
-        if (!relation.equals(update.relation)) return false;
-        if (!java.util.Objects.equals(where, update.where)) return false;
-        if (!java.util.Objects.equals(returning, update.returning)) return false;
-
-        return true;
+        return "Update{" +
+               "relation=" + relation +
+               ", assignments=" + assignments +
+               ", where=" + where +
+               ", returning=" + returning +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ValuesList.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ValuesList.java
@@ -21,10 +21,8 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-
 import java.util.List;
+import java.util.Objects;
 
 public class ValuesList extends Node {
 
@@ -39,28 +37,27 @@ public class ValuesList extends Node {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(values);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValuesList that = (ValuesList) o;
+        return Objects.equals(values, that.values);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(values);
+    }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("values", values)
-            .toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ValuesList that = (ValuesList) o;
-
-        if (!values.equals(that.values)) return false;
-
-        return true;
+        return "ValuesList{" +
+               "values=" + values +
+               '}';
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -25,8 +25,6 @@ package io.crate.sql;
 
 import org.junit.Test;
 
-import java.util.stream.Collectors;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -22,7 +22,7 @@
 
 package io.crate.sql.parser;
 
-import com.google.common.base.Joiner;
+import io.crate.common.collections.Lists2;
 import io.crate.sql.tree.Cast;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CreateTable;
@@ -410,14 +410,14 @@ public class TestSqlParser {
     public void testStackOverflowExpression() {
         expectedException.expect(ParsingException.class);
         expectedException.expectMessage("line 1:1: expression is too large (stack overflow while parsing)");
-        SqlParser.createExpression(Joiner.on(" OR ").join(nCopies(4000, "x = y")));
+        SqlParser.createExpression(Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x));
     }
 
     @Test
     public void testStackOverflowStatement() {
         expectedException.expect(ParsingException.class);
         expectedException.expectMessage("line 1:1: statement is too large (stack overflow while parsing)");
-        SqlParser.createStatement("SELECT " + Joiner.on(" OR ").join(nCopies(4000, "x = y")));
+        SqlParser.createStatement("SELECT " + Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x));
     }
 
     @Test

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -22,7 +22,6 @@
 
 package io.crate.sql.parser;
 
-import com.google.common.io.Resources;
 import io.crate.sql.Literals;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.ArrayComparisonExpression;
@@ -80,7 +79,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.google.common.base.Strings.repeat;
 import static io.crate.sql.parser.TreeAssertions.assertFormattedSql;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -1656,7 +1654,7 @@ public class TestStatementBuilder {
                 assertFormattedSql(statement);
         }
 
-        println(repeat("=", 60));
+        println("=".repeat(60));
         println("");
     }
 
@@ -1685,9 +1683,12 @@ public class TestStatementBuilder {
         printStatement(sql);
     }
 
-    private static String readResource(String name)
-        throws IOException {
-        return Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);
+    private static String readResource(String name) throws IOException {
+        var inputStream = TestStatementBuilder.class.getClassLoader().getResourceAsStream(name);
+        if (inputStream == null) {
+            throw new IOException("'" + name + "' resource is not found");
+        }
+        return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
     }
 
     private static String fixTpchQuery(String s) {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
@@ -21,12 +21,12 @@
 
 package io.crate.sql.parser;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
+import io.crate.common.collections.Lists2;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.Statement;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static io.crate.sql.SqlFormatter.formatSql;
@@ -64,22 +64,22 @@ final class TreeAssertions {
     }
 
     private static List<Node> linearizeTree(Node tree) {
-        final ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        ArrayList<Node> nodes = new ArrayList<>();
         new DefaultTraversalVisitor<Node, Void>() {
             void process(Node node) {
                 node.accept(this, null);
                 nodes.add(node);
             }
         }.process(tree);
-        return nodes.build();
+        return nodes;
     }
 
     private static <T> void assertListEquals(List<T> actual, List<T> expected) {
         if (actual.size() != expected.size()) {
-            Joiner joiner = Joiner.on("\n    ");
-            fail(format("Lists not equal%nActual [%s]:%n    %s%nExpected [%s]:%n    %s",
-                actual.size(), joiner.join(actual),
-                expected.size(), joiner.join(expected)));
+            fail(format(
+                "Lists not equal%nActual [%s]:%n    %s%nExpected [%s]:%n    %s",
+                actual.size(), Lists2.joinOn("\n    ", actual, Object::toString),
+                expected.size(), Lists2.joinOn("\n    ", expected, Object::toString)));
         }
         assertEquals(actual, expected);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Remove the Guava dependency from the sql-parser module.

The library was mainly used to check preconditions
(checkNotNull, checkArgument), implement equals/hashCode/toString
methods, and as well provided a couple of util methods to join
strings, etc. Such as all of the above can be easily replaced with
`java.base` there is no reason to depend on Guava in the sql-parser module.


I've also dropped some preconditions checks that made no sense, e.g. checking optional and lists for null, etc.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
