### PR TITLE
Use the new func registry for the not and is null predicates.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -63,8 +63,8 @@ public class EqualityExtractor {
 
     private static final Function NULL_MARKER = new Function(
         new FunctionInfo(
-            new FunctionIdent("null_marker", ImmutableList.<DataType>of()),
-            DataTypes.UNDEFINED), ImmutableList.<Symbol>of());
+            new FunctionIdent("null_marker", List.of()),
+            DataTypes.UNDEFINED), List.of());
     private static final EqProxy NULL_MARKER_PROXY = new EqProxy(NULL_MARKER);
 
     private EvaluatingNormalizer normalizer;
@@ -443,7 +443,7 @@ public class EqualityExtractor {
                 if (!context.proxyBelow && function.valueType().equals(DataTypes.BOOLEAN)) {
                     return Literal.BOOLEAN_TRUE;
                 }
-                return new Function(function.info(), newArgs);
+                return new Function(function.info(), function.signature(), newArgs);
             }
             context.seenUnknown = true;
             return Literal.BOOLEAN_TRUE;

--- a/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -28,22 +28,42 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class NotPredicate extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "op_not";
     public static final FunctionInfo INFO = FunctionInfo.of(NAME, List.of(DataTypes.BOOLEAN), DataTypes.BOOLEAN);
+    public static final Signature SIGNATURE = Signature.scalar(
+        NAME,
+        DataTypes.BOOLEAN.getTypeSignature(),
+        DataTypes.BOOLEAN.getTypeSignature());
 
     public static void register(PredicateModule module) {
-        module.register(new NotPredicate());
+        module.register(
+            SIGNATURE,
+            (signature, argTypes) -> new NotPredicate(signature));
+    }
+
+    private final Signature signature;
+
+    private NotPredicate(Signature signature) {
+        this.signature = signature;
     }
 
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/predicate/PredicateModule.java
+++ b/sql/src/main/java/io/crate/expression/predicate/PredicateModule.java
@@ -21,34 +21,13 @@
 
 package io.crate.expression.predicate;
 
-import io.crate.metadata.FunctionIdent;
+import io.crate.expression.AbstractFunctionModule;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionName;
-import io.crate.metadata.FunctionResolver;
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.inject.multibindings.MapBinder;
 
-public class PredicateModule extends AbstractModule {
-
-    private MapBinder<FunctionIdent, FunctionImplementation> functionBinder;
-    private MapBinder<FunctionName, FunctionResolver> resolverBinder;
-
-    public void register(FunctionImplementation impl) {
-        functionBinder.addBinding(impl.info().ident()).toInstance(impl);
-    }
-
-    public void register(String name, FunctionResolver functionResolver) {
-        register(new FunctionName(name), functionResolver);
-    }
-
-    public void register(FunctionName qualifiedName, FunctionResolver functionResolver) {
-        resolverBinder.addBinding(qualifiedName).toInstance(functionResolver);
-    }
+public class PredicateModule extends AbstractFunctionModule<FunctionImplementation> {
 
     @Override
-    protected void configure() {
-        functionBinder = MapBinder.newMapBinder(binder(), FunctionIdent.class, FunctionImplementation.class);
-        resolverBinder = MapBinder.newMapBinder(binder(), FunctionName.class, FunctionResolver.class);
+    public void configureFunctions() {
         IsNullPredicate.register(this);
         NotPredicate.register(this);
         MatchPredicate.register(this);

--- a/sql/src/main/java/io/crate/lucene/NotQuery.java
+++ b/sql/src/main/java/io/crate/lucene/NotQuery.java
@@ -30,7 +30,6 @@ import io.crate.expression.scalar.conditional.CoalesceFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -149,8 +148,10 @@ final class NotQuery implements FunctionToQuery {
             }
         }
         if (ctx.hasStrictThreeValuedLogicFunction) {
-            FunctionInfo isNullInfo = IsNullPredicate.generateInfo(Collections.singletonList(arg.valueType()));
-            Function isNullFunction = new Function(isNullInfo, Collections.singletonList(arg));
+            Function isNullFunction = new Function(
+                IsNullPredicate.generateInfo(Collections.singletonList(arg.valueType())),
+                IsNullPredicate.SIGNATURE,
+                Collections.singletonList(arg));
             builder.add(
                 Queries.not(LuceneQueryBuilder.genericFunctionFilter(isNullFunction, context)),
                 BooleanClause.Occur.MUST

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -663,8 +663,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testNotTimestamp() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `date` of type `timestamp with time zone` to type `boolean`");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_not(timestamp with time zone)");
         analyze("select id, name from parted where not date");
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
