### PR TITLE
Remove realtime and readFromTranslog flag from Get

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1291,24 +1291,16 @@ public abstract class Engine implements Closeable {
     }
 
     public static class Get {
-        private final boolean realtime;
         private final Term uid;
         private final String id;
-        private final boolean readFromTranslog;
         private long version = Versions.MATCH_ANY;
         private VersionType versionType = VersionType.INTERNAL;
         private long ifSeqNo = UNASSIGNED_SEQ_NO;
         private long ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
 
-        public Get(boolean realtime, boolean readFromTranslog, String id, Term uid) {
-            this.realtime = realtime;
+        public Get(String id, Term uid) {
             this.id = id;
             this.uid = uid;
-            this.readFromTranslog = readFromTranslog;
-        }
-
-        public boolean realtime() {
-            return this.realtime;
         }
 
         public String id() {
@@ -1335,10 +1327,6 @@ public abstract class Engine implements Closeable {
         public Get versionType(VersionType versionType) {
             this.versionType = versionType;
             return this;
-        }
-
-        public boolean isReadFromTranslog() {
-            return readFromTranslog;
         }
 
         public Get setIfSeqNo(long seqNo) {

--- a/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -638,8 +638,8 @@ public abstract class EngineTestCase extends ESTestCase {
         return newUid(doc.id());
     }
 
-    protected Engine.Get newGet(boolean realtime, ParsedDocument doc) {
-        return new Engine.Get(realtime, false, doc.id(), newUid(doc));
+    protected Engine.Get newGet(ParsedDocument doc) {
+        return new Engine.Get(doc.id(), newUid(doc));
     }
 
     protected Engine.Index indexForDoc(ParsedDocument doc) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -79,7 +79,7 @@ public final class PKLookupOperation {
     @Nullable
     public static Doc lookupDoc(IndexShard shard, String id, long version, VersionType versionType, long seqNo, long primaryTerm) {
         Term uidTerm = new Term(IdFieldMapper.NAME, Uid.encodeId(id));
-        Engine.Get get = new Engine.Get(true, true, id, uidTerm)
+        Engine.Get get = new Engine.Get(id, uidTerm)
             .version(version)
             .versionType(versionType)
             .setIfSeqNo(seqNo)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The only place where we created a `Get` is in `PKLookupOperation` and it
always passed `true` for both, `realtime` and `readFromTranslog`.

That means we can remove the two options and simplifly the handling
within `InternalEngine` a bit.

Encountered this while looking into
https://github.com/elastic/elasticsearch/pull/48843/ - a candidate for
backport according to https://github.com/crate/crate/issues/9796 - but
turns out it doesn't apply to us, as we already allowed reads from
translog.

The `source` inconsistency mentioned in one of the issues also doesn't
apply - we don't expose includes/excludes for source. (And could follow
up on removing the related logic)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)