### PR TITLE
Migrate more system tables to use SystemTable

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -627,7 +627,7 @@ public class ProjectionToProjectorVisitor
         } else {
             InputFactory.Context<NestableCollectExpression<SysNodeCheck, ?>> cntx = new InputFactory(
                 functions).ctxForRefs(
-                context.txnCtx, new StaticTableReferenceResolver<>(SysNodeChecksTableInfo.expressions()));
+                context.txnCtx, new StaticTableReferenceResolver<>(SysNodeChecksTableInfo.create().expressions()));
             cntx.add(List.of(projection.returnValues()));
             return new SysUpdateResultSetProjector(rowUpdater,
                                                    rowWriter,

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -43,7 +43,7 @@ public class InformationSchemaInfo implements SchemaInfo {
     public InformationSchemaInfo() {
         tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
             .put(InformationTablesTableInfo.NAME, new InformationTablesTableInfo())
-            .put(InformationViewsTableInfo.NAME, new InformationViewsTableInfo())
+            .put(InformationViewsTableInfo.NAME, InformationViewsTableInfo.create())
             .put(InformationColumnsTableInfo.NAME, InformationColumnsTableInfo.create())
             .put(InformationKeyColumnUsageTableInfo.NAME, InformationKeyColumnUsageTableInfo.create())
             .put(InformationPartitionsTableInfo.NAME, InformationPartitionsTableInfo.create())

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -57,7 +57,7 @@ public class InformationSchemaTableDefinitions {
         tableDefinitions.put(InformationViewsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::views,
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident().fqn()),
-            InformationViewsTableInfo.expressions()
+            InformationViewsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationPartitionsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::partitions,

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
@@ -22,57 +22,24 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
-
-import java.util.Collections;
-import java.util.Map;
-import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
+import static io.crate.types.DataTypes.STRING;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
 
 
-public class PgAttrDefTable extends StaticTableInfo<Void> {
+public class PgAttrDefTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attrdef");
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    private static ColumnRegistrar<Void> columnRegistrar() {
-        return new ColumnRegistrar<Void>(IDENT, RowGranularity.DOC)
-            .register("oid", INTEGER, () -> constant(0))
-            .register("adrelid", INTEGER, () -> constant(0))
-            .register("adnum", INTEGER, () -> constant(0))
-            .register("adbin", STRING, () -> constant(null))
-            .register("adsrc", STRING, () -> constant(null));
-    }
-
-    PgAttrDefTable() {
-        super(IDENT, columnRegistrar(), Collections.emptyList());
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(IDENT, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("oid", INTEGER, x -> 0)
+            .add("adrelid", INTEGER, x -> 0)
+            .add("adnum", INTEGER, x -> 0)
+            .add("adbin", STRING, x -> null)
+            .add("adsrc", STRING, x -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -22,84 +22,49 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
+import static io.crate.metadata.pgcatalog.OidHash.relationOid;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
+import static io.crate.types.DataTypes.isArray;
+
 import io.crate.expression.reference.information.ColumnContext;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
+import io.crate.metadata.SystemTable;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.ArrayType;
 import io.crate.types.ObjectType;
-import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.metadata.pgcatalog.OidHash.relationOid;
-import static io.crate.types.DataTypes.isArray;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.SHORT;
-import static io.crate.types.DataTypes.BOOLEAN;
-import static io.crate.types.DataTypes.STRING_ARRAY;
-
-public class PgAttributeTable extends StaticTableInfo<ColumnContext> {
+public class PgAttributeTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attribute");
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<ColumnContext>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    @SuppressWarnings({"unchecked"})
-    private static ColumnRegistrar<ColumnContext> columnRegistrar() {
-        return new ColumnRegistrar<ColumnContext>(IDENT, RowGranularity.DOC)
-            .register("attrelid", INTEGER, () -> forFunction(c -> relationOid(c.tableInfo)))
-            .register("attname", STRING, () -> forFunction(c -> c.info.column().fqn()))
-            .register("atttypid", INTEGER, () -> forFunction(c -> PGTypes.get(c.info.valueType()).oid()))
-            .register("attstattarget", INTEGER, () -> constant(0))
-            .register("attlen", SHORT, () -> forFunction(c -> PGTypes.get(c.info.valueType()).typeLen()))
-            .register("attnum", INTEGER, () -> forFunction(c -> c.ordinal))
-            .register("attndims", INTEGER, () -> forFunction(c -> isArray(c.info.valueType()) ? 1 : 0))
-            .register("attcacheoff", INTEGER, () -> constant(-1))
-            .register("atttypmod", INTEGER, () -> constant(-1))
-            .register("attbyval", BOOLEAN, () -> constant(false))
-            .register("attstorage", STRING, () -> constant(null))
-            .register("attalign", STRING, () -> constant(null))
-            .register("attnotnull", BOOLEAN, () -> forFunction(c -> !c.info.isNullable()))
-            .register("atthasdef", BOOLEAN, () -> constant(false)) // don't support default values
-            .register("attidentity", STRING, () -> constant(""))
-            .register("attisdropped", BOOLEAN, () -> constant(false)) // don't support dropping columns
-            .register("attislocal", BOOLEAN, () -> constant(true))
-            .register("attinhcount", INTEGER, () -> constant(0))
-            .register("attcollation", INTEGER, () -> constant(0))
-            .register("attacl", new ArrayType(ObjectType.untyped()),() -> constant(null))
-            .register("attoptions", STRING_ARRAY, () -> constant(null))
-            .register("attfdwoptions", STRING_ARRAY, () -> constant(null));
-    }
-
-    PgAttributeTable() {
-        super(IDENT, columnRegistrar());
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(IDENT, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+    public static SystemTable<ColumnContext> create() {
+        return SystemTable.<ColumnContext>builder(IDENT)
+            .add("attrelid", INTEGER, c -> relationOid(c.tableInfo))
+            .add("attname", STRING, c -> c.info.column().fqn())
+            .add("atttypid", INTEGER, c -> PGTypes.get(c.info.valueType()).oid())
+            .add("attstattarget", INTEGER, c -> 0)
+            .add("attlen", SHORT, c -> PGTypes.get(c.info.valueType()).typeLen())
+            .add("attnum", INTEGER, c -> c.ordinal)
+            .add("attndims", INTEGER, c -> isArray(c.info.valueType()) ? 1 : 0)
+            .add("attcacheoff", INTEGER, c -> -1)
+            .add("atttypmod", INTEGER, c -> -1)
+            .add("attbyval", BOOLEAN, c -> false)
+            .add("attstorage", STRING, c -> null)
+            .add("attalign", STRING, c -> null)
+            .add("attnotnull", BOOLEAN, c -> !c.info.isNullable())
+            .add("atthasdef", BOOLEAN, c -> false) // don't support default values
+            .add("attidentity", STRING, c -> "")
+            .add("attisdropped", BOOLEAN, c -> false) // don't support dropping columns
+            .add("attislocal", BOOLEAN, c -> true)
+            .add("attinhcount", INTEGER, c -> 0)
+            .add("attcollation", INTEGER, c -> 0)
+            .add("attacl", new ArrayType<>(ObjectType.untyped()), c -> null)
+            .add("attoptions", STRING_ARRAY, c -> null)
+            .add("attfdwoptions", STRING_ARRAY, c -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -54,7 +54,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgStatsTable.NAME.name(), new PgStatsTable())
             .put(PgTypeTable.IDENT.name(), new PgTypeTable())
             .put(PgClassTable.IDENT.name(), pgClassTable)
-            .put(PgNamespaceTable.IDENT.name(), new PgNamespaceTable())
+            .put(PgNamespaceTable.IDENT.name(), PgNamespaceTable.create())
             .put(PgAttrDefTable.IDENT.name(), PgAttrDefTable.create())
             .put(PgAttributeTable.IDENT.name(), PgAttributeTable.create())
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -59,7 +59,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgAttributeTable.IDENT.name(), PgAttributeTable.create())
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
             .put(PgConstraintTable.IDENT.name(), PgConstraintTable.create())
-            .put(PgDatabaseTable.NAME.name(), new PgDatabaseTable())
+            .put(PgDatabaseTable.NAME.name(), PgDatabaseTable.create())
             .put(PgDescriptionTable.NAME.name(), new PgDescriptionTable())
             .put(PgSettingsTable.IDENT.name(), new PgSettingsTable())
             .put(PgProcTable.IDENT.name(), PgProcTable.create())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -52,7 +52,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
         this.pgClassTable = PgClassTable.create(tableStats);
         tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
             .put(PgStatsTable.NAME.name(), PgStatsTable.create())
-            .put(PgTypeTable.IDENT.name(), new PgTypeTable())
+            .put(PgTypeTable.IDENT.name(), PgTypeTable.create())
             .put(PgClassTable.IDENT.name(), pgClassTable)
             .put(PgNamespaceTable.IDENT.name(), PgNamespaceTable.create())
             .put(PgAttrDefTable.IDENT.name(), PgAttrDefTable.create())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -56,7 +56,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgClassTable.IDENT.name(), pgClassTable)
             .put(PgNamespaceTable.IDENT.name(), new PgNamespaceTable())
             .put(PgAttrDefTable.IDENT.name(), PgAttrDefTable.create())
-            .put(PgAttributeTable.IDENT.name(), new PgAttributeTable())
+            .put(PgAttributeTable.IDENT.name(), PgAttributeTable.create())
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
             .put(PgConstraintTable.IDENT.name(), new PgConstraintTable())
             .put(PgDatabaseTable.NAME.name(), new PgDatabaseTable())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -61,7 +61,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgConstraintTable.IDENT.name(), PgConstraintTable.create())
             .put(PgDatabaseTable.NAME.name(), PgDatabaseTable.create())
             .put(PgDescriptionTable.NAME.name(), PgDescriptionTable.create())
-            .put(PgSettingsTable.IDENT.name(), new PgSettingsTable())
+            .put(PgSettingsTable.IDENT.name(), PgSettingsTable.create())
             .put(PgProcTable.IDENT.name(), PgProcTable.create())
             .build();
     }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -60,7 +60,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
             .put(PgConstraintTable.IDENT.name(), PgConstraintTable.create())
             .put(PgDatabaseTable.NAME.name(), PgDatabaseTable.create())
-            .put(PgDescriptionTable.NAME.name(), new PgDescriptionTable())
+            .put(PgDescriptionTable.NAME.name(), PgDescriptionTable.create())
             .put(PgSettingsTable.IDENT.name(), new PgSettingsTable())
             .put(PgProcTable.IDENT.name(), PgProcTable.create())
             .build();

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -51,7 +51,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
         this.udfService = udfService;
         this.pgClassTable = PgClassTable.create(tableStats);
         tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
-            .put(PgStatsTable.NAME.name(), new PgStatsTable())
+            .put(PgStatsTable.NAME.name(), PgStatsTable.create())
             .put(PgTypeTable.IDENT.name(), new PgTypeTable())
             .put(PgClassTable.IDENT.name(), pgClassTable)
             .put(PgNamespaceTable.IDENT.name(), PgNamespaceTable.create())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -55,7 +55,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgTypeTable.IDENT.name(), new PgTypeTable())
             .put(PgClassTable.IDENT.name(), pgClassTable)
             .put(PgNamespaceTable.IDENT.name(), new PgNamespaceTable())
-            .put(PgAttrDefTable.IDENT.name(), new PgAttrDefTable())
+            .put(PgAttrDefTable.IDENT.name(), PgAttrDefTable.create())
             .put(PgAttributeTable.IDENT.name(), new PgAttributeTable())
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
             .put(PgConstraintTable.IDENT.name(), new PgConstraintTable())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -58,7 +58,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgAttrDefTable.IDENT.name(), PgAttrDefTable.create())
             .put(PgAttributeTable.IDENT.name(), PgAttributeTable.create())
             .put(PgIndexTable.IDENT.name(), PgIndexTable.create())
-            .put(PgConstraintTable.IDENT.name(), new PgConstraintTable())
+            .put(PgConstraintTable.IDENT.name(), PgConstraintTable.create())
             .put(PgDatabaseTable.NAME.name(), new PgDatabaseTable())
             .put(PgDescriptionTable.NAME.name(), new PgDescriptionTable())
             .put(PgSettingsTable.IDENT.name(), new PgSettingsTable())

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -99,7 +99,7 @@ public class PgCatalogTableDefinitions {
         tableDefinitions.put(PgConstraintTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relationName().fqn()),
-            PgConstraintTable.expressions()
+            PgConstraintTable.create().expressions()
         ));
         tableDefinitions.put(PgDescriptionTable.NAME, new StaticTableDefinition<>(
             () -> completedFuture(emptyList()),

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -112,7 +112,7 @@ public class PgCatalogTableDefinitions {
                 .iterator();
         tableDefinitions.put(PgSettingsTable.IDENT, new StaticTableDefinition<>(
             () -> sessionSettings,
-            PgSettingsTable.expressions(),
+            PgSettingsTable.create().expressions(),
             (txnCtx, settingInfo) -> settingInfo.resolveValue(txnCtx)
             )
         );

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -90,7 +90,7 @@ public class PgCatalogTableDefinitions {
             informationSchemaIterables::columns,
             (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.tableInfo.ident().fqn())
                          || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.tableInfo.ident().fqn()),
-            PgAttributeTable.expressions()
+            PgAttributeTable.create().expressions()
         ));
         tableDefinitions.put(PgIndexTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(informationSchemaIterables.pgIndices()),

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -84,7 +84,7 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgAttrDefTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(Collections.emptyList()),
-            PgAttrDefTable.expressions(),
+            PgAttrDefTable.create().expressions(),
             false));
         tableDefinitions.put(PgAttributeTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -54,7 +54,7 @@ public class PgCatalogTableDefinitions {
             new StaticTableDefinition<>(
                 tableStats::statsEntries,
                 (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relation().fqn()),
-                PgStatsTable.expressions()
+                PgStatsTable.create().expressions()
             )
         );
         tableDefinitions.put(PgTypeTable.IDENT, new StaticTableDefinition<>(

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -103,7 +103,7 @@ public class PgCatalogTableDefinitions {
         ));
         tableDefinitions.put(PgDescriptionTable.NAME, new StaticTableDefinition<>(
             () -> completedFuture(emptyList()),
-            PgDescriptionTable.expressions(),
+            PgDescriptionTable.create().expressions(),
             false)
         );
         Iterable<NamedSessionSetting> sessionSettings =

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -75,7 +75,7 @@ public class PgCatalogTableDefinitions {
         );
         tableDefinitions.put(PgDatabaseTable.NAME, new StaticTableDefinition<>(
             () -> completedFuture(singletonList(null)),
-            PgDatabaseTable.expressions(),
+            PgDatabaseTable.create().expressions(),
             false));
         tableDefinitions.put(PgNamespaceTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::schemas,

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -80,7 +80,7 @@ public class PgCatalogTableDefinitions {
         tableDefinitions.put(PgNamespaceTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::schemas,
             (user, s) -> user.hasAnyPrivilege(Privilege.Clazz.SCHEMA, s.name()),
-            PgNamespaceTable.expressions()
+            PgNamespaceTable.create().expressions()
         ));
         tableDefinitions.put(PgAttrDefTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(Collections.emptyList()),

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -22,6 +22,16 @@
 
 package io.crate.metadata.pgcatalog;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.common.inject.Inject;
+
 import io.crate.analyze.user.Privilege;
 import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
 import io.crate.expression.reference.StaticTableDefinition;
@@ -30,15 +40,6 @@ import io.crate.metadata.settings.session.NamedSessionSetting;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.statistics.TableStats;
-import org.elasticsearch.common.inject.Inject;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class PgCatalogTableDefinitions {
 
@@ -59,7 +60,7 @@ public class PgCatalogTableDefinitions {
         );
         tableDefinitions.put(PgTypeTable.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(PGTypes.pgTypes()),
-            PgTypeTable.expressions(),
+            PgTypeTable.create().expressions(),
             false));
         tableDefinitions.put(PgClassTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::pgClasses,

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
@@ -22,66 +22,36 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.Constants;
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
-
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgDatabaseTable extends StaticTableInfo<Void> {
+import io.crate.Constants;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+public class PgDatabaseTable {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_database");
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    private static ColumnRegistrar<Void> columnRegistrar() {
-        return new ColumnRegistrar<Void>(NAME, RowGranularity.DOC)
-            .register("oid", INTEGER, () -> constant(0))
-            .register("datname", STRING, () -> constant(Constants.DB_NAME))
-            .register("datdba", INTEGER, () -> constant(1))
-            .register("encoding", INTEGER, () -> constant(6))
-            .register("datcollate", STRING, () -> constant("en_US.UTF-8"))
-            .register("datctype", STRING, () -> constant("en_US.UTF-8"))
-            .register("datistemplate", BOOLEAN,() -> constant(false))
-            .register("datallowconn", BOOLEAN, () -> constant(true))
-            .register("datconnlimit", INTEGER,() -> constant(-1)) // no limit
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(NAME)
+            .add("oid", INTEGER, c -> 0)
+            .add("datname", STRING, c -> Constants.DB_NAME)
+            .add("datdba", INTEGER, c -> 1)
+            .add("encoding", INTEGER, c -> 6)
+            .add("datcollate", STRING, c -> "en_US.UTF-8")
+            .add("datctype", STRING, c -> "en_US.UTF-8")
+            .add("datistemplate", BOOLEAN,c -> false)
+            .add("datallowconn", BOOLEAN, c -> true)
+            .add("datconnlimit", INTEGER,c -> -1) // no limit
             // We don't have any good values for these
-            .register("datlastsysoid", INTEGER, () -> constant(null))
-            .register("datfrozenxid", INTEGER, () -> constant(null))
-            .register("datminmxid", INTEGER, () -> constant(null))
-            .register("dattablespace", INTEGER, () -> constant(null))
-            .register("datacl", STRING_ARRAY, () -> constant(null));
-    }
-
-    PgDatabaseTable() {
-        super(NAME, columnRegistrar());
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+            .add("datlastsysoid", INTEGER, c -> null)
+            .add("datfrozenxid", INTEGER, c -> null)
+            .add("datminmxid", INTEGER, c -> null)
+            .add("dattablespace", INTEGER, c -> null)
+            .add("datacl", STRING_ARRAY, c -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
@@ -22,52 +22,22 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
-
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
 
-public final class PgDescriptionTable extends StaticTableInfo<Void> {
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+public final class PgDescriptionTable {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_description");
 
-    PgDescriptionTable() {
-        super(NAME, columnRegistrar());
-    }
-
-    private static ColumnRegistrar<Void> columnRegistrar() {
-        return new ColumnRegistrar<Void>(NAME, RowGranularity.DOC)
-            .register("objoid", INTEGER, () -> constant(null))
-            .register("classoid", INTEGER, () -> constant(null))
-            .register("objsubid", INTEGER, () -> constant(null))
-            .register("description", STRING , () -> constant(null));
-    }
-
-    static Map<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(NAME, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(NAME)
+            .add("objoid", INTEGER, c -> null)
+            .add("classoid", INTEGER, c -> null)
+            .add("objsubid", INTEGER, c -> null)
+            .add("description", STRING , c -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
@@ -22,60 +22,26 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.metadata.ColumnIdent;
+import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.SystemTable;
 import io.crate.metadata.table.SchemaInfo;
-import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.ArrayType;
 import io.crate.types.ObjectType;
-import org.elasticsearch.cluster.ClusterState;
 
-import java.util.Map;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.INTEGER;
-
-public class PgNamespaceTable extends StaticTableInfo<SchemaInfo> {
+public class PgNamespaceTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_namespace");
 
-    static Map<ColumnIdent, RowCollectExpressionFactory<SchemaInfo>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    @SuppressWarnings({"unchecked"})
-    private static ColumnRegistrar<SchemaInfo> columnRegistrar() {
-        return new ColumnRegistrar<SchemaInfo>(IDENT, RowGranularity.DOC)
-            .register("oid", INTEGER, () -> forFunction(s -> schemaOid(s.name())))
-            .register("nspname", STRING, () -> forFunction(SchemaInfo::name))
-            .register("nspowner", INTEGER, () -> constant(0))
-            .register("nspacl", new ArrayType(ObjectType.untyped()), () -> constant(null));
-    }
-
-    PgNamespaceTable() {
-        super(IDENT, columnRegistrar());
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(IDENT, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+    public static SystemTable<SchemaInfo> create() {
+        return SystemTable.<SchemaInfo>builder(IDENT)
+            .add("oid", INTEGER, s -> schemaOid(s.name()))
+            .add("nspname", STRING, SchemaInfo::name)
+            .add("nspowner", INTEGER, c -> 0)
+            .add("nspacl", new ArrayType<>(ObjectType.untyped()), c -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
@@ -22,74 +22,39 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.analyze.WhereClause;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.settings.session.NamedSessionSetting;
-import io.crate.metadata.table.ColumnRegistrar;
-import io.crate.metadata.table.StaticTableInfo;
-import org.elasticsearch.cluster.ClusterState;
-
-import java.util.Map;
-
-import static io.crate.execution.engine.collect.NestableCollectExpression.constant;
-import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.BOOLEAN;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.metadata.settings.session.NamedSessionSetting;
 
 
-public class PgSettingsTable extends StaticTableInfo<NamedSessionSetting> {
+public class PgSettingsTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_settings");
 
-    @SuppressWarnings({"unchecked"})
-    private static ColumnRegistrar<NamedSessionSetting> columnRegistrar() {
-        return new ColumnRegistrar<NamedSessionSetting>(IDENT, RowGranularity.DOC)
-            .register("name", STRING, () -> forFunction(NamedSessionSetting::name))
-            .register("setting", STRING, () -> forFunction(NamedSessionSetting::value))
-            .register("unit", STRING, () -> constant(null))
-            .register("category", STRING, () -> constant(null))
-            .register("short_desc", STRING, () -> forFunction(NamedSessionSetting::description))
-            .register("extra_desc", STRING, () -> constant(null))
-            .register("context", STRING, () -> constant(null))
-            .register("vartype", STRING, () -> forFunction(NamedSessionSetting::type))
-            .register("source", STRING, () -> constant(null))
-            .register("enumvals", STRING_ARRAY, () -> constant(null))
-            .register("min_val", STRING, () -> constant(null))
-            .register("max_val", STRING, () -> constant(null))
-            .register("boot_val", STRING, () -> forFunction(NamedSessionSetting::defaultValue))
-            .register("reset_val", STRING, () -> forFunction(NamedSessionSetting::defaultValue))
-            .register("sourcefile", STRING, () -> constant(null))
-            .register("sourceline", INTEGER, () -> constant(null))
-            .register("pending_restart", BOOLEAN, () -> constant(null));
-    }
-
-    PgSettingsTable() {
-        super(IDENT, columnRegistrar());
-    }
-
-    static Map<ColumnIdent, RowCollectExpressionFactory<NamedSessionSetting>> expressions() {
-        return columnRegistrar().expressions();
-    }
-
-    @Override
-    public Routing getRouting(ClusterState state,
-                              RoutingProvider routingProvider,
-                              WhereClause whereClause,
-                              RoutingProvider.ShardSelection shardSelection,
-                              SessionContext sessionContext) {
-        return Routing.forTableOnSingleNode(IDENT, state.getNodes().getLocalNodeId());
-    }
-
-    @Override
-    public RowGranularity rowGranularity() {
-        return RowGranularity.DOC;
+    public static SystemTable<NamedSessionSetting> create() {
+        return SystemTable.<NamedSessionSetting>builder(IDENT)
+            .add("name", STRING, NamedSessionSetting::name)
+            .add("setting", STRING, NamedSessionSetting::value)
+            .add("unit", STRING, c -> null)
+            .add("category", STRING, c -> null)
+            .add("short_desc", STRING, NamedSessionSetting::description)
+            .add("extra_desc", STRING, c -> null)
+            .add("context", STRING, c -> null)
+            .add("vartype", STRING, NamedSessionSetting::type)
+            .add("source", STRING, c -> null)
+            .add("enumvals", STRING_ARRAY, c -> null)
+            .add("min_val", STRING, c -> null)
+            .add("max_val", STRING, c -> null)
+            .add("boot_val", STRING, NamedSessionSetting::defaultValue)
+            .add("reset_val", STRING, NamedSessionSetting::defaultValue)
+            .add("sourcefile", STRING, c -> null)
+            .add("sourceline", INTEGER, c -> null)
+            .add("pending_restart", BOOLEAN, c -> null)
+            .build();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -55,7 +55,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysOperationsTableInfo.IDENT.name(), SysOperationsTableInfo.create(localNode));
         tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), SysOperationsLogTableInfo.create());
         tableInfos.put(SysChecksTableInfo.IDENT.name(), SysChecksTableInfo.create());
-        tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), new SysNodeChecksTableInfo());
+        tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), SysNodeChecksTableInfo.create());
         tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), SysRepositoriesTableInfo.create(clusterService.getClusterSettings().maskedSettings()));
         tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), SysSnapshotsTableInfo.create());
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.create());

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -56,7 +56,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), SysOperationsLogTableInfo.create());
         tableInfos.put(SysChecksTableInfo.IDENT.name(), SysChecksTableInfo.create());
         tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), new SysNodeChecksTableInfo());
-        tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), new SysRepositoriesTableInfo(clusterService.getClusterSettings().maskedSettings()));
+        tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), SysRepositoriesTableInfo.create(clusterService.getClusterSettings().maskedSettings()));
         tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), SysSnapshotsTableInfo.create());
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.create());
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), SysAllocationsTableInfo.create());

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -99,7 +99,7 @@ public class SysTableDefinitions {
 
         tableDefinitions.put(SysNodeChecksTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysNodeChecks),
-            SysNodeChecksTableInfo.expressions(),
+            SysNodeChecksTableInfo.create().expressions(),
             true));
         tableDefinitions.put(SysRepositoriesTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(repositoriesService.getRepositoriesList()),

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -103,7 +103,7 @@ public class SysTableDefinitions {
             true));
         tableDefinitions.put(SysRepositoriesTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(repositoriesService.getRepositoriesList()),
-            SysRepositoriesTableInfo.expressions(clusterService.getClusterSettings().maskedSettings()),
+            SysRepositoriesTableInfo.create(clusterService.getClusterSettings().maskedSettings()).expressions(),
             false));
         tableDefinitions.put(SysSnapshotsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysSnapshots.currentSnapshots()),


### PR DESCRIPTION
This also adds support for queries like: 

    select settings['bucket'] from sys.repositories

Which previously failed with:

    ColumnUnknownException: Column settings['bucket'] unknown

After this I think only 3 more tables need to be migrated (`sys.shards`, `information_schema.tables` (https://github.com/crate/crate/pull/9896) and `sys.cluster`). 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)