### PR TITLE
Use the new func registry for the _values and unnest functions.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -708,9 +708,15 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 columnValues
             ));
         }
-        FunctionIdent functionIdent = new FunctionIdent(ValuesFunction.NAME, Symbols.typeView(arrays));
-        FunctionImplementation implementation = functions.getQualified(functionIdent);
-        Function function = new Function(implementation.info(), arrays);
+        FunctionImplementation implementation = functions.getQualified(
+            ValuesFunction.SIGNATURE,
+            Symbols.typeView(arrays)
+        );
+        Function function = new Function(
+            implementation.info(),
+            implementation.signature(),
+            arrays
+        );
         TableFunctionImplementation<?> tableFunc = TableFunctionFactory.from(implementation);
         TableFunctionRelation relation = new TableFunctionRelation(tableFunc, function);
         context.startRelation();

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1689,8 +1689,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `1` of type `bigint` to type `undefined_array`");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: unnest(bigint, text)");
         analyze("select * from unnest(1, 'foo')");
     }
 

--- a/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.mock;
 
 public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
 
-    private SqlExpressions sqlExpressions;
+    protected SqlExpressions sqlExpressions;
     protected Functions functions;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Depends on and should be only merged after https://github.com/crate/crate/pull/9903, so the first commit should not be reviewed, such as it is part of #9903.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
