### PR TITLE
Fix bug in selecting license object column.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,6 +163,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would lead to incorrect result when selecting the
+  :ref:`cluster license <sys-cluster-license>` object column, namely, the
+  fields of the object would contain the null values, even though the license.
+
 - Fixed an issue that caused a ``OFFSET`` as part of a ``UNION`` to be applied
   incorrectly.
 

--- a/enterprise/licensing/src/test/java/io/crate/integrationtests/LicenseITest.java
+++ b/enterprise/licensing/src/test/java/io/crate/integrationtests/LicenseITest.java
@@ -21,9 +21,12 @@ package io.crate.integrationtests;
 import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.license.LicenseKey;
 import io.crate.testing.SQLResponse;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 
 public class LicenseITest extends SQLTransportIntegrationTest {
@@ -45,6 +48,16 @@ public class LicenseITest extends SQLTransportIntegrationTest {
     @Test
     public void testLicenseCheckIsAvailableOnSysChecks() {
         SQLResponse response = execute("select severity, passed from sys.checks where id = 6");
-        assertThat(response.rows()[0][0], Matchers.is(SysCheck.Severity.LOW.value()));
+        assertThat(response.rows()[0][0], is(SysCheck.Severity.LOW.value()));
+    }
+
+    @Test
+    public void test_select_license_object_column_result_in_non_null_values_for_its_fields() {
+        SQLResponse response = execute("select license from sys.cluster");
+        //noinspection unchecked
+        Map<String, Object> license = (Map<String, Object>) response.rows()[0][0];
+        assertThat(license.get("max_nodes"), not(nullValue()));
+        assertThat(license.get("expiry_date"), nullValue()); // unlimited license expiry date
+        assertThat(license.get("issued_to"), not(nullValue()));
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
@@ -31,8 +31,6 @@ import org.elasticsearch.common.inject.Inject;
 import java.util.Map;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-
 
 public class ClusterLicenseExpression extends NestedObjectExpression {
 
@@ -59,15 +57,12 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
 
     private void fillChildImplementations(LicenseData licenseData) {
         if (licenseData != null) {
-            childImplementations.put(EXPIRY_DATE, forFunction(ignored -> {
-                if (licenseData.expiryDateInMs() == Long.MAX_VALUE) {
-                    return null;
-                } else {
-                    return licenseData.expiryDateInMs();
-                }
-            }));
-            childImplementations.put(ISSUED_TO, forFunction(ignored -> licenseData.issuedTo()));
-            childImplementations.put(MAX_NODES, forFunction(ignored -> licenseData.maxNumberOfNodes()));
+            var expiryDateInMs = licenseData.expiryDateInMs() == Long.MAX_VALUE
+                ? null
+                : licenseData.expiryDateInMs();
+            childImplementations.put(EXPIRY_DATE, constant(expiryDateInMs));
+            childImplementations.put(ISSUED_TO, constant(licenseData.issuedTo()));
+            childImplementations.put(MAX_NODES, constant(licenseData.maxNumberOfNodes()));
         } else if (licenseService.getMode() == LicenseService.Mode.ENTERPRISE) {
             // The admin-ui will switch it's view between CE and Enterprise based on a non-null value of `issued_to`.
             // To prevent a race-condition (wrong admin-ui view) on node startup, we set a dummy value here.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Selecting the license object column from sys.cluster results
in the row with the object that contains null values for its
keys even though the license is set and the access to each of
the license object key separately returns the correct result.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
