### PR TITLE
Load sql features entries on-demand

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/files/SqlFeatures.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/SqlFeatures.java
@@ -30,27 +30,23 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
-public class SqlFeaturesIterable implements Iterable<SqlFeatureContext> {
+public final class SqlFeatures {
 
     private static final int NUM_COLS = 7;
 
-    private final List<SqlFeatureContext> featuresList;
-
-    public SqlFeaturesIterable() throws IOException {
-        try (InputStream sqlFeatures = SqlFeaturesIterable.class.getResourceAsStream("/sql_features.tsv")) {
+    public static Iterable<SqlFeatureContext> loadFeatures() throws IOException {
+        try (InputStream sqlFeatures = SqlFeatures.class.getResourceAsStream("/sql_features.tsv")) {
             if (sqlFeatures == null) {
                 throw new ResourceNotFoundException("sql_features.tsv file not found");
             }
+            ArrayList<SqlFeatureContext> featuresList = new ArrayList<>();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(sqlFeatures, StandardCharsets.UTF_8))) {
-                featuresList = new ArrayList<>();
-                SqlFeatureContext ctx;
                 String next;
                 while ((next = reader.readLine()) != null) {
                     List<String> parts = List.of(next.split("\t", NUM_COLS));
-                    ctx = new SqlFeatureContext(parts.get(0),
+                    var ctx = new SqlFeatureContext(parts.get(0),
                         parts.get(1),
                         parts.get(2),
                         parts.get(3),
@@ -60,11 +56,7 @@ public class SqlFeaturesIterable implements Iterable<SqlFeatureContext> {
                     featuresList.add(ctx);
                 }
             }
+            return featuresList;
         }
-    }
-
-    @Override
-    public Iterator<SqlFeatureContext> iterator() {
-        return featuresList.iterator();
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FilesIterablesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FilesIterablesTest.java
@@ -38,10 +38,9 @@ public class FilesIterablesTest {
 
     @Test
     public void testSqlFeatureIterable() throws Exception {
-        SqlFeaturesIterable featuresIterable = new SqlFeaturesIterable();
-        Iterator iterator = featuresIterable.iterator();
+        Iterator<SqlFeatureContext> iterator = SqlFeatures.loadFeatures().iterator();
         assertTrue(iterator.hasNext());
-        SqlFeatureContext context = (SqlFeatureContext) iterator.next();
+        SqlFeatureContext context = iterator.next();
         assertEquals("B011", context.featureId);
         assertEquals("Embedded Ada", context.featureName);
         assertEquals("", context.subFeatureId);
@@ -56,7 +55,7 @@ public class FilesIterablesTest {
     @Test
     public void testSummitsIterable() throws Exception {
         SummitsIterable summitsIterable = new SummitsIterable();
-        Iterator iterator = summitsIterable.iterator();
+        var iterator = summitsIterable.iterator();
         assertTrue(iterator.hasNext());
         assertThat(Iterators.size(iterator), is(1605));
         assertFalse(iterator.hasNext());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The table is queried so rarely that there is no need to keep the data
in-memory.

Queries on the table still return in ~1-2ms

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)