### PR TITLE
WIP: Use smallest numeric literal at the sql parser

### DIFF
--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1253,7 +1253,7 @@ Returns: Same as input type.
 
 ::
 
-    cr> select exp(1.0) AS exp;
+    cr> select exp(1.0::double precision) AS exp;
     +-------------------+
     |               exp |
     +-------------------+
@@ -2690,11 +2690,11 @@ Example:
 ::
 
     cr> select pg_typeof([1, 2, 3]) as typeof;
-    +--------------+
-    | typeof       |
-    +--------------+
-    | bigint_array |
-    +--------------+
+    +----------------+
+    | typeof         |
+    +----------------+
+    | smallint_array |
+    +----------------+
     SELECT 1 row in set (... sec)
 
 .. _version:

--- a/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -101,7 +101,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagWithDefaultValueAndEmptyOver() throws Throwable {
         assertEvaluate(
             "lag(x, 1, -1) over()",
-            contains(new Object[]{-1L, 1L, 2L, 3L}),
+            contains(new Object[]{-1, 1, 2, 3}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
@@ -114,7 +114,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagWithExpressionAsArgumentAndEmptyOver() throws Throwable {
         assertEvaluate(
             "lag(coalesce(x, 1), 1, -1) over()",
-            contains(new Object[]{-1L, 1L, 1L}),
+            contains(new Object[]{-1, 1, 1}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{null},
@@ -204,7 +204,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Throwable {
         assertEvaluate(
             "lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
-            contains(new Object[]{2L, 3L, 4L, 42L, 42L}),
+            contains(new Object[]{2, 3, 4, 42, 42}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -40,12 +40,14 @@ import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.ExistsPredicate;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Extract;
+import io.crate.sql.tree.BigDecimalLiteral;
 import io.crate.sql.tree.FrameBound;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
@@ -64,6 +66,7 @@ import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.RecordSubscript;
 import io.crate.sql.tree.SearchedCaseExpression;
+import io.crate.sql.tree.ShortLiteral;
 import io.crate.sql.tree.SimpleCaseExpression;
 import io.crate.sql.tree.SortItem;
 import io.crate.sql.tree.StringLiteral;
@@ -246,8 +249,26 @@ public final class ExpressionFormatter {
         }
 
         @Override
+        protected String visitIntegerLiteral(IntegerLiteral node,
+                                             List<Expression> context) {
+            return Integer.toString(node.getValue());
+        }
+
+        @Override
+        protected String visitShortLiteral(ShortLiteral node,
+                                           List<Expression> context) {
+            return Short.toString(node.getValue());
+        }
+
+        @Override
         protected String visitDoubleLiteral(DoubleLiteral node, @Nullable List<Expression> parameters) {
             return Double.toString(node.getValue());
+        }
+
+        @Override
+        protected String visitBigDecimalLiteral(BigDecimalLiteral node,
+                                                List<Expression> context) {
+            return node.getValue().toString();
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -65,7 +65,6 @@ import io.crate.sql.tree.Join;
 import io.crate.sql.tree.JoinCriteria;
 import io.crate.sql.tree.JoinOn;
 import io.crate.sql.tree.JoinUsing;
-import io.crate.sql.tree.LongLiteral;
 import io.crate.sql.tree.NaturalJoin;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.NotNullColumnConstraint;
@@ -670,12 +669,6 @@ public final class SqlFormatter {
                 }
                 append(indent, ")");
             }
-            return null;
-        }
-
-        @Override
-        protected Void visitLongLiteral(LongLiteral node, Integer indent) {
-            builder.append(String.format(Locale.ENGLISH, "%d", node.getValue()));
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -60,6 +60,10 @@ public abstract class AstVisitor<R, C> {
         return visitLiteral(node, context);
     }
 
+    protected R visitBigDecimalLiteral(BigDecimalLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
     protected R visitStatement(Statement node, C context) {
         return visitNode(node, context);
     }
@@ -197,6 +201,14 @@ public abstract class AstVisitor<R, C> {
     }
 
     protected R visitLongLiteral(LongLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
+    protected R visitIntegerLiteral(IntegerLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
+    protected R visitShortLiteral(ShortLiteral node, C context) {
         return visitLiteral(node, context);
     }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/BigDecimalLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/BigDecimalLiteral.java
@@ -20,38 +20,50 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.sql.tree;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.junit.Test;
+import java.math.BigDecimal;
+import java.util.Objects;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+public class BigDecimalLiteral extends Literal {
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
+    private final BigDecimal value;
 
-    @Test
-    public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, smallint, text)");
-        assertEvaluate("_map('foo', 1, 'bar')", null);
+    public BigDecimalLiteral(float value) {
+        this(new BigDecimal(Float.toString(value)));
     }
 
-    @Test
-    public void testKeyNotOfTypeString() {
-        assertEvaluate("_map(10, 2)", Collections.singletonMap("10", (short) 2));
+    public BigDecimalLiteral(String value) {
+        this(new BigDecimal(value));
     }
 
-    @Test
-    public void testEvaluation() {
-        Map<String, Object> m = new HashMap<>();
-        m.put("foo", (short) 10);
-        // minimum args
-        assertEvaluate("_map('foo', 10)", m);
+    public BigDecimalLiteral(BigDecimal bd) {
+        this.value = bd;
+    }
 
-        // variable args
-        m.put("bar", "some");
-        assertEvaluate("_map('foo', 10, 'bar', 'some')", m);
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitBigDecimalLiteral(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BigDecimalLiteral that = (BigDecimalLiteral) o;
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
@@ -21,14 +21,12 @@
 
 package io.crate.sql.tree;
 
-import static java.util.Objects.requireNonNull;
-
 public class DoubleLiteral extends Literal {
 
     private final double value;
 
-    public DoubleLiteral(String value) {
-        this.value = Double.parseDouble(requireNonNull(value, "value is null"));
+    public DoubleLiteral(double value) {
+        this.value = value;
     }
 
     public double getValue() {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
@@ -86,8 +86,8 @@ public class FrameBound extends Node {
                                     @Nullable Comparator<T> cmp,
                                     List<T> rows) {
                 if (mode == ROWS) {
-                    assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
-                    return Math.max(pStart, currentRowIdx - ((Long) offset).intValue());
+                    assert offset instanceof Number : "In ROWS mode the offset must be a non-null, non-negative number";
+                    return Math.max(pStart, currentRowIdx - ((Number) offset).intValue());
                 } else {
                     int firstGTEProbeValue = findFirstGTEProbeValue(rows, pStart, currentRowIdx, offsetProbeValue, cmp);
                     if (firstGTEProbeValue == -1) {
@@ -199,8 +199,8 @@ public class FrameBound extends Node {
                                   List<T> rows) {
                 // end index is exclusive so we increment it by one when finding the interval end index
                 if (mode == ROWS) {
-                    assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
-                    return Math.min(pEnd, currentRowIdx + ((Long) offset).intValue() + 1);
+                    assert offset instanceof Number : "In ROWS mode the offset must be a non-null, non-negative number";
+                    return Math.min(pEnd, currentRowIdx + ((Number) offset).intValue() + 1);
                 } else {
                     return findFirstLTEProbeValue(rows, pEnd, currentRowIdx, offsetProbeValue, cmp) + 1;
                 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/IntegerLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/IntegerLiteral.java
@@ -20,38 +20,41 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.sql.tree;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.junit.Test;
+import java.util.Objects;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+public class IntegerLiteral extends Literal {
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
+    private final int value;
 
-    @Test
-    public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, smallint, text)");
-        assertEvaluate("_map('foo', 1, 'bar')", null);
+    public IntegerLiteral(int value) {
+        this.value = value;
     }
 
-    @Test
-    public void testKeyNotOfTypeString() {
-        assertEvaluate("_map(10, 2)", Collections.singletonMap("10", (short) 2));
+    public int getValue() {
+        return value;
     }
 
-    @Test
-    public void testEvaluation() {
-        Map<String, Object> m = new HashMap<>();
-        m.put("foo", (short) 10);
-        // minimum args
-        assertEvaluate("_map('foo', 10)", m);
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitIntegerLiteral(this, context);
+    }
 
-        // variable args
-        m.put("bar", "some");
-        assertEvaluate("_map('foo', 10, 'bar', 'some')", m);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntegerLiteral that = (IntegerLiteral) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
@@ -35,15 +35,19 @@ public abstract class Literal
     }
 
     public static Literal fromObject(Object value) {
-        Literal literal = null;
+        Literal literal;
         if (value == null) {
             literal = NullLiteral.INSTANCE;
-        } else if (value instanceof Number) {
-            if (value instanceof Float || value instanceof Double) {
-                literal = new DoubleLiteral(value.toString());
-            } else if (value instanceof Short || value instanceof Integer || value instanceof Long) {
-                literal = new LongLiteral(value.toString());
-            }
+        } else if (value instanceof Double) {
+            literal = new DoubleLiteral((double) value);
+        } else if (value instanceof Float) {
+            literal = new BigDecimalLiteral((float) value);
+        } else if (value instanceof Short) {
+            literal = new ShortLiteral((short) value);
+        } else if (value instanceof Integer) {
+            literal = new IntegerLiteral((int) value);
+        } else if (value instanceof Long) {
+            literal = new LongLiteral((long) value);
         } else if (value instanceof Boolean) {
             literal = (Boolean) value ? BooleanLiteral.TRUE_LITERAL : BooleanLiteral.FALSE_LITERAL;
         } else if (value instanceof Object[]) {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
@@ -21,14 +21,12 @@
 
 package io.crate.sql.tree;
 
-import static java.util.Objects.requireNonNull;
-
 public class LongLiteral extends Literal {
 
     private final long value;
 
-    public LongLiteral(String value) {
-        this.value = Long.parseLong(requireNonNull(value, "value is null"));
+    public LongLiteral(long value) {
+        this.value = value;
     }
 
     public long getValue() {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
@@ -33,7 +33,10 @@ public class MatchPredicateColumnIdent extends Expression {
         this.ident = ident;
         if (boost != null) {
             if (!(boost instanceof LongLiteral ||
+                  boost instanceof IntegerLiteral ||
+                  boost instanceof ShortLiteral ||
                   boost instanceof DoubleLiteral ||
+                  boost instanceof BigDecimalLiteral ||
                   boost instanceof ParameterExpression)) {
                 throw new IllegalArgumentException("'boost' value must be a numeric literal or a parameter expression");
             }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ShortLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ShortLiteral.java
@@ -20,38 +20,41 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.sql.tree;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.junit.Test;
+import java.util.Objects;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+public class ShortLiteral extends Literal {
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
+    private final short value;
 
-    @Test
-    public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, smallint, text)");
-        assertEvaluate("_map('foo', 1, 'bar')", null);
+    public ShortLiteral(short value) {
+        this.value = value;
     }
 
-    @Test
-    public void testKeyNotOfTypeString() {
-        assertEvaluate("_map(10, 2)", Collections.singletonMap("10", (short) 2));
+    public short getValue() {
+        return value;
     }
 
-    @Test
-    public void testEvaluation() {
-        Map<String, Object> m = new HashMap<>();
-        m.put("foo", (short) 10);
-        // minimum args
-        assertEvaluate("_map('foo', 10)", m);
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitShortLiteral(this, context);
+    }
 
-        // variable args
-        m.put("bar", "some");
-        assertEvaluate("_map('foo', 10, 'bar', 'some')", m);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ShortLiteral that = (ShortLiteral) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/NumericLiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/NumericLiteralsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql;
+
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.DoubleLiteral;
+import io.crate.sql.tree.BigDecimalLiteral;
+import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.Literal;
+import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.ShortLiteral;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+
+public class NumericLiteralsTest {
+
+    private static void assertExpression(String expression, Literal expected) {
+        var expr = SqlParser.createExpression(expression);
+        assertThat(expr, instanceOf(expected.getClass()));
+        assertThat(expr, is(expected));
+    }
+
+    @Test
+    public void test_short_literal() {
+        assertExpression("32767", new ShortLiteral(Short.MAX_VALUE));
+    }
+
+    @Test
+    public void test_integer_literal() {
+        assertExpression("2147483647", new IntegerLiteral(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void test_long_literal() {
+        assertExpression("2147483648", new LongLiteral(Integer.MAX_VALUE + 1L));
+    }
+
+    @Test
+    public void test_float_literal() {
+        assertExpression("12345.123", new BigDecimalLiteral(12345.123f));
+
+        assertExpression("123.", new BigDecimalLiteral("123."));
+        assertExpression("123.0", new BigDecimalLiteral("123.0"));
+        assertExpression(".5", new BigDecimalLiteral(".5"));
+        assertExpression("123.5", new BigDecimalLiteral("123.5"));
+
+        assertExpression("123E7", new BigDecimalLiteral("123E7"));
+        assertExpression("123.E7", new BigDecimalLiteral("123E7"));
+
+        assertExpression("123.0E7", new BigDecimalLiteral("123.0E7"));
+        assertExpression("123E+7", new BigDecimalLiteral("123E7"));
+        assertExpression("123E-7", new BigDecimalLiteral("123E-7"));
+
+        assertExpression("123.456E7", new BigDecimalLiteral("123.456E7"));
+        assertExpression("123.456E+7", new BigDecimalLiteral("123.456E7"));
+        assertExpression("123.456E-7", new BigDecimalLiteral("123.456E-7"));
+
+        assertExpression(".4E-42", new BigDecimalLiteral(".4E-42"));
+    }
+
+    @Test
+    public void test_double_literal() {
+        assertExpression("12345.1234", new DoubleLiteral(12345.1234d));
+
+        assertExpression(".4E42", new DoubleLiteral(.4E42));
+        assertExpression(".4E+42", new DoubleLiteral(.4E42d));
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -135,29 +135,6 @@ public class TestSqlParser {
     }
 
     @Test
-    public void testDouble()
-        throws Exception {
-        assertExpression("123.", new DoubleLiteral("123"));
-        assertExpression("123.0", new DoubleLiteral("123"));
-        assertExpression(".5", new DoubleLiteral(".5"));
-        assertExpression("123.5", new DoubleLiteral("123.5"));
-
-        assertExpression("123E7", new DoubleLiteral("123E7"));
-        assertExpression("123.E7", new DoubleLiteral("123E7"));
-        assertExpression("123.0E7", new DoubleLiteral("123E7"));
-        assertExpression("123E+7", new DoubleLiteral("123E7"));
-        assertExpression("123E-7", new DoubleLiteral("123E-7"));
-
-        assertExpression("123.456E7", new DoubleLiteral("123.456E7"));
-        assertExpression("123.456E+7", new DoubleLiteral("123.456E7"));
-        assertExpression("123.456E-7", new DoubleLiteral("123.456E-7"));
-
-        assertExpression(".4E42", new DoubleLiteral(".4E42"));
-        assertExpression(".4E+42", new DoubleLiteral(".4E42"));
-        assertExpression(".4E-42", new DoubleLiteral(".4E-42"));
-    }
-
-    @Test
     public void testParameter() throws Exception {
         assertExpression("?", new ParameterExpression(1));
         for (int i = 0; i < 1000; i++) {
@@ -167,10 +144,10 @@ public class TestSqlParser {
 
     @Test
     public void testDoubleInQuery() {
-        assertStatement("SELECT 123.456E7 FROM DUAL",
+        assertStatement("SELECT 12345.1234 FROM DUAL",
             new Query(
                 new QuerySpecification(
-                    selectList(new DoubleLiteral("123.456E7")),
+                    selectList(new DoubleLiteral(12345.1234)),
                     table(QualifiedName.of("dual")),
                     Optional.empty(),
                     List.of(),

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -51,7 +51,6 @@ import io.crate.sql.tree.GCDanglingArtifacts;
 import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.Insert;
 import io.crate.sql.tree.KillStatement;
-import io.crate.sql.tree.LongLiteral;
 import io.crate.sql.tree.MatchPredicate;
 import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.ObjectLiteral;
@@ -61,6 +60,7 @@ import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.Query;
 import io.crate.sql.tree.RevokePrivilege;
 import io.crate.sql.tree.SetStatement;
+import io.crate.sql.tree.ShortLiteral;
 import io.crate.sql.tree.ShowCreateTable;
 import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
@@ -69,7 +69,6 @@ import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.SwapTable;
 import io.crate.sql.tree.Update;
 import io.crate.sql.tree.Window;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1228,8 +1227,8 @@ public class TestStatementBuilder {
         expression = SqlParser.createExpression("[1,2,3][1]");
         assertThat(expression, instanceOf(SubscriptExpression.class));
         subscript = (SubscriptExpression) expression;
-        assertThat(subscript.index(), instanceOf(LongLiteral.class));
-        assertThat(((LongLiteral) subscript.index()).getValue(), is(1L));
+        assertThat(subscript.index(), instanceOf(ShortLiteral.class));
+        assertThat(((ShortLiteral) subscript.index()).getValue(), is((short) 1));
         assertThat(subscript.base(), instanceOf(ArrayLiteral.class));
     }
 
@@ -1268,14 +1267,14 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(ShortLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(QualifiedNameReference.class));
 
         Expression someExpression = SqlParser.createExpression("1 = SOME (arrayColumnRef)");
         assertThat(someExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression someArrayComparison = (ArrayComparisonExpression) someExpression;
         assertThat(someArrayComparison.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(someArrayComparison.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(someArrayComparison.getLeft(), instanceOf(ShortLiteral.class));
         assertThat(someArrayComparison.getRight(), instanceOf(QualifiedNameReference.class));
 
         Expression allExpression = SqlParser.createExpression("'StringValue' = ALL (arrayColumnRef)");
@@ -1292,7 +1291,7 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(ShortLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
 
         // It's possible to omit the parenthesis
@@ -1300,7 +1299,7 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(ShortLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
     }
 
@@ -1358,7 +1357,7 @@ public class TestStatementBuilder {
 
         ObjectLiteral objectLiteral = (ObjectLiteral) SqlParser.createExpression("{a=1, aa=-1, b='str', c=[], d={}}");
         assertThat(objectLiteral.values().size(), is(5));
-        assertThat(objectLiteral.values().get("a"), instanceOf(LongLiteral.class));
+        assertThat(objectLiteral.values().get("a"), instanceOf(ShortLiteral.class));
         assertThat(objectLiteral.values().get("aa"), instanceOf(NegativeExpression.class));
         assertThat(objectLiteral.values().get("b"), instanceOf(StringLiteral.class));
         assertThat(objectLiteral.values().get("c"), instanceOf(ArrayLiteral.class));
@@ -1366,7 +1365,7 @@ public class TestStatementBuilder {
 
         ObjectLiteral quotedObjectLiteral = (ObjectLiteral) SqlParser.createExpression("{\"AbC\"=123}");
         assertThat(quotedObjectLiteral.values().size(), is(1));
-        assertThat(quotedObjectLiteral.values().get("AbC"), instanceOf(LongLiteral.class));
+        assertThat(quotedObjectLiteral.values().get("AbC"), instanceOf(ShortLiteral.class));
         assertThat(quotedObjectLiteral.values().get("abc"), CoreMatchers.nullValue());
         assertThat(quotedObjectLiteral.values().get("ABC"), CoreMatchers.nullValue());
 
@@ -1383,7 +1382,7 @@ public class TestStatementBuilder {
 
         ArrayLiteral singleArrayLiteral = (ArrayLiteral) SqlParser.createExpression("[1]");
         assertThat(singleArrayLiteral.values().size(), is(1));
-        assertThat(singleArrayLiteral.values().get(0), instanceOf(LongLiteral.class));
+        assertThat(singleArrayLiteral.values().get(0), instanceOf(ShortLiteral.class));
 
         ArrayLiteral multipleArrayLiteral = (ArrayLiteral) SqlParser.createExpression(
             "['str', -12.56, {}, ['another', 'array']]");

--- a/server/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -246,7 +246,7 @@ public class MetaDataToASTNodeResolver {
             Expression clusteredBy = clusteredByColumn == null || clusteredByColumn.isSystemColumn()
                 ? null
                 : expressionFromColumn(clusteredByColumn);
-            Expression numShards = new LongLiteral(Integer.toString(tableInfo.numberOfShards()));
+            Expression numShards = new LongLiteral(tableInfo.numberOfShards());
             return Optional.of(new ClusteredBy<>(Optional.ofNullable(clusteredBy), Optional.of(numShards)));
         }
 

--- a/server/src/main/java/io/crate/analyze/NegateLiterals.java
+++ b/server/src/main/java/io/crate/analyze/NegateLiterals.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.FloatLiteral;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
@@ -54,9 +55,12 @@ public final class NegateLiterals extends SymbolVisitor<Void, Symbol> {
             case DoubleType.ID:
                 return Literal.of(valueType, (Double) value * -1);
             case FloatType.ID:
-                return Literal.of(valueType, (Double) value * -1);
+                if (symbol instanceof FloatLiteral) {
+                    return ((FloatLiteral) symbol).negate();
+                }
+                return Literal.of(valueType, (Float) value * -1);
             case ShortType.ID:
-                return Literal.of(valueType, (Short) value * -1);
+                return Literal.of(valueType, ((Integer) ((Short) value * -1)).shortValue());
             case IntegerType.ID:
                 return Literal.of(valueType, (Integer) value * -1);
             case LongType.ID:

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -48,7 +48,9 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.ShortLiteral;
 import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.Update;
 import io.crate.types.ArrayType;
@@ -213,12 +215,26 @@ public final class UpdateAnalyzer {
             return super.visitSubscriptExpression(node, childOfSubscript);
         }
 
-        @Override
-        protected Void visitLongLiteral(LongLiteral node, Boolean childOfSubscript) {
+        private Void validateLiteral(Boolean childOfSubscript) {
             if (childOfSubscript) {
                 throw new IllegalArgumentException("Updating a single element of an array is not supported");
             }
             return null;
+        }
+
+        @Override
+        protected Void visitLongLiteral(LongLiteral node, Boolean childOfSubscript) {
+            return validateLiteral(childOfSubscript);
+        }
+
+        @Override
+        protected Void visitIntegerLiteral(IntegerLiteral node, Boolean childOfSubscript) {
+            return validateLiteral(childOfSubscript);
+        }
+
+        @Override
+        protected Void visitShortLiteral(ShortLiteral node, Boolean childOfSubscript) {
+            return validateLiteral(childOfSubscript);
         }
     }
 }

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -60,6 +60,7 @@ import io.crate.expression.scalar.arithmetic.NegateFunctions;
 import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
+import io.crate.expression.symbol.FloatLiteral;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ScopedSymbol;
@@ -87,6 +88,7 @@ import io.crate.sql.tree.ArrayLiteral;
 import io.crate.sql.tree.ArraySubQueryExpression;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BetweenPredicate;
+import io.crate.sql.tree.BigDecimalLiteral;
 import io.crate.sql.tree.BooleanLiteral;
 import io.crate.sql.tree.Cast;
 import io.crate.sql.tree.ComparisonExpression;
@@ -100,6 +102,7 @@ import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
@@ -118,6 +121,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.RecordSubscript;
 import io.crate.sql.tree.SearchedCaseExpression;
+import io.crate.sql.tree.ShortLiteral;
 import io.crate.sql.tree.SimpleCaseExpression;
 import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.SubqueryExpression;
@@ -902,6 +906,24 @@ public class ExpressionAnalyzer {
 
         @Override
         protected Symbol visitLongLiteral(LongLiteral node, ExpressionAnalysisContext context) {
+            return Literal.of(node.getValue());
+        }
+
+        @Override
+        protected Symbol visitBigDecimalLiteral(BigDecimalLiteral node,
+                                                ExpressionAnalysisContext context) {
+            return new FloatLiteral(node.getValue());
+        }
+
+        @Override
+        protected Symbol visitIntegerLiteral(IntegerLiteral node,
+                                             ExpressionAnalysisContext context) {
+            return Literal.of(node.getValue());
+        }
+
+        @Override
+        protected Symbol visitShortLiteral(ShortLiteral node,
+                                           ExpressionAnalysisContext context) {
             return Literal.of(node.getValue());
         }
 

--- a/server/src/main/java/io/crate/expression/symbol/FloatLiteral.java
+++ b/server/src/main/java/io/crate/expression/symbol/FloatLiteral.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.math.BigDecimal;
+
+/**
+ * This is a literal for handling explicit and implicit casts of <p>float</p> values.
+ * It will be streamed as a <p>Literal<Float>()</p> and thus special casting is only available during the
+ * analyzer and plan phases.
+ */
+public class FloatLiteral extends Literal<Float> {
+
+    private final BigDecimal bd;
+
+    public FloatLiteral(BigDecimal bd) {
+        super(DataTypes.FLOAT, bd.floatValue());
+        this.bd = bd;
+    }
+
+    @Override
+    public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
+        return super.accept(visitor, context);
+    }
+
+    @Override
+    public Symbol cast(DataType<?> targetType, boolean tryCast, boolean explicitCast) {
+        // To prevent floating number rounding issues, casting it to Double will use
+        // the double of the parsed BigDecimal value.
+        if (targetType.id() == DataTypes.DOUBLE.id()) {
+            return new Literal<>(DataTypes.DOUBLE, bd.doubleValue());
+        }
+
+        // On explicit casts, any further implicit cast is based on the float value.
+        if (explicitCast && targetType.id() == DataTypes.FLOAT.id()) {
+            return new Literal<>(DataTypes.FLOAT, bd.floatValue());
+        }
+
+        return super.cast(targetType, tryCast, explicitCast);
+    }
+
+    public Literal<Float> negate() {
+        // BigDecimal does not support negating of ZERO values like -0.0, it always return 0.0.
+        // Thus we return a generic float literal here as no BigDecimal information(original double value)
+        // is needed later on (casts) for zero values.
+        if (bd.intValue() == 0) {
+            return Literal.of(bd.floatValue() * -1);
+        }
+        return new FloatLiteral(bd.negate());
+    }
+}

--- a/server/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/server/src/main/java/io/crate/expression/symbol/Literal.java
@@ -211,6 +211,10 @@ public class Literal<T> extends Symbol implements Input<T>, Comparable<Literal<T
         return new Literal<>(type, value);
     }
 
+    public static Literal<Short> of(Short value) {
+        return new Literal<>(DataTypes.SHORT, value);
+    }
+
     public static Literal<Integer> of(Integer value) {
         return new Literal<>(DataTypes.INTEGER, value);
     }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -168,8 +168,8 @@ public final class DataTypes {
             NUMBER_CONVERSIONS.stream()
         ).collect(toSet())),
         entry(IP.id(), Set.of(STRING.id())),
-        entry(TIMESTAMPZ.id(), Set.of(DOUBLE.id(), LONG.id(), STRING.id(), TIMESTAMP.id())),
-        entry(TIMESTAMP.id(), Set.of(DOUBLE.id(), LONG.id(), STRING.id(), TIMESTAMPZ.id())),
+        entry(TIMESTAMPZ.id(), Set.of(DOUBLE.id(), FLOAT.id(), LONG.id(), STRING.id(), TIMESTAMP.id())),
+        entry(TIMESTAMP.id(), Set.of(DOUBLE.id(), FLOAT.id(), LONG.id(), STRING.id(), TIMESTAMPZ.id())),
         entry(UNDEFINED.id(), Set.of()), // actually convertible to every type, see NullType
         entry(GEO_POINT.id(), Set.of()),
         entry(GEO_SHAPE.id(), Set.of(ObjectType.ID)),

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -136,10 +136,10 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         assertThat(session.getParamType("S_1", 2), is(DataTypes.UNDEFINED));
 
         DescribeResult describe = session.describe('S', "S_1");
-        assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.LONG, DataTypes.LONG }));
+        assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER }));
 
-        assertThat(session.getParamType("S_1", 0), is(DataTypes.LONG));
-        assertThat(session.getParamType("S_1", 1), is(DataTypes.LONG));
+        assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
+        assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Requested parameter index exceeds the number of parameters");

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -347,7 +347,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testObjectWithInvalidValueTypeAsNodeFiltersArgument() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("node_filters argument 'name' must be a String, not 20 (Long)");
+        expectedException.expectMessage("node_filters argument 'name' must be a String, not 20 (Short)");
         analyze("COPY users FROM '/' WITH (node_filters={name=20})");
     }
 }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1297,11 +1297,11 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         AnalyzedColumnDefinition<Object> obj = stmt.analyzedTableElements().columns().get(0);
         AnalyzedColumnDefinition c = obj.children().get(0);
 
-        assertThat(c.dataType(), is(DataTypes.LONG));
+        assertThat(c.dataType(), is(DataTypes.INTEGER));
         assertThat(c.formattedGeneratedExpression(), is("2"));
         assertThat(AnalyzedTableElements.toMapping(stmt.analyzedTableElements()).toString(),
                    is("{_meta={generated_columns={obj.c=2}}, " +
-                      "properties={obj={dynamic=true, position=1, type=object, properties={c={type=long}}}}}"));
+                      "properties={obj={dynamic=true, position=1, type=object, properties={c={type=integer}}}}}"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -168,7 +168,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select 58 as fiftyEight from foo.users group by fiftyEight;");
         assertThat(relation.groupBy().isEmpty(), is(false));
         List<Symbol> groupBySymbols = relation.groupBy();
-        assertThat(groupBySymbols.get(0), isAlias("fiftyeight", isLiteral(58L)));
+        assertThat(groupBySymbols.get(0), isAlias("fiftyeight", isLiteral((short) 58)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -456,7 +456,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testWhereInSelectDifferentDataTypeValueIncompatibleDataTypes() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         analyze("select 'found' from users where 1 in (1, 'foo', 2)");
     }
 
@@ -844,7 +844,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `smallint`");
         analyze("select * from users where 5 = friends['id']");
     }
 
@@ -933,15 +933,15 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testPrefixedNumericLiterals() throws Exception {
         AnalyzedRelation relation = analyze("select - - - 10");
         List<Symbol> outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(-10L)));
+        assertThat(outputs.get(0), is(Literal.of((short) -10)));
 
         relation = analyze("select - + - 10");
         outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(10L)));
+        assertThat(outputs.get(0), is(Literal.of((short) 10)));
 
         relation = analyze("select - (- 10 - + 10) * - (+ 10 + - 10)");
         outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(0L)));
+        assertThat(outputs.get(0), is(Literal.of(0)));
     }
 
     @Test
@@ -1093,7 +1093,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchPredicateWithWrongQueryTerm() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast expressions from type `bigint_array` to type `text`");
+        expectedException.expectMessage("Cannot cast expressions from type `smallint_array` to type `text`");
         analyze("select name from users order by match(name, [10, 20])");
     }
 
@@ -1117,7 +1117,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         Symbol query = relation.where();
         assertThat(query, instanceOf(MatchPredicate.class));
         MatchPredicate match = (MatchPredicate) query;
-        assertThat(match.identBoostMap(), hasEntry(isReference("name"), isLiteral(1.2)));
+        assertThat(match.identBoostMap(), hasEntry(isReference("name"), isLiteral(1.2f)));
         assertThat(match.identBoostMap(), hasEntry(isReference("text"), isLiteral(null)));
         assertThat(match.queryTerm(), isLiteral("awesome"));
         assertThat(match.matchType(), is("best_fields"));
@@ -1188,17 +1188,17 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         MatchPredicate match = (MatchPredicate) relation.where();
         assertThat(match.options(), isLiteral(Map.ofEntries(
             Map.entry("analyzer", "german"),
-            Map.entry("boost", 4.6),
-            Map.entry("cutoff_frequency", 5L),
-            Map.entry("fuzziness", 12L),
+            Map.entry("boost", 4.6f),
+            Map.entry("cutoff_frequency", (short) 5),
+            Map.entry("fuzziness", (short) 12),
             Map.entry("fuzzy_rewrite", "top_terms_20"),
-            Map.entry("max_expansions", 3L),
-            Map.entry("minimum_should_match", 4L),
+            Map.entry("max_expansions", (short) 3),
+            Map.entry("minimum_should_match", (short) 4),
             Map.entry("operator", "or"),
-            Map.entry("prefix_length", 4L),
+            Map.entry("prefix_length", (short) 4),
             Map.entry("rewrite", "constant_score_boolean"),
-            Map.entry("slop", 3L),
-            Map.entry("tie_breaker", 0.75),
+            Map.entry("slop", (short) 3),
+            Map.entry("tie_breaker", 0.75f),
             Map.entry("zero_terms_query", "all")
         )));
     }
@@ -1691,7 +1691,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: unnest(bigint, text)");
+        expectedException.expectMessage("unknown function: unnest(smallint, text)");
         analyze("select * from unnest(1, 'foo')");
     }
 
@@ -1825,7 +1825,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testColumnOutputWithSingleRowSubselect() {
         AnalyzedRelation relation = analyze("select 1 = \n (select \n 2\n)\n");
         assertThat(relation.outputs(), contains(
-            isFunction("op_=", isLiteral(1L), instanceOf(SelectSymbol.class)))
+            isFunction("op_=", isLiteral((short) 1), instanceOf(SelectSymbol.class)))
         );
     }
 
@@ -1966,7 +1966,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation rel = analyze("select ({x=10}).x");
         assertThat(
             rel.outputs(),
-            contains(isLiteral(10L))
+            contains(isLiteral((short) 10))
         );
     }
 

--- a/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -57,14 +57,14 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analysis.scope(), is(SetStatement.Scope.GLOBAL));
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of((short) 1)))));
 
         analysis = analyze("SET GLOBAL TRANSIENT stats.jobs_log_size=2");
         assertThat(analysis.isPersistent(), is(false));
         assertThat(analysis.scope(), is(SetStatement.Scope.GLOBAL));
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of((short) 2)))));
 
 
         analysis = analyze("SET GLOBAL TRANSIENT stats.enabled=false, stats.operations_log_size=0, stats.jobs_log_size=0");
@@ -77,11 +77,11 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(1),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(0L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of((short) 0)))));
 
         assertThat(
             analysis.settings().get(2),
-            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(0L)))));
+            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of((short) 0)))));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of((short) 2)))));
 
 
         analysis = analyze("SET LOCAL something TO DEFAULT");
@@ -121,14 +121,21 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of((short) 2)))));
 
         analysis = analyze("SET SESSION something = 1,2,3");
         assertThat(analysis.scope(), is(SetStatement.Scope.SESSION));
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(1L), Literal.of(2L), Literal.of(3L)))));
+            is(new Assignment<>(
+                Literal.of("something"),
+                List.of(Literal.of((short) 1),
+                        Literal.of((short) 2),
+                        Literal.of((short) 3L)
+                )
+            ))
+        );
     }
 
     @Test
