### PR TITLE
Always generate `cast` function for implicit casts

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -387,14 +387,19 @@ public class AnalyzedTableElements<T> {
             } else {
                 columnDataType = definedType;
             }
-            if (!valueType.isConvertableTo(columnDataType)) {
+            if (!valueType.isConvertableTo(columnDataType, false)) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "expression value type '%s' not supported for conversion to '%s'",
                     valueType, columnDataType.getName())
                 );
             }
 
-            Symbol castFunction = CastFunctionResolver.generateCastFunction(function, columnDataType, false);
+            Symbol castFunction = CastFunctionResolver.generateCastFunction(
+                function,
+                columnDataType,
+                false,
+                false
+            );
             formattedExpression = castFunction.toString(Style.UNQUALIFIED);
         } else {
             if (valueType instanceof ArrayType) {

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -267,7 +267,7 @@ class InsertAnalyzer {
             Reference targetCol = targetColumns.get(i);
             Symbol source = sources.get(i);
             DataType<?> targetType = targetCol.valueType();
-            if (targetType.id() == DataTypes.UNDEFINED.id() || source.valueType().isConvertableTo(targetType)) {
+            if (targetType.id() == DataTypes.UNDEFINED.id() || source.valueType().isConvertableTo(targetType, false)) {
                 continue;
             }
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
@@ -307,7 +307,8 @@ class InsertAnalyzer {
             Symbol valueSymbol = ValueNormalizer.normalizeInputForReference(
                 normalizer.normalize(expressionAnalyzer.convert(assignment.expression(), exprCtx), txnCtx),
                 targetCol,
-                targetTable.tableInfo()
+                targetTable.tableInfo(),
+                s -> normalizer.normalize(s, txnCtx)
             );
             updateAssignments.put(targetCol, valueSymbol);
         }

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -177,7 +177,8 @@ public final class UpdateAnalyzer {
             Symbol source = ValueNormalizer.normalizeInputForReference(
                 normalizer.normalize(sourceExprAnalyzer.convert(assignment.expression(), exprCtx), txnCtx),
                 targetCol,
-                tableInfo
+                tableInfo,
+                s -> normalizer.normalize(s, txnCtx)
             );
             if (assignmentByTargetCol.put(targetCol, source) != null) {
                 throw new IllegalArgumentException("Target expression repeated: " + targetCol.column().sqlFqn());

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -92,7 +92,7 @@ public class ColumnIndexWriterProjector implements Projector {
             updateColumnNames = null;
             assignments = null;
         } else {
-            Assignments convert = Assignments.convert(updateAssignments);
+            Assignments convert = Assignments.convert(updateAssignments, functions);
             updateColumnNames = convert.targetNames();
             assignments = convert.sources();
         }

--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -27,11 +27,11 @@ import io.crate.data.Input;
 import io.crate.expression.NestableInput;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.scalar.arithmetic.MapFunction;
-import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.MatchPredicate;
+import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
@@ -45,8 +45,10 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 
 /**
@@ -66,9 +68,28 @@ public class EvaluatingNormalizer {
     private final ReferenceResolver<? extends Input<?>> referenceResolver;
     private final FieldResolver fieldResolver;
     private final BaseVisitor visitor;
+    private final Predicate<Function> onFunctionCondition;
 
     public static EvaluatingNormalizer functionOnlyNormalizer(Functions functions) {
         return new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, null);
+    }
+
+    public static EvaluatingNormalizer functionOnlyNormalizer(Functions functions,
+                                                              Predicate<Function> onFunctionCondition) {
+        return new EvaluatingNormalizer(
+            functions,
+            RowGranularity.CLUSTER,
+            null,
+            null,
+            onFunctionCondition
+        );
+    }
+
+    public EvaluatingNormalizer(Functions functions,
+                                RowGranularity granularity,
+                                @Nullable ReferenceResolver<? extends Input<?>> referenceResolver,
+                                @Nullable FieldResolver fieldResolver) {
+        this(functions, granularity, referenceResolver, fieldResolver, function -> true);
     }
 
     /**
@@ -80,12 +101,14 @@ public class EvaluatingNormalizer {
     public EvaluatingNormalizer(Functions functions,
                                 RowGranularity granularity,
                                 @Nullable ReferenceResolver<? extends Input<?>> referenceResolver,
-                                @Nullable FieldResolver fieldResolver) {
+                                @Nullable FieldResolver fieldResolver,
+                                Predicate<Function> onFunctionCondition) {
         this.functions = functions;
         this.granularity = granularity;
         this.referenceResolver = referenceResolver;
         this.fieldResolver = fieldResolver;
         this.visitor = new BaseVisitor();
+        this.onFunctionCondition = onFunctionCondition;
     }
 
     private class BaseVisitor extends FunctionCopyVisitor<TransactionContext> {
@@ -133,7 +156,20 @@ public class EvaluatingNormalizer {
                     ));
                 return ((Symbol) function).accept(this, context);
             }
-            return matchPredicate;
+
+            HashMap<Symbol, Symbol> fieldBoostMap = new HashMap<>(matchPredicate.identBoostMap().size());
+            for (var entry : matchPredicate.identBoostMap().entrySet()) {
+                fieldBoostMap.put(
+                    entry.getKey().accept(this, context),
+                    entry.getValue().accept(this, context)
+                );
+            }
+            return new MatchPredicate(
+                fieldBoostMap,
+                matchPredicate.queryTerm().accept(this, context),
+                matchPredicate.matchType(),
+                matchPredicate.options().accept(this, context)
+            );
         }
 
         @Override
@@ -159,6 +195,9 @@ public class EvaluatingNormalizer {
         }
 
         private Symbol normalizeFunction(Function function, TransactionContext context) {
+            if (onFunctionCondition.test(function) == false) {
+                return function;
+            }
             function = processAndMaybeCopy(function, context);
             var ident = function.info().ident();
             var signature = function.signature();

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -66,17 +66,15 @@ public final class TrigonometricFunctions {
     }
 
     private static void register(ScalarFunctionModule module, String name, DoubleUnaryOperator func) {
-        for (DataType<?> inputType : NUMERIC_PRIMITIVE_TYPES) {
-            module.register(
-                scalar(
-                    name,
-                    inputType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
-                (signature, argumentTypes) ->
-                    new DoubleScalar(name, signature, inputType, func)
-            );
-        }
+        module.register(
+            scalar(
+                name,
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            (signature, argumentTypes) ->
+                new DoubleScalar(name, signature, argumentTypes.get(0), func)
+        );
     }
 
     private static double checkRange(double value) {

--- a/server/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -59,16 +59,12 @@ public class CastFunction extends Scalar<Object, Object> {
                 Signature.builder()
                     .name(new FunctionName(null, function.getKey()))
                     .kind(FunctionInfo.Type.SCALAR)
-                    .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
-                    .argumentTypes(parseTypeSignature("E"), parseTypeSignature("V"))
+                    .typeVariableConstraints(typeVariable("E"))
+                    .argumentTypes(parseTypeSignature("E"), parseTypeSignature("E"))
                     .returnType(function.getValue().getTypeSignature())
                     .build(),
                 (signature, args) -> {
-                    DataType<?> sourceType = args.get(0);
                     DataType<?> targetType = args.get(1);
-                    if (!sourceType.isConvertableTo(targetType)) {
-                        throw new ConversionException(sourceType, targetType);
-                    }
                     return new CastFunction(
                         new FunctionInfo(new FunctionIdent(function.getKey(), args), targetType),
                         signature,
@@ -94,9 +90,6 @@ public class CastFunction extends Scalar<Object, Object> {
                 (signature, args) -> {
                     DataType<?> sourceType = args.get(0);
                     DataType<?> targetType = function.getValue();
-                    if (!sourceType.isConvertableTo(targetType)) {
-                        throw new ConversionException(sourceType, targetType);
-                    }
                     return new CastFunction(
                         new FunctionInfo(new FunctionIdent(function.getKey(), args), targetType),
                         signature,
@@ -115,8 +108,8 @@ public class CastFunction extends Scalar<Object, Object> {
                 Signature.builder()
                     .name(new FunctionName(null, tryCastName))
                     .kind(FunctionInfo.Type.SCALAR)
-                    .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
-                    .argumentTypes(parseTypeSignature("E"), parseTypeSignature("V"))
+                    .typeVariableConstraints(typeVariable("E"))
+                    .argumentTypes(parseTypeSignature("E"), parseTypeSignature("E"))
                     .returnType(function.getValue().getTypeSignature())
                     .build(),
                 (signature, args) -> new CastFunction(
@@ -189,6 +182,10 @@ public class CastFunction extends Scalar<Object, Object> {
     @Override
     public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
         Symbol argument = symbol.arguments().get(0);
+        if (argument.valueType().equals(returnType)) {
+            return argument;
+        }
+
         if (argument instanceof Input) {
             Object value = ((Input<?>) argument).value();
             try {

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -35,7 +35,7 @@ import static io.crate.metadata.functions.Signature.scalar;
 public final class CoordinateFunction {
 
     private static final List<DataType<?>> SUPPORTED_INPUT_TYPES =
-        List.of(DataTypes.GEO_POINT, DataTypes.STRING, DataTypes.DOUBLE_ARRAY, DataTypes.UNDEFINED);
+        List.of(DataTypes.GEO_POINT, DataTypes.STRING, DataTypes.DOUBLE_ARRAY);
 
     private static void register(ScalarFunctionModule module, String name, Function<Object, Double> func) {
         for (DataType<?> inputType : SUPPORTED_INPUT_TYPES) {

--- a/server/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/server/src/main/java/io/crate/expression/symbol/Literal.java
@@ -23,7 +23,6 @@
 package io.crate.expression.symbol;
 
 import io.crate.data.Input;
-import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.format.Style;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -135,19 +134,6 @@ public class Literal<T> extends Symbol implements Input<T>, Comparable<Literal<T
     @Override
     public SymbolType symbolType() {
         return SymbolType.LITERAL;
-    }
-
-    @Override
-    public Symbol cast(DataType<?> targetType, boolean tryCast) {
-        if (type.equals(targetType)) {
-            return this;
-        }
-        try {
-            //noinspection unchecked
-            return new Literal<>((DataType<Object>) targetType, targetType.value(value));
-        } catch (IllegalArgumentException | ClassCastException e) {
-            throw new ConversionException(this, targetType);
-        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
@@ -66,7 +66,7 @@ public class ParameterSymbol extends Symbol {
     }
 
     @Override
-    public ParameterSymbol cast(DataType<?> targetType, boolean tryCast) {
+    public ParameterSymbol cast(DataType<?> targetType, boolean tryCast, boolean explicitCast) {
         return new ParameterSymbol(index, boundType, targetType);
     }
 

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -48,7 +48,7 @@ public abstract class Symbol implements FuncArg, Writeable {
      * @return An instance of {@link Function} which casts this symbol.
      */
     public final Symbol cast(DataType<?> targetType) {
-        return cast(targetType, false);
+        return cast(targetType, false, false);
     }
 
     /**
@@ -58,14 +58,14 @@ public abstract class Symbol implements FuncArg, Writeable {
      * @param tryCast If set to true, will return null the symbol cannot be casted.
      * @return An instance of {@link Function} which casts this symbol.
      */
-    public Symbol cast(DataType<?> targetType, boolean tryCast) {
+    public Symbol cast(DataType<?> targetType, boolean tryCast, boolean explicitCast) {
         if (targetType.equals(valueType())) {
             return this;
         } else if (ArrayType.unnest(targetType).equals(DataTypes.UNTYPED_OBJECT)
                    && valueType().id() == targetType.id()) {
             return this;
         }
-        return CastFunctionResolver.generateCastFunction(this, targetType, tryCast);
+        return CastFunctionResolver.generateCastFunction(this, targetType, tryCast, explicitCast);
     }
 
     @Override

--- a/server/src/main/java/io/crate/lucene/WithinQuery.java
+++ b/server/src/main/java/io/crate/lucene/WithinQuery.java
@@ -79,7 +79,7 @@ class WithinQuery implements FunctionToQuery, InnerFunctionToQuery {
             innerPair.reference().column().fqn(),
             context.mapperService);
 
-        Map<String, Object> geoJSON = (Map<String, Object>) innerPair.literal().value();
+        Map<String, Object> geoJSON = DataTypes.GEO_SHAPE.value(innerPair.literal().value());
         Geometry geometry;
         Shape shape = GeoJSONUtils.map2Shape(geoJSON);
         if (shape instanceof ShapeCollection) {

--- a/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -441,7 +441,7 @@ public class SignatureBinder {
                                              TypeSignature toTypeSignature) {
         switch (coercionType) {
             case FULL:
-                return fromType.isConvertableTo(toTypeSignature.createType());
+                return fromType.isConvertableTo(toTypeSignature.createType(), false);
             case PRECEDENCE_ONLY:
                 var toType = toTypeSignature.createType();
                 return fromType.equals(toType) || toType.precedes(fromType);

--- a/server/src/main/java/io/crate/metadata/functions/params/Param.java
+++ b/server/src/main/java/io/crate/metadata/functions/params/Param.java
@@ -224,7 +224,7 @@ public final class Param {
     }
 
     private static FuncArg convert(FuncArg source, DataType target) {
-        if (source.canBeCasted() && source.valueType().isConvertableTo(target)) {
+        if (source.canBeCasted() && source.valueType().isConvertableTo(target, false)) {
             return new ConvertedArg(source, target);
         }
         return null;
@@ -296,10 +296,10 @@ public final class Param {
         final DataType higherPrecedenceType = higherPrecedenceArg.valueType();
 
         final boolean lowerPrecedenceCastable =
-            lowerPrecedenceArg.canBeCasted() && lowerPrecedenceType.isConvertableTo(higherPrecedenceType) &&
+            lowerPrecedenceArg.canBeCasted() && lowerPrecedenceType.isConvertableTo(higherPrecedenceType, false) &&
             isTypeValid(higherPrecedenceType);
         final boolean higherPrecedenceCastable =
-            higherPrecedenceArg.canBeCasted() && higherPrecedenceType.isConvertableTo(lowerPrecedenceType) &&
+            higherPrecedenceArg.canBeCasted() && higherPrecedenceType.isConvertableTo(lowerPrecedenceType, false) &&
             isTypeValid(lowerPrecedenceType);
 
         // Check if one of the two arguments is a value symbol which can be converted easily, e.g. Literal
@@ -319,9 +319,9 @@ public final class Param {
 
         // if neither the source, nor the target can be casted, yet either one *IS* convertible to the other, we will
         // try to do the conversion (comparing two columns will never utilize the index anyway)
-        if (lowerPrecedenceType.isConvertableTo(higherPrecedenceType)) {
+        if (lowerPrecedenceType.isConvertableTo(higherPrecedenceType, false)) {
             return higherPrecedenceArg;
-        } else if (higherPrecedenceType.isConvertableTo(lowerPrecedenceType)) {
+        } else if (higherPrecedenceType.isConvertableTo(lowerPrecedenceType, false)) {
             return lowerPrecedenceArg;
         }
 

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -116,12 +116,12 @@ public final class InsertFromSubQueryPlanner {
             Symbol output = sourceCols.get(i);
             Reference targetCol = targetCols.get(i);
             InputColumn inputColumn = new InputColumn(i, output.valueType());
-            DataType targetType = targetCol.valueType();
+            DataType<?> targetType = targetCol.valueType();
             if (targetType.id() == DataTypes.UNDEFINED.id() || targetType.equals(output.valueType())) {
                 casts.add(inputColumn);
             } else {
                 requiresCasts = true;
-                casts.add(inputColumn.cast(targetType, false));
+                casts.add(inputColumn.cast(targetType, false, false));
             }
         }
         return requiresCasts ? new EvalProjection(casts) : null;

--- a/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -136,7 +136,13 @@ public final class UpdatePlanner {
             normalizer, query, tableInfo, plannerCtx.transactionContext());
 
         if (detailedQuery.docKeys().isPresent()) {
-            return new UpdateById(tableInfo, assignmentByTargetCol, detailedQuery.docKeys().get(), returnValues);
+            return new UpdateById(
+                tableInfo,
+                assignmentByTargetCol,
+                detailedQuery.docKeys().get(),
+                returnValues,
+                plannerCtx.functions()
+            );
         }
 
         return new Update((plannerContext, params, subQueryValues) ->
@@ -257,7 +263,7 @@ public final class UpdatePlanner {
         DocTableInfo tableInfo = table.tableInfo();
         Reference idReference = requireNonNull(tableInfo.getReference(DocSysColumns.ID),
                                                "Table must have a _id column");
-        Assignments assignments = Assignments.convert(assignmentByTargetCol);
+        Assignments assignments = Assignments.convert(assignmentByTargetCol, functions);
         Symbol[] assignmentSources = assignments.bindSources(tableInfo, params, subQueryResults);
         Symbol[] outputSymbols;
         if (returnValues == null) {

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -32,6 +32,7 @@ import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.DependencyCarrier;
@@ -58,9 +59,10 @@ public final class UpdateById implements Plan {
     public UpdateById(DocTableInfo table,
                       Map<Reference, Symbol> assignmentByTargetCol,
                       DocKeys docKeys,
-                      @Nullable List<Symbol> returnValues) {
+                      @Nullable List<Symbol> returnValues,
+                      Functions functions) {
         this.table = table;
-        this.assignments = Assignments.convert(assignmentByTargetCol);
+        this.assignments = Assignments.convert(assignmentByTargetCol, functions);
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.docKeys = docKeys;
         this.returnValues = returnValues == null ? null : returnValues.toArray(new Symbol[0]);

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -198,7 +198,10 @@ public class InsertFromValues implements LogicalPlan {
             updateColumnNames = null;
             assignmentSources = null;
         } else {
-            Assignments assignments = Assignments.convert(writerProjection.onDuplicateKeyAssignments());
+            Assignments assignments = Assignments.convert(
+                writerProjection.onDuplicateKeyAssignments(),
+                plannerContext.functions()
+            );
             assignmentSources = assignments.bindSources(tableInfo, params, subQueryResults);
             updateColumnNames = assignments.targetNames();
         }
@@ -306,7 +309,7 @@ public class InsertFromValues implements LogicalPlan {
             assignments = null;
             updateColumnNames = null;
         } else {
-            assignments = Assignments.convert(writerProjection.onDuplicateKeyAssignments());
+            assignments = Assignments.convert(writerProjection.onDuplicateKeyAssignments(), plannerContext.functions());
             updateColumnNames = assignments.targetNames();
         }
 

--- a/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
+++ b/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
@@ -86,6 +86,9 @@ public class SelectivityFunctions {
                 Boolean val = (Boolean) value;
                 return !val ? 0.0 : 1.0;
             }
+            if (value == null) {
+                return 0.0;
+            }
             return super.visitLiteral(literal, context);
         }
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -165,10 +165,10 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
-    public boolean isConvertableTo(DataType<?> other) {
+    public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
         return other.id() == UndefinedType.ID || other.id() == GeoPointType.ID ||
                ((other instanceof ArrayType)
-                && this.innerType.isConvertableTo(((ArrayType<?>) other).innerType()));
+                && this.innerType.isConvertableTo(((ArrayType<?>) other).innerType(), explicitCast));
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -107,7 +107,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * @param other the DataType to check conversion to
      * @return true or false
      */
-    public boolean isConvertableTo(DataType<?> other) {
+    public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
         if (this.equals(other)) {
             return true;
         }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -81,6 +81,7 @@ public final class DataTypes {
     public static final ArrayType<Integer> INTEGER_ARRAY = new ArrayType<>(INTEGER);
     public static final ArrayType<Short> SHORT_ARRAY = new ArrayType<>(SHORT);
     public static final ArrayType<Long> BIGINT_ARRAY = new ArrayType<>(LONG);
+    public static final ArrayType<Boolean> BOOLEAN_ARRAY = new ArrayType<>(BOOLEAN);
 
     public static final IntervalType INTERVAL = IntervalType.INSTANCE;
 

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -173,7 +173,11 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
     }
 
     @Override
-    public boolean isConvertableTo(DataType<?> other) {
-        return other.id() == id() || other instanceof ArrayType && ((ArrayType<?>) other).innerType().equals(DataTypes.DOUBLE);
+    public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
+        if (other.id() == id()
+            || other instanceof ArrayType && ((ArrayType<?>) other).innerType().equals(DataTypes.DOUBLE)) {
+            return true;
+        }
+        return super.isConvertableTo(other, explicitCast);
     }
 }

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -26,7 +26,9 @@ import io.crate.geo.GeoJSONUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
@@ -69,6 +71,10 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
         try {
             if (value instanceof String) {
                 return GeoJSONUtils.wkt2Map(BytesRefs.toString(value));
+            }
+            if (value instanceof Point) {
+                Point point = (Point) value;
+                return GeoJSONUtils.shape2Map(SpatialContext.GEO.getShapeFactory().pointXY(point.getX(), point.getY()));
             }
             if (value instanceof Shape) {
                 return GeoJSONUtils.shape2Map((Shape) value);

--- a/server/src/main/java/io/crate/types/NotSupportedType.java
+++ b/server/src/main/java/io/crate/types/NotSupportedType.java
@@ -32,7 +32,7 @@ public class NotSupportedType extends DataType<Void> {
     }
 
     @Override
-    public boolean isConvertableTo(DataType other) {
+    public boolean isConvertableTo(DataType other, boolean explicitCast) {
         return false;
     }
 

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -178,9 +178,12 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     }
 
     @Override
-    public boolean isConvertableTo(DataType<?> o) {
+    public boolean isConvertableTo(DataType<?> o, boolean explicitCast) {
         Set<Integer> conversions = ALLOWED_CONVERSIONS.getOrDefault(id(), Set.of());
         if (conversions.contains(o.id())) {
+            return true;
+        }
+        if (explicitCast && o.id() == DataTypes.STRING.id()) {
             return true;
         }
 
@@ -195,7 +198,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
                 var thisInnerType = thisInnerField.getValue();
                 var thatInnerType = that.innerTypes().get(thisInnerField.getKey());
                 if (thatInnerType == null
-                    || !thisInnerType.isConvertableTo(thatInnerType)) {
+                    || !thisInnerType.isConvertableTo(thatInnerType, explicitCast)) {
                     return false;
                 }
             }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -105,6 +105,19 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
+    public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
+        if (explicitCast) {
+            if (other.id() == ArrayType.ID && ((ArrayType<?>) other).innerType().id() == id()) {
+                return true;
+            }
+            if (other.id() == IntervalType.ID) {
+                return true;
+            }
+        }
+        return super.isConvertableTo(other, explicitCast);
+    }
+
+    @Override
     public int compare(String val1, String val2) {
         return val1.compareTo(val2);
     }

--- a/server/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/server/src/main/java/io/crate/types/TypeCompatibility.java
@@ -73,8 +73,8 @@ public final class TypeCompatibility {
             lowerPrecedenceArg = arg1;
         }
 
-        final boolean lowerPrecedenceCastable = lowerPrecedenceArg.isConvertableTo(higherPrecedenceArg);
-        final boolean higherPrecedenceCastable = higherPrecedenceArg.isConvertableTo(lowerPrecedenceArg);
+        final boolean lowerPrecedenceCastable = lowerPrecedenceArg.isConvertableTo(higherPrecedenceArg, false);
+        final boolean higherPrecedenceCastable = higherPrecedenceArg.isConvertableTo(lowerPrecedenceArg, false);
 
         if (lowerPrecedenceCastable) {
             return higherPrecedenceArg;

--- a/server/src/main/java/io/crate/types/UndefinedType.java
+++ b/server/src/main/java/io/crate/types/UndefinedType.java
@@ -62,7 +62,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
     }
 
     @Override
-    public boolean isConvertableTo(DataType other) {
+    public boolean isConvertableTo(DataType other, boolean explicitCast) {
         return true;
     }
 

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -96,7 +96,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             assertThat(subQueryColumn, instanceOf(Symbol.class));
             Reference insertColumn = statement.columns().get(i);
             assertThat(
-                subQueryColumn.valueType().isConvertableTo(insertColumn.valueType()),
+                subQueryColumn.valueType().isConvertableTo(insertColumn.valueType(), false),
                 is(true)
             );
         }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -219,7 +219,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(ref, not(instanceOf(DynamicReference.class)));
         assertEquals(DataTypes.LONG, ref.valueType());
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         Symbol[] sources = assignments.bindSources(
             ((DocTableInfo) update.table().tableInfo()), Row.EMPTY, SubQueryResults.EMPTY);
         assertThat(sources[0], isLiteral(9L));
@@ -282,7 +282,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new Long[]{1L, 2L, 3L}};
         AnalyzedUpdateStatement update = analyze("update users set name=?, friends=? where other_id=?");
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot cast [{}] to type TEXT");
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
@@ -293,7 +293,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Object[] params = {new Map[0], 0};
         AnalyzedUpdateStatement update = analyze("update users set friends=? where other_id=0");
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         Symbol[] sources = assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
 
 
@@ -401,7 +401,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             }
         };
         AnalyzedUpdateStatement update = analyze("update users set new=? where id=1");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         Symbol[] sources = assignments.bindSources(
             ((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
 
@@ -420,7 +420,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot cast [a, b] to type TEXT");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }
 

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -48,7 +48,6 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws Exception {
         expressions = new SqlExpressions(T3.sources(clusterService));
-        expressions.context().allowEagerNormalize(false);
     }
 
     private Symbol asSymbol(String expression) {
@@ -66,10 +65,11 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_query_splitter_retains_literals() {
+        expressions.context().allowEagerNormalize(false);
         Symbol symbol = asSymbol("t1.a = 10 and t1.x = t2.y and (false)");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
-        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = '10')"));
+        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = cast(10 AS text))"));
         assertThat(split.get(Set.of(tr1, tr2)), isSQL("((doc.t1.x = doc.t2.y) AND false)"));
     }
 

--- a/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -279,7 +279,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnyInvalidArrayType() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `['foo', 'bar', 'baz']` of type `text_array` to type `boolean_array`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
         analyzeSelectWhere("select * from users_multi_pk where awesome = any(['foo', 'bar', 'baz'])");
     }
 

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -63,7 +63,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         AnalyzedUpdateStatement update = e.analyze("update t set x = x + p");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),
@@ -102,7 +102,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (y int)")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set y = _id::integer * 2");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),
@@ -138,7 +138,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as x + 1))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),
@@ -170,7 +170,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, gen as current_schema)")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 1");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen sourceGen = new UpdateSourceGen(
             e.functions(),
@@ -194,7 +194,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as 'foo'))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4, obj = {y='bar'}");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),
@@ -227,7 +227,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as 'foo'))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4, obj = {y='foo'}");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),
@@ -258,7 +258,7 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (obj object as (x int))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set obj['x'] = 10");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
             e.functions(),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -102,8 +102,10 @@ public class ArbitraryAggregationTest extends AggregationTest {
         assertThat(result, is(oneOf(data[0][0], data[1][0])));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: arbitrary(object)");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -81,8 +81,10 @@ public class AverageAggregationTest extends AggregationTest {
         assertEquals(5d, result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: avg(geo_point)");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -95,8 +95,10 @@ public class GeometricMeanAggregationtest extends AggregationTest {
         assertEquals(1.0d, result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: geometric_mean(boolean)");
         executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -87,8 +87,10 @@ public class MaximumAggregationTest extends AggregationTest {
         assertEquals("Youri", result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: max(object)");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -87,8 +87,10 @@ public class MinimumAggregationTest extends AggregationTest {
         assertEquals("Ruben", result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: min(object)");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -145,8 +145,10 @@ public class PercentileAggregationTest extends AggregationTest {
         });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: percentile(geo_point, double precision)");
         execSingleFractionPercentile(DataTypes.GEO_POINT, new Object[][]{});
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -103,8 +103,10 @@ public class StdDevAggregationTest extends AggregationTest {
         assertEquals(0d, result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: stddev(geo_point)");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -107,8 +107,10 @@ public class SumAggregationTest extends AggregationTest {
         assertEquals(10L, result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: sum(geo_point)");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -100,8 +100,10 @@ public class VarianceAggregationTest extends AggregationTest {
         assertEquals(0d, result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: variance(geo_point)");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -16,8 +16,8 @@ public class EqOperatorTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEqArrayLeftSideIsNull_RightSideNull() throws Exception {
-        assertEvaluate("[ [1, 1], [10] ] = null", null);
-        assertEvaluate("null = [ [1, 1], [10] ]", null);
+        assertEvaluate("[1, 10] = null", null);
+        assertEvaluate("null = [1, 10]", null);
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.scalar;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Lists2;
@@ -285,17 +284,6 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
     protected FunctionImplementation getFunction(String functionName, List<DataType> argTypes) {
         return functions.get(
             null, functionName, Lists2.map(argTypes, t -> new InputColumn(0, t)), SearchPath.pathWithPGCatalogAndDoc());
-    }
-
-    protected Symbol normalize(CoordinatorTxnCtx coordinatorTxnCtx, String functionName, Symbol... args) {
-        List<Symbol> argList = Arrays.asList(args);
-        FunctionImplementation function = functions.get(null, functionName, argList, SearchPath.pathWithPGCatalogAndDoc());
-        return function.normalizeSymbol(new Function(function.info(),
-            argList), coordinatorTxnCtx);
-    }
-
-    protected Symbol normalize(String functionName, Symbol... args) {
-        return normalize(new CoordinatorTxnCtx(SessionContext.systemSessionContext()), functionName, args);
     }
 
     private static class AssertMax1ValueCallInput implements Input {

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -105,7 +105,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testConvertNonNumericStringToNumber() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `['foo', 'bar']` of type `text_array` to type `bigint_array`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
         assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -75,7 +75,7 @@ public class IntervalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_unallowed_operations() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'PT1S'` of type `interval` to any of the types");
+        expectedException.expectMessage("Cannot cast `cast('1 second' AS interval)` of type `interval` to any of the types");
         assertEvaluate("interval '1 second' - '86401000'::timestamp", Matchers.is(86400000L));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.expression.scalar.geo;
 
-import io.crate.expression.symbol.Literal;
-import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -43,8 +43,8 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'1'` of type `text` to type `geo_point`");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: distance(bigint, text)");
         assertNormalize("distance(1, 'POINT (11 21)')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.symbol;
 
+import io.crate.expression.scalar.cast.CastFunction;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.ArrayType;
 import io.crate.types.BooleanType;
@@ -32,6 +33,7 @@ import org.locationtech.spatial4j.shape.Point;
 
 import java.util.List;
 
+import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
@@ -111,6 +113,6 @@ public class LiteralTest extends CrateUnitTest {
     @Test
     public void testCasting() {
         Symbol intLiteral = Literal.of(1);
-        assertThat(intLiteral.cast(DataTypes.LONG), isLiteral(1L));
+        assertThat(intLiteral.cast(DataTypes.LONG), isFunction("to_bigint"));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -681,7 +681,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast `[10.3, 20.2]` of type `double precision_array` to type `integer`"));
+                assertThat(e.getMessage(), Matchers.containsString("Cannot cast expressions from type `double precision_array` to type `integer`"));
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -214,7 +214,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast `['a']` of type `text_array` to type `char_array`");
+        expectedException.expectMessage("Cannot cast `'a'` of type `text` to type `char`");
 
         setUpSimple();
         execute("update t1 set byte_field=0 where byte_field in ('a')");

--- a/server/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -86,7 +86,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
 
     @Test
     public void testNormalizeDoesNotRemoveOrderBy() throws Exception {
-        Symbol toInt10 = CastFunctionResolver.generateCastFunction(Literal.of(10L), DataTypes.INTEGER, false);
+        Symbol toInt10 = CastFunctionResolver.generateCastFunction(Literal.of(10L), DataTypes.INTEGER, false, false);
         RoutedCollectPhase collect = new RoutedCollectPhase(
             UUID.randomUUID(),
             1,
@@ -108,7 +108,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
 
     @Test
     public void testNormalizePreservesNodePageSizeHint() throws Exception {
-        Symbol toInt10 = CastFunctionResolver.generateCastFunction(Literal.of(10L), DataTypes.INTEGER, false);
+        Symbol toInt10 = CastFunctionResolver.generateCastFunction(Literal.of(10L), DataTypes.INTEGER, false, false);
         RoutedCollectPhase collect = new RoutedCollectPhase(
             UUID.randomUUID(),
             1,

--- a/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -41,7 +41,6 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_eq_null_value_is_always_0() {
         SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
-        expressions.context().allowEagerNormalize(false);
         Symbol query = expressions.asSymbol("x = null");
         var numbers = IntStream.range(1, 50)
             .boxed()

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -87,7 +87,7 @@ public class GeoPointTypeTest extends CrateUnitTest {
 
     @Test
     public void testConversionFromArrayType() {
-        assertThat(new ArrayType(DataTypes.LONG).isConvertableTo(GeoPointType.INSTANCE), is(true));
+        assertThat(new ArrayType(DataTypes.LONG).isConvertableTo(GeoPointType.INSTANCE, false), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/server/src/test/java/io/crate/types/TypeConversionTest.java
@@ -195,12 +195,12 @@ public class TypeConversionTest extends CrateUnitTest {
             List.of(DataTypes.UNDEFINED, DataTypes.GEO_POINT, DataTypes.GEO_SHAPE, DataTypes.UNTYPED_OBJECT))) {
             assertThat(
                 "type '" + type + "' is not self convertible",
-                type.isConvertableTo(type), is(true));
+                type.isConvertableTo(type, false), is(true));
 
             ArrayType<?> arrayType = new ArrayType<>(type);
             assertThat(
                 "type '" +  arrayType + "' is not self convertible",
-                arrayType.isConvertableTo(arrayType), is(true));
+                arrayType.isConvertableTo(arrayType, false), is(true));
         }
     }
 
@@ -210,7 +210,7 @@ public class TypeConversionTest extends CrateUnitTest {
             DataTypes.PRIMITIVE_TYPES,
             Arrays.asList(DataTypes.GEO_POINT, DataTypes.GEO_SHAPE, DataTypes.UNTYPED_OBJECT))) {
 
-            assertFalse(DataTypes.NOT_SUPPORTED.isConvertableTo(type));
+            assertFalse(DataTypes.NOT_SUPPORTED.isConvertableTo(type, false));
         }
     }
 
@@ -219,29 +219,28 @@ public class TypeConversionTest extends CrateUnitTest {
         for (DataType<?> type : Lists2.concat(
             DataTypes.PRIMITIVE_TYPES,
             Arrays.asList(DataTypes.GEO_POINT, DataTypes.GEO_SHAPE, DataTypes.UNTYPED_OBJECT))) {
-            assertThat(type.isConvertableTo(DataTypes.UNDEFINED), is(false));
+            assertThat(type.isConvertableTo(DataTypes.UNDEFINED, false), is(false));
         }
-        assertThat(DataTypes.UNDEFINED.isConvertableTo(DataTypes.UNDEFINED), is(true));
+        assertThat(DataTypes.UNDEFINED.isConvertableTo(DataTypes.UNDEFINED, false), is(true));
     }
 
     @Test
     public void testGeoPointConversion() throws Exception {
-        assertThat(DataTypes.GEO_POINT.isConvertableTo(new ArrayType<>(DataTypes.DOUBLE)), is(true));
-        assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_POINT), is(true));
+        assertThat(DataTypes.GEO_POINT.isConvertableTo(new ArrayType<>(DataTypes.DOUBLE), false), is(true));
+        assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_POINT, false), is(true));
     }
 
     @Test
     public void testGeoShapeConversion() throws Exception {
-        DataType<?> objectType = DataTypes.UNTYPED_OBJECT;
-        assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_SHAPE), is(true));
-        assertThat(objectType.isConvertableTo(DataTypes.GEO_SHAPE), is(true));
+        assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_SHAPE, false), is(true));
+        assertThat(DataTypes.UNTYPED_OBJECT.isConvertableTo(DataTypes.GEO_SHAPE, false), is(true));
     }
 
     @Test
     public void testTimestampToDoubleConversion() {
-        assertThat(TimestampType.INSTANCE_WITH_TZ.isConvertableTo(DoubleType.INSTANCE),
+        assertThat(TimestampType.INSTANCE_WITH_TZ.isConvertableTo(DoubleType.INSTANCE, false),
             is(true));
-        assertThat(TimestampType.INSTANCE_WITHOUT_TZ.isConvertableTo(DoubleType.INSTANCE),
+        assertThat(TimestampType.INSTANCE_WITHOUT_TZ.isConvertableTo(DoubleType.INSTANCE, false),
             is(true));
 
     }
@@ -251,8 +250,8 @@ public class TypeConversionTest extends CrateUnitTest {
         var objectTypeWithInner = ObjectType.builder().setInnerType("field", DataTypes.STRING).build();
         var objectTypeWithoutInner = DataTypes.UNTYPED_OBJECT;
 
-        assertThat(objectTypeWithInner.isConvertableTo(objectTypeWithoutInner), is(true));
-        assertThat(objectTypeWithoutInner.isConvertableTo(objectTypeWithInner), is(true));
+        assertThat(objectTypeWithInner.isConvertableTo(objectTypeWithoutInner, false), is(true));
+        assertThat(objectTypeWithoutInner.isConvertableTo(objectTypeWithInner, false), is(true));
     }
 
     @Test
@@ -260,7 +259,7 @@ public class TypeConversionTest extends CrateUnitTest {
         var thisObj = ObjectType.builder().setInnerType("field", DataTypes.GEO_POINT).build();
         var thatObj = ObjectType.builder().setInnerType("field", DataTypes.INTEGER).build();
 
-        assertThat(thisObj.isConvertableTo(thatObj), is(false));
+        assertThat(thisObj.isConvertableTo(thatObj, false), is(false));
     }
 
     @Test
@@ -268,6 +267,6 @@ public class TypeConversionTest extends CrateUnitTest {
         var thisObj = ObjectType.builder().setInnerType("field1", DataTypes.INTEGER).build();
         var thatObj = ObjectType.builder().setInnerType("field2", DataTypes.INTEGER).build();
 
-        assertThat(thisObj.isConvertableTo(thatObj), is(false));
+        assertThat(thisObj.isConvertableTo(thatObj, false), is(false));
     }
 }


### PR DESCRIPTION
Casting literals used a special logic and resulted in immediately converted literals. Some plans relied on this logic and break if non-literals are used.
Early normalization of literal casts, over the special logic or by normalizing the `cast` function, removes relevant information maybe required by outer symbols (functions).
E.g. normalizing of array literals converts them into an array object and thus looses  the ability of using concrete type cast functionality of each literal array element.

All these issues can be solved by removing the early “on-function-resolving” normalization and early literal conversion.
Instead the complete symbol tree will be normalized after it has been build.

Additionally we differentiate between explicit and implicit casts.
This was already the case from a user perspective but internally hidden due to the special early literal cast (conversion) logic.
An example where explicit casts are possible but implicit casts not is the supported `ObjectType<->StringType` conversion to allow object literals of type JSON string.
This is still allowed on explicit casts but not on implicit ones.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
