### PR TITLE
Fix signature parameter binding for nested variables of any type.

### DIFF
--- a/sql/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -356,6 +356,62 @@ public class SignatureBinderTest extends CrateUnitTest {
     }
 
     @Test
+    public void test_variable_arity_with_array_nested_variable_constraint_of_any_type() {
+        Signature signature = functionSignature()
+            .returnType(parseTypeSignature("integer"))
+            .argumentTypes(parseTypeSignature("array(E)"))
+            .typeVariableConstraints(List.of(typeVariableOfAnyType("E")))
+            .setVariableArity(true)
+            .build();
+
+        // arity 1
+        assertThat(signature)
+            .boundTo("array(text)")
+            .produces(new BoundVariables(
+                Map.of(
+                    "E", type("text")
+                )
+            ));
+        // arity 2
+        assertThat(signature)
+            .boundTo("array(text)", "array(integer)")
+            .produces(new BoundVariables(
+                Map.of(
+                    "E", type("text"),
+                    "_generated_E1", type("integer")
+                )
+            ));
+    }
+
+    @Test
+    public void test_variable_arity_with_multi_array_nested_variable_constraint_of_any_type() {
+        Signature signature = functionSignature()
+            .returnType(parseTypeSignature("integer"))
+            .argumentTypes(parseTypeSignature("array(array(E))"))
+            .typeVariableConstraints(List.of(typeVariableOfAnyType("E")))
+            .setVariableArity(true)
+            .build();
+
+        // arity 1
+        assertThat(signature)
+            .boundTo("array(array(text))")
+            .produces(new BoundVariables(
+                Map.of(
+                    "E", type("text")
+                )
+            ));
+        // arity 2
+        assertThat(signature)
+            .boundTo("array(array(text))", "array(array(long))")
+            .produces(new BoundVariables(
+                Map.of(
+                    "E", type("text"),
+                    "_generated_E1", type("long")
+                )
+            ));
+    }
+
+    @Test
     public void testVarArgs() {
         Signature variableArityFunction = functionSignature()
             .returnType(parseTypeSignature("boolean"))


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change fixes the corner case in the signature parameters binding
when 
- the type variable constraint is a type variable of any type
- has the variable arity > 1
- used as a nested type parameter of the function type parameter

For example, the following declared signature that matches function
signatures with N arrays of any type as type parameters:

```
Signature.builder()
    .argumentTypes(parseTypeSignature("array(E)"))
    .typeVariableConstraints(List.of(typeVariableOfAnyType("E")))
    .setVariableArity(true)

    .name(...)
    .kind(...)
    .returnType(...)
    .build();
```

but previously it would not be matched for the following type parameters:

```
List.of(
    parseTypeSignature("array(integer)"),
    parseTypeSignature("array(text)")
)
```

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