@@ -138,7 +145,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of((short) 2)))));
 
         analysis = analyze("SET something = DEFAULT");
         assertThat(analysis.scope(), is(SetStatement.Scope.SESSION));
@@ -162,7 +169,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of((short) 1)))));
     }
 //
     @Test

--- a/server/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -98,7 +98,7 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
             "select * from users where match(shape 1.2, (select shape from users limit 1))");
         assertThat(relation.where(), instanceOf(MatchPredicate.class));
         MatchPredicate match = (MatchPredicate) relation.where();
-        assertThat(match.identBoostMap(), hasEntry(isReference("shape"), isLiteral(1.2)));
+        assertThat(match.identBoostMap(), hasEntry(isReference("shape"), isLiteral(1.2f)));
         assertThat(match.queryTerm(), instanceOf(SelectSymbol.class));
         assertThat(match.matchType(), is("intersects"));
     }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -168,14 +168,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNumericTypeOutOfRange() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for shorts: Cannot cast expression `-100000` of type `bigint` to `smallint`");
+        expectedException.expectMessage("Validation failed for shorts: Cannot cast expression `-100000` of type `integer` to `smallint`");
         analyze("update users set shorts=-100000");
     }
 
     @Test
     public void testNumericOutOfRangeFromFunction() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for bytes: Cannot cast expression `1234` of type `bigint` to `char`");
