### PR TITLE
Lower http netty worker count in tests to 1

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -71,6 +71,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
@@ -177,6 +178,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(SETTING_HTTP_COMPRESSION.getKey(), false)
+            .put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1)
             .put(PSQL_PORT_SETTING.getKey(), 0);
         if (randomBoolean()) {
             builder.put("memory.allocation.type", "off-heap");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Only a small fraction of the tests use HTTP. Most go either through
pgwire or use the sessions directly. We can reduce the load a bit by
lowering the worker count for http.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)