### PR TITLE
Optimize getAsMap in AffixSettings

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -814,11 +814,17 @@ public class Setting<T> implements ToXContentObject {
          * Returns a map of all namespaces to it's values give the provided settings
          */
         public Map<String, T> getAsMap(Settings settings) {
-            Map<String, T> map = new HashMap<>();
-            matchStream(settings).distinct().forEach(key -> {
-                Setting<T> concreteSetting = getConcreteSetting(key);
-                map.put(getNamespace(concreteSetting), concreteSetting.get(settings));
-            });
+            HashMap<String, T> map = new HashMap<>();
+            Matcher matcher = this.key.pattern.matcher("");
+            for (String key : settings.keySet()) {
+                matcher.reset(key);
+                if (matcher.matches()) {
+                    String concreteKey = matcher.group(1);
+                    String namespace = matcher.group(2);
+                    Setting<T> concreteSetting = delegateFactory.apply(concreteKey);
+                    map.put(namespace, concreteSetting.get(settings));
+                }
+            }
             return Collections.unmodifiableMap(map);
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/commit/9c526d6f268403c666966097b942276499848e15
introduced a regression for `information_schema.tables` queries, mostly
because the way the affix settings are included changed.

This reduces the amount of garbage generated a bit to get closer to the
performance prior to the change

    V1: 4.2.0-3e85bde7e3b4ac48cb895f44026987832215b9c3 (latest-nightly)
    V2: 4.2.0-10d5de3793e60d25724c9da729f0f9b02ec41b9d (change in this PR)
    Q: select * from information_schema.tables
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       10.393 ±    6.690 |      5.793 |      9.566 |     10.176 |    197.010 |
    |   V2    |        9.457 ±    6.071 |      5.383 |      8.948 |      9.547 |    185.390 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   9.43%                           -   6.68%
    There is a 99.89% probability that the observed difference is not random, and the best estimate of that difference is 9.43%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
    V1 |    7    12.51     8.28 |    0     0.00     0.00 |     2147       72 |   584.01       7871
    V2 |    2    21.94    38.16 |    0     0.00     0.00 |     2147       70 |   169.49       2146

    V1 top allocation frames
      Matcher.<init>(...):4366410504
      Pattern.matcher(...):1229964194
      HashMap.newNode(...):336593647
      HashMap.resize():268468679
      SystemTable$ObjectExpression.apply(Object):238707119
    V2 top allocation frames
      HashMap.newNode(...):367183748
      SystemTable$ObjectExpression.apply(Object):252332598
      HashMap.resize():250666864
      Arrays.copyOf(...):157999674
      Matcher.<init>(...):152147696


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)