### PR TITLE
Remove unused headers and startTimeNanos property from Task

### DIFF
--- a/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -193,8 +193,8 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     }
 
     @Override
-    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-        return new ReplicationTask(id, type, action, getDescription(), parentTaskId, headers);
+    public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new ReplicationTask(id, type, action, getDescription(), parentTaskId);
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationTask.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/replication/ReplicationTask.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.support.replication;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 
-import java.util.Map;
 
 /**
  * Task that tracks replication actions.
@@ -30,8 +29,8 @@ import java.util.Map;
 public class ReplicationTask extends Task {
     private volatile String phase = "starting";
 
-    public ReplicationTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
-        super(id, type, action, description, parentTaskId, headers);
+    public ReplicationTask(long id, String type, String action, String description, TaskId parentTaskId) {
+        super(id, type, action, description, parentTaskId);
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/es/es-server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1198,8 +1198,8 @@ public abstract class TransportReplicationAction<
         }
 
         @Override
-        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return request.createTask(id, type, action, parentTaskId, headers);
+        public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+            return request.createTask(id, type, action, parentTaskId);
         }
 
         @Override

--- a/es/es-server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/es/es-server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -280,8 +280,8 @@ public class PrimaryReplicaSyncer {
         }
 
         @Override
-        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new ResyncTask(id, type, action, getDescription(), parentTaskId, headers);
+        public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+            return new ResyncTask(id, type, action, getDescription(), parentTaskId);
         }
 
         @Override
@@ -300,8 +300,8 @@ public class PrimaryReplicaSyncer {
         private volatile int totalOperations;
         private volatile int resyncedOperations;
 
-        public ResyncTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
-            super(id, type, action, description, parentTaskId, headers);
+        public ResyncTask(long id, String type, String action, String description, TaskId parentTaskId) {
+            super(id, type, action, description, parentTaskId);
         }
 
         /**

--- a/es/es-server/src/main/java/org/elasticsearch/node/Node.java
+++ b/es/es-server/src/main/java/org/elasticsearch/node/Node.java
@@ -441,17 +441,12 @@ public class Node implements Closeable {
                                                                                                             indexMetaDataUpgraders);
             new TemplateUpgradeService(client, clusterService, threadPool, indexTemplateMetaDataUpgraders);
             final Transport transport = networkModule.getTransportSupplier().get();
-            Set<String> taskHeaders = Stream.concat(
-                pluginsService.filterPlugins(ActionPlugin.class).stream().flatMap(p -> p.getTaskHeaders().stream()),
-                Stream.of(Task.X_OPAQUE_ID)
-            ).collect(Collectors.toSet());
             final TransportService transportService = newTransportService(settings,
                                                                           transport,
                                                                           threadPool,
                                                                           networkModule.getTransportInterceptor(),
                                                                           localNodeFactory,
-                                                                          settingsModule.getClusterSettings(),
-                                                                          taskHeaders);
+                                                                          settingsModule.getClusterSettings());
             final GatewayMetaState gatewayMetaState = new GatewayMetaState(settings,
                                                                            nodeEnvironment,
                                                                            metaStateService,
@@ -576,11 +571,13 @@ public class Node implements Closeable {
         }
     }
 
-    protected TransportService newTransportService(Settings settings, Transport transport, ThreadPool threadPool,
+    protected TransportService newTransportService(Settings settings,
+                                                   Transport transport,
+                                                   ThreadPool threadPool,
                                                    TransportInterceptor interceptor,
                                                    Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                                   ClusterSettings clusterSettings, Set<String> taskHeaders) {
-        return new TransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders);
+                                                   ClusterSettings clusterSettings) {
+        return new TransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings);
     }
 
     protected void processRecoverySettings(ClusterSettings clusterSettings, RecoverySettings recoverySettings) {

--- a/es/es-server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/es/es-server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -58,13 +58,6 @@ public interface ActionPlugin {
         return Collections.emptyList();
     }
 
-    /**
-     * Returns headers which should be copied from internal requests into tasks.
-     */
-    default Collection<String> getTaskHeaders() {
-        return Collections.emptyList();
-    }
-
     final class ActionHandler<Request extends TransportRequest, Response extends TransportResponse> {
         private final GenericAction<Request, Response> action;
         private final Class<? extends TransportAction<Request, Response>> transportAction;

--- a/es/es-server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
+++ b/es/es-server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
@@ -31,8 +31,8 @@ public abstract class CancellableTask extends Task {
 
     private final AtomicReference<String> reason = new AtomicReference<>();
 
-    public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
-        super(id, type, action, description, parentTaskId, headers);
+    public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId) {
+        super(id, type, action, description, parentTaskId);
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/es/es-server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -20,20 +20,11 @@
 
 package org.elasticsearch.tasks;
 
-import org.elasticsearch.common.io.stream.NamedWriteable;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-
-import java.util.Map;
 
 /**
  * Current task information
  */
 public class Task {
-
-    /**
-     * The request header to mark tasks with specific ids
-     */
-    public static final String X_OPAQUE_ID = "X-Opaque-Id";
 
     private final long id;
 
@@ -45,32 +36,22 @@ public class Task {
 
     private final TaskId parentTask;
 
-    private final Map<String, String> headers;
-
     /**
      * The task's start time as a wall clock time since epoch ({@link System#currentTimeMillis()} style).
      */
     private final long startTime;
 
-    /**
-     * The task's start time as a relative time ({@link System#nanoTime()} style).
-     */
-    private final long startTimeNanos;
-
-    public Task(long id, String type, String action, String description, TaskId parentTask, Map<String, String> headers) {
-        this(id, type, action, description, parentTask, System.currentTimeMillis(), System.nanoTime(), headers);
+    public Task(long id, String type, String action, String description, TaskId parentTask) {
+        this(id, type, action, description, parentTask, System.currentTimeMillis());
     }
 
-    public Task(long id, String type, String action, String description, TaskId parentTask, long startTime, long startTimeNanos,
-                Map<String, String> headers) {
+    public Task(long id, String type, String action, String description, TaskId parentTask, long startTime) {
         this.id = id;
         this.type = type;
         this.action = action;
         this.description = description;
         this.parentTask = parentTask;
         this.startTime = startTime;
-        this.startTimeNanos = startTimeNanos;
-        this.headers = headers;
     }
 
     /**
@@ -114,18 +95,4 @@ public class Task {
     public TaskId getParentTaskId() {
         return parentTask;
     }
-
-    /**
-     * Report of the internal status of a task. These can vary wildly from task
-     * to task because each task is implemented differently but we should try
-     * to keep each task consistent from version to version where possible.
-     * That means each implementation of {@linkplain Task.Status#toXContent}
-     * should avoid making backwards incompatible changes to the rendered
-     * result. But if we change the way a request is implemented it might not
-     * be possible to preserve backwards compatibility. In that case, we
-     * <b>can</b> change this on version upgrade but we should be careful
-     * because some statuses (reindex) have become defacto standardized because
-     * they are used by systems like Kibana.
-     */
-    public interface Status extends ToXContentObject, NamedWriteable {}
 }

--- a/es/es-server/src/main/java/org/elasticsearch/tasks/TaskAwareRequest.java
+++ b/es/es-server/src/main/java/org/elasticsearch/tasks/TaskAwareRequest.java
@@ -46,8 +46,8 @@ public interface TaskAwareRequest {
     /**
      * Returns the task object that should be used to keep track of the processing of the request.
      */
-    default Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-        return new Task(id, type, action, getDescription(), parentTaskId, headers);
+    default Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new Task(id, type, action, getDescription(), parentTaskId);
     }
 
     /**

--- a/es/es-server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/es/es-server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -144,16 +144,30 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
      * @param clusterSettings if non null, the {@linkplain TransportService} will register with the {@link ClusterSettings} for settings
  *        updates for {@link TransportSettings#TRACE_LOG_EXCLUDE_SETTING} and {@link TransportSettings#TRACE_LOG_INCLUDE_SETTING}.
      */
-    public TransportService(Settings settings, Transport transport, ThreadPool threadPool, TransportInterceptor transportInterceptor,
-                            Function<BoundTransportAddress, DiscoveryNode> localNodeFactory, @Nullable ClusterSettings clusterSettings,
-                            Set<String> taskHeaders) {
-        this(settings, transport, threadPool, transportInterceptor, localNodeFactory, clusterSettings, taskHeaders,
-            new ConnectionManager(settings, transport, threadPool));
+    public TransportService(Settings settings,
+                            Transport transport,
+                            ThreadPool threadPool,
+                            TransportInterceptor transportInterceptor,
+                            Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
+                            @Nullable ClusterSettings clusterSettings) {
+        this(
+            settings,
+            transport,
+            threadPool,
+            transportInterceptor,
+            localNodeFactory,
+            clusterSettings,
+            new ConnectionManager(settings, transport, threadPool)
+        );
     }
 
-    public TransportService(Settings settings, Transport transport, ThreadPool threadPool, TransportInterceptor transportInterceptor,
-                            Function<BoundTransportAddress, DiscoveryNode> localNodeFactory, @Nullable ClusterSettings clusterSettings,
-                            Set<String> taskHeaders, ConnectionManager connectionManager) {
+    public TransportService(Settings settings,
+                            Transport transport,
+                            ThreadPool threadPool,
+                            TransportInterceptor transportInterceptor,
+                            Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
+                            @Nullable ClusterSettings clusterSettings,
+                            ConnectionManager connectionManager) {
         this.transport = transport;
         this.threadPool = threadPool;
         this.localNodeFactory = localNodeFactory;
@@ -162,7 +176,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         setTracerLogInclude(TRACE_LOG_INCLUDE_SETTING.get(settings));
         setTracerLogExclude(TRACE_LOG_EXCLUDE_SETTING.get(settings));
         tracerLog = Loggers.getLogger(logger, ".tracer");
-        taskManager = createTaskManager(settings, threadPool, taskHeaders);
+        taskManager = createTaskManager(settings, threadPool);
         this.interceptor = transportInterceptor;
         this.asyncSender = interceptor.interceptSender(this::sendRequestInternal);
         responseHandlers = transport.getResponseHandlers();
@@ -187,8 +201,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         return taskManager;
     }
 
-    protected TaskManager createTaskManager(Settings settings, ThreadPool threadPool, Set<String> taskHeaders) {
-        return new TaskManager(settings, threadPool, taskHeaders);
+    protected TaskManager createTaskManager(Settings settings, ThreadPool threadPool) {
+        return new TaskManager(settings, threadPool);
     }
 
     /**

--- a/es/es-server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -107,8 +107,13 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
     @Before
     public void setupForTest() {
         final MockTransport transport = new MockTransport();
-        transportService = transport.createTransportService(Settings.EMPTY, threadPool,
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        transportService = transport.createTransportService(
+            Settings.EMPTY,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
 
         new TransportAddVotingConfigExclusionsAction(
             transportService, clusterService, threadPool, new IndexNameExpressionResolver()); // registers action

--- a/es/es-server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -93,8 +93,13 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
     @Before
     public void setupForTest() {
         final MockTransport transport = new MockTransport();
-        transportService = transport.createTransportService(Settings.EMPTY, threadPool,
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        transportService = transport.createTransportService(
+            Settings.EMPTY,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
 
         new TransportClearVotingConfigExclusionsAction(
             transportService, clusterService, threadPool, new IndexNameExpressionResolver()); // registers action

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -83,8 +83,13 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
             }
         };
 
-        transportService = transport.createTransportService(Settings.EMPTY, deterministicTaskQueue.getThreadPool(),
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        transportService = transport.createTransportService(
+            Settings.EMPTY,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
     }
 
     private DiscoveryNode newDiscoveryNode(String nodeName) {

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1869,8 +1869,12 @@ public class CoordinatorTests extends ESTestCase {
                     .putList(ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.getKey(),
                         ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.get(Settings.EMPTY)).build(); // suppress auto-bootstrap
                 transportService = mockTransport.createTransportService(
-                    settings, deterministicTaskQueue.getThreadPool(this::onNode), NOOP_TRANSPORT_INTERCEPTOR,
-                    a -> localNode, null, emptySet());
+                    settings,
+                    deterministicTaskQueue.getThreadPool(this::onNode),
+                    NOOP_TRANSPORT_INTERCEPTOR,
+                    a -> localNode,
+                    null
+                );
                 masterService = new AckedFakeThreadPoolMasterService(localNode.getId(), "test",
                     runnable -> deterministicTaskQueue.scheduleNow(onNode(runnable)));
                 final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -100,8 +100,13 @@ public class FollowersCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings, deterministicTaskQueue.getThreadPool(),
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -266,8 +271,13 @@ public class FollowersCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings, deterministicTaskQueue.getThreadPool(),
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -327,8 +337,13 @@ public class FollowersCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings, deterministicTaskQueue.getThreadPool(),
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -414,8 +429,13 @@ public class FollowersCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings, deterministicTaskQueue.getThreadPool(),
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> follower, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> follower,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -554,8 +574,13 @@ public class FollowersCheckerTests extends ESTestCase {
         CapturingTransport capturingTransport = new CapturingTransport();
         final Settings settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), nodes.get(0).getName()).build();
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(settings, random());
-        TransportService transportService = capturingTransport.createTransportService(Settings.EMPTY,
-                deterministicTaskQueue.getThreadPool(), TransportService.NOOP_TRANSPORT_INTERCEPTOR, x -> nodes.get(0), null, emptySet());
+        TransportService transportService = capturingTransport.createTransportService(
+            Settings.EMPTY,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> nodes.get(0),
+            null
+        );
         final FollowersChecker followersChecker = new FollowersChecker(Settings.EMPTY, transportService, fcr -> {
             assert false : fcr;
         }, (node, reason) -> {

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -45,9 +45,13 @@ public class JoinHelperTests extends ESTestCase {
             Settings.builder().put(NODE_NAME_SETTING.getKey(), "node0").build(), random());
         CapturingTransport capturingTransport = new CapturingTransport();
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
-        TransportService transportService = capturingTransport.createTransportService(Settings.EMPTY,
-            deterministicTaskQueue.getThreadPool(), TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            x -> localNode, null, Collections.emptySet());
+        TransportService transportService = capturingTransport.createTransportService(
+            Settings.EMPTY,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> localNode,
+            null
+        );
         JoinHelper joinHelper = new JoinHelper(Settings.EMPTY, null, null, transportService, () -> 0L, () -> null,
             (joinRequest, joinCallback) -> { throw new AssertionError(); }, startJoinRequest -> { throw new AssertionError(); },
             Collections.emptyList());

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -138,8 +138,13 @@ public class LeaderCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings,
-            deterministicTaskQueue.getThreadPool(), NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -240,8 +245,13 @@ public class LeaderCheckerTests extends ESTestCase {
             }
         };
 
-        final TransportService transportService = mockTransport.createTransportService(settings,
-            deterministicTaskQueue.getThreadPool(), NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -311,8 +321,13 @@ public class LeaderCheckerTests extends ESTestCase {
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(settings, random());
         final CapturingTransport capturingTransport = new CapturingTransport();
 
-        final TransportService transportService = capturingTransport.createTransportService(settings,
-            deterministicTaskQueue.getThreadPool(), NOOP_TRANSPORT_INTERCEPTOR, boundTransportAddress -> localNode, null, emptySet());
+        final TransportService transportService = capturingTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -167,10 +167,13 @@ public class NodeJoinTests extends ESTestCase {
             }
         };
         final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        TransportService transportService = capturingTransport.createTransportService(Settings.EMPTY, threadPool,
+        TransportService transportService = capturingTransport.createTransportService(
+            Settings.EMPTY,
+            threadPool,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> initialState.nodes().getLocalNode(),
-            clusterSettings, Collections.emptySet());
+            clusterSettings
+        );
         coordinator = new Coordinator("test_node", Settings.EMPTY, clusterSettings,
             transportService, writableRegistry(),
             ESAllocationTestCase.createAllocationService(Settings.EMPTY),

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
@@ -104,9 +104,13 @@ public class PreVoteCollectorTests extends ESTestCase {
 
         localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
         responsesByNode.put(localNode, new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion));
-        transportService = mockTransport.createTransportService(settings,
-            deterministicTaskQueue.getThreadPool(), TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            boundTransportAddress -> localNode, null, emptySet());
+        transportService = mockTransport.createTransportService(
+            settings,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundTransportAddress -> localNode,
+            null
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
 

--- a/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/es/es-server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -47,11 +47,13 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             new DeterministicTaskQueue(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test").build(), random());
         final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final DiscoveryNode localNode = new DiscoveryNode("localNode", buildNewFakeTransportAddress(), Version.CURRENT);
-        final TransportService transportService = new CapturingTransport().createTransportService(Settings.EMPTY,
+        final TransportService transportService = new CapturingTransport().createTransportService(
+            Settings.EMPTY,
             deterministicTaskQueue.getThreadPool(),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> localNode,
-            clusterSettings, Collections.emptySet());
+            clusterSettings
+        );
         final PublicationTransportHandler handler = new PublicationTransportHandler(transportService,
             writableRegistry(), pu -> null, (pu, l) -> {});
         transportService.start();

--- a/es/es-testing/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -716,7 +716,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
             .build();
         replica.updateShardState(routingEntry, replica.getPendingPrimaryTerm() + 1,
             (is, listener) ->
-                listener.onResponse(new PrimaryReplicaSyncer.ResyncTask(1, "type", "action", "desc", null, Collections.emptyMap())),
+                listener.onResponse(new PrimaryReplicaSyncer.ResyncTask(1, "type", "action", "desc", null)),
             currentClusterStateVersion.incrementAndGet(),
             inSyncIds, newRoutingTable);
     }

--- a/es/es-testing/src/main/java/org/elasticsearch/node/MockNode.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/node/MockNode.java
@@ -115,18 +115,20 @@ public class MockNode extends Node {
     }
 
     @Override
-    protected TransportService newTransportService(Settings settings, Transport transport, ThreadPool threadPool,
+    protected TransportService newTransportService(Settings settings,
+                                                   Transport transport,
+                                                   ThreadPool threadPool,
                                                    TransportInterceptor interceptor,
                                                    Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                                   ClusterSettings clusterSettings, Set<String> taskHeaders) {
+                                                   ClusterSettings clusterSettings) {
         // we use the MockTransportService.TestPlugin class as a marker to create a network
         // module with this MockNetworkService. NetworkService is such an integral part of the systme
         // we don't allow to plug it in from plugins or anything. this is a test-only override and
         // can't be done in a production env.
         if (getPluginsService().filterPlugins(MockTransportService.TestPlugin.class).isEmpty()) {
-            return super.newTransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders);
+            return super.newTransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings);
         } else {
-            return new MockTransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders);
+            return new MockTransportService(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings);
         }
     }
 

--- a/es/es-testing/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
@@ -78,10 +78,12 @@ public abstract class DisruptableMockTransport extends MockTransport {
     }
 
     @Override
-    public TransportService createTransportService(Settings settings, ThreadPool threadPool, TransportInterceptor interceptor,
+    public TransportService createTransportService(Settings settings,
+                                                   ThreadPool threadPool,
+                                                   TransportInterceptor interceptor,
                                                    Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                                   @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
-        return new TransportService(settings, this, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders);
+                                                   @Nullable ClusterSettings clusterSettings) {
+        return new TransportService(settings, this, threadPool, interceptor, localNodeFactory, clusterSettings);
     }
 
     @Override

--- a/es/es-testing/src/main/java/org/elasticsearch/test/tasks/MockTaskManager.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/tasks/MockTaskManager.java
@@ -47,8 +47,8 @@ public class MockTaskManager extends TaskManager {
 
     private final Collection<MockTaskManagerListener> listeners = new CopyOnWriteArrayList<>();
 
-    public MockTaskManager(Settings settings, ThreadPool threadPool, Set<String> taskHeaders) {
-        super(settings, threadPool, taskHeaders);
+    public MockTaskManager(Settings settings, ThreadPool threadPool) {
+        super(settings, threadPool);
     }
 
     @Override

--- a/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -75,15 +75,24 @@ public class MockTransport implements Transport, LifecycleComponent {
     private TransportMessageListener listener;
     private ConcurrentMap<Long, Tuple<DiscoveryNode, String>> requests = new ConcurrentHashMap<>();
 
-    public TransportService createTransportService(Settings settings, ThreadPool threadPool, TransportInterceptor interceptor,
+    public TransportService createTransportService(Settings settings,
+                                                   ThreadPool threadPool,
+                                                   TransportInterceptor interceptor,
                                                    Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                                   @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
+                                                   @Nullable ClusterSettings clusterSettings) {
         StubbableConnectionManager connectionManager = new StubbableConnectionManager(new ConnectionManager(settings, this, threadPool),
             settings, this, threadPool);
         connectionManager.setDefaultNodeConnectedBehavior((cm, discoveryNode) -> nodeConnected(discoveryNode));
         connectionManager.setDefaultGetConnectionBehavior((cm, discoveryNode) -> openConnection(discoveryNode, null));
-        return new TransportService(settings, this, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders,
-            connectionManager);
+        return new TransportService(
+            settings,
+            this,
+            threadPool,
+            interceptor,
+            localNodeFactory,
+            clusterSettings,
+            connectionManager
+        );
     }
 
     /**

--- a/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/es/es-testing/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -97,11 +97,12 @@ public final class MockTransportService extends TransportService {
         }
     }
 
-    public static MockTransportService createNewService(Settings settings, Version version, ThreadPool threadPool,
+    public static MockTransportService createNewService(Settings settings,
+                                                        Version version,
+                                                        ThreadPool threadPool,
                                                         @Nullable ClusterSettings clusterSettings) {
         MockTcpTransport mockTcpTransport = newMockTransport(settings, version, threadPool);
-        return createNewService(settings, mockTcpTransport, version, threadPool, clusterSettings,
-            Collections.emptySet());
+        return createNewService(settings, mockTcpTransport, version, threadPool, clusterSettings);
     }
 
     public static MockTcpTransport newMockTransport(Settings settings, Version version, ThreadPool threadPool) {
@@ -116,13 +117,26 @@ public final class MockTransportService extends TransportService {
             new NoneCircuitBreakerService(), namedWriteableRegistry, new NetworkService(Collections.emptyList()), version);
     }
 
-    public static MockTransportService createNewService(Settings settings, Transport transport, Version version, ThreadPool threadPool,
-                                                        @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
-        return new MockTransportService(settings, transport, threadPool, TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            boundAddress ->
-                new DiscoveryNode(Node.NODE_NAME_SETTING.get(settings), UUIDs.randomBase64UUID(), boundAddress.publishAddress(),
-                    Node.NODE_ATTRIBUTES.getAsMap(settings), DiscoveryNode.getRolesFromSettings(settings), version),
-            clusterSettings, taskHeaders);
+    public static MockTransportService createNewService(Settings settings,
+                                                        Transport transport,
+                                                        Version version,
+                                                        ThreadPool threadPool,
+                                                        @Nullable ClusterSettings clusterSettings) {
+        return new MockTransportService(
+            settings,
+            transport,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundAddress -> new DiscoveryNode(
+                Node.NODE_NAME_SETTING.get(settings),
+                UUIDs.randomBase64UUID(),
+                boundAddress.publishAddress(),
+                Node.NODE_ATTRIBUTES.getAsMap(settings),
+                DiscoveryNode.getRolesFromSettings(settings),
+                version
+            ),
+            clusterSettings
+        );
     }
 
     private final Transport original;
@@ -135,9 +149,19 @@ public final class MockTransportService extends TransportService {
      */
     public MockTransportService(Settings settings, Transport transport, ThreadPool threadPool, TransportInterceptor interceptor,
                                 @Nullable ClusterSettings clusterSettings) {
-        this(settings, transport, threadPool, interceptor, (boundAddress) ->
-            DiscoveryNode.createLocal(settings, boundAddress.publishAddress(), settings.get(Node.NODE_NAME_SETTING.getKey(),
-                UUIDs.randomBase64UUID())), clusterSettings, Collections.emptySet());
+        this(
+            settings,
+            transport,
+            threadPool,
+            interceptor,
+            (boundAddress) -> DiscoveryNode.createLocal(
+                settings,
+                boundAddress.publishAddress(),
+                settings.get(Node.NODE_NAME_SETTING.getKey(),
+                UUIDs.randomBase64UUID())
+            ),
+            clusterSettings
+        );
     }
 
     /**
@@ -146,17 +170,30 @@ public final class MockTransportService extends TransportService {
      * @param clusterSettings if non null the {@linkplain TransportService} will register with the {@link ClusterSettings} for settings
      *                        updates for {@link TransportSettings#TRACE_LOG_EXCLUDE_SETTING} and {@link TransportSettings#TRACE_LOG_INCLUDE_SETTING}.
      */
-    public MockTransportService(Settings settings, Transport transport, ThreadPool threadPool, TransportInterceptor interceptor,
+    public MockTransportService(Settings settings,
+                                Transport transport,
+                                ThreadPool threadPool,
+                                TransportInterceptor interceptor,
                                 Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
-        this(settings, new StubbableTransport(transport), threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders);
+                                @Nullable ClusterSettings clusterSettings) {
+        this(settings, new StubbableTransport(transport), threadPool, interceptor, localNodeFactory, clusterSettings);
     }
 
-    private MockTransportService(Settings settings, StubbableTransport transport, ThreadPool threadPool, TransportInterceptor interceptor,
+    private MockTransportService(Settings settings,
+                                 StubbableTransport transport,
+                                 ThreadPool threadPool,
+                                 TransportInterceptor interceptor,
                                  Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
-                                 @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
-        super(settings, transport, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders,
-            new StubbableConnectionManager(new ConnectionManager(settings, transport, threadPool), settings, transport, threadPool));
+                                 @Nullable ClusterSettings clusterSettings) {
+        super(
+            settings,
+            transport,
+            threadPool,
+            interceptor,
+            localNodeFactory,
+            clusterSettings,
+            new StubbableConnectionManager(new ConnectionManager(settings, transport, threadPool), settings, transport, threadPool)
+        );
         this.original = transport.getDelegate();
     }
 
@@ -169,11 +206,11 @@ public final class MockTransportService extends TransportService {
     }
 
     @Override
-    protected TaskManager createTaskManager(Settings settings, ThreadPool threadPool, Set<String> taskHeaders) {
+    protected TaskManager createTaskManager(Settings settings, ThreadPool threadPool) {
         if (MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.get(settings)) {
-            return new MockTaskManager(settings, threadPool, taskHeaders);
+            return new MockTaskManager(settings, threadPool);
         } else {
-            return super.createTaskManager(settings, threadPool, taskHeaders);
+            return super.createTaskManager(settings, threadPool);
         }
     }
 


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)