+        expectedException.expectMessage("Validation failed for bytes: Cannot cast expression `1234` of type `smallint` to `char`");
         analyze("update users set bytes=abs(-1234)");
     }
 
@@ -201,7 +201,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         Reference ref = update.assignmentByTargetCol().keySet().iterator().next();
         assertThat(ref, instanceOf(DynamicReference.class));
-        Assert.assertEquals(DataTypes.LONG, ref.valueType());
+        Assert.assertEquals(DataTypes.SHORT, ref.valueType());
         assertThat(ref.column().isTopLevel(), is(false));
         assertThat(ref.column().fqn(), is("details.arms"));
     }
@@ -384,8 +384,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUpdateDynamicNestedArrayParamLiteral() throws Exception {
         AnalyzedUpdateStatement update = analyze("update users set new=[[1.9, 4.8], [9.7, 12.7]]");
-        DataType dataType = update.assignmentByTargetCol().values().iterator().next().valueType();
-        assertThat(dataType, is(new ArrayType(new ArrayType(DoubleType.INSTANCE))));
+        DataType<?> dataType = update.assignmentByTargetCol().values().iterator().next().valueType();
+        assertThat(dataType, is(new ArrayType<>(new ArrayType<>(DataTypes.FLOAT))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -53,7 +53,7 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_error_is_raised_if_the_types_of_the_rows_are_not_compatible() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         e.analyze("VALUES (1), ('foo')");
     }
 
@@ -69,18 +69,18 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_nulls_in_column_values_must_not_fail_type_validation() {
         AnalyzedRelation relation = e.analyze("VALUES (1), (null), (2), (null)");
-        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.LONG)));
+        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.SHORT)));
     }
 
     @Test
     public void test_implicitly_convertible_column_values_must_not_fail_type_validation() {
         AnalyzedRelation relation = e.analyze("VALUES (1), (1.0)");
-        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.DOUBLE)));
+        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.FLOAT)));
     }
 
     @Test
