### PR TITLE
Migrate more table definitions to SystemTable

### DIFF
--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -312,38 +312,38 @@ infinite recursion of your mind, beware!)::
     +--------------------------+-----------+------------------+
     | column_name              | data_type | ordinal_position |
     +--------------------------+-----------+------------------+
-    | character_maximum_length | integer   |               11 |
-    | character_octet_length   | integer   |               12 |
-    | character_set_catalog    | text      |               19 |
-    | character_set_name       | text      |               21 |
-    | character_set_schema     | text      |               20 |
-    | check_action             | integer   |               32 |
-    | check_references         | text      |               31 |
-    | collation_catalog        | text      |               22 |
-    | collation_name           | text      |               24 |
-    | collation_schema         | text      |               23 |
-    | column_default           | text      |               10 |
-    | column_name              | text      |                4 |
-    | data_type                | text      |                6 |
-    | datetime_precision       | integer   |               16 |
-    | domain_catalog           | text      |               25 |
-    | domain_name              | text      |               27 |
-    | domain_schema            | text      |               26 |
-    | generation_expression    | text      |                9 |
-    | interval_precision       | integer   |               18 |
-    | interval_type            | text      |               17 |
-    | is_generated             | text      |                7 |
-    | is_nullable              | boolean   |                8 |
-    | numeric_precision        | integer   |               13 |
-    | numeric_precision_radix  | integer   |               14 |
-    | numeric_scale            | integer   |               15 |
-    | ordinal_position         | integer   |                5 |
-    | table_catalog            | text      |                3 |
-    | table_name               | text      |                2 |
-    | table_schema             | text      |                1 |
-    | udt_catalog              | text      |               28 |
-    | udt_name                 | text      |               30 |
-    | udt_schema               | text      |               29 |
+    | character_maximum_length | integer   |                1 |
+    | character_octet_length   | integer   |                2 |
+    | character_set_catalog    | text      |                3 |
+    | character_set_name       | text      |                4 |
+    | character_set_schema     | text      |                5 |
+    | check_action             | integer   |                6 |
+    | check_references         | text      |                7 |
+    | collation_catalog        | text      |                8 |
+    | collation_name           | text      |                9 |
+    | collation_schema         | text      |               10 |
+    | column_default           | text      |               11 |
+    | column_name              | text      |               12 |
+    | data_type                | text      |               13 |
+    | datetime_precision       | integer   |               14 |
+    | domain_catalog           | text      |               15 |
+    | domain_name              | text      |               16 |
+    | domain_schema            | text      |               17 |
+    | generation_expression    | text      |               18 |
+    | interval_precision       | integer   |               19 |
+    | interval_type            | text      |               20 |
+    | is_generated             | text      |               21 |
+    | is_nullable              | boolean   |               22 |
+    | numeric_precision        | integer   |               23 |
+    | numeric_precision_radix  | integer   |               24 |
+    | numeric_scale            | integer   |               25 |
+    | ordinal_position         | integer   |               26 |
+    | table_catalog            | text      |               27 |
+    | table_name               | text      |               28 |
+    | table_schema             | text      |               29 |
+    | udt_catalog              | text      |               30 |
+    | udt_name                 | text      |               31 |
+    | udt_schema               | text      |               32 |
     +--------------------------+-----------+------------------+
     SELECT 32 rows in set (... sec)
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocation.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/shard/SysAllocation.java
@@ -160,11 +160,8 @@ public class SysAllocation {
         }
 
         @Nullable
-        public String[] explanations() {
-            if (explanations == null) {
-                return null;
-            }
-            return explanations.toArray(new String[0]);
+        public List<String> explanations() {
+            return explanations;
         }
     }
 }

