### PR TITLE
Add logic to prefer function signatures with higher exact matches

### DIFF
--- a/sql/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/sql/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -168,4 +168,29 @@ public class FunctionsTest extends CrateUnitTest {
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
         assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.STRING));
     }
+
+    @Test
+    public void test_signature_with_more_exact_argument_matches_is_more_specific() {
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+        register(
+            Signature.scalar(
+                "foo",
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            args -> () -> new FunctionInfo(new FunctionIdent("foo", args), DataTypes.INTEGER)
+        );
+
+        var impl = resolve("foo", List.of(Literal.of(1), Literal.of(1L)));
+        assertThat(impl.info().ident().argumentTypes(), contains(DataTypes.INTEGER, DataTypes.INTEGER));
+    }
 }


### PR DESCRIPTION
When no exact function signature can be matched, signature matching will be repeated with allowed coercion for all argument types. This can lead to multiple applicable functions where some or all arguments will be cast.
Most specific selection is then made by type precedence, a function with more specific argument types than the other will match.

Without taking the number of exact argument type matches, the wrong function maybe selected.

Example:

Registered functions:

	foo(double precision, int):int
    foo(int, int):int

User input:
  
    foo(double precision, bigint)

Wanted function:

    foo(double precision, int):int

Matched signature by type precedence only:

	foo(int, int):int

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