-    public void test_highest_precedence_type_is_chosen_as_target_column_type() {
+    public void test_lowest_guessed_type_is_chosen_as_target_column_type() {
         AnalyzedRelation relation = e.analyze("VALUES (null), (1.0), (1), ('1')");
-        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.DOUBLE)));
+        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.FLOAT)));
     }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -191,7 +191,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new QualifiedName("subscript"),
             ImmutableList.of(
                 new ArrayLiteral(ImmutableList.of(new StringLiteral("obj"))),
-                new LongLiteral("1")));
+                new LongLiteral(1)));
 
         Symbol symbol = expressionAnalyzer.convert(subscriptFunctionCall, expressionAnalysisContext);
         assertThat(symbol, isLiteral("obj"));
@@ -316,8 +316,8 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testIncompatibleLiteralThrowsException() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `2147483648` of type `bigint` to type `integer`");
-        executor.asSymbol("doc.t2.i = 1 + " + Integer.MAX_VALUE);
+        expectedException.expectMessage("Cannot cast `21474836472` of type `bigint` to type `integer`");
+        executor.asSymbol("doc.t2.i = 1 + " + Integer.MAX_VALUE + 1);
     }
 
     @Test
@@ -365,24 +365,24 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testParameterExpressionInAny() throws Exception {
         Symbol s = expressions.asSymbol("5 = ANY(?)");
-        assertThat(s, isFunction(AnyOperators.Names.EQ, isLiteral(5L), instanceOf(ParameterSymbol.class)));
+        assertThat(s, isFunction(AnyOperators.Names.EQ, isLiteral((short) 5), instanceOf(ParameterSymbol.class)));
     }
 
     @Test
     public void testParameterExpressionInLikeAny() throws Exception {
         Symbol s = expressions.asSymbol("5 LIKE ANY(?)");
-        assertThat(s, isFunction(LikeOperators.ANY_LIKE, isLiteral(5L), instanceOf(ParameterSymbol.class)));
+        assertThat(s, isFunction(LikeOperators.ANY_LIKE, isLiteral((short) 5), instanceOf(ParameterSymbol.class)));
     }
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `smallint`");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 
     @Test
     public void testCallingUnknownFunctionWithExplicitSchemaRaisesNiceError() {
-        expectedException.expectMessage("unknown function: foo.bar(bigint)");
+        expectedException.expectMessage("unknown function: foo.bar(smallint)");
         executor.analyze("select foo.bar(1)");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -28,6 +28,7 @@ import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -38,7 +39,10 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeWithValueSymbols() throws Exception {
-        assertNormalize("array_cat([10, 20], [10, 30])", isLiteral(Arrays.asList(10L, 20L, 10L, 30L)));
+        assertNormalize(
+            "array_cat([10, 20], [10, 30])",
+            isLiteral(List.of((short) 10, (short) 20, (short) 10, (short) 30))
+        );
     }
 
     @Test
@@ -48,7 +52,10 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        assertNormalize("array_cat([1, 2, 3], null)", isLiteral(Arrays.asList(1L, 2L, 3L)));
+        assertNormalize(
+            "array_cat([1, 2, 3], null)",
+            isLiteral(List.of((short) 1, (short) 2, (short) 3))
+        );
     }
 
     @Test
