### PR TITLE
Avoid multiple value evaluation in hash joins

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -22,9 +22,29 @@
 
 package io.crate.data.join;
 
+import static io.crate.data.SentinelRow.SENTINEL;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccounting;
-import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.breaker.RowCellsAccountingWithEstimators;
 import io.crate.data.BatchIterator;
 import io.crate.data.BatchIterators;
 import io.crate.data.CloseAssertingBatchIterator;
@@ -44,33 +64,14 @@ import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.testing.RowGenerator;
 import io.crate.types.DataTypes;
 import io.crate.window.NthValueFunctions;
-import org.elasticsearch.common.inject.ModulesBuilder;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.StreamSupport;
-
-import static io.crate.data.SentinelRow.SENTINEL;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class RowsBatchIteratorBenchmark {
 
-    private final RowAccountingWithEstimators rowAccounting = new RowAccountingWithEstimators(
-        Collections.singleton(DataTypes.INTEGER), RamAccounting.NO_ACCOUNTING);
+    private final RowCellsAccountingWithEstimators rowAccounting = new RowCellsAccountingWithEstimators(
+        Collections.singleton(DataTypes.INTEGER), RamAccounting.NO_ACCOUNTING, 0);
 
     // use materialize to not have shared row instances
     // this is done in the startup, otherwise the allocation costs will make up the majority of the benchmark.
@@ -138,7 +139,7 @@ public class RowsBatchIteratorBenchmark {
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
             () -> 1000,
-            new NoRowAccounting()
+            new NoRowAccounting<>()
         );
         while (crossJoin.moveNext()) {
             blackhole.consume(crossJoin.currentElement().get(0));
@@ -202,7 +203,7 @@ public class RowsBatchIteratorBenchmark {
         InputCollectExpression input = new InputCollectExpression(0);
         BatchIterator<Row> batchIterator = WindowFunctionBatchIterator.of(
             new InMemoryBatchIterator<>(rows, SENTINEL, false),
-            new NoRowAccounting(),
+            new NoRowAccounting<>(),
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,
             (arg1, arg2) -> 0,
@@ -217,9 +218,10 @@ public class RowsBatchIteratorBenchmark {
         BatchIterators.collect(batchIterator, Collectors.summingInt(x -> { blackhole.consume(x); return 1; })).get();
     }
 
-    private static class NoRowAccounting implements RowAccounting<Row> {
+    private static class NoRowAccounting<T> implements RowAccounting<T> {
+
         @Override
-        public void accountForAndMaybeBreak(Row row) {
+        public void accountForAndMaybeBreak(T row) {
         }
 
         @Override

--- a/libs/dex/src/main/java/io/crate/data/UnsafeArrayRow.java
+++ b/libs/dex/src/main/java/io/crate/data/UnsafeArrayRow.java
@@ -35,8 +35,9 @@ public class UnsafeArrayRow implements Row {
 
     private Object[] cells;
 
-    public void cells(Object[] cells) {
+    public UnsafeArrayRow cells(Object[] cells) {
         this.cells = cells;
+        return this;
     }
 
     public Object[] cells() {

--- a/libs/dex/src/main/java/io/crate/data/join/CrossJoinBlockNLBatchIterator.java
+++ b/libs/dex/src/main/java/io/crate/data/join/CrossJoinBlockNLBatchIterator.java
@@ -54,7 +54,7 @@ public class CrossJoinBlockNLBatchIterator extends JoinBatchIterator<Row, Row, R
     private final IntSupplier blockSizeCalculator;
     private final ArrayList<Object[]> blockBuffer;
     private final UnsafeArrayRow rowWrapper;
-    private final RowAccounting<Row> rowAccounting;
+    private final RowAccounting<Object[]> rowAccounting;
 
     private int blockBufferMaxSize;
     private int bufferPos;
@@ -64,7 +64,7 @@ public class CrossJoinBlockNLBatchIterator extends JoinBatchIterator<Row, Row, R
                                   BatchIterator<Row> right,
                                   ElementCombiner<Row, Row, Row> combiner,
                                   IntSupplier blockSizeCalculator,
-                                  RowAccounting<Row> rowAccounting) {
+                                  RowAccounting<Object[]> rowAccounting) {
         super(left, right, combiner);
         this.blockSizeCalculator = blockSizeCalculator;
         this.blockBuffer = new ArrayList<>(0);
@@ -107,9 +107,9 @@ public class CrossJoinBlockNLBatchIterator extends JoinBatchIterator<Row, Row, R
                 activeIt = left;
                 while (blockBuffer.size() < blockBufferMaxSize) {
                     if (left.moveNext()) {
-                        Row row = left.currentElement();
+                        Object[] row = left.currentElement().materialize();
                         rowAccounting.accountForAndMaybeBreak(row);
-                        blockBuffer.add(row.materialize());
+                        blockBuffer.add(row);
                     } else {
                         if (left.allLoaded()) {
                             break;

--- a/libs/dex/src/main/java/io/crate/data/join/JoinBatchIterators.java
+++ b/libs/dex/src/main/java/io/crate/data/join/JoinBatchIterators.java
@@ -72,7 +72,7 @@ public final class JoinBatchIterators {
                                                       BatchIterator<Row> right,
                                                       ElementCombiner<Row, Row, Row> combiner,
                                                       IntSupplier blockSizeCalculator,
-                                                      RowAccounting<Row> rowAccounting) {
+                                                      RowAccounting<Object[]> rowAccounting) {
         return new CrossJoinBlockNLBatchIterator(left, right, combiner, blockSizeCalculator, rowAccounting);
     }
 

--- a/libs/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
@@ -224,13 +224,13 @@ public class CrossJoinBlockNLBatchIteratorTest {
         assertThat(expectedResults.toArray(), hasItemInArray(batchIterator.currentElement().materialize()));
     }
 
-    private static class TestingRowAccounting implements RowAccounting<Row> {
+    private static class TestingRowAccounting implements RowAccounting<Object[]> {
 
         int numRows;
         int numReleaseCalled;
 
         @Override
-        public void accountForAndMaybeBreak(Row row) {
+        public void accountForAndMaybeBreak(Object[] row) {
             numRows++;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -53,7 +53,7 @@ public class HashJoinOperation implements CompletionListenable {
                              Predicate<Row> joinPredicate,
                              List<Symbol> joinLeftInputs,
                              List<Symbol> joinRightInputs,
-                             RowAccounting<Row> rowAccounting,
+                             RowAccounting<Object[]> rowAccounting,
                              TransactionContext txnCtx,
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
@@ -133,7 +133,7 @@ public class HashJoinOperation implements CompletionListenable {
                                                              Predicate<Row> joinCondition,
                                                              ToIntFunction<Row> hashBuilderForLeft,
                                                              ToIntFunction<Row> hashBuilderForRight,
-                                                             RowAccounting<Row> rowAccounting,
+                                                             RowAccounting<Object[]> rowAccounting,
                                                              RamBlockSizeCalculator blockSizeCalculator) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         return new HashInnerJoinBatchIterator(

--- a/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -21,9 +21,17 @@
 
 package io.crate.execution.engine.join;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntSupplier;
+import java.util.function.Predicate;
+
 import com.google.common.annotations.VisibleForTesting;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
 import io.crate.breaker.RamAccounting;
-import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.breaker.RowCellsAccountingWithEstimators;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.BatchIterator;
 import io.crate.data.CapturingRowConsumer;
@@ -35,12 +43,6 @@ import io.crate.data.join.CombinedRow;
 import io.crate.data.join.JoinBatchIterators;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.types.DataType;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.IntSupplier;
-import java.util.function.Predicate;
 
 
 public class NestedLoopOperation implements CompletionListenable {
@@ -163,7 +165,7 @@ public class NestedLoopOperation implements CompletionListenable {
                 estimatedRowsSizeLeft,
                 estimatedNumberOfRowsLeft
             );
-            RowAccountingWithEstimators rowAccounting = new RowAccountingWithEstimators(leftSideColumnTypes, ramAccounting);
+            var rowAccounting = new RowCellsAccountingWithEstimators(leftSideColumnTypes, ramAccounting, 0);
             return JoinBatchIterators.crossJoinBlockNL(left, right, combiner, blockSizeCalculator, rowAccounting);
         } else {
             return JoinBatchIterators.crossJoinNL(left, right, combiner);

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterables;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.breaker.RamAccounting;
-import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.breaker.RowCellsAccountingWithEstimators;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
@@ -268,9 +267,10 @@ public class ProjectionToProjectorVisitor
 
     @Override
     public Projector visitTopNDistinct(TopNDistinctProjection topNDistinct, Context context) {
-        var rowAccounting = new RowAccountingWithEstimators(
+        var rowAccounting = new RowCellsAccountingWithEstimators(
             Symbols.typeView(topNDistinct.outputs()),
-            context.ramAccounting
+            context.ramAccounting,
+            0
         );
         return new TopNDistinctProjector(topNDistinct.limit(), rowAccounting);
     }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/TopNDistinctProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/TopNDistinctProjector.java
@@ -32,9 +32,9 @@ import io.crate.data.TopNDistinctBatchIterator;
 public final class TopNDistinctProjector implements Projector {
 
     private final int limit;
-    private final RowAccounting<Row> rowAccounting;
+    private final RowAccounting<Object[]> rowAccounting;
 
-    TopNDistinctProjector(int limit, RowAccounting<Row> rowAccounting) {
+    TopNDistinctProjector(int limit, RowAccounting<Object[]> rowAccounting) {
         this.limit = limit;
         this.rowAccounting = rowAccounting;
     }
@@ -42,8 +42,9 @@ public final class TopNDistinctProjector implements Projector {
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> source) {
         return new TopNDistinctBatchIterator<>(source, limit, row -> {
-            rowAccounting.accountForAndMaybeBreak(row);
-            return new RowN(row.materialize());
+            var cells = row.materialize();
+            rowAccounting.accountForAndMaybeBreak(cells);
+            return new RowN(cells);
         });
     }
 

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -72,6 +72,7 @@ import io.crate.breaker.BlockBasedRamAccounting;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.breaker.RowCellsAccountingWithEstimators;
 import io.crate.common.collections.Tuple;
 import io.crate.data.Paging;
 import io.crate.data.Row;
@@ -932,7 +933,7 @@ public class JobSetup {
                 //    96 bytes for each ArrayList +
                 //    7 bytes per key for the IntHashObjectHashMap  (should be 4 but the map pre-allocates more)
                 //    7 bytes perv value (pointer from the map to the list) (should be 4 but the map pre-allocates more)
-                new RowAccountingWithEstimators(phase.leftOutputTypes(), ramAccountingOfOperation, 110),
+                new RowCellsAccountingWithEstimators(phase.leftOutputTypes(), ramAccountingOfOperation, 110),
                 context.transactionContext,
                 inputFactory,
                 breaker(),

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -56,7 +56,6 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
@@ -71,7 +71,7 @@ public class HashInnerJoinBatchIteratorMemoryTest {
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
 
-        RowAccounting<Row> rowAccounting = mock(RowAccounting.class);
+        RowAccounting<Object[]> rowAccounting = mock(RowAccounting.class);
         BatchIterator<Row> it = new HashInnerJoinBatchIterator(
             leftIterator,
             rightIterator,
@@ -86,6 +86,6 @@ public class HashInnerJoinBatchIteratorMemoryTest {
         consumer.accept(it, null);
         consumer.getResult();
         verify(rowAccounting, times(8)).release();
-        verify(rowAccounting, times(12)).accountForAndMaybeBreak(Mockito.any(Row.class));
+        verify(rowAccounting, times(12)).accountForAndMaybeBreak(Mockito.any(Object[].class));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/pull/9941 caused a performance regression
for joins because the column values were evaluated multiple times:

- Once to estimate the size of the row
- Once to calculate the hash code
- Once to materialize the row to store it in a buffer

This changes the flow to first materialize the row, and then calculate
the size and hash code based on the materialized row.


Compared to latest nightly:

```
# Results (server side duration in ms)
V1: 4.2.0-ad867dd5d64cc17767720ce2a9b563752edf189e
V2: 4.2.0-b98d0b3f48ffbd528eef591cad80e8d165810a25

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000
C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      889.275 ±  114.294 |    692.867 |    871.997 |    920.144 |   1553.772 |
|   V2    |      512.498 ±   76.971 |    326.107 |    499.481 |    546.659 |    800.218 |
mean:   -  53.76%
median: -  54.32%
```

Compared to 4.1.5:

```
# Results (server side duration in ms)
V1: 4.1.5-135aede817dc392095e10e7a05fb7248d0140c14
V2: 4.2.0-f37f820022db71ec73b92f012e442be03b1c5f57

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000
C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      511.212 ±   59.637 |    412.827 |    498.073 |    545.260 |    665.121 |
|   V2    |      502.937 ±   91.335 |    350.771 |    487.188 |    537.455 |    829.317 |
mean:   -   1.63%
median: -   2.21%
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)