--- a/sql/src/main/java/io/crate/metadata/SystemTable.java
+++ b/sql/src/main/java/io/crate/metadata/SystemTable.java
@@ -174,6 +174,9 @@ public final class SystemTable<T> implements TableInfo {
         private List<ColumnIdent> primaryKeys = List.of();
         private BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting;
 
+        /**
+         * Override the routing funciton, if not overriden it defaults to `Routing.forTableOnSingleNode`
+         */
         public RelationBuilder<T> withRouting(BiFunction<DiscoveryNodes, RoutingProvider, Routing> getRouting) {
             this.getRouting = getRouting;
             return this;

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -21,35 +21,30 @@
 
 package io.crate.metadata.information;
 
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.NUMERIC_PRIMITIVE_TYPES;
+import static io.crate.types.DataTypes.TIMESTAMPZ;
+import static io.crate.types.DataTypes.TIMESTAMP;
+
+import java.util.Map;
+
 import io.crate.expression.reference.information.ColumnContext;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.SystemTable;
 import io.crate.types.ByteType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
-import org.elasticsearch.common.collect.MapBuilder;
-
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.types.DataTypes.BOOLEAN;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.NUMERIC_PRIMITIVE_TYPES;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.TIMESTAMP;
-import static io.crate.types.DataTypes.TIMESTAMPZ;
 
 
-public class InformationColumnsTableInfo extends InformationTableInfo<ColumnContext> {
+public class InformationColumnsTableInfo {
 
     public static final String NAME = "columns";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
@@ -57,85 +52,74 @@ public class InformationColumnsTableInfo extends InformationTableInfo<ColumnCont
     private static final String IS_GENERATED_NEVER = "NEVER";
     private static final String IS_GENERATED_ALWAYS = "ALWAYS";
 
-    private static ColumnRegistrar<ColumnContext> columnRegistrar() {
-        return new ColumnRegistrar<ColumnContext>(IDENT, RowGranularity.DOC)
-            .register("table_schema", STRING, false,
-                () -> forFunction(r -> r.info.ident().tableIdent().schema()))
-            .register("table_name", STRING, false,
-                () -> forFunction(r -> r.info.ident().tableIdent().name()))
-            .register("table_catalog", STRING, false,
-                () -> forFunction(r -> r.info.ident().tableIdent().schema()))
-            .register("column_name", STRING, false,
-                () -> forFunction(r -> r.info.column().sqlFqn()))
-            .register("ordinal_position", INTEGER, false,
-                () -> forFunction(ColumnContext::getOrdinal))
-            .register("data_type", STRING, false,
-                () -> forFunction(r -> r.info.valueType().getName()))
-            .register("is_generated", STRING, false,
-                () -> forFunction(r -> {
-                    if (r.info instanceof GeneratedReference) {
-                        return IS_GENERATED_ALWAYS;
-                    }
-                    return IS_GENERATED_NEVER;
-                }))
-            .register("is_nullable", BOOLEAN, false,
-                () -> forFunction(r -> !r.tableInfo.primaryKey().contains(r.info.column()) && r.info.isNullable()))
-
-            .register("generation_expression", STRING,
-                () -> forFunction(r -> {
-                    if (r.info instanceof GeneratedReference) {
-                        return ((GeneratedReference) r.info).formattedGeneratedExpression();
-                    }
+    public static SystemTable<ColumnContext> create() {
+        return SystemTable.<ColumnContext>builder()
+            .addNonNull("table_schema", STRING, r -> r.info.ident().tableIdent().schema())
+            .addNonNull("table_name", STRING, r -> r.info.ident().tableIdent().name())
+            .addNonNull("table_catalog", STRING, r -> r.info.ident().tableIdent().schema())
+            .addNonNull("column_name", STRING, r -> r.info.column().sqlFqn())
+            .addNonNull("ordinal_position", INTEGER, ColumnContext::getOrdinal)
+            .addNonNull("data_type", STRING, r -> r.info.valueType().getName())
+            .addNonNull("is_generated", STRING, r -> {
+                if (r.info instanceof GeneratedReference) {
+                    return IS_GENERATED_ALWAYS;
+                }
+                return IS_GENERATED_NEVER;
+            })
+            .addNonNull("is_nullable", BOOLEAN, r -> !r.tableInfo.primaryKey().contains(r.info.column()) && r.info.isNullable())
+            .add("generation_expression", STRING, r -> {
+                if (r.info instanceof GeneratedReference) {
+                    return ((GeneratedReference) r.info).formattedGeneratedExpression();
+                }
+                return null;
+            })
+            .add("column_default", STRING, r -> {
+                Symbol defaultExpression = r.info.defaultExpression();
+                if (defaultExpression != null) {
+                    return defaultExpression.toString();
+                } else {
                     return null;
-                }))
-            .register("column_default", STRING,
-                () -> forFunction(r -> {
-                    Symbol defaultExpression = r.info.defaultExpression();
-                    if (defaultExpression != null) {
-                        return defaultExpression.toString();
-                    } else {
-                        return null;
-                    }
-                }))
-            .register("character_maximum_length", INTEGER, () -> constant(null))
-            .register("character_octet_length", INTEGER, () -> constant(null))
-            .register("numeric_precision", INTEGER, () -> forFunction(r -> PRECISION_BY_TYPE_ID.get(r.info.valueType().id())))
-            .register("numeric_precision_radix", INTEGER,
-                () -> forFunction(r -> {
-                    if (NUMERIC_PRIMITIVE_TYPES.contains(r.info.valueType())) {
-                        return NUMERIC_PRECISION_RADIX;
-                    }
-                    return null;
-                }))
-            .register("numeric_scale", INTEGER, () -> constant(null))
-
-            .register("datetime_precision", INTEGER, () -> forFunction(r -> {
-                if (r.info.valueType() == TIMESTAMPZ
-                    || r.info.valueType() == TIMESTAMP) {
+                }
+            })
+            .add("character_maximum_length", INTEGER, ignored -> null)
+            .add("character_octet_length", INTEGER, ignored -> null)
+            .add("numeric_precision", INTEGER, r -> PRECISION_BY_TYPE_ID.get(r.info.valueType().id()))
+            .add("numeric_precision_radix", INTEGER, r -> {
+                if (NUMERIC_PRIMITIVE_TYPES.contains(r.info.valueType())) {
+                    return NUMERIC_PRECISION_RADIX;
+                }
+                return null;
+            })
+            .add("numeric_scale", INTEGER, ignored -> null)
+            .add("datetime_precision", INTEGER, r -> {
+                if (r.info.valueType() == TIMESTAMPZ || r.info.valueType() == TIMESTAMP) {
                     return DATETIME_PRECISION;
                 }
                 return null;
-            }))
-            .register("interval_type", STRING, () -> constant(null))
-            .register("interval_precision", INTEGER, () -> constant(null))
-            .register("character_set_catalog", STRING, () -> constant(null))
-            .register("character_set_schema", STRING, () -> constant(null))
-            .register("character_set_name", STRING, () -> constant(null))
-            .register("collation_catalog", STRING, () -> constant(null))
-            .register("collation_schema", STRING, () -> constant(null))
-            .register("collation_name", STRING, () -> constant(null))
-            .register("domain_catalog", STRING, () -> constant(null))
-            .register("domain_schema", STRING, () -> constant(null))
-            .register("domain_name", STRING, () -> constant(null))
-            .register("udt_catalog", STRING, () -> constant(null))
-            .register("udt_schema", STRING, () -> constant(null))
-            .register("udt_name", STRING, () -> constant(null))
-            .register("check_references", STRING, () -> constant(null))
-            .register("check_action", INTEGER, () -> constant(null));
-    }
-
-    static Map<ColumnIdent, RowCollectExpressionFactory<ColumnContext>> expression() {
-        return columnRegistrar().expressions();
+            })
+            .add("interval_type", STRING, ignored -> null)
+            .add("interval_precision", INTEGER, ignored -> null)
+            .add("character_set_catalog", STRING, ignored -> null)
+            .add("character_set_schema", STRING, ignored -> null)
+            .add("character_set_name", STRING, ignored -> null)
+            .add("collation_catalog", STRING, ignored -> null)
+            .add("collation_schema", STRING, ignored -> null)
+            .add("collation_name", STRING, ignored -> null)
+            .add("domain_catalog", STRING, ignored -> null)
+            .add("domain_schema", STRING, ignored -> null)
+            .add("domain_name", STRING, ignored -> null)
+            .add("udt_catalog", STRING, ignored -> null)
+            .add("udt_schema", STRING, ignored -> null)
+            .add("udt_name", STRING, ignored -> null)
+            .add("check_references", STRING, ignored -> null)
+            .add("check_action", INTEGER, ignored -> null)
+            .setPrimaryKeys(
+                new ColumnIdent("table_catalog"),
+                new ColumnIdent("table_name"),
+                new ColumnIdent("table_schema"),
+                new ColumnIdent("column_name")
+            )
+            .build(IDENT);
     }
 
     private static final Integer NUMERIC_PRECISION_RADIX = 2; // Binary
@@ -145,16 +129,12 @@ public class InformationColumnsTableInfo extends InformationTableInfo<ColumnCont
      * For floating point numbers please refer to:
      * https://en.wikipedia.org/wiki/IEEE_floating_point
      */
-    private static final Map<Integer, Integer> PRECISION_BY_TYPE_ID = new MapBuilder<Integer, Integer>()
-        .put(ByteType.ID, 8)
-        .put(ShortType.ID, 16)
-        .put(FloatType.ID, 24)
-        .put(IntegerType.ID, 32)
-        .put(DoubleType.ID, 53)
-        .put(LongType.ID, 64)
-        .map();
-
-    InformationColumnsTableInfo() {
-        super(IDENT, columnRegistrar(), "table_catalog", "table_name", "table_schema", "column_name");
-    }
+    private static final Map<Integer, Integer> PRECISION_BY_TYPE_ID = Map.ofEntries(
+        Map.entry(ByteType.ID, 8),
+        Map.entry(ShortType.ID, 16),
+        Map.entry(FloatType.ID, 24),
+        Map.entry(IntegerType.ID, 32),
+        Map.entry(DoubleType.ID, 53),
+        Map.entry(LongType.ID, 64)
+    );
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -44,7 +44,7 @@ public class InformationSchemaInfo implements SchemaInfo {
         tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
             .put(InformationTablesTableInfo.NAME, new InformationTablesTableInfo())
             .put(InformationViewsTableInfo.NAME, new InformationViewsTableInfo())
-            .put(InformationColumnsTableInfo.NAME, new InformationColumnsTableInfo())
+            .put(InformationColumnsTableInfo.NAME, InformationColumnsTableInfo.create())
             .put(InformationKeyColumnUsageTableInfo.NAME, new InformationKeyColumnUsageTableInfo())
             .put(InformationPartitionsTableInfo.NAME, new InformationPartitionsTableInfo())
             .put(InformationTableConstraintsTableInfo.NAME, new InformationTableConstraintsTableInfo())

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -69,7 +69,7 @@ public class InformationSchemaTableDefinitions {
             (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.tableInfo.ident().fqn())
                          // we also need to check for views which have privileges set
                          || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.tableInfo.ident().fqn()),
-            InformationColumnsTableInfo.expression()
+            InformationColumnsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
@@ -21,70 +21,35 @@
 
 package io.crate.metadata.sys;
 
-import com.google.common.collect.ImmutableMap;
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.expression.reference.sys.operation.OperationContext;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.ObjectType;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-
-import java.util.Map;
-import java.util.function.Supplier;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 
-public class SysOperationsTableInfo extends StaticTableInfo<OperationContext> {
+import java.util.function.Supplier;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import io.crate.expression.reference.sys.operation.OperationContext;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.SystemTable;
+
+public class SysOperationsTableInfo {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "operations");
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<OperationContext>> expressions(Supplier<DiscoveryNode> localNode) {
-        return columnRegistrar(localNode).expressions();
-    }
-
-    private static ColumnRegistrar<OperationContext> columnRegistrar(Supplier<DiscoveryNode> localNode) {
-        return new ColumnRegistrar<OperationContext>(IDENT, RowGranularity.DOC)
-            .register("id", STRING, () -> forFunction(c -> String.valueOf(c.id())))
-            .register("job_id", STRING, () -> forFunction(c -> c.jobId().toString()))
-            .register("name", STRING, () -> forFunction(OperationContext::name))
-            .register("started", TIMESTAMPZ, () -> forFunction(OperationContext::started))
-            .register("used_bytes", LONG, () -> forFunction(OperationContext::usedBytes))
-            .register("node", ObjectType.builder()
-                .setInnerType("id", STRING)
-                .setInnerType("name", STRING).build(), () -> forFunction(ignored -> ImmutableMap.of(
-                "id", localNode.get().getId(),
-                "name", localNode.get().getName()
-            )))
-            .register("node", "id", STRING, () -> forFunction(ignored -> localNode.get().getId()))
-            .register("node", "name", STRING, () -> forFunction(ignored -> localNode.get().getName()));
-    }
-
-    SysOperationsTableInfo(Supplier<DiscoveryNode> localNode) {
-        super(IDENT, columnRegistrar(localNode));
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
-    }
-
-    @Override
-    public Routing getRouting(ClusterState clusterState,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnAllNodes(IDENT, clusterState.getNodes());
+    public static SystemTable<OperationContext> create(Supplier<DiscoveryNode> localNode) {
+        return SystemTable.<OperationContext>builder()
+            .add("id", STRING, c -> String.valueOf(c.id()))
+            .add("job_id", STRING, c -> c.jobId().toString())
+            .add("name", STRING, OperationContext::name)
+            .add("started", TIMESTAMPZ, OperationContext::started)
+            .add("used_bytes", LONG, OperationContext::usedBytes)
+            .startObject("node")
+                .add("id", STRING, ignored -> localNode.get().getId())
+                .add("name", STRING, ignored -> localNode.get().getName())
+            .endObject()
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnAllNodes(IDENT, nodes))
+            .build(IDENT);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -52,7 +52,7 @@ public class SysSchemaInfo implements SchemaInfo {
         Supplier<DiscoveryNode> localNode = clusterService::localNode;
         tableInfos.put(SysJobsTableInfo.IDENT.name(), SysJobsTableInfo.create(localNode));
         tableInfos.put(SysJobsLogTableInfo.IDENT.name(), SysJobsLogTableInfo.create(localNode));
-        tableInfos.put(SysOperationsTableInfo.IDENT.name(), new SysOperationsTableInfo(localNode));
+        tableInfos.put(SysOperationsTableInfo.IDENT.name(), SysOperationsTableInfo.create(localNode));
         tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), SysOperationsLogTableInfo.create());
         tableInfos.put(SysChecksTableInfo.IDENT.name(), SysChecksTableInfo.create());
         tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), new SysNodeChecksTableInfo());

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -59,7 +59,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), new SysRepositoriesTableInfo(clusterService.getClusterSettings().maskedSettings()));
         tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), SysSnapshotsTableInfo.create());
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.create());
-        tableInfos.put(SysAllocationsTableInfo.IDENT.name(), new SysAllocationsTableInfo());
+        tableInfos.put(SysAllocationsTableInfo.IDENT.name(), SysAllocationsTableInfo.create());
         tableInfos.put(SysHealth.IDENT.name(), SysHealth.create());
         tableInfos.put(SysMetricsTableInfo.NAME.name(), SysMetricsTableInfo.create(localNode));
         tableInfos.put(SysSegmentsTableInfo.IDENT.name(), new SysSegmentsTableInfo(clusterService::localNode));

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -62,7 +62,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), SysAllocationsTableInfo.create());
         tableInfos.put(SysHealth.IDENT.name(), SysHealth.create());
         tableInfos.put(SysMetricsTableInfo.NAME.name(), SysMetricsTableInfo.create(localNode));
-        tableInfos.put(SysSegmentsTableInfo.IDENT.name(), new SysSegmentsTableInfo(clusterService::localNode));
+        tableInfos.put(SysSegmentsTableInfo.IDENT.name(), SysSegmentsTableInfo.create(clusterService::localNode));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysSegmentsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSegmentsTableInfo.java
@@ -22,82 +22,50 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.expression.reference.sys.shard.ShardSegment;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import io.crate.types.ObjectType;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.LONG;
+import static io.crate.types.DataTypes.STRING;
 
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.types.DataTypes.BOOLEAN;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.LONG;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 
-public class SysSegmentsTableInfo extends StaticTableInfo<ShardSegment> {
+import io.crate.expression.reference.sys.shard.ShardSegment;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.SystemTable;
+import io.crate.types.ObjectType;
+
+public class SysSegmentsTableInfo {
 
     public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "segments");
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<ShardSegment>> expressions(Supplier<DiscoveryNode> localNode) {
-        return columnRegistrar(localNode).expressions();
-    }
-
-    private static ColumnRegistrar<ShardSegment> columnRegistrar(Supplier<DiscoveryNode> localNode) {
-        return new ColumnRegistrar<ShardSegment>(IDENT, RowGranularity.DOC)
-            .register("table_schema", STRING, () -> forFunction(r -> r.getIndexParts().getSchema()))
-            .register("table_name", STRING, () -> forFunction(r -> r.getIndexParts().getTable()))
-            .register("partition_ident", STRING, () -> forFunction(r -> r.getIndexParts().getPartitionIdent()))
-            .register("shard_id", INTEGER, () -> forFunction(ShardSegment::getShardId))
-            .register("node", ObjectType.builder()
-                .setInnerType("id", STRING)
-                .setInnerType("name", STRING)
-                .build(), () -> forFunction(ignored -> Map.of(
-                "id", localNode.get().getId(),
-                "name", localNode.get().getName()
-            )))
-            .register("node", "id", STRING, () -> forFunction(ignored -> localNode.get().getId()))
-            .register("node", "name", STRING, () -> forFunction(ignored -> localNode.get().getName()))
-            .register("segment_name", STRING, () -> forFunction(r -> r.getSegment().getName()))
-            .register("generation", LONG, () -> forFunction(r -> r.getSegment().getGeneration()))
-            .register("num_docs", INTEGER, () -> forFunction(r -> r.getSegment().getNumDocs()))
-            .register("deleted_docs", INTEGER, () -> forFunction(r -> r.getSegment().getDeletedDocs()))
-            .register("size", LONG, () -> forFunction(r -> r.getSegment().sizeInBytes))
-            .register("memory", LONG, () -> forFunction(r -> r.getSegment().memoryInBytes))
-            .register("committed", BOOLEAN, () -> forFunction(r -> r.getSegment().committed))
-            .register("primary", BOOLEAN, () -> forFunction(ShardSegment::primary))
-            .register("search", BOOLEAN, () -> forFunction(r -> r.getSegment().search))
-            .register("version", STRING, () -> forFunction(r -> r.getSegment().getVersion().toString()))
-            .register("compound", BOOLEAN, () -> forFunction(r -> r.getSegment().compound))
-            .register("attributes", ObjectType.untyped(), () -> forFunction(r -> r.getSegment().getAttributes()));
-    }
-
-    SysSegmentsTableInfo(Supplier<DiscoveryNode> localNode) {
-        super(IDENT, columnRegistrar(localNode));
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
-    }
-
-    @Override
-    public Routing getRouting(ClusterState clusterState,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnAllNodes(IDENT, clusterState.getNodes());
+    @SuppressWarnings("unchecked")
+    public static SystemTable<ShardSegment> create(Supplier<DiscoveryNode> localNode) {
+        return SystemTable.<ShardSegment>builder()
+            .add("table_schema", STRING, r -> r.getIndexParts().getSchema())
+            .add("table_name", STRING, r -> r.getIndexParts().getTable())
+            .add("partition_ident", STRING, r -> r.getIndexParts().getPartitionIdent())
+            .add("shard_id", INTEGER, ShardSegment::getShardId)
+            .startObject("node")
+                .add("id", STRING, ignored -> localNode.get().getId())
+                .add("name", STRING, ignored -> localNode.get().getName())
+            .endObject()
+            .add("segment_name", STRING, r -> r.getSegment().getName())
+            .add("generation", LONG, r -> r.getSegment().getGeneration())
+            .add("num_docs", INTEGER, r -> r.getSegment().getNumDocs())
+            .add("deleted_docs", INTEGER, r -> r.getSegment().getDeletedDocs())
+            .add("size", LONG, r -> r.getSegment().sizeInBytes)
+            .add("memory", LONG, r -> r.getSegment().memoryInBytes)
+            .add("committed", BOOLEAN, r -> r.getSegment().committed)
+            .add("primary", BOOLEAN, ShardSegment::primary)
+            .add("search", BOOLEAN, r -> r.getSegment().search)
+            .add("version", STRING, r -> r.getSegment().getVersion().toString())
+            .add("compound", BOOLEAN, r -> r.getSegment().compound)
+            .add("attributes", ObjectType.untyped(), r -> (Map<String, Object>) (Map<?, ?>) r.getSegment().getAttributes())
+            .withRouting((nodes, routingProvider) -> Routing.forTableOnAllNodes(IDENT, nodes))
+            .build(IDENT);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -84,7 +84,7 @@ public class SysTableDefinitions {
             false));
         tableDefinitions.put(SysOperationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.activeOperations()),
-            SysOperationsTableInfo.expressions(localNode),
+            SysOperationsTableInfo.create(localNode).expressions(),
             false));
         tableDefinitions.put(SysOperationsLogTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(jobsLogs.operationsLog()),

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -113,7 +113,7 @@ public class SysTableDefinitions {
         tableDefinitions.put(SysAllocationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> sysAllocations,
             (user, allocation) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, allocation.fqn()),
-            SysAllocationsTableInfo.expressions()
+            SysAllocationsTableInfo.create().expressions()
         ));
 
         SummitsIterable summits = new SummitsIterable();

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -135,7 +135,7 @@ public class SysTableDefinitions {
             false));
         tableDefinitions.put(SysSegmentsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(shardSegmentInfos),
-            SysSegmentsTableInfo.expressions(clusterService::localNode),
+            SysSegmentsTableInfo.create(clusterService::localNode).expressions(),
             true));
     }
 

