### PR TITLE
Fix runDebug gradle task

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -433,6 +433,7 @@ task(runDebug, dependsOn: 'classes', type: JavaExec) {
         executable = rootProject.jdks.runtime.getBinJavaPath()
     }
     systemProperties += ['es.path.home': "${rootDir}/sandbox/crate"]
+    systemProperties System.getProperties()
 }
 
 task(run, dependsOn: 'classes', type: JavaExec) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

systemProperties weren't initialized correctly. This led to a exception
once a debug client attached.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)