### PR TITLE
Optimize return values in Upsert operation

### DIFF
--- a/sql/src/main/java/io/crate/execution/dml/ShardRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/ShardRequest.java
@@ -77,13 +77,6 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
         jobId = new UUID(in.readLong(), in.readLong());
     }
 
-    protected void readItems(StreamInput in, int size) throws IOException {
-        items = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            items.add(readItem(in));
-        }
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -117,8 +110,6 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
                ", timeout=" + timeout +
                '}';
     }
-
-    protected abstract I readItem(StreamInput input) throws IOException;
 
     public abstract static class Item implements Writeable {
 

--- a/sql/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
+++ b/sql/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.UUID;
 
 public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDeleteRequest.Item> {
@@ -64,15 +65,15 @@ public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDe
     public ShardDeleteRequest(StreamInput in) throws IOException {
         super(in);
         int numItems = in.readVInt();
-        readItems(in, numItems);
+        if (numItems > 0) {
+            items = new ArrayList<>(numItems);
+            for (int i = 0; i < numItems; i++) {
+                items.add(new ShardDeleteRequest.Item(in));
+            }
+        }
         if (in.readBoolean()) {
             skipFromLocation = in.readVInt();
         }
-    }
-
-    @Override
-    protected Item readItem(StreamInput input) throws IOException {
-        return new Item(input);
     }
 
     public static class Item extends ShardRequest.Item {

--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -123,7 +123,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     protected WritePrimaryResult<ShardUpsertRequest, ShardResponse> processRequestItems(IndexShard indexShard,
                                                                                         ShardUpsertRequest request,
                                                                                         AtomicBoolean killed) {
-        ShardResponse shardResponse = new ShardResponse(request.getReturnValues());
+        ShardResponse shardResponse = new ShardResponse(request.returnValues());
         String indexName = request.index();
         DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName), Operation.INSERT);
         Reference[] insertColumns = request.insertColumns();
@@ -143,9 +143,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                   tableInfo,
                                   request.updateColumns());
 
-        ReturnValueGen returnValueGen = request.getReturnValues() == null
+        ReturnValueGen returnValueGen = request.returnValues() == null
             ? null
-            : new ReturnValueGen(functions, txnCtx, tableInfo, request.getReturnValues());
+            : new ReturnValueGen(functions, txnCtx, tableInfo, request.returnValues());
 
         Translog.Location translogLocation = null;
         for (ShardUpsertRequest.Item item : request.items()) {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -97,8 +97,6 @@ public class ColumnIndexWriterProjector implements Projector {
             assignments = convert.sources();
         }
 
-        Symbol[] returnValueOrNull = returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[0]);
-
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
@@ -106,7 +104,7 @@ public class ColumnIndexWriterProjector implements Projector {
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),
-            returnValueOrNull,
+            returnValues.isEmpty() ? null : returnValues.toArray(new Symbol[0]),
             jobId,
             true);
 
@@ -117,8 +115,8 @@ public class ColumnIndexWriterProjector implements Projector {
                                               insertValues.materialize(),
                                               null,
                                               null,
-                                              null,
-                                              returnValueOrNull);
+                                              null
+                                              );
 
         var upsertResultContext = returnValues.isEmpty() ? UpsertResultContext.forRowCount() : UpsertResultContext.forResultRows();
 

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -112,7 +112,7 @@ public class IndexWriterProjector implements Projector {
             false);
 
         Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null, null);
+            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -539,8 +539,7 @@ public class ProjectionToProjectorVisitor
                                               null,
                                               projection.requiredVersion(),
                                               null,
-                                              null,
-                                              projection.returnValues()),
+                                              null),
             transportActionProvider.transportShardUpsertAction()::execute,
             collector);
     }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -168,8 +168,7 @@ public final class UpdateById implements Plan {
                                                                        null,
                                                                        version,
                                                                        seqNo,
-                                                                       primaryTerm,
-                                                                       request.getReturnValues());
+                                                                       primaryTerm);
             request.add(location, item);
         }
     }

--- a/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/sql/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -454,7 +454,7 @@ public class InsertFromValues implements LogicalPlan {
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null, this.writerProjection.returnValues().toArray(new Symbol[0]));
+                null, null, null);
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -78,14 +78,12 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             null,
             jobId,
             false
-        ).newRequest(shardId);
-        request.validateConstraints(false);
+            ).newRequest(shardId);
 
         request.add(123, new ShardUpsertRequest.Item(
             "99",
             null,
             new Object[]{99, "Marvin"},
-            null,
             null,
             null,
             null));
@@ -95,7 +93,6 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
             null));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
@@ -103,8 +100,8 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             null,
             2L,
             1L,
-            5L,
-            null));
+            5L
+            ));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
@@ -132,7 +129,6 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             jobId,
             false
         ).newRequest(shardId);
-        request.validateConstraints(false);
 
         request.add(123, new ShardUpsertRequest.Item(
             "99",
@@ -140,24 +136,21 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null,
-            new Symbol[0]));
+            null));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L,
-            new Symbol[0]));
+            5L));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -183,7 +183,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             UUID.randomUUID(),
             false
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -205,7 +205,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             UUID.randomUUID(),
             false
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
@@ -247,7 +247,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             UUID.randomUUID(),
             false
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
@@ -269,7 +269,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             UUID.randomUUID(),
             false
         ).newRequest(shardId);
-        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null, null));
+        request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null, null, null));
 
         reset(indexShard);
 

--- a/sql/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
@@ -34,10 +34,6 @@ import static org.hamcrest.Matchers.is;
 public class BulkShardCreationLimiterTest extends CrateUnitTest {
 
     private static class DummyShardRequest extends ShardRequest<DummyShardRequest, DummyRequestItem> {
-        @Override
-        protected DummyRequestItem readItem(StreamInput input) throws IOException {
-            return null;
-        }
     }
 
     private static class DummyRequestItem extends ShardRequest.Item {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This optimises the `ShardUpsertRequest` and the related `ShardUpsertRequest.Item`. Return values have been removed from the `ShardUpsertRequest.Item`, `Streamers` for insert values are generated on demand. Change is backward-compatible.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