@@ -61,14 +68,15 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(bigint_array)");
+        expectedException.expectMessage("unknown function: array_cat(smallint_array)");
         assertEvaluate("array_cat([1])", null);
     }
 
     @Test
     public void testThreeArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(bigint_array, bigint_array, bigint_array)");
+        expectedException.expectMessage(
+            "unknown function: array_cat(smallint_array, smallint_array, smallint_array)");
         assertEvaluate("array_cat([1], [2], [3])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -55,25 +55,25 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testArrayDifferenceRemovesTheNestedArraysInTheFirstArrayThatAreContainedWithinTheSecondArray() {
         assertEvaluate(
             "array_difference([[1, 2], [1, 3]], [[1, 2]])",
-            Matchers.contains(Matchers.contains(1L, 3L)));
+            Matchers.contains(Matchers.contains((short) 1, (short) 3)));
     }
 
     @Test
     public void testArrayDifferenceRemovesTheObjectsInTheFirstArrayThatAreContainedInTheSecond() {
         assertEvaluate(
             "array_difference([{x=[1, 2]}, {x=[1, 3]}], [{x=[1, 3]}])",
-            Matchers.contains(Matchers.hasEntry(is("x"), Matchers.contains(1L, 2L))));
+            Matchers.contains(Matchers.hasEntry(is("x"), Matchers.contains((short) 1, (short) 2))));
     }
 
     @Test
     public void testNormalize() throws Exception {
-        assertNormalize("array_difference([10, 20], [10, 30])", isLiteral(List.of(20L)));
+        assertNormalize("array_difference([10, 20], [10, 30])", isLiteral(List.of((short) 20)));
         assertNormalize("array_difference([], [10, 30])", isLiteral(List.of()));
     }
 
     @Test
     public void testNormalizeNullArguments() throws Exception {
-        assertNormalize("array_difference([1], null)", isLiteral(List.of(1L)));
+        assertNormalize("array_difference([1], null)", isLiteral(List.of((short) 1)));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_difference(bigint_array)");
+        expectedException.expectMessage("unknown function: array_difference(smallint_array)");
         assertNormalize("array_difference([1])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -66,21 +66,23 @@ public class ArrayLowerFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array)");
+        expectedException.expectMessage("unknown function: array_lower(smallint_array)");
         assertEvaluate("array_lower([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array, bigint, bigint_array)");
+        expectedException.expectMessage(
+            "unknown function: array_lower(smallint_array, smallint, smallint_array)");
         assertEvaluate("array_lower([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array, bigint_array)");
+        expectedException.expectMessage(
+            "unknown function: array_lower(smallint_array, smallint_array)");
         assertEvaluate("array_lower([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -41,7 +41,10 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeWithValueSymbols() throws Exception {
-        assertNormalize("array_unique([10, 20], [10, 30])", isLiteral(Arrays.asList(10L, 20L, 30L)));
+        assertNormalize(
+            "array_unique([10, 20], [10, 30])",
+            isLiteral(List.of((short) 10, (short) 20, (short) 30))
+        );
     }
 
     @Test
@@ -51,7 +54,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        assertNormalize("array_unique([1], null)", isLiteral(List.of(1L)));
+        assertNormalize("array_unique([1], null)", isLiteral(List.of((short) 1)));
     }
 
     @Test
@@ -64,8 +67,13 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testArrayUniqueOnNestedArrayReturnsUniqueInnerArrays() {
-        assertEvaluate("array_unique([[0, 0], [1, 1]], [[0, 0], [1, 1]])",
-            List.of(List.of(0L, 0L), List.of(1L, 1L)));
+        assertEvaluate(
+            "array_unique([[0, 0], [1, 1]], [[0, 0], [1, 1]])",
+            List.of(
+                List.of((short) 0, (short) 0),
+                List.of((short) 1, (short) 1)
+            )
+        );
     }
 
     @Test
@@ -73,7 +81,9 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate(
             "array_unique([{x=[1, 1]}], [{x=[1, 1]}])",
              Matchers.contains(
-               Matchers.hasEntry(is("x"), Matchers.contains(is(1L), is(1L)))
+               Matchers.hasEntry(is("x"),
+                                 Matchers.contains(is((short) 1), is((short) 1))
+               )
            )
         );
     }
@@ -99,13 +109,16 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testDifferentButConvertableInnerTypes() throws Exception {
-        assertEvaluate("array_unique([10, 20], [10.1, 20.0])", Arrays.asList(10.0, 20.0, 10.1));
+        assertEvaluate(
+            "array_unique([10, 20], [10.1, 20.0])",
+            List.of(10.0f, 20.0f, 10.1f)
+        );
     }
 
     @Test
     public void testConvertNonNumericStringToNumber() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 
@@ -118,12 +131,18 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullElements() throws Exception {
-        assertEvaluate("array_unique([1, null, 3], [null, 2, 3])", Arrays.asList(1L, null, 3L, 2L));
+        assertEvaluate(
+            "array_unique([1, null, 3], [null, 2, 3])",
+            Arrays.asList((short) 1, null, (short) 3, (short) 2)
+        );
     }
 
     @Test
-    public void testEmptyArrayAndLongArray() throws Exception {
-        assertEvaluate("array_unique([], [111, 222, 333])", Arrays.asList(111L, 222L, 333L));
+    public void testEmptyArrayAndNumericArray() throws Exception {
+        assertEvaluate(
+            "array_unique([], [111, 222, 333])",
+            List.of((short) 111, (short) 222, (short) 333)
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -71,21 +71,22 @@ public class ArrayUpperFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array)");
+        expectedException.expectMessage("unknown function: array_upper(smallint_array)");
         assertEvaluate("array_upper([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array, bigint, bigint_array)");
+        expectedException.expectMessage(
+            "unknown function: array_upper(smallint_array, smallint, smallint_array)");
         assertEvaluate("array_upper([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array, bigint_array)");
+        expectedException.expectMessage("unknown function: array_upper(smallint_array, smallint_array)");
         assertEvaluate("array_upper([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -39,7 +39,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testArgumentThatHasNoStringRepr() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(text, bigint_array)");
+        expectedException.expectMessage("unknown function: concat(text, smallint_array)");
         assertNormalize("concat('foo', [1])", null);
     }
 
@@ -76,18 +76,21 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTwoArrays() throws Exception {
-        assertNormalize("concat([1, 2], [2, 3])", isLiteral(List.of(1L, 2L, 2L, 3L)));
+        assertNormalize(
+            "concat([1, 2], [2, 3])",
+            isLiteral(List.of((short) 1, (short) 2, (short) 2, (short) 3))
+        );
     }
 
     @Test
     public void testArrayWithAUndefinedInnerType() throws Exception {
-        assertNormalize("concat([], [1, 2])", isLiteral(List.of(1L, 2L)));
+        assertNormalize("concat([], [1, 2])", isLiteral(List.of((short) 1, (short) 2)));
     }
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(bigint_array, bigint_array_array)");
+        expectedException.expectMessage("unknown function: concat(smallint_array, smallint_array_array)");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 
@@ -101,7 +104,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluate() throws Exception {
-        assertEvaluate("concat([1], [2::integer, 3::integer])", List.of(1L, 2L, 3L));
+        assertEvaluate("concat([1], [2::integer, 3::integer])", List.of(1, 2, 3));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -41,7 +41,7 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_subscript_can_retrieve_items_of_objects_within_array() {
-        assertEvaluate("[{x=10}, {x=2}]['x']", List.of(10L, 2L));
+        assertEvaluate("[{x=10}, {x=2}]['x']", List.of((short) 10, (short) 2));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -33,8 +33,8 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluate() throws Exception {
-        assertEvaluate("subscript_obj({x=10}, 'x')", 10L);
-        assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'x'), 'y')", 10L);
+        assertEvaluate("subscript_obj({x=10}, 'x')", (short) 10);
+        assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'x'), 'y')", (short) 10);
     }
 
     @Test
