### PR TITLE
Use native epoll transport on Linux

### DIFF
--- a/es/es-transport/build.gradle
+++ b/es/es-transport/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation "io.netty:netty-handler:${versions.netty4}"
     implementation "io.netty:netty-resolver:${versions.netty4}"
     implementation "io.netty:netty-transport:${versions.netty4}"
+    implementation "io.netty:netty-transport-native-epoll:${versions.netty4}:linux-x86_64"
 }

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile "org.hdrhistogram:HdrHistogram:2.1.9"
     implementation "io.netty:netty-codec-http:${versions.netty4}"
     compile "io.netty:netty-transport:${versions.netty4}"
+    compile "io.netty:netty-transport-native-epoll:${versions.netty4}:linux-x86_64"
     compile "io.netty:netty-codec:${versions.netty4}"
     compile "io.netty:netty-buffer:${versions.netty4}"
     compile "com.google.guava:guava:${versions.guava}"


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

From https://github.com/netty/netty/wiki/Native-transports

    These JNI transports add features specific to a particular platform,
    generate less garbage, and generally improve performance when
    compared to the NIO based transport.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)