### PR TITLE
Add support for the varchar with the length limit in CrateDB parser and analyzer.

### DIFF
--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -537,11 +537,16 @@ rerouteOption
     ;
 
 dataType
-    : definedDataType           #definedDataTypeDefault
-    | ident                     #dataTypeIdent
-    | objectTypeDefinition      #objectDataType
-    | ARRAY '(' dataType ')'    #arrayDataType
-    | dataType '[]'             #arrayDataType
+    : baseDataType
+        ('(' integerLiteral (',' integerLiteral )* ')')?    #maybeParametrizedDataType
+    | objectTypeDefinition                                  #objectDataType
+    | ARRAY '(' dataType ')'                                #arrayDataType
+    | dataType '[]'                                         #arrayDataType
+    ;
+
+baseDataType
+    : definedDataType   #definedDataTypeDefault
+    | ident             #identDataType
     ;
 
 definedDataType

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -638,7 +638,16 @@ public final class ExpressionFormatter {
 
         @Override
         public String visitColumnType(ColumnType<?> node, @Nullable List<Expression> parameters) {
-            return node.name();
+            var builder = new StringBuilder(node.name());
+            if (node.parametrized()) {
+                builder
+                    .append("(")
+                    .append(node.parameters().stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(", ")))
+                    .append(")");
+            }
+            return builder.toString();
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -721,6 +721,15 @@ public final class SqlFormatter {
         @Override
         public Void visitColumnType(ColumnType node, Integer indent) {
             builder.append(node.name().toUpperCase(Locale.ENGLISH));
+            if (node.parametrized()) {
+                builder
+                    .append("(")
+                    .append(
+                        node.parameters().stream()
+                            .map(String::valueOf)
+                            .collect(Collectors.joining(", ")))
+                    .append(')');
+            }
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
@@ -22,18 +22,34 @@
 package io.crate.sql.tree;
 
 
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class ColumnType<T> extends Expression {
 
-    protected final String name;
+    private final String name;
+    private final List<Integer> parameters;
 
     public ColumnType(String name) {
+        this(name, List.of());
+    }
+
+    public ColumnType(String name, List<Integer> parameters) {
         this.name = name;
+        this.parameters = parameters;
     }
 
     public String name() {
         return name;
+    }
+
+    public List<Integer> parameters() {
+        return parameters;
+    }
+
+    public boolean parametrized() {
+        return !parameters.isEmpty();
     }
 
     @Override
@@ -49,19 +65,18 @@ public class ColumnType<T> extends Expression {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        ColumnType that = (ColumnType) o;
-
-        return name.equals(that.name);
+        ColumnType<?> that = (ColumnType<?>) o;
+        return Objects.equals(name, that.name) &&
+               Objects.equals(parameters, that.parameters);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return Objects.hash(name, parameters);
     }
 
     public <U> ColumnType<U> map(Function<? super T, ? extends U> mapper) {
-        return new ColumnType<>(name);
+        return new ColumnType<>(name, parameters);
     }
 
     public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1642,6 +1642,12 @@ public class TestStatementBuilder {
             "FROM t");
     }
 
+    @Test
+    public void test_create_table_with_parametrized_varchar_data_type   () {
+        printStatement("create table test(col varchar(1))");
+        printStatement("create table test(col character varying(2))");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -242,18 +242,18 @@ public class AnalyzedColumnDefinition<T> {
     }
 
     public void dataType(String dataType) {
-        dataType(dataType, true);
+        dataType(dataType, List.of(), true);
     }
 
-    public void dataType(String dataType, boolean logWarnings) {
-        if ("timestamp".equals(dataType) && logWarnings) {
+    public void dataType(String typeName, List<Integer> parameters, boolean logWarnings) {
+        if ("timestamp".equals(typeName) && logWarnings) {
             DEPRECATION_LOGGER.deprecated(
                 "Column [{}]: Usage of the `TIMESTAMP` data type as a timestamp with zone " +
                 "is deprecated, use the `TIMESTAMPTZ` or `TIMESTAMP WITH TIME ZONE` data type instead.",
                 ident.fqn()
             );
         }
-        this.dataType = DataTypes.ofName(dataType);
+        this.dataType = DataTypes.of(typeName, parameters);
     }
 
     public DataType dataType() {
@@ -355,10 +355,12 @@ public class AnalyzedColumnDefinition<T> {
 
     public void validate() {
         if (indexType == Reference.IndexType.ANALYZED && !DataTypes.STRING.equals(dataType)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "Can't use an Analyzer on column %s because analyzers are only allowed on columns of type \"string\".",
-                              ident.sqlFqn()
-                ));
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "Can't use an Analyzer on column %s because analyzers are only allowed on " +
+                "columns of type \"" + DataTypes.STRING.getName() + "\" of the unbound length limit.",
+                ident.sqlFqn()
+            ));
         }
         if (indexType != null && UNSUPPORTED_INDEX_TYPE_IDS.contains(dataType.id())) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
@@ -461,8 +463,11 @@ public class AnalyzedColumnDefinition<T> {
                 if (definition.analyzer != null) {
                     mapping.put("analyzer", DataTypes.STRING.value(definition.analyzer));
                 }
+                var stringType = (StringType) definition.dataType;
+                if (!stringType.unbound()) {
+                    mapping.put("length_limit", stringType.lengthLimit());
+                }
                 break;
-
             default:
                 // noop
                 break;

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -190,7 +190,7 @@ public class TableElementsAnalyzer {
 
         @Override
         public Void visitColumnType(ColumnType<?> node, ColumnDefinitionContext<T> context) {
-            context.analyzedColumnDefinition.dataType(node.name(), context.logWarnings);
+            context.analyzedColumnDefinition.dataType(node.name(), node.parameters(), context.logWarnings);
             return null;
         }
 

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -154,6 +154,7 @@ import static io.crate.sql.tree.IntervalLiteral.IntervalField.MINUTE;
 import static io.crate.sql.tree.IntervalLiteral.IntervalField.MONTH;
 import static io.crate.sql.tree.IntervalLiteral.IntervalField.SECOND;
 import static io.crate.sql.tree.IntervalLiteral.IntervalField.YEAR;
+import static java.util.stream.Collectors.toList;
 
 /**
  * <p>This Analyzer can be used to convert Expression from the SQL AST into symbols.</p>
@@ -1162,14 +1163,14 @@ public class ExpressionAnalyzer {
     }
 
     private static void ensureResultTypesMatch(Collection<? extends Symbol> results) {
-        HashSet<DataType> resultTypes = new HashSet<>();
+        HashSet<DataType<?>> resultTypes = new HashSet<>(results.size());
         for (Symbol result : results) {
             resultTypes.add(result.valueType());
         }
         if (resultTypes.size() == 2 && !resultTypes.contains(DataTypes.UNDEFINED) || resultTypes.size() > 2) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
                 "Data types of all result expressions of a CASE statement must be equal, found: %s",
-                resultTypes));
+                results.stream().map(Symbol::valueType).collect(toList())));
         }
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -57,12 +57,14 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+import io.crate.types.StringType;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import io.crate.common.Booleans;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -285,8 +287,8 @@ public class DocIndexMetaData {
      * @param columnProperties map of String to Object containing column properties
      * @return dataType of the column with columnProperties
      */
-    static DataType getColumnDataType(Map<String, Object> columnProperties) {
-        DataType type;
+    static DataType<?> getColumnDataType(Map<String, Object> columnProperties) {
+        DataType<?> type;
         String typeName = (String) columnProperties.get("type");
 
         if (typeName == null || ObjectType.NAME.equals(typeName)) {
@@ -301,21 +303,27 @@ public class DocIndexMetaData {
                 type = MoreObjects.firstNonNull(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
             }
         } else if (typeName.equalsIgnoreCase("array")) {
-
             Map<String, Object> innerProperties = Maps.get(columnProperties, "inner");
-            DataType innerType = getColumnDataType(innerProperties);
-            type = new ArrayType(innerType);
+            DataType<?> innerType = getColumnDataType(innerProperties);
+            type = new ArrayType<>(innerType);
         } else {
             typeName = typeName.toLowerCase(Locale.ENGLISH);
-            if (DateFieldMapper.CONTENT_TYPE.equals(typeName)) {
-                Boolean ignoreTimezone = (Boolean) columnProperties.get("ignore_timezone");
-                if (ignoreTimezone != null && ignoreTimezone) {
-                    return DataTypes.TIMESTAMP;
-                } else {
-                    return DataTypes.TIMESTAMPZ;
-                }
+            switch (typeName) {
+                case DateFieldMapper.CONTENT_TYPE:
+                    Boolean ignoreTimezone = (Boolean) columnProperties.get("ignore_timezone");
+                    if (ignoreTimezone != null && ignoreTimezone) {
+                        return DataTypes.TIMESTAMP;
+                    } else {
+                        return DataTypes.TIMESTAMPZ;
+                    }
+                case KeywordFieldMapper.CONTENT_TYPE:
+                    Integer lengthLimit = (Integer) columnProperties.get("length_limit");
+                    return lengthLimit != null
+                        ? StringType.of(lengthLimit)
+                        : DataTypes.STRING;
+                default:
+                    type = MoreObjects.firstNonNull(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
             }
-            type = MoreObjects.firstNonNull(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
         }
         return type;
     }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -353,6 +353,22 @@ public final class DataTypes {
         return dataType;
     }
 
+    public static DataType<?> of(String typeName, List<Integer> parameters) {
+        DataType<?> dataType = ofNameOrNull(typeName);
+        if (dataType == null) {
+            throw new IllegalArgumentException("Cannot find data type: " + typeName);
+        }
+        if (!parameters.isEmpty()) {
+            if (dataType.id() == StringType.ID) {
+                return StringType.of(parameters);
+            }
+            throw new IllegalArgumentException(
+                "The '" + typeName + "' type doesn't support type parameters.");
+        } else {
+            return dataType;
+        }
+    }
+
     @Nullable
     public static DataType<?> ofNameOrNull(String typeName) {
         return TYPES_BY_NAME_OR_ALIAS.get(typeName);

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -22,18 +22,20 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import io.crate.common.unit.TimeValue;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 public class StringType extends DataType<String> implements Streamer<String> {
 
@@ -42,7 +44,30 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public static final String T = "t";
     public static final String F = "f";
 
+    private final int lengthLimit;
+
+    public static StringType of(List<Integer> parameters) {
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException(
+                "The number of parameters for the text data is wrong: " + parameters.size());
+        }
+        return StringType.of(parameters.get(0));
+    }
+
+    public static StringType of(int lengthLimit) {
+        if (lengthLimit < 0) {
+                throw new IllegalArgumentException(
+                    "Invalid text data type length limit: " + lengthLimit);
+            }
+        return new StringType(lengthLimit);
+    }
+
+    private StringType(int lengthLimit) {
+        this.lengthLimit = lengthLimit;
+    }
+
     protected StringType() {
+        this(Integer.MAX_VALUE);
     }
 
     @Override
@@ -58,6 +83,14 @@ public class StringType extends DataType<String> implements Streamer<String> {
     @Override
     public String getName() {
         return "text";
+    }
+
+    public int lengthLimit() {
+        return lengthLimit;
+    }
+
+    public boolean unbound() {
+        return lengthLimit == Integer.MAX_VALUE;
     }
 
     @Override
@@ -117,5 +150,25 @@ public class StringType extends DataType<String> implements Streamer<String> {
     @Override
     public void writeValueTo(StreamOutput out, String v) throws IOException {
         out.writeOptionalString(v);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        StringType that = (StringType) o;
+        return lengthLimit == that.lengthLimit;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lengthLimit);
     }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -56,9 +56,9 @@ public class StringType extends DataType<String> implements Streamer<String> {
 
     public static StringType of(int lengthLimit) {
         if (lengthLimit < 0) {
-                throw new IllegalArgumentException(
-                    "Invalid text data type length limit: " + lengthLimit);
-            }
+            throw new IllegalArgumentException(
+                "Invalid text data type length limit: " + lengthLimit);
+        }
         return new StringType(lengthLimit);
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import io.crate.common.collections.Maps;
 import io.crate.data.Row;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
@@ -110,7 +109,8 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
     public void testAddColumnWithAnalyzerAndNonStringType() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
-            "Can't use an Analyzer on column foobar['age'] because analyzers are only allowed on columns of type \"string\"");
+            "Can't use an Analyzer on column foobar['age'] because analyzers are only allowed " +
+            "on columns of type \"" + DataTypes.STRING.getName() + "\" of the unbound length limit");
         analyze("alter table users add column foobar object as (age int index using fulltext)");
     }
 
@@ -137,7 +137,6 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         assertNull(primaryKeys); // _id shouldn't be included
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void testAddColumnAsPrimaryKey() throws Exception {
         BoundAddColumn analysis = analyze(

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -29,7 +29,6 @@ import io.crate.exceptions.InvalidRelationName;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationAlreadyExists;
-import io.crate.exceptions.SQLParseException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
@@ -1344,5 +1343,22 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         assertThat(
             mapToSortedString(stmt.mappingProperties()),
             is("name={position=1, type=keyword}"));
+    }
+
+    @Test
+    public void test_create_table_with_varchar_column_of_limited_length() {
+        BoundCreateTable stmt = analyze("CREATE TABLE tbl (name character varying(2))");
+        assertThat(
+            mapToSortedString(stmt.mappingProperties()),
+            is("name={length_limit=2, position=1, type=keyword}"));
+    }
+
+    @Test
+    public void test_create_table_with_varchar_column_of_limited_length_with_analyzer_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(
+            "Can't use an Analyzer on column name because analyzers are only allowed on columns " +
+            "of type \"" + DataTypes.STRING.getName() + "\" of the unbound length limit.");
+        analyze("CREATE TABLE tbl (name varchar(2) INDEX using fulltext WITH (analyzer='german'))");
     }
 }

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -280,6 +280,27 @@ public class DataTypesTest extends CrateUnitTest {
     }
 
     @Test
+    public void test_text_with_length_limit() throws Exception {
+        var stringDataType = StringType.of(10);
+        assertThat(stringDataType.unbound(), is(false));
+        assertThat(stringDataType.lengthLimit(), is(10));
+    }
+
+    @Test
+    public void test_text_with_negative_length_limit() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid text data type length limit: -1");
+        StringType.of(-1);
+    }
+
+    @Test
+    public void test_crate_text_type_with_wrong_number_of_parameters_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The number of parameters for the text data is wrong: 2");
+        StringType.of(List.of(1, 2));
+    }
+
+    @Test
     public void testInt4IsAliasedToInteger() {
         assertThat(DataTypes.ofName("int4"), is(DataTypes.INTEGER));
     }

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -348,6 +348,18 @@ public class DataTypesTest extends CrateUnitTest {
             is(false));
     }
 
+    @Test
+    public void test_resolve_text_data_type_with_length_limit() {
+        assertThat(DataTypes.of("varchar", List.of(1)), is(StringType.of(1)));
+    }
+
+    @Test
+    public void test_resolve_data_type_that_does_not_support_parameters_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The 'integer' type doesn't support type parameters.");
+        DataTypes.of("integer", List.of(1));
+    }
+
     private static void assertCompareValueTo(Object val1, Object val2, int expected) {
         DataType type = DataTypes.guessType(Objects.requireNonNullElse(val1, val2));
         assertThat(type, not(instanceOf(DataTypes.UNDEFINED.getClass())));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
