### PR TITLE
Add pg_catalog.format_type scalar

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -158,6 +158,9 @@ Changes
 - Added the :ref:`obj_description(integer, text) <obj_description>` scalar
   function for improved PostgreSQL compatibility.
 
+- Added the :ref:`format_type(integer, integer) <format_type>` scalar
+  function for improved PostgreSQL compatibility.
+
 - Added support for using columns of type ``long`` inside subscript expressions
   (e.g., ``array_expr[column]``).
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -2748,6 +2748,42 @@ Example:
     SELECT 1 row in set (... sec)
 
 
+.. _format_type:
+
+``format_type(integer, integer)``
+---------------------------------
+
+Returns the type name of a type. The first argument is the ``OID`` of the type.
+The second argument is the type modifier. This function exits for PostgreSQL
+compatibility and the type modifier is always ignored.
+
+Returns: ``text``
+
+Example:
+
+::
+
+    cr> SELECT pg_catalog.format_type(25, null) AS name;
+    +------+
+    | name |
+    +------+
+    | text |
+    +------+
+    SELECT 1 row in set (... sec)
+
+
+If the given ``OID`` is not know, ``???`` is returned::
+
+
+    cr> SELECT pg_catalog.format_type(3, null) AS name;
+    +------+
+    | name |
+    +------+
+    |  ??? |
+    +------+
+    SELECT 1 row in set (... sec)
+
+
 Special functions
 =================
 

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -69,6 +69,7 @@ import io.crate.expression.scalar.string.StringRepeatFunction;
 import io.crate.expression.scalar.string.TrimFunctions;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
+import io.crate.expression.scalar.systeminformation.FormatTypeFunction;
 import io.crate.expression.scalar.systeminformation.ObjDescriptionFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
@@ -169,5 +170,6 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         CurrentDatabaseFunction.register(this);
         VersionFunction.register(this);
         ObjDescriptionFunction.register(this);
+        FormatTypeFunction.register(this);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.protocols.postgres.types.PGTypes;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+public final class FormatTypeFunction extends Scalar<String, Object> {
+
+    private static final String NAME = "format_type";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                FQN,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            FormatTypeFunction::new
+        );
+    }
+
+    private final FunctionInfo info;
+    private final Signature signature;
+
+    public FormatTypeFunction(Signature signature, List<DataType> argumentTypes) {
+        this.info = new FunctionInfo(new FunctionIdent(FQN, argumentTypes), DataTypes.STRING);
+        this.signature = signature;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return this.info;
+    }
+
+    @Override
+    public Signature signature() {
+        return this.signature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        var typeOid = (Integer) args[0].value();
+        if (typeOid == null) {
+            return null;
+        }
+        var type = PGTypes.fromOID(typeOid);
+        if (type == null) {
+            return "???";
+        } else {
+            return type.getName();
+        }
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -37,6 +37,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 public class PGTypes {
 
     private static final Map<DataType<?>, PGType> CRATE_TO_PG_TYPES = ImmutableMap.<DataType<?>, PGType>builder()
@@ -105,6 +107,7 @@ public class PGTypes {
         return TYPES;
     }
 
+    @Nullable
     public static DataType<?> fromOID(int oid) {
         return PG_TYPES_TO_CRATE_TYPE.get(oid);
     }

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/FormatTypeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/FormatTypeFunctionTest.java
@@ -1,0 +1,23 @@
+package io.crate.expression.scalar.systeminformation;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+
+public class FormatTypeFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_format_type_null_oid_returns_null() throws Exception {
+        assertEvaluate("format_type(null, null)", null);
+    }
+
+    @Test
+    public void test_format_type_for_unknown_oid_returns_questionmarks() throws Exception {
+        assertEvaluate("format_type(2, null)", "???");
+    }
+
+    @Test
+    public void test_format_type_for_known_oid_returns_type_name() throws Exception {
+        assertEvaluate("format_type(25, null)", "text");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://www.postgresql.org/docs/current/functions-info.html

`format_type` is called by the JDBC client on
`conn.getMetaData().getFunctions(...)`


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)