### PR TITLE
Enable JS UDF by default

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -99,9 +99,9 @@ auth:
 
 #///////////////////////// User Defined Functions ////////////////////////////
 
-# To enable Javascript language for user defined functions, you can set it as
-# follows:
-#lang.js.enabled: true
+# To disable Javascript language for user defined functions, you can set it as
+# follows. Default is enabled:
+#lang.js.enabled: false
 
 # The Javascript language is an experimental feature and is not securely
 # sandboxed, so it is disabled by default.

--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -55,8 +55,6 @@ CRATE_SETTINGS = {
     'node.name': 'crate',
     'cluster.name': 'Testing-CrateDB'
 }
-if not CRATE_CE:
-    CRATE_SETTINGS['lang.js.enabled'] = 'true'
 
 
 class CrateTestShell(CrateShell):

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,9 @@ None
 Changes
 =======
 
+- The JavaScript user defined function language is now enabled by default in
+  the CrateDB enterprise edition.
+
 - Added the ``varchar`` and ``character varying`` types. Currently as aliases
   for ``text``. Length limitations are not supported.
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -658,11 +658,10 @@ Javascript language
 ===================
 
 **lang.js.enabled**
-  | *Default:*  ``false``
+  | *Default:*  ``true``
   | *Runtime:*  ``no``
 
-  Setting to enable the Javascript language. As The Javascript language is an
-  experimental feature and is not securely sandboxed its disabled by default.
+  Setting to enable or disable :ref:`JavaScript UDF support <udf_lang_js>`.
 
   .. NOTE::
 

--- a/docs/general/user-defined-functions.rst
+++ b/docs/general/user-defined-functions.rst
@@ -227,20 +227,13 @@ privileges to allow for the safe execution of less trusted guest language
 code. The guest language application context for each user-defined function
 is created with default access modifiers, so any access to managed resources
 is denied. The only exception is the host language interoperability
-configuration which explicitly allows access to Java lists and arrays. Please
-refer to `GraalVM Security Guide`_ for more detailed information.
-
-**This, however, does not mean that JavaScript is securely sandboxed.**
+configuration which explicitly allows access to Java lists and arrays. **Please
+refer to `GraalVM Security Guide`_ for more detailed information**
 
 Also, even though user-defined functions implemented with ECMA-compliant
 JavaScript, objects that are normally accessible with a web browser
 (e.g. ``window``, ``console``, and so on) are not available.
 
-.. CAUTION::
-
-   The :ref:`udf_lang_js` language is an experimental feature and is disabled
-   by default. You can enable the :ref:`conf-node-lang-js` via the configuration
-   file.
 
 Supported Types
 ...............

--- a/enterprise/lang-js/src/main/java/io/crate/module/JavaScriptLanguageModule.java
+++ b/enterprise/lang-js/src/main/java/io/crate/module/JavaScriptLanguageModule.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.settings.Setting;
 public class JavaScriptLanguageModule extends AbstractModule {
 
     public static final Setting<Boolean> LANG_JS_ENABLED =
-        Setting.boolSetting("lang.js.enabled", false, Setting.Property.NodeScope);
+        Setting.boolSetting("lang.js.enabled", true, Setting.Property.NodeScope);
 
     @Override
     protected void configure() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The access restrictions with GraalVM are better than they used to be
with Nashorn. Users can still disable it if they've concerns.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)