### PR TITLE
Add cast support for the string type with the length limit.

### DIFF
--- a/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -40,7 +40,7 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
 
     private static final DataTypeAnalyzer INSTANCE = new DataTypeAnalyzer();
 
-    public static DataType convert(ColumnType<?> columnType) {
+    public static DataType<?> convert(ColumnType<?> columnType) {
         return columnType.accept(INSTANCE, null);
     }
 
@@ -50,15 +50,14 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
         if (typeName == null) {
             return DataTypes.NOT_SUPPORTED;
         } else {
-            return DataTypes.ofName(typeName.toLowerCase(Locale.ENGLISH));
+            return DataTypes.of(typeName.toLowerCase(Locale.ENGLISH), node.parameters());
         }
     }
 
     @Override
     public DataType<?> visitObjectColumnType(ObjectColumnType<?> node, Void context) {
-        ObjectColumnType<?> objectColumnType = node;
         ObjectType.Builder builder = ObjectType.builder();
-        for (ColumnDefinition<?> columnDefinition : objectColumnType.nestedColumns()) {
+        for (ColumnDefinition<?> columnDefinition : node.nestedColumns()) {
             ColumnType<?> type = columnDefinition.type();
             // can be null for generated columns, as then the type is inferred from the expression.
             builder.setInnerType(

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -49,7 +49,9 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public static StringType of(List<Integer> parameters) {
         if (parameters.size() != 1) {
             throw new IllegalArgumentException(
-                "The number of parameters for the text data is wrong: " + parameters.size());
+                "The text type can only have a single parameter value, received: " +
+                parameters.size()
+            );
         }
         return StringType.of(parameters.get(0));
     }
@@ -57,7 +59,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public static StringType of(int lengthLimit) {
         if (lengthLimit <= 0) {
             throw new IllegalArgumentException(
-                "Invalid text data type length limit: " + lengthLimit);
+                "The text type length must be at least 1, received: " + lengthLimit);
         }
         return new StringType(lengthLimit);
     }

--- a/server/src/test/java/io/crate/analyze/DataTypeAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DataTypeAnalyzerTest.java
@@ -37,7 +37,7 @@ public class DataTypeAnalyzerTest {
     @Test
     public void testCastToNestedArrayExpressionReturnsArrayType() {
         Cast cast = (Cast) SqlParser.createExpression("xs::array(array(int))");
-        DataType dataType = DataTypeAnalyzer.convert(cast.getType());
-        assertThat(dataType, is(new ArrayType(new ArrayType(DataTypes.INTEGER))));
+        DataType<?> dataType = DataTypeAnalyzer.convert(cast.getType());
+        assertThat(dataType, is(new ArrayType<>(new ArrayType<>(DataTypes.INTEGER))));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -222,7 +222,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             argument.calls = 0;
         }
 
-        actualValue = scalar.evaluate(txnCtx, (Input[]) arguments);
+        actualValue = scalar.evaluate(txnCtx, arguments);
         assertThat((T) actualValue, expectedValue);
     }
 
@@ -276,12 +276,10 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     protected FunctionImplementation getFunction(String functionName, DataType... argTypes) {
         return getFunction(functionName, Arrays.asList(argTypes));
     }
 
-    @SuppressWarnings("unchecked")
     protected FunctionImplementation getFunction(String functionName, List<DataType> argTypes) {
         return functions.get(
             null, functionName, Lists2.map(argTypes, t -> new InputColumn(0, t)), SearchPath.pathWithPGCatalogAndDoc());

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -84,6 +84,11 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void test_cast_string_literal_text_with_length_truncates_exceeding_chars() {
+        assertEvaluate("'abcde'::varchar(2)", "ab");
+    }
+
+    @Test
     public void test_cannot_cast_text_to_object_array() {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("Cannot cast expressions from type `text` to type `object_array`");

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -37,12 +37,6 @@ import static org.hamcrest.core.IsNot.not;
 public class DataTypesTest extends CrateUnitTest {
 
     @Test
-    public void testConvertBooleanToString() {
-        String value = DataTypes.STRING.value(true);
-        assertEquals("t", value);
-    }
-
-    @Test
     public void testConvertStringToBoolean() {
         assertEquals(true, DataTypes.BOOLEAN.value("t"));
         assertEquals(false, DataTypes.BOOLEAN.value("false"));
@@ -66,7 +60,6 @@ public class DataTypesTest extends CrateUnitTest {
         assertEquals((Short) (short) 123, DataTypes.SHORT.value(longValue));
         assertEquals((Byte) (byte) 123, DataTypes.BYTE.value(longValue));
         assertEquals((Long) 123L, DataTypes.TIMESTAMPZ.value(longValue));
-        assertEquals("123", DataTypes.STRING.value(longValue));
     }
 
     private static Map<String, Object> testMap = Map.of(
@@ -158,7 +151,6 @@ public class DataTypesTest extends CrateUnitTest {
         assertEquals((Float) 123.0f, DataTypes.FLOAT.value(value));
         assertEquals((Short) (short) 123, DataTypes.SHORT.value(value));
         assertEquals((Byte) (byte) 123, DataTypes.BYTE.value(value));
-        assertEquals("123", DataTypes.STRING.value(value));
     }
 
     @Test(expected = NumberFormatException.class)
@@ -277,27 +269,6 @@ public class DataTypesTest extends CrateUnitTest {
     @Test
     public void test_varchar_is_aliased_to_string() throws Exception {
         assertThat(DataTypes.ofName("varchar"), is(DataTypes.STRING));
-    }
-
-    @Test
-    public void test_text_with_length_limit() throws Exception {
-        var stringDataType = StringType.of(10);
-        assertThat(stringDataType.unbound(), is(false));
-        assertThat(stringDataType.lengthLimit(), is(10));
-    }
-
-    @Test
-    public void test_text_with_negative_length_limit() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid text data type length limit: -1");
-        StringType.of(-1);
-    }
-
-    @Test
-    public void test_crate_text_type_with_wrong_number_of_parameters_throws_exception() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The number of parameters for the text data is wrong: 2");
-        StringType.of(List.of(1, 2));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class StringTypeTest extends CrateUnitTest {
+
+    @Test
+    public void test_convert_boolean_to_text() {
+        assertThat(DataTypes.STRING.value(true), is("t"));
+        assertThat(DataTypes.STRING.value(false), is("f"));
+    }
+
+    @Test
+    public void test_convert_long_to_text() {
+        assertThat(DataTypes.STRING.value(123L), is("123"));
+    }
+
+    @Test
+    public void test_create_text_type_with_length_limit() {
+        var stringDataType = StringType.of(10);
+        assertThat(stringDataType.unbound(), is(false));
+        assertThat(stringDataType.lengthLimit(), is(10));
+    }
+
+    @Test
+    public void test_text_type_without_length_limit_on_string_literal() {
+        assertThat(StringType.INSTANCE.value("abc"), is("abc"));
+    }
+
+    @Test
+    public void test_text_type_with_length_on_string_literal_of_length_gt_length_limit_truncates_chars() {
+        assertThat(StringType.of(1).value("abcde"), is("a"));
+        assertThat(StringType.of(2).value("a    "), is("a "));
+    }
+
+    @Test
+    public void test_text_type_with_length_on_string_literal_of_length_lte_length() {
+        assertThat(StringType.of(5).value("abc"), is("abc"));
+        assertThat(StringType.of(1).value("a"), is("a"));
+    }
+
+    @Test
+    public void test_create_text_type_with_negative_length_limit_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid text data type length limit: -1");
+        StringType.of(-1);
+    }
+
+    @Test
+    public void test_create_text_type_with_zero_length_limit_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid text data type length limit: 0");
+        StringType.of(0);
+    }
+
+    @Test
+    public void test_create_text_type_with_wrong_number_of_parameters_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The number of parameters for the text data is wrong: 2");
+        StringType.of(List.of(1, 2));
+    }
+}

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -68,21 +68,21 @@ public class StringTypeTest extends CrateUnitTest {
     @Test
     public void test_create_text_type_with_negative_length_limit_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid text data type length limit: -1");
+        expectedException.expectMessage("The text type length must be at least 1, received: -1");
         StringType.of(-1);
     }
 
     @Test
     public void test_create_text_type_with_zero_length_limit_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid text data type length limit: 0");
+        expectedException.expectMessage("The text type length must be at least 1, received: 0");
         StringType.of(0);
     }
 
     @Test
     public void test_create_text_type_with_wrong_number_of_parameters_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The number of parameters for the text data is wrong: 2");
+        expectedException.expectMessage("The text type can only have a single parameter value, received: 2");
         StringType.of(List.of(1, 2));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