@@ -62,11 +62,11 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testFunctionCanBeUsedAsIndexInSubscript() {
-        assertNormalize("{\"x\" = 10}['x' || '']", isLiteral(10L));
+        assertNormalize("{\"x\" = 10}['x' || '']", isLiteral((short) 10));
     }
 
     @Test
     public void testSubscriptOnObjectWithPath() {
-        assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", 10L);
+        assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", (short) 10);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
@@ -40,7 +40,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("'1' = 1", true);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         assertEvaluate("'foo' = 1", true);
     }
 
@@ -66,7 +66,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("case 1 when 1.0 then 'foo' else 'bar' end", "foo");
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         assertEvaluate("case 1 when 'foo' then 'foo' else 'bar' end", "bar");
     }
 
@@ -78,7 +78,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("1.2 in (null, 1::integer, 2::long, 3.0)", null);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `real`");
         assertEvaluate("1 in (null, 1::integer, 2::long, 3.0, 'foo')", true);
     }
 
@@ -90,7 +90,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("1.2 = ANY ([null, 1::integer, 2::long, 3.0])", null);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `real`");
         assertEvaluate("1 = ANY ([null, 1::integer, 2::long, 3.0, 'foo'])", true);
     }
 
@@ -101,6 +101,6 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
     public void testTimestampOperations() {
         assertEvaluate("3::timestamp with time zone - 1", 2L);
         assertEvaluate("3000::timestamp with time zone / 1000", 3L);
-        assertEvaluate("3000::timestamp with time zone/ 1000.0", 3.0);
+        assertEvaluate("3000::timestamp with time zone/ 1000.0", 3.0f);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -33,10 +33,10 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testAbs() throws Exception {
-        assertEvaluate("abs(-2)", 2L);
-        assertEvaluate("abs(-2.0)", 2.0);
+        assertEvaluate("abs(-2)", (short) 2);
+        assertEvaluate("abs(-2.0)", 2.0f);
         assertEvaluate("abs(cast(-2 as integer))", 2);
-        assertEvaluate("abs(cast(-2.0 as float))", 2.0f);
+        assertEvaluate("abs(cast(-2.0 as double))", 2.0d);
         assertEvaluate("abs(null)", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
@@ -37,21 +37,21 @@ public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTypeValidation() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `smallint`");
         assertEvaluate("ARRAY[1, 'foo']", null);
     }
 
     @Test
     public void testEvaluateArrayWithExpr() {
-        assertEvaluate("ARRAY[1 + 2]", List.of(3L));
-        assertEvaluate("[1 + 1]", List.of(2L));
+        assertEvaluate("ARRAY[1 + 2]", List.of(3));
+        assertEvaluate("[1 + 1]", List.of(2));
     }
 
     @Test
     public void testEvaluateNestedArrays() {
         assertEvaluate("ARRAY[[]]", List.of(List.of()));
         assertEvaluate("[ARRAY[]]", List.of(List.of()));
-        assertEvaluate("[[1 + 1], ARRAY[1 + 2]]", List.of(List.of(2L), List.of(3L)));
+        assertEvaluate("[[1 + 1], ARRAY[1 + 2]]", List.of(List.of(2), List.of(3)));
     }
 
     public void testEvaluateArrayOnColumnIdents() {
@@ -64,8 +64,8 @@ public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeArrays() {
-        assertNormalize("ARRAY[1 + 2]", isLiteral(List.of(3L)));
-        assertNormalize("[ARRAY[1 + 2]]", isLiteral(List.of(List.of(3L))));
+        assertNormalize("ARRAY[1 + 2]", isLiteral(List.of(3)));
+        assertNormalize("[ARRAY[1 + 2]]", isLiteral(List.of(List.of(3))));
         assertNormalize("[[null is null], ARRAY[4 is not null], [false]]",
             isLiteral(List.of(List.of(true), List.of(true), List.of(false))));
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -32,27 +32,27 @@ public class CeilFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateOnDouble() throws Exception {
-        assertNormalize("ceil(29.9)", isLiteral(30L));
+        assertNormalize("ceil(29.9::double precision)", isLiteral(30L));
         assertNormalize("ceil(null)", isLiteral(null));
     }
 
     @Test
     public void testEvaluateOnFloat() throws Exception {
-        assertNormalize("ceil(cast(29.9 as float))", isLiteral(30));
+        assertNormalize("ceil(29.9)", isLiteral(30));
         assertNormalize("ceil(cast(null as float))", isLiteral(null, DataTypes.INTEGER));
     }
 
     @Test
     public void test_ceiling_works_as_alias_for_ceil() {
-        assertEvaluate("ceiling(-95.3)", -95L);
+        assertEvaluate("ceiling(-95.3)", -95);
     }
 
     @Test
     public void testEvaluateOnIntAndLong() throws Exception {
-        assertNormalize("ceil(cast(20 as integer))", isLiteral(20));
+        assertNormalize("ceil(20)", isLiteral(20));
         assertNormalize("ceil(cast(null as integer))", isLiteral(null, DataTypes.INTEGER));
 
-        assertNormalize("ceil(20)", isLiteral(20L));
+        assertNormalize("ceil(20::bigint)", isLiteral(20L));
         assertNormalize("ceil(cast(null as long))", isLiteral(null, DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -31,9 +31,10 @@ public class ExpFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_exp_scalar() {
-        assertNormalize("exp(1)", isLiteral(2L));
+        assertNormalize("exp(1)", isLiteral((short) 2));
         assertNormalize("exp(1::int)", isLiteral(2));
-        assertNormalize("exp(1.0)", isLiteral(2.718281828459045));
-        assertNormalize("exp(1.0::real)", isLiteral(2.7182817F));
+        assertNormalize("exp(1::bigint)", isLiteral(2L));
+        assertNormalize("exp(1.0::double precision)", isLiteral(2.718281828459045));
+        assertNormalize("exp(1.0)", isLiteral(2.7182817F));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
@@ -32,13 +32,13 @@ public class FloorFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateOnDouble() throws Exception {
-        assertNormalize("floor(29.9)", isLiteral(29L));
+        assertNormalize("floor(29.9::double precision)", isLiteral(29L));
         assertNormalize("floor(cast(null as double))", isLiteral(null, DataTypes.LONG));
     }
 
     @Test
     public void testEvaluateOnFloat() throws Exception {
-        assertNormalize("floor(cast(29.9 as float))", isLiteral(29));
+        assertNormalize("floor(29.9)", isLiteral(29));
         assertNormalize("floor(cast(null as float))", isLiteral(null, DataTypes.INTEGER));
     }
 
@@ -46,9 +46,9 @@ public class FloorFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateOnIntAndLong() throws Exception {
         assertNormalize("floor(cast(20 as integer))", isLiteral(20));
         assertNormalize("floor(cast(null as integer))", isLiteral(null, DataTypes.INTEGER));
-        assertNormalize("floor(42.9)", isLiteral(42L));
+        assertNormalize("floor(42.9)", isLiteral(42));
 
-        assertNormalize("floor(20)", isLiteral(20L));
+        assertNormalize("floor(20::bigint)", isLiteral(20L));
         assertNormalize("floor(cast(null as long))", isLiteral(null, DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
@@ -31,19 +31,19 @@ public class ModulusFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_modulus_scalar() {
-        assertNormalize("modulus(3, 2)", isLiteral(1L));
-        assertNormalize("modulus(3::int, 2::int)", isLiteral(1));
-        assertNormalize("modulus(3.5, 2)", isLiteral(1.5d));
-        assertNormalize("modulus(3.5::real, 2)", isLiteral(1.5f));
+        assertNormalize("modulus(3, 2)", isLiteral(1));
+        assertNormalize("modulus(3::bigint, 2::bigint)", isLiteral(1L));
+        assertNormalize("modulus(3.5, 2)", isLiteral(1.5f));
+        assertNormalize("modulus(3.5::double precision, 2)", isLiteral(1.5d));
     }
 
     @Test
     public void test_modulus_operator() {
-        assertNormalize("3 % 2", isLiteral(1L));
+        assertNormalize("3 % 2", isLiteral(1));
     }
 
     @Test
     public void test_mod_works_as_alias_for_modulus() {
-        assertNormalize("mod(3, 2)", isLiteral(1L));
+        assertNormalize("mod(3, 2)", isLiteral(1));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -64,7 +64,7 @@ public class PowerFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidNumberOfArguments() {
-        expectedException.expectMessage("unknown function: power(bigint)");
+        expectedException.expectMessage("unknown function: power(smallint)");
         assertEvaluate("power(2)", null);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -32,10 +32,10 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testRound() throws Exception {
-        assertEvaluate("round(42.2)", 42L);
-        assertEvaluate("round(42)", 42L);
-        assertEvaluate("round(cast(42 as integer))", 42);
-        assertEvaluate("round(cast(42.2 as float))", 42);
+        assertEvaluate("round(42.2)", 42);
+        assertEvaluate("round(42)", 42);
+        assertEvaluate("round(42::bigint)", 42L);
+        assertEvaluate("round(42.2::double precision)", 42L);
         assertEvaluate("round(null)", null);
 
         assertNormalize("round(id)", isFunction("round"));

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
@@ -250,4 +250,9 @@ public class TrigonometricFunctionsTest extends AbstractScalarFunctionsTest {
         assertNormalize("atan2(1, 1::int)", isLiteral(0.7853981633974483));
         assertNormalize("atan2(1, 1::real)", isLiteral(0.7853981633974483));
     }
+
+    @Test
+    public void testExplicitFloatCast() {
+        assertNormalize("asin(cast (0.4321 as float))", isLiteral(0.44682008883801516, DataTypes.DOUBLE));
+    }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
@@ -35,11 +35,11 @@ public class TruncFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeOnDouble() throws Exception {
-        assertNormalize("trunc(29.1947)", isLiteral(29L));
-        assertNormalize("trunc(-29.1947)", isLiteral(-29L));
-        assertNormalize("trunc(-29.1947, 0)", isLiteral(-29.0));
-        assertNormalize("trunc(29.1947, 0)", isLiteral(29.0));
-        assertNormalize("trunc(29.1947, 1)", isLiteral(29.1d));
+        assertNormalize("trunc(29.1947::double)", isLiteral(29L));
+        assertNormalize("trunc(-29.1947::double)", isLiteral(-29L));
+        assertNormalize("trunc(-29.1947::double, 0)", isLiteral(-29.0));
+        assertNormalize("trunc(29.1947::double, 0)", isLiteral(29.0));
+        assertNormalize("trunc(29.1947::double, 1)", isLiteral(29.1d));
         assertNormalize("trunc(cast(null as double))", isLiteral(null,  DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -119,7 +119,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     public void testDoubleColonOperatorCast() {
         assertEvaluate("10.4::string", "10.4");
         assertEvaluate("[1, 2, 0]::array(boolean)", List.of(true, true, false));
-        assertEvaluate("(1+3)/2::string", 2L);
+        assertEvaluate("(1+3)/2::string", 2);
         assertEvaluate("((1+3)/2)::string", "2");
         assertEvaluate("'10'::long + 5", 15L);
         assertEvaluate("(-4)::string", "-4");

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -32,31 +32,31 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCoalesce() throws Exception {
         assertEvaluate("coalesce(null)", null);
-        assertEvaluate("coalesce(10, null, 20)", 10L);
+        assertEvaluate("coalesce(10, null, 20)", (short) 10);
         assertEvaluate("coalesce(name, 'foo')", "foo", Literal.NULL);
     }
 
     @Test
     public void testGreatest() throws Exception {
         assertEvaluate("greatest(null, null)", null);
-        assertEvaluate("greatest(10)", 10L);
-        assertEvaluate("greatest(10, 20, null, 30)", 30L);
-        assertEvaluate("greatest(11.1, 22.2, null)", 22.2);
+        assertEvaluate("greatest(10)", (short) 10);
+        assertEvaluate("greatest(10, 20, null, 30)", (short) 30);
+        assertEvaluate("greatest(11.1, 22.2, null)", 22.2f);
         assertEvaluate("greatest('foo', name, 'bar')", "foo", Literal.NULL);
     }
 
     @Test
     public void testLeast() throws Exception {
         assertEvaluate("least(null, null)", null);
-        assertEvaluate("least(10)", 10L);
-        assertEvaluate("least(10, 20, null, 30)", 10L);
-        assertEvaluate("least(11.1, 22.2, null)", 11.1);
+        assertEvaluate("least(10)", (short) 10);
+        assertEvaluate("least(10, 20, null, 30)", (short) 10);
+        assertEvaluate("least(11.1, 22.2, null)", 11.1f);
         assertEvaluate("least('foo', name, 'bar')", "bar", Literal.NULL);
     }
 
     @Test
     public void testNullIf() throws Exception {
-        assertEvaluate("nullif(10, 12)", 10L);
+        assertEvaluate("nullif(10, 12)", (short) 10);
         assertEvaluate("nullif(name, 'foo')", null, Literal.of("foo"));
         assertEvaluate("nullif(null, 'foo')", null);
     }
@@ -64,7 +64,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNullIfInvalidArgsLength() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: nullif(bigint, bigint, bigint)");
+        expectedException.expectMessage("unknown function: nullif(smallint, smallint, smallint)");
         assertEvaluate("nullif(1, 2, 3)", null);
     }
 
@@ -105,7 +105,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     public void testCaseIncompatibleTypes() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Data types of all result expressions of a CASE statement must be equal, " +
-                                        "found: [text, bigint]");
+                                        "found: [text, smallint]");
         assertEvaluate("case name when 'foo' then 'hello foo' when 'bar' then 1 end",
             "hello foo",
             Literal.of("foo"), Literal.of("foo"));
@@ -129,7 +129,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
         // x = long
         // a = integer
         String expression = "case x + 1 when a::long then 111 end";
-        assertEvaluate(expression, 111L,
+        assertEvaluate(expression, (short) 111,
             Literal.of(110L),    // x
             Literal.of(111));    // a
     }
@@ -137,7 +137,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCaseWithNullArgument() throws Exception {
         String expression = "CASE 68 WHEN 38 THEN NULL ELSE 1 END";
-        assertEvaluate(expression, 1L);
+        assertEvaluate(expression, (short) 1);
     }
 
     @Test
@@ -153,27 +153,27 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    public void testCaseWithNullArgumentIfReturnsLong() throws Exception {
+    public void testCaseWithNullArgumentIfReturnsNonNull() throws Exception {
         String expression = "CASE 38 WHEN 38 THEN 1 ELSE NULL END";
-        assertEvaluate(expression, 1L);
+        assertEvaluate(expression, (short) 1);
     }
 
     @Test
-    public void testCaseWithDifferentResultTypesReturnsLong() throws Exception {
+    public void testCaseWithDifferentResultTypesReturnsNonNull() throws Exception {
         String expression1 = "CASE 47 WHEN 38 THEN 1 ELSE 12::integer END";
-        assertEvaluate(expression1, 12L);
+        assertEvaluate(expression1, 12);
         String expression2 = "CASE 34 WHEN 38 THEN 1::integer ELSE 12 END";
-        assertEvaluate(expression2, 12L);
+        assertEvaluate(expression2, 12);
     }
 
     @Test
-    public void testCaseWithStringAndLongResultTypesReturnsLong() throws Exception {
-        assertEvaluate("CASE 38 WHEN 38 THEN '38' ELSE 40 END",38L);
+    public void testCaseWithStringAndNumeric() throws Exception {
+        assertEvaluate("CASE 38 WHEN 38 THEN '38' ELSE 40 END",(short) 38);
     }
 
     @Test
-    public void testCaseWithStringDefaultTypeReturnsLong() throws Exception {
-        assertEvaluate("CASE 45 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",40L);
-        assertEvaluate("CASE 34 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",34L);
+    public void testCaseWithStringDefaultType() throws Exception {
+        assertEvaluate("CASE 45 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",(short) 40);
+        assertEvaluate("CASE 34 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",(short) 34);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -44,7 +44,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testResolveWithInvalidType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: distance(bigint, text)");
+        expectedException.expectMessage("unknown function: distance(smallint, text)");
         assertNormalize("distance(1, 'POINT (11 21)')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -73,7 +73,7 @@ public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_replace(text, text, bigint_array)");
+        expectedException.expectMessage("unknown function: regexp_replace(text, text, smallint_array)");
 
         assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
     }

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -39,7 +39,7 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_expressions() {
-        assertEvaluate("pg_typeof(1 + 1::short)", DataTypes.LONG.getName());
+        assertEvaluate("pg_typeof(1 + 1::short)", DataTypes.INTEGER.getName());
     }
 
     @Test
@@ -63,10 +63,10 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("pg_typeof(8765134432441)", "bigint");
         assertEvaluate("pg_typeof(x)", DataTypes.LONG.getName(), Literal.of(8765134432441L));
 
-        assertEvaluate("pg_typeof(42.0::real)", DataTypes.FLOAT.getName());
+        assertEvaluate("pg_typeof(42.0)", DataTypes.FLOAT.getName());
         assertEvaluate("pg_typeof(float_val)", DataTypes.FLOAT.getName(), Literal.of(42.0));
 
-        assertEvaluate("pg_typeof(42.0)", DataTypes.DOUBLE.getName());
+        assertEvaluate("pg_typeof(42.0::double precision)", DataTypes.DOUBLE.getName());
         assertEvaluate("pg_typeof(double_val)", DataTypes.DOUBLE.getName(), Literal.of(42.0));
 
         assertEvaluate("pg_typeof('name')", DataTypes.STRING.getName());
@@ -106,9 +106,10 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("pg_typeof(obj_ignored)", ObjectType.NAME, Literal.of("{}"));
 
         assertEvaluate("pg_typeof(['Hello', 'World'])", DataTypes.STRING_ARRAY.getName());
-        assertEvaluate("pg_typeof([1::smallint, 2::smallint])", DataTypes.SHORT_ARRAY.getName());
+        assertEvaluate("pg_typeof([1, 2])", DataTypes.SHORT_ARRAY.getName());
         assertEvaluate("pg_typeof([1::integer, 2::integer])", DataTypes.INTEGER_ARRAY.getName());
-        assertEvaluate("pg_typeof([1, 2])", DataTypes.BIGINT_ARRAY.getName());
+        assertEvaluate("pg_typeof([1::bigint, 2::bigint])", DataTypes.BIGINT_ARRAY.getName());
+        assertEvaluate("pg_typeof([1.0, 2.0])", DataTypes.FLOAT_ARRAY.getName());
         assertEvaluate("pg_typeof([1.0::double precision, 2.0::double precision])",
                        DataTypes.DOUBLE_ARRAY.getName());
 

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -237,8 +237,8 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testExtract() {
-        assertPrintIsParseable("extract(century from '1970-01-01')::bigint");
-        assertPrintIsParseable("extract(day_of_week from current_timestamp)::bigint");
+        assertPrintIsParseable("extract(century from '1970-01-01')::smallint");
+        assertPrintIsParseable("extract(day_of_week from current_timestamp)::smallint");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -105,7 +105,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_function_arguments_must_have_array_types() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _values(bigint)");
+        expectedException.expectMessage("unknown function: _values(smallint)");
         assertExecute("_values(200)", "");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -681,7 +681,10 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast expressions from type `double precision_array` to type `integer`"));
+                assertThat(
+                    e.getMessage(),
+                    Matchers.containsString("Cannot cast expressions from type `real_array` to type `integer`")
+                );
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -205,7 +205,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast `129` of type `bigint` to type `char`");
+        expectedException.expectMessage("Cannot cast `129` of type `smallint` to type `char`");
 
         setUpSimple();
         execute("delete from t1 where byte_field=129");

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -77,7 +77,7 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testGlobalAggregationFromUnnest() {
-        assertThat(execute("select max(col1) from unnest([1, 2, 3, 4])").rows()[0][0], is(4L));
+        assertThat(execute("select max(col1) from unnest([1, 2, 3, 4])").rows()[0][0], is((short) 4));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
     @Test
     public void testAggregationOnResultOfTableFunctionWithinSubQuery() {
         execute("select max(x) from (select unnest([1, 2, 3, 4]) as x) as t");
-        assertThat(response.rows()[0][0], is(4L));
+        assertThat(response.rows()[0][0], is((short) 4));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -395,14 +395,13 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     @Test
     public void testArithmeticFunctions() throws Exception {
         execute("select ((2 * 4 - 2 + 1) / 2) % 3 from sys.cluster");
-        assertThat(response.cols()[0], is("0"));
-        assertThat(response.rows()[0][0], is(0L));
+        assertThat(response.rows()[0][0], is(0));
 
         execute("select ((2 * 4.0 - 2 + 1) / 2) % 3 from sys.cluster");
-        assertThat(response.rows()[0][0], is(0.5));
+        assertThat(response.rows()[0][0], is(0.5f));
 
         execute("select ? + 2 from sys.cluster", $(1));
-        assertThat(response.rows()[0][0], is(3L));
+        assertThat(response.rows()[0][0], is(3));
 
         if (!Constants.WINDOWS) {
             response = execute("select load['1'] + load['5'], load['1'], load['5'] from sys.nodes limit 1");

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -65,12 +65,12 @@ public class UnionIntegrationTest extends SQLTransportIntegrationTest {
                 "union all " +
                 "select * from unnest([4, 5, 6], ['4', '5', '6'])");
         assertThat(response.rows(), arrayContainingInAnyOrder(
-            new Object[] {1L, "1"},
-            new Object[] {2L, "2"},
-            new Object[] {3L, "3"},
-            new Object[] {4L, "4"},
-            new Object[] {5L, "5"},
-            new Object[] {6L, "6"}
+            new Object[] {(short) 1, "1"},
+            new Object[] {(short) 2, "2"},
+            new Object[] {(short) 3, "3"},
+            new Object[] {(short) 4, "4"},
+            new Object[] {(short) 5, "5"},
+            new Object[] {(short) 6, "6"}
         ));
     }
 
@@ -238,7 +238,7 @@ public class UnionIntegrationTest extends SQLTransportIntegrationTest {
     public void testUnionAllArrayAndObjectColumns() {
         execute("select * from (select t1.id, t1.text, t3.arr, t3.obj from t1 join t3 on arr is not null) a " +
                 "union all " +
-                "select id, text, [1,2], {custom = true} from t3 where arr is not null " +
+                "select id, text, [1::bigint, 2::bigint], {custom = true} from t3 where arr is not null " +
                 "order by id");
         assertThat(printedTable(response.rows()), is(
             "1| text| [1, 2, 3]| {temperature=42}\n" +

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -225,7 +225,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(ltQuery.toString(), is("d_array:[1.5000000000000002 TO Infinity]"));
 
         // d < ANY ([1.2, 3.5])
-        Query ltQuery2 = convert("d < any ([1.2, 3.5])");
+        Query ltQuery2 = convert("d < any ([1.2::double, 3.5::double])");
         assertThat(ltQuery2.toString(), is("(d:[-Infinity TO 1.1999999999999997] d:[-Infinity TO 3.4999999999999996])~1"));
 
         // 1.5d <= ANY (d_array)

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -367,12 +367,12 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         Reference integerIndexed = md.references().get(new ColumnIdent("integerIndexed"));
         assertThat(integerIndexed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
-        assertThat(integerIndexed.defaultExpression(), isLiteral(1L));
+        assertThat(integerIndexed.defaultExpression(), isLiteral((short) 1));
 
 
         Reference integerNotIndexed = md.references().get(new ColumnIdent("integerNotIndexed"));
         assertThat(integerNotIndexed.indexType(), is(Reference.IndexType.NO));
-        assertThat(integerNotIndexed.defaultExpression(), isLiteral(1L));
+        assertThat(integerNotIndexed.defaultExpression(), isLiteral((short) 1));
 
         Reference stringNotIndexed = md.references().get(new ColumnIdent("stringNotIndexed"));
         assertThat(stringNotIndexed.indexType(), is(Reference.IndexType.NO));
@@ -1463,7 +1463,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
     public void testArrayAsGeneratedColumn() throws Exception {
         DocIndexMetaData md = getDocIndexMetaDataFromStatement("create table t1 (x as ([10, 20]))");
         GeneratedReference generatedReference = md.generatedColumnReferences().get(0);
-        assertThat(generatedReference.valueType(), is(new ArrayType(DataTypes.LONG)));
+        assertThat(generatedReference.valueType(), is(new ArrayType<>(DataTypes.SHORT)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -33,7 +33,10 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testSetPlan() throws Exception {
         UpdateSettingsPlan plan = e.plan("set GLOBAL PERSISTENT stats.jobs_log_size=1024");
 
-        assertThat(plan.settings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
+        assertThat(
+            plan.settings(),
+            contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of((short) 1024))))
+        );
         assertThat(plan.isPersistent(), is(true));
 
         plan = e.plan("set GLOBAL TRANSIENT stats.enabled=false,stats.jobs_log_size=0");

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -719,14 +719,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "ProjectSet[unnest([1, 2])]\n" +
             "  └ TableFunction[empty_row | [] | true]"));
         Symbol output = plan.outputs().get(0);
-        assertThat(output.valueType(), is(DataTypes.LONG));
+        assertThat(output.valueType(), is(DataTypes.SHORT));
     }
 
     @Test
     public void testScalarCanBeUsedAroundTableGeneratingFunctionInSelectList() {
         LogicalPlan plan = e.logicalPlan("select unnest([1, 2]) + 1");
         assertThat(plan, isPlan(
-            "Eval[(unnest([1, 2]) + 1)]\n" +
+            "Eval[(cast(unnest([1, 2]) AS integer) + 1)]\n" +
             "  └ ProjectSet[unnest([1, 2])]\n" +
             "    └ TableFunction[empty_row | [] | true]"));
     }
@@ -890,9 +890,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "   unnest(ARRAY[2.5, 4, 5, 6, 7.5, 8.5, 10, 12]) as t(col1)";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[col1, sum(col1) OVER (ORDER BY power(col1, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
-            "  └ WindowAgg[col1, power(col1, 2.0), sum(col1) OVER (ORDER BY power(col1, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
-            "    └ Eval[col1, power(col1, 2.0)]\n" +
+            "Eval[col1, sum(col1) OVER (ORDER BY power(cast(col1 AS double precision), 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
+            "  └ WindowAgg[col1, power(cast(col1 AS double precision), 2.0), sum(col1) OVER (ORDER BY power(cast(col1 AS double precision), 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
+            "    └ Eval[col1, power(cast(col1 AS double precision), 2.0)]\n" +
             "      └ Rename[col1] AS t\n" +
             "        └ TableFunction[unnest | [col1] | true]";
         assertThat(plan, isPlan(expectedPlan));

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -63,7 +63,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10"
         );
         var expectedPlan =
-            "Filter[(coalesce(cast(x AS bigint), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | true]";
@@ -77,7 +77,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10 AND t1.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(cast(x AS bigint), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | (x > 5)]\n" +
             "    └ Collect[doc.t2 | [x] | true]";
@@ -91,7 +91,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(cast(x AS bigint), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[RIGHT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | (x > 5)]";
@@ -105,7 +105,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[((coalesce(cast(x AS bigint), 10) = 10) AND (x > 5))]\n" +
+            "Filter[((coalesce(x, 10) = 10) AND (x > 5))]\n" +
             "  └ NestedLoopJoin[FULL | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | (x > 5)]";

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -302,7 +302,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readByte(), is((byte) 't'));
                 assertThat(response.readInt(), is(10));
                 assertThat(response.readShort(), is((short) 1));
-                assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).oid()));
+                assertThat(response.readInt(), is(PGTypes.get(DataTypes.SHORT).oid()));
             } finally {
                 response.release();
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change will use the smallest numeric literal when converting untyped literal
inputs at the sql parser. Till now a numeric literal input resulted either in a
`LongLiteral` or `DoubleLiteral`.
A special logic inside the (old) function parameter binding tried to downcast
these literals later on which resulted in bugs on nested function expressions.
See https://github.com/crate/crate/issues/9652.
Using smallest possible numeric literal at the parser will supersede such logic
while ensuring correct function matching also on nested expressions.


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
