### PR TITLE
Make some generic definitions explicit for eclipse jdt

### DIFF
--- a/server/src/main/java/io/crate/auth/AuthSettings.java
+++ b/server/src/main/java/io/crate/auth/AuthSettings.java
@@ -43,9 +43,16 @@ public final class AuthSettings {
     public static final CrateSetting<Settings> AUTH_HOST_BASED_CONFIG_SETTING = CrateSetting.of(Setting.groupSetting(
         "auth.host_based.config.", Setting.Property.NodeScope), DataTypes.UNTYPED_OBJECT);
 
-    public static final CrateSetting<String> AUTH_TRUST_HTTP_DEFAULT_HEADER = CrateSetting.of(new Setting<>(
-        "auth.trust.http_default_user", "crate", Function.identity(), Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final CrateSetting<String> AUTH_TRUST_HTTP_DEFAULT_HEADER = CrateSetting.of(
+        // Explicit generic is required for eclipse JDT, otherwise it won't compile
+        new Setting<String>(
+            "auth.trust.http_default_user",
+            "crate",
+            Function.identity(),
+            Setting.Property.NodeScope
+        ),
+        DataTypes.STRING
+    );
 
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
 }

--- a/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -71,9 +71,18 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
     public static final CrateSetting<Settings> DECOMMISSION_INTERNAL_SETTING_GROUP = CrateSetting.of(Setting.groupSetting(
         DECOMMISSION_PREFIX, Setting.Property.NodeScope, Setting.Property.Dynamic), DataTypes.UNTYPED_OBJECT);
 
-    public static final CrateSetting<DataAvailability> GRACEFUL_STOP_MIN_AVAILABILITY_SETTING = CrateSetting.of(new Setting<>(
-        "cluster.graceful_stop.min_availability", DataAvailability.PRIMARIES.name(), DataAvailability::of,
-        Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
+    public static final CrateSetting<DataAvailability> GRACEFUL_STOP_MIN_AVAILABILITY_SETTING = CrateSetting.of(
+        // Explicit generic is required for eclipse JDT, otherwise it won't compile
+        new Setting<DataAvailability>(
+            "cluster.graceful_stop.min_availability",
+            DataAvailability.PRIMARIES.name(),
+            DataAvailability::of,
+            Setting.Property.Dynamic,
+            Setting.Property.NodeScope
+        ),
+        DataTypes.STRING
+    );
+
     public static final CrateSetting<Boolean> GRACEFUL_STOP_FORCE_SETTING = CrateSetting.of(Setting.boolSetting(
         "cluster.graceful_stop.force", false, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.BOOLEAN);
     public static final CrateSetting<TimeValue> GRACEFUL_STOP_TIMEOUT_SETTING = CrateSetting.of(Setting.positiveTimeSetting(

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -94,7 +94,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
 
     private static final FilterValidator FILTER_VALIDATOR = new FilterValidator();
     public static final CrateSetting<String> STATS_JOBS_LOG_FILTER = CrateSetting.of(
-        new Setting<>(
+        // Explicit generic is required for eclipse JDT, otherwise it won't compile
+        new Setting<String>(
             "stats.jobs_log_filter",
             "true",
             Function.identity(),
@@ -104,7 +105,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
         DataTypes.STRING
     );
     public static final CrateSetting<String> STATS_JOBS_LOG_PERSIST_FILTER = CrateSetting.of(
-        new Setting<>(
+        // Explicit generic is required for eclipse JDT, otherwise it won't compile
+        new Setting<String>(
             "stats.jobs_log_persistent_filter",
             "false",
             Function.identity(),

--- a/server/src/main/java/io/crate/memory/MemoryManagerFactory.java
+++ b/server/src/main/java/io/crate/memory/MemoryManagerFactory.java
@@ -63,7 +63,8 @@ public final class MemoryManagerFactory implements Function<RamAccounting, Memor
 
     private static final Set<String> TYPES = Set.of(MemoryType.OFF_HEAP.value(), MemoryType.ON_HEAP.value());
     public static final CrateSetting<String> MEMORY_ALLOCATION_TYPE = CrateSetting.of(
-        new Setting<>(
+        // Explicit generic is required for eclipse JDT, otherwise it won't compile
+        new Setting<String>(
             "memory.allocation.type",
             MemoryType.ON_HEAP.value(),
             input -> {

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
@@ -73,7 +73,9 @@ public class PostgresNetty extends AbstractLifecycleComponent {
     public static final CrateSetting<Boolean> PSQL_ENABLED_SETTING = CrateSetting.of(Setting.boolSetting(
         "psql.enabled", true,
         Setting.Property.NodeScope), DataTypes.BOOLEAN);
-    public static final CrateSetting<String> PSQL_PORT_SETTING = CrateSetting.of(new Setting<>(
+
+    // Explicit generic is required for eclipse JDT, otherwise it won't compile
+    public static final CrateSetting<String> PSQL_PORT_SETTING = CrateSetting.of(new Setting<String>(
         "psql.port", "5432-5532",
         Function.identity(), Setting.Property.NodeScope), DataTypes.STRING);
 

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -102,13 +102,17 @@ public final class TransportAnalyzeAction {
             INVOKE_ANALYZE,
             AnalyzeRequest::new,
             ThreadPool.Names.SAME, // goes async right away
-            new NodeActionRequestHandler<>(req -> fetchSamplesThenGenerateAndPublishStats())
+            // Explicit generic is required for eclipse JDT, otherwise it won't compile
+            new NodeActionRequestHandler<AnalyzeRequest, AcknowledgedResponse>(
+                req -> fetchSamplesThenGenerateAndPublishStats()
+            )
         );
         transportService.registerRequestHandler(
             FETCH_SAMPLES,
             FetchSampleRequest::new,
             ThreadPool.Names.SEARCH,
-            new NodeActionRequestHandler<>(
+            // Explicit generic is required for eclipse JDT, otherwise it won't compile
+            new NodeActionRequestHandler<FetchSampleRequest, FetchSampleResponse>(
                 req -> completedFuture(new FetchSampleResponse(
                     reservoirSampler.getSamples(req.relation(), req.columns(), req.maxSamples())))
             )
@@ -117,7 +121,8 @@ public final class TransportAnalyzeAction {
             RECEIVE_TABLE_STATS,
             PublishTableStatsRequest::new,
             ThreadPool.Names.SAME, // cheap operation
-            new NodeActionRequestHandler<>(
+            // Explicit generic is required for eclipse JDT, otherwise it won't compile
+            new NodeActionRequestHandler<PublishTableStatsRequest, AcknowledgedResponse>(
                 req -> {
                     tableStats.updateTableStats(req.tableStats());
                     return completedFuture(new AcknowledgedResponse(true));

--- a/server/src/main/java/io/crate/udc/service/UDCService.java
+++ b/server/src/main/java/io/crate/udc/service/UDCService.java
@@ -47,9 +47,12 @@ public class UDCService extends AbstractLifecycleComponent {
     public static final CrateSetting<Boolean> UDC_ENABLED_SETTING = CrateSetting.of(Setting.boolSetting(
         "udc.enabled", true,
         Setting.Property.NodeScope), DataTypes.BOOLEAN);
-    public static final CrateSetting<String> UDC_URL_SETTING = CrateSetting.of(new Setting<>(
+
+    // Explicit generic is required for eclipse JDT, otherwise it won't compile
+    public static final CrateSetting<String> UDC_URL_SETTING = CrateSetting.of(new Setting<String>(
         "udc.url", "https://udc.crate.io/",
         Function.identity(), Setting.Property.NodeScope), DataTypes.STRING);
+
     public static final CrateSetting<TimeValue> UDC_INITIAL_DELAY_SETTING = CrateSetting.of(Setting.positiveTimeSetting(
         "udc.initial_delay", new TimeValue(10, TimeUnit.MINUTES),
         Setting.Property.NodeScope), DataTypes.STRING);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For some reason these caused compile errors if using eclipse.jdt.ls

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)