### PR TITLE
Avoid .toArray calls in AggregationContext

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
@@ -24,22 +24,20 @@ package io.crate.execution.engine.aggregation;
 
 import io.crate.data.Input;
 
-import java.util.ArrayList;
 import java.util.List;
 
-public class AggregationContext {
+public final class AggregationContext {
 
     private final AggregationFunction impl;
-    private final List<Input<?>> inputs = new ArrayList<>();
     private final Input<Boolean> filter;
+    private final Input[] inputs;
 
-    public AggregationContext(AggregationFunction aggregationFunction, Input<Boolean> filter) {
+    public AggregationContext(AggregationFunction aggregationFunction,
+                              Input<Boolean> filter,
+                              List<Input<?>> inputs) {
         this.impl = aggregationFunction;
         this.filter = filter;
-    }
-
-    public void addInput(Input<?> input) {
-        inputs.add(input);
+        this.inputs = inputs.toArray(new Input[0]);
     }
 
     public AggregationFunction function() {
@@ -47,7 +45,7 @@ public class AggregationContext {
     }
 
     public Input<?>[] inputs() {
-        return inputs.toArray(new Input[0]);
+        return inputs;
     }
 
     public Input<Boolean> filter() {

--- a/server/src/main/java/io/crate/expression/InputFactory.java
+++ b/server/src/main/java/io/crate/expression/InputFactory.java
@@ -200,9 +200,9 @@ public class InputFactory {
         }
 
         @Override
-        public Input<?> visitAggregation(Aggregation symbol, Void context) {
-            var ident = symbol.functionIdent();
-            var signature = symbol.signature();
+        public Input<?> visitAggregation(Aggregation aggregation, Void context) {
+            var ident = aggregation.functionIdent();
+            var signature = aggregation.signature();
             FunctionImplementation impl;
             if (signature == null) {
                 impl = functions.getQualified(ident);
@@ -212,11 +212,12 @@ public class InputFactory {
             assert impl != null : "Function implementation not found using full qualified lookup";
 
             //noinspection unchecked
-            Input<Boolean> filter = (Input<Boolean>) symbol.filter().accept(this, context);
-            AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl, filter);
-            for (Symbol aggInput : symbol.inputs()) {
-                aggregationContext.addInput(aggInput.accept(this, context));
+            Input<Boolean> filter = (Input<Boolean>) aggregation.filter().accept(this, context);
+            ArrayList<Input<?>> inputs = new ArrayList<>(aggregation.inputs().size());
+            for (Symbol aggInput : aggregation.inputs()) {
+                inputs.add(aggInput.accept(this, context));
             }
+            AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl, filter, inputs);
             aggregationContexts.add(aggregationContext);
 
             // can't generate an input from an aggregation.

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -94,7 +94,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             CountAggregation.COUNT_STAR_SIGNATURE,
             Collections.emptyList()
         );
-        aggregationContexts = Collections.singletonList(new AggregationContext(aggregation, () -> true));
+        aggregationContexts = List.of(new AggregationContext(aggregation, () -> true, List.of()));
     }
 
     private Supplier<BatchIterator<Row>> createBatchIterator(Runnable onOrdinalsValues) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`inputs()` is called in an inner loop in `GroupByOptimizedIterator`. The
`toArray` call causes a lot of allocations that are not necessary.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)