### PR TITLE
Move the terms index of `_id` off-heap

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2245,10 +2245,10 @@ public class InternalEngine extends Engine {
         Directory unwrap = FilterDirectory.unwrap(directory);
         boolean defaultOffHeap = FsDirectoryService.isHybridFs(unwrap) || unwrap instanceof MMapDirectory;
         return Map.of(
-            BlockTreeTermsReader.FST_MODE_KEY, // if we are using MMAP for term dics we force all off heap unless it's the ID field
+            // if we are using MMAP for term dics we force all off heap
+            BlockTreeTermsReader.FST_MODE_KEY,
             defaultOffHeap ? FSTLoadMode.OFF_HEAP.name() : FSTLoadMode.ON_HEAP.name()
-            , BlockTreeTermsReader.FST_MODE_KEY + "." + IdFieldMapper.NAME, // always force ID field on-heap for fast updates
-            FSTLoadMode.ON_HEAP.name());
+        );
     }
 
 

--- a/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5354,8 +5354,7 @@ public class InternalEngineTests extends EngineTestCase {
             Directory unwrap = FilterDirectory.unwrap(dir);
             boolean isMMap = unwrap instanceof MMapDirectory;
             Map<String, String> readerAttributes = InternalEngine.getReaderAttributes(dir);
-            assertEquals(2, readerAttributes.size());
-            assertEquals("ON_HEAP", readerAttributes.get("blocktree.terms.fst._id"));
+            assertEquals(1, readerAttributes.size());
             if (isMMap) {
                 assertEquals("OFF_HEAP", readerAttributes.get("blocktree.terms.fst"));
             } else {
@@ -5367,8 +5366,7 @@ public class InternalEngineTests extends EngineTestCase {
             Map<String, String> readerAttributes =
                 InternalEngine.getReaderAttributes(randomBoolean() ? dir :
                     new MockDirectoryWrapper(random(), dir));
-            assertEquals(2, readerAttributes.size());
-            assertEquals("ON_HEAP", readerAttributes.get("blocktree.terms.fst._id"));
+            assertEquals(1, readerAttributes.size());
             assertEquals("OFF_HEAP", readerAttributes.get("blocktree.terms.fst"));
         }
 
@@ -5383,18 +5381,16 @@ public class InternalEngineTests extends EngineTestCase {
             Map<String, String> readerAttributes =
                 InternalEngine.getReaderAttributes(randomBoolean() ? directory :
                     new MockDirectoryWrapper(random(), directory));
-            assertEquals(2, readerAttributes.size());
+            assertEquals(1, readerAttributes.size());
 
             switch (IndexModule.defaultStoreType(true)) {
                 case HYBRIDFS:
                 case MMAPFS:
-                    assertEquals("ON_HEAP", readerAttributes.get("blocktree.terms.fst._id"));
                     assertEquals("OFF_HEAP", readerAttributes.get("blocktree.terms.fst"));
                     break;
                 case NIOFS:
                 case SIMPLEFS:
                 case FS:
-                    assertEquals("ON_HEAP", readerAttributes.get("blocktree.terms.fst._id"));
                     assertEquals("ON_HEAP", readerAttributes.get("blocktree.terms.fst"));
                     break;
                     default:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Port of https://github.com/elastic/elasticsearch/pull/52405 but excludes
the undocumented setting.

Relates to https://github.com/crate/crate/issues/9796


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)