### PR TITLE
Add a pg_range table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -96,6 +96,8 @@ SQL Standard and PostgreSQL compatibility improvements
 
 - Added the `pg_catalog.pg_proc <postgres_pg_catalog>`_ table.
 
+- Added the `pg_catalog.pg_range <postgres_pg_catalog>`_ table.
+
 - Added :ref:`postgres_pg_type` columns: ``typbyval``, ``typcategory``,
   ``typowner``, ``typisdefined``, ``typrelid``, ``typndims``,
   ``typcollation``, ``typinput``, ``typoutput``, and ``typndefault`` for improved

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -89,6 +89,7 @@ number of replicas.
     | pg_catalog         | pg_index                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_namespace            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_proc                 | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_range                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_settings             | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
@@ -111,7 +112,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 44 rows in set (... sec)
+    SELECT 45 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -143,6 +143,7 @@ following tables:
  - `pg_constraint <pgsql_pg_constraint_>`__
  - `pg_settings <pgsql_pg_settings_>`__
  - `pg_description`_
+ - `pg_range`_
 
 
 .. _postgres_pg_type:
@@ -392,3 +393,4 @@ either because of the table is empty or by a not matching where clause.
 .. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
 .. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html
 .. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
+.. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -22,7 +22,8 @@
 
 package io.crate.metadata.pgcatalog;
 
-import com.google.common.collect.ImmutableSortedMap;
+
+import io.crate.common.collections.MapBuilder;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import io.crate.metadata.SystemTable;
@@ -37,12 +38,15 @@ import org.elasticsearch.common.inject.Singleton;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Singleton
 public class PgCatalogSchemaInfo implements SchemaInfo {
 
     public static final String NAME = "pg_catalog";
-    private final ImmutableSortedMap<String, TableInfo> tableInfoMap;
+    private final Map<String, TableInfo> tableInfoMap;
     private final UserDefinedFunctionService udfService;
     private final SystemTable<PgClassTable.Entry> pgClassTable;
 
@@ -50,7 +54,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
     public PgCatalogSchemaInfo(UserDefinedFunctionService udfService, TableStats tableStats) {
         this.udfService = udfService;
         this.pgClassTable = PgClassTable.create(tableStats);
-        tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
+        tableInfoMap = MapBuilder.<String, TableInfo>newMapBuilder(new TreeMap<>(Comparator.naturalOrder()))
             .put(PgStatsTable.NAME.name(), PgStatsTable.create())
             .put(PgTypeTable.IDENT.name(), PgTypeTable.create())
             .put(PgClassTable.IDENT.name(), pgClassTable)
@@ -63,7 +67,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             .put(PgDescriptionTable.NAME.name(), PgDescriptionTable.create())
             .put(PgSettingsTable.IDENT.name(), PgSettingsTable.create())
             .put(PgProcTable.IDENT.name(), PgProcTable.create())
-            .build();
+            .put(PgRangeTable.IDENT.name(), PgRangeTable.create())
+            .immutableMap();
     }
 
     SystemTable<PgClassTable.Entry> pgClassTable() {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -108,6 +108,11 @@ public class PgCatalogTableDefinitions {
             PgDescriptionTable.create().expressions(),
             false)
         );
+        tableDefinitions.put(PgRangeTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgRangeTable.create().expressions(),
+            false
+        ));
         Iterable<NamedSessionSetting> sessionSettings =
             () -> sessionSettingRegistry.settings().entrySet().stream()
                 .map(s -> new NamedSessionSetting(s.getKey(), s.getValue()))

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
@@ -20,47 +20,25 @@
  * agreement.
  */
 
-package io.crate.common.collections;
+package io.crate.metadata.pgcatalog;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
 
-public final class MapBuilder<K, V> {
+public final class PgRangeTable {
 
-    public static <K, V> MapBuilder<K, V> newMapBuilder() {
-        return new MapBuilder<>();
-    }
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_range");
 
-    public static <K, V> MapBuilder<K, V> newMapBuilder(Map<K, V> map) {
-        return new MapBuilder<>(new HashMap<>(map));
-    }
-
-    public static <K extends Comparable<?>, V> MapBuilder<K, V> treeMapBuilder() {
-        return new MapBuilder<>(new TreeMap<>());
-    }
-
-    private final Map<K, V> map;
-
-    private MapBuilder() {
-        this.map = new HashMap<>();
-    }
-
-    private MapBuilder(Map<K, V> map) {
-        this.map = map;
-    }
-
-    public MapBuilder<K, V> put(K key, V value) {
-        this.map.put(key, value);
-        return this;
-    }
-
-    public Map<K, V> map() {
-        return this.map;
-    }
-
-    public Map<K, V> immutableMap() {
-        return Collections.unmodifiableMap(map);
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("rngtypid", INTEGER, ignored -> null)
+            .add("rngsubtype", INTEGER, ignored -> null)
+            .add("rngcollation", INTEGER, ignored -> null)
+            .add("rngsubopc", INTEGER, ignored -> null)
+            .add("rngcanonical", STRING, ignored -> null)
+            .add("rngsubdiff", STRING, ignored -> null)
+            .build();
     }
 }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -75,6 +75,7 @@ public class PgTypeTable {
                     return t.typName() + "_out";
                 }
             })
+            .add("typreceive", STRING, t -> t.typName() + "recv")
             .add("typnotnull", BOOLEAN, c -> false)
             .build();
     }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -60,7 +60,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(38L, response.rowCount());
+        assertEquals(39L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
@@ -82,6 +82,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_index| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_namespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_proc| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_range| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_settings| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
@@ -181,13 +182,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(38L, response.rowCount());
+        assertEquals(39L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(39L, response.rowCount());
+        assertEquals(40L, response.rowCount());
     }
 
     @Test
@@ -515,7 +516,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(774, response.rowCount());
+        assertEquals(781, response.rowCount());
     }
 
     @Test
@@ -583,6 +584,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "typnotnull| boolean\n" +
             "typoutput| text\n" +
             "typowner| integer\n" +
+            "typreceive| text\n" +
             "typrelid| integer\n" +
             "typtype| text\n" +
             "typtypmod| integer\n")
@@ -756,10 +758,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t1 (id integer, col1 string) clustered into 10 shards with(number_of_replicas=0)");
         execute("create table t2 (id integer, col1 string) clustered into 5 shards with(number_of_replicas=0)");
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
-        ensureYellow();
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(41L, response.rows()[0][0]);
+        assertEquals(42L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -91,7 +91,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(38L, response.rowCount());
+        assertEquals(39L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The table is used by the stock npgsql client.
See https://www.postgresql.org/docs/10/catalog-pg-range.html

The table is always empty.

(There is more missing, so this commit doesn't add support for it).


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)