### PR TITLE
Add length_limit type options to keyword field mappers.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -32,7 +32,6 @@ import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -45,6 +44,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -78,6 +78,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         protected String nullValue = Defaults.NULL_VALUE;
         protected int ignoreAbove = Defaults.IGNORE_ABOVE;
+        private Integer lengthLimit;
         private IndexAnalyzers indexAnalyzers;
         private String normalizerName;
 
@@ -96,6 +97,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("[ignore_above] must be positive, got " + ignoreAbove);
             }
             this.ignoreAbove = ignoreAbove;
+            return this;
+        }
+
+        public Builder lengthLimit(int lengthLimit) {
+            if (lengthLimit < 0) {
+                throw new IllegalArgumentException("[legnth_limit] must be positive, got " + lengthLimit);
+            }
+            this.lengthLimit = lengthLimit;
             return this;
         }
 
@@ -150,6 +159,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 fieldType,
                 defaultFieldType,
                 ignoreAbove,
+                lengthLimit,
                 context.indexSettings(),
                 multiFieldsBuilder.build(this, context),
                 copyTo
@@ -175,6 +185,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                 } else if (propName.equals("ignore_above")) {
                     builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));
                     iterator.remove();
+                } else if (propName.equals("length_limit")) {
+                    builder.lengthLimit(XContentMapValues.nodeIntegerValue(propNode, -1));
+                    iterator.remove();
                 } else if (propName.equals("norms")) {
                     TypeParsers.parseNorms(builder, name, propNode);
                     iterator.remove();
@@ -199,6 +212,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private NamedAnalyzer normalizer = null;
         private boolean splitQueriesOnWhitespace;
+        private Integer lengthLimit;
 
         public KeywordFieldType() {
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
@@ -208,21 +222,12 @@ public final class KeywordFieldMapper extends FieldMapper {
         protected KeywordFieldType(KeywordFieldType ref) {
             super(ref);
             this.normalizer = ref.normalizer;
+            this.lengthLimit = ref.lengthLimit;
             this.splitQueriesOnWhitespace = ref.splitQueriesOnWhitespace;
         }
 
         public KeywordFieldType clone() {
             return new KeywordFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (super.equals(o) == false) {
-                return false;
-            }
-            KeywordFieldType other = (KeywordFieldType) o;
-            return Objects.equals(normalizer, other.normalizer) &&
-                splitQueriesOnWhitespace == other.splitQueriesOnWhitespace;
         }
 
         @Override
@@ -241,8 +246,25 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            KeywordFieldType that = (KeywordFieldType) o;
+            return splitQueriesOnWhitespace == that.splitQueriesOnWhitespace &&
+                   Objects.equals(normalizer, that.normalizer) &&
+                   Objects.equals(lengthLimit, that.lengthLimit);
+        }
+
+        @Override
         public int hashCode() {
-            return 31 * super.hashCode() + Objects.hash(normalizer, splitQueriesOnWhitespace);
+            return Objects.hash(super.hashCode(), normalizer, splitQueriesOnWhitespace, lengthLimit);
         }
 
         @Override
@@ -261,6 +283,10 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         public boolean splitQueriesOnWhitespace() {
             return splitQueriesOnWhitespace;
+        }
+
+        public void setLengthLimit(Integer lengthLimit) {
+            this.lengthLimit = lengthLimit;
         }
 
         public void setSplitQueriesOnWhitespace(boolean splitQueriesOnWhitespace) {
@@ -325,6 +351,7 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     private int ignoreAbove;
+    private Integer lengthLimit;
 
     protected KeywordFieldMapper(String simpleName,
                                  Integer position,
@@ -332,12 +359,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                                  MappedFieldType fieldType,
                                  MappedFieldType defaultFieldType,
                                  int ignoreAbove,
+                                 Integer lengthLimit,
                                  Settings indexSettings,
                                  MultiFields multiFields,
                                  CopyTo copyTo) {
         super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.ignoreAbove = ignoreAbove;
+        this.lengthLimit = lengthLimit;
     }
 
     /** Values that have more chars than the return value of this method will
@@ -420,7 +449,13 @@ public final class KeywordFieldMapper extends FieldMapper {
     @Override
     protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
         super.doMerge(mergeWith, updateAllTypes);
-        this.ignoreAbove = ((KeywordFieldMapper) mergeWith).ignoreAbove;
+        var mw = ((KeywordFieldMapper) mergeWith);
+        this.ignoreAbove = mw.ignoreAbove;
+        if (!Objects.equals(this.lengthLimit, mw.lengthLimit)) {
+            throw new IllegalArgumentException(
+                "mapper [" + name() + "] has different length_limit settings, current ["
+                + this.lengthLimit + "], merged [" + mw.lengthLimit + "]");
+        }
     }
 
     @Override
@@ -433,6 +468,10 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         if (includeDefaults || ignoreAbove != Defaults.IGNORE_ABOVE) {
             builder.field("ignore_above", ignoreAbove);
+        }
+
+        if (includeDefaults || lengthLimit != null) {
+            builder.field("length_limit", lengthLimit);
         }
 
         if (fieldType().normalizer() != null) {

--- a/server/src/test/java/io/crate/metadata/doc/mappers/KeywordFieldMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/KeywordFieldMapperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.doc.mappers;
+
+import io.crate.Constants;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.MapperTestUtils;
+import org.elasticsearch.index.mapper.ArrayMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class KeywordFieldMapperTest extends CrateDummyClusterServiceUnitTest {
+
+    private static final String TYPE = Constants.DEFAULT_MAPPING_TYPE;
+
+    private static DocumentMapperParser parser(Mapper.TypeParser parser) throws IOException {
+        MapperService mapperService = MapperTestUtils.newMapperService(
+            NamedXContentRegistry.EMPTY,
+            createTempDir(),
+            Settings.EMPTY,
+            new IndicesModule(Collections.singletonList(new MapperPlugin() {
+                @Override
+                public Map<String, Mapper.TypeParser> getMappers() {
+                    return Collections.singletonMap(ArrayMapper.CONTENT_TYPE, parser);
+                }
+            })),
+            ""
+        );
+        return mapperService.documentMapperParser();
+    }
+
+    @Test
+    public void test_keyword_field_parser_on_mapping_with_length_limit() throws Exception {
+        String expectedMapping = Strings.toString(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                    .startObject(TYPE)
+                        .startObject("properties")
+                            .startObject("text_col")
+                                .field("type", "keyword")
+                                .field("index", false)
+                                .field("length_limit", 1)
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject());
+
+        var parser = parser(new KeywordFieldMapper.TypeParser());
+        // string -> doXContentBody -> parse -> string
+        var compressedXContent = new CompressedXContent(expectedMapping);
+        var mapper = parser.parse(TYPE, compressedXContent);
+        var actualMapping = mapper.mappingSource().toString();
+
+        assertThat(expectedMapping, is(actualMapping));
+        assertThat(actualMapping, is(
+            "{\"default\":{\"properties\":" +
+            "{\"text_col\":{\"type\":\"keyword\",\"index\":false,\"length_limit\":1}}}}"));
+    }
+
+    @Test
+    public void test_keywords_fields_mapping_merge_fail_on_different_length_limit() throws Exception {
+        var parser = parser(new TextFieldMapper.TypeParser());
+
+        var mapper = parser.parse(TYPE, new CompressedXContent(Strings.toString(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                    .startObject(TYPE)
+                        .startObject("properties")
+                            .startObject("text_col")
+                                .field("type", "keyword")
+                                .field("length_limit", 2)
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject())));
+        var anotherMapper = parser.parse(TYPE, new CompressedXContent(Strings.toString(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                    .startObject(TYPE)
+                        .startObject("properties")
+                            .startObject("text_col")
+                                .field("type", "keyword")
+                                .field("index", false)
+                                .field("length_limit", 1)
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject())));
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("mapper [text_col] has different length_limit settings, current [2], merged [1]");
+        mapper.merge(anotherMapper.mapping(), false);
+    }
+}

--- a/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
@@ -1,25 +1,26 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
- * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.  You may
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
  *
  * However, if you have executed another commercial license agreement
  * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial agreement.
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
  */
 
-package io.crate.metadata.doc.array;
+package io.crate.metadata.doc.mappers.array;
 
 import io.crate.Constants;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
