### PR TITLE
Add parse type signature support for the text type with length.

### DIFF
--- a/server/src/main/java/io/crate/types/IntegerLiteralTypeSignature.java
+++ b/server/src/main/java/io/crate/types/IntegerLiteralTypeSignature.java
@@ -27,33 +27,37 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-final class ParameterTypeSignature extends TypeSignature {
+final class IntegerLiteralTypeSignature extends TypeSignature {
 
-    private final String parameterName;
+    private final int value;
 
-    public ParameterTypeSignature(String parameterName,
-                                  TypeSignature typeSignature) {
-        super(typeSignature.getBaseTypeName(), typeSignature.getParameters());
-        this.parameterName = parameterName;
+    public IntegerLiteralTypeSignature(int value) {
+        super("");
+        this.value = value;
     }
 
-    public ParameterTypeSignature(StreamInput in) throws IOException {
+    public IntegerLiteralTypeSignature(StreamInput in) throws IOException {
         super(in);
-        parameterName = in.readString();
+        value = in.readInt();
     }
 
-    public String parameterName() {
-        return parameterName;
+    public int value() {
+        return value;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(parameterName);
+        out.writeInt(value);
     }
 
     @Override
     public TypeSignatureType type() {
-        return TypeSignatureType.PARAMETER_TYPE_SIGNATURE;
+        return TypeSignatureType.INTEGER_LITERAL_SIGNATURE;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
     }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -94,6 +94,26 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
+    public TypeSignature getTypeSignature() {
+        if (unbound()) {
+            return super.getTypeSignature();
+        } else {
+            return new TypeSignature(
+                getName(),
+                List.of(TypeSignature.of(lengthLimit)));
+        }
+    }
+
+    @Override
+    public List<DataType<?>> getTypeParameters() {
+        if (unbound()) {
+            return List.of();
+        } else {
+            return List.of(DataTypes.INTEGER);
+        }
+    }
+
+    @Override
     public Streamer<String> streamer() {
         return this;
     }
@@ -118,7 +138,8 @@ public class StringType extends DataType<String> implements Streamer<String> {
         }
         if (value instanceof Map) {
             try {
-                return Strings.toString(XContentFactory.jsonBuilder().map((Map) value));
+                //noinspection unchecked
+                return Strings.toString(XContentFactory.jsonBuilder().map((Map<String, ?>) value));
             } catch (IOException e) {
                 throw new IllegalArgumentException("Cannot cast `" + value + "` to type TEXT", e);
             }

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import static java.lang.Character.isDigit;
 import static java.lang.String.format;
 
 public class TypeSignature implements Writeable {
@@ -56,15 +57,10 @@ public class TypeSignature implements Writeable {
      * <p>
      */
     public static TypeSignature parseTypeSignature(String signature) {
-        if (!signature.contains("(")) {
-            if (isNamedTypeSignature(signature)) {
-                int split = signature.indexOf(" ");
-                return new ParameterTypeSignature(
-                    signature.substring(0, split),
-                    new TypeSignature(signature.substring(split + 1)));
-            } else {
-                return new TypeSignature(signature);
-            }
+        if (isDigit(signature.charAt(0))) {
+            return TypeSignature.of(Integer.parseInt(signature));
+        } else if (!signature.contains("(")) {
+            return TypeSignature.of(signature, List.of());
         }
 
         String baseName = null;
@@ -88,14 +84,7 @@ public class TypeSignature implements Writeable {
                     parameters.add(parseTypeSignatureParameter(signature, parameterStart, i));
                     parameterStart = i + 1;
                     if (i == signature.length() - 1) {
-                        if (isNamedTypeSignature(baseName)) {
-                            int split = baseName.indexOf(" ");
-                            return new ParameterTypeSignature(
-                                baseName.substring(0, split),
-                                new TypeSignature(baseName.substring(split + 1), parameters));
-                        } else {
-                            return new TypeSignature(baseName, parameters);
-                        }
+                        return TypeSignature.of(baseName, parameters);
                     }
                 }
             } else if (c == ',') {
@@ -109,6 +98,22 @@ public class TypeSignature implements Writeable {
 
         throw new IllegalArgumentException(format(Locale.ENGLISH, "Bad type signature: '%s'", signature));
     }
+
+    protected static TypeSignature of(int parseInt) {
+        return new IntegerLiteralTypeSignature(parseInt);
+    }
+
+    private static TypeSignature of(String signature, List<TypeSignature> parameters) {
+        if (isNamedTypeSignature(signature)) {
+            int split = signature.indexOf(" ");
+            return new ParameterTypeSignature(
+                signature.substring(0, split),
+                new TypeSignature(signature.substring(split + 1), parameters));
+        } else {
+            return new TypeSignature(signature, parameters);
+        }
+    }
+
 
     private static boolean isNamedTypeSignature(String signature) {
         return !DataTypes.PRIMITIVE_TYPE_NAMES_WITH_SPACES.contains(signature)
@@ -170,8 +175,7 @@ public class TypeSignature implements Writeable {
             }
             DataType<?> innerType = parameters.get(0).createType();
             return new ArrayType<>(innerType);
-        }
-        if (baseTypeName.equalsIgnoreCase(ObjectType.NAME)) {
+        } else if (baseTypeName.equalsIgnoreCase(ObjectType.NAME)) {
             var builder = ObjectType.builder();
             for (int i = 0; i < parameters.size() - 1;) {
                 var valTypeSignature = parameters.get(i + 1);
@@ -194,8 +198,18 @@ public class TypeSignature implements Writeable {
                 dataTypes.add(parameterTypeSignature.createType());
             }
             return new RowType(dataTypes, fields);
+        } else {
+            var integerLiteralParameters = new ArrayList<Integer>(parameters.size());
+            for (var parameter : parameters) {
+                if (!parameter.type().equals(TypeSignatureType.INTEGER_LITERAL_SIGNATURE)) {
+                    throw new IllegalArgumentException(
+                        "The signature type of the based data type parameters can only be: "
+                        + TypeSignatureType.INTEGER_LITERAL_SIGNATURE.toString());
+                }
+                integerLiteralParameters.add(((IntegerLiteralTypeSignature) parameter).value());
+            }
+            return DataTypes.of(baseTypeName, integerLiteralParameters);
         }
-        return DataTypes.ofName(baseTypeName);
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/TypeSignatureType.java
+++ b/server/src/main/java/io/crate/types/TypeSignatureType.java
@@ -31,7 +31,8 @@ import java.util.List;
 public enum TypeSignatureType {
 
     TYPE_SIGNATURE(TypeSignature::new),
-    OBJECT_PARAMETER_TYPE_SIGNATURE(ParameterTypeSignature::new);
+    PARAMETER_TYPE_SIGNATURE(ParameterTypeSignature::new),
+    INTEGER_LITERAL_SIGNATURE(IntegerLiteralTypeSignature::new);
 
     public static final List<TypeSignatureType> VALUES = List.of(values());
 

--- a/server/src/test/java/io/crate/types/TypeSignatureTest.java
+++ b/server/src/test/java/io/crate/types/TypeSignatureTest.java
@@ -132,4 +132,35 @@ public class TypeSignatureTest extends CrateUnitTest {
             innerSignature.getParameters(),
             contains(new TypeSignature(DataTypes.TIMESTAMP.getName())));
     }
+
+    @Test
+    public void test_parse_text_type_signature_with_length_limit() {
+        var signature = parseTypeSignature("text(12)");
+        assertThat(signature.getBaseTypeName(), is("text"));
+        assertThat(signature.getParameters(), contains(new IntegerLiteralTypeSignature(12)));
+    }
+
+    @Test
+    public void test_create_type_signature_from_text_type_with_length_limit() {
+        assertThat(StringType.of(11).getTypeSignature().toString(), is("text(11)"));
+    }
+
+    @Test
+    public void test_parse_nested_named_text_type_signature_with_length_limit() {
+        var signature = parseTypeSignature("object(name text(11))");
+        assertThat(signature.getBaseTypeName(), is("object"));
+        assertThat(signature.getParameters().size(), is(1));
+
+        var textTypeSignature = signature.getParameters().get(0);
+        assertThat(textTypeSignature.getBaseTypeName(), is("text"));
+        assertThat(textTypeSignature.getParameters(), contains(new IntegerLiteralTypeSignature(11)));
+    }
+
+    @Test
+    public void test_create_type_signature_from_nested_named_text_type_with_length_limit() {
+        var objectType = ObjectType.builder()
+            .setInnerType("name", StringType.of(1))
+            .build();
+        assertThat(objectType.getTypeSignature().toString(), is("object(text,text(1))"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
