### PR TITLE
Fix the github actions test setup for windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         bundled-jdk: [14.0.1+7]
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Run tests
-        run: |
-          ./gradlew :sql:test -Dbundled_jdk_version="${{ matrix.bundled-jdk }}"
+      - name: Run tests on ${{ matrix.os }}
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: :sql:test -Dbundled_jdk_version=${{ matrix.bundled-jdk }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,7 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - status-success=ci/jenkins/pr_tests
       - status-success~=^Test CrateDB SQL on ubuntu
+      - status-success~=^Test CrateDB SQL on windows
     name: default
   - actions:
       backport:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We were supposed to invoke Gradle command correctly on each OS.
Running Gradle on Windows with `.\gradle` resolved the issue with unzipping the JDK bundle.
I didn't want to introduce conditional steps and just decided to use the existing Gradle GitHub action.  

Reverts https://github.com/crate/crate/pull/9875

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