--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -123,13 +123,6 @@ public class ColumnRegistrar<T> {
         return register(new ColumnIdent(column), type, true, expression);
     }
 
-    public <R> ColumnRegistrar<T> register(String column,
-                                           DataType<R> type,
-                                           boolean nullable,
-                                           @Nullable RowCollectExpressionFactory<T> expression) {
-        return register(new ColumnIdent(column), type, nullable, expression);
-    }
-
     public ColumnRegistrar<T> register(ColumnIdent column,
                                        DataType<?> type,
                                        boolean nullable,

--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -118,13 +118,6 @@ public class ColumnRegistrar<T> {
     }
 
     public <R> ColumnRegistrar<T> register(String column,
-                                           String child,
-                                           DataType<R> type,
-                                           @Nullable RowCollectExpressionFactory<T> expression) {
-        return register(new ColumnIdent(column, child), type, true, expression);
-    }
-
-    public <R> ColumnRegistrar<T> register(String column,
                                            DataType<R> type,
                                            @Nullable RowCollectExpressionFactory<T> expression) {
         return register(new ColumnIdent(column), type, true, expression);

--- a/sql/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
@@ -78,7 +78,7 @@ public class SysAllocationsTest extends SQLTransportIntegrationTest {
         Map decision = (Map) decisions.get(0);
         assertNotNull("nodeId must not be null", decision.get("node_id"));
         assertNotNull("nodeName must not be null", decision.get("node_name"));
-        assertThat(((String[]) decision.get("explanations"))[0],
+        assertThat(((List<String>) decision.get("explanations")).get(0),
             startsWith("the shard cannot be allocated to the same node on which a copy of the shard already exists"));
 
         // second row: STARTED shard


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Getting us closer to removing the ColumnRegistrar, so we have fewer ways
to do the same thing.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)