### PR TITLE
Add Bulk Delete Api to BlobStore

### DIFF
--- a/blackbox/test_s3.py
+++ b/blackbox/test_s3.py
@@ -124,3 +124,7 @@ class S3SnapshotIntegrationTest(unittest.TestCase):
                 c.execute('SELECT COUNT(*) FROM t1')
                 rowcount = c.fetchone()[0]
                 self.assertEqual(rowcount, 3)
+                c.execute('DROP SNAPSHOT r1.s1')
+                c.execute('''SELECT COUNT(*) FROM sys.snapshots WHERE name = 's1' ''')
+                rowcount = c.fetchone()[0]
+                self.assertEqual(rowcount, 0)

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
@@ -62,27 +60,6 @@ class S3BlobStore implements BlobStore {
         this.cannedACL = initCannedACL(cannedACL);
         this.storageClass = initStorageClass(storageClass);
         this.metadata = metadata;
-
-        // Note: the method client.doesBucketExist() may return 'true' is the bucket exists
-        // but we don't have access to it (ie, 403 Forbidden response code)
-        try (AmazonS3Reference clientReference = clientReference()) {
-            try {
-                clientReference.client().headBucket(new HeadBucketRequest(bucket));
-            } catch (final AmazonServiceException e) {
-                if (e.getStatusCode() == 301) {
-                    throw new IllegalArgumentException("the bucket [" + bucket + "] is in a different region than you configured", e);
-                } else if (e.getStatusCode() == 403) {
-                    throw new IllegalArgumentException("you do not have permissions to access the bucket [" + bucket + "]", e);
-                } else if (e.getStatusCode() == 404) {
-                    throw new IllegalArgumentException(
-                            "the bucket [" + bucket + "] does not exist;"
-                                    + " please create it before creating an S3 snapshot repository backed by it",
-                            e);
-                } else {
-                    throw new IllegalArgumentException("error checking the existence of bucket [" + bucket + "]", e);
-                }
-            }
-        }
     }
 
     @Override

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -1,23 +1,20 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
- *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.repositories.s3;
@@ -30,8 +27,6 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
-import com.amazonaws.services.s3.model.HeadBucketResult;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -144,12 +139,6 @@ import static org.hamcrest.Matchers.nullValue;
             }
         }
         return listing;
-    }
-
-    @Override
-    public HeadBucketResult headBucket(HeadBucketRequest request) throws SdkClientException {
-        assertThat(request.getBucketName(), equalTo(bucket));
-        return new HeadBucketResult();
     }
 
     @Override

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -57,7 +57,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-class MockAmazonS3 extends AbstractAmazonS3 {
+    class MockAmazonS3 extends AbstractAmazonS3 {
 
     private final ConcurrentMap<String, byte[]> blobs;
     private final String bucket;

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -77,7 +77,7 @@ public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
 
     @Override
     @Test
-    public void testDeleteBlob() {
+    public void testDeleteBlobs() {
         assumeFalse("not implemented because of S3's weak consistency model", true);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -103,7 +104,7 @@ public interface BlobContainer {
     }
 
     /**
-     * Deletes a blob with giving name, if the blob exists. If the blob does not exist,
+     * Deletes the blob with the given name, if the blob exists. If the blob does not exist,
      * this method throws a NoSuchFileException.
      *
      * @param   blobName
@@ -112,6 +113,33 @@ public interface BlobContainer {
      * @throws  IOException if the blob exists but could not be deleted.
      */
     void deleteBlob(String blobName) throws IOException;
+
+    /**
+     * Deletes the blobs with given names. Unlike {@link #deleteBlob(String)} this method will not throw an exception
+     * when one or multiple of the given blobs don't exist and simply ignore this case.
+     *
+     * @param   blobNames  The names of the blob to delete.
+     * @throws  IOException if a subset of blob exists but could not be deleted.
+     */
+    default void deleteBlobsIgnoringIfNotExists(List<String> blobNames) throws IOException {
+        IOException ioe = null;
+        for (String blobName : blobNames) {
+            try {
+                deleteBlob(blobName);
+            } catch (NoSuchFileException e) {
+                // ignored
+            } catch (IOException e) {
+                if (ioe == null) {
+                    ioe = e;
+                } else {
+                    ioe.addSuppressed(e);
+                }
+            }
+        }
+        if (ioe != null) {
+            throw ioe;
+        }
+    }
 
     /**
      * Deletes a blob with giving name, ignoring if the blob does not exist.

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -217,13 +217,14 @@ public class RepositoriesService implements ClusterStateApplier {
 
     public void verifyRepository(final String repositoryName, final ActionListener<VerifyResponse> listener) {
         final Repository repository = repository(repositoryName);
+        final boolean readOnly = repository.isReadOnly();
         try {
             threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() -> {
                 try {
                     final String verificationToken = repository.startVerification();
                     if (verificationToken != null) {
                         try {
-                            verifyAction.verify(repositoryName, verificationToken, new ActionListener<VerifyResponse>() {
+                            verifyAction.verify(repositoryName, readOnly, verificationToken, new ActionListener<VerifyResponse>() {
                                 @Override
                                 public void onResponse(VerifyResponse verifyResponse) {
                                     threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() -> {

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -66,7 +67,7 @@ public class VerifyNodeRepositoryAction {
         transportService.registerRequestHandler(ACTION_NAME, VerifyNodeRepositoryRequest::new, ThreadPool.Names.SNAPSHOT, new VerifyNodeRepositoryRequestHandler());
     }
 
-    public void verify(String repository, String verificationToken, final ActionListener<VerifyResponse> listener) {
+    public void verify(String repository, boolean readOnly, String verificationToken, final ActionListener<VerifyResponse> listener) {
         final DiscoveryNodes discoNodes = clusterService.state().nodes();
         final DiscoveryNode localNode = discoNodes.getLocalNode();
 
@@ -74,6 +75,9 @@ public class VerifyNodeRepositoryAction {
         final List<DiscoveryNode> nodes = new ArrayList<>();
         for (ObjectCursor<DiscoveryNode> cursor : masterAndDataNodes) {
             DiscoveryNode node = cursor.value;
+            if (readOnly && node.getVersion().before(Version.V_4_2_0)) {
+                continue;
+            }
             nodes.add(node);
         }
         final CopyOnWriteArrayList<VerificationFailure> errors = new CopyOnWriteArrayList<>();

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -659,12 +659,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public String startVerification() {
         try {
             if (isReadOnly()) {
-                // TODO: add repository verification for read-only repositories
-
-                // It's readonly - so there is not much we can do here to verify it apart try to create blobStore()
-                // and check that is is accessible on the master
-                blobStore();
-                return null;
+                // It's readonly - so there is not much we can do here to verify it apart from reading the blob store metadata
+                latestIndexBlobId();
+                return "read-only";
             } else {
                 String seed = UUIDs.randomBase64UUID();
                 byte[] testBytes = seed.getBytes(StandardCharsets.UTF_8);
@@ -683,13 +680,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     @Override
     public void endVerification(String seed) {
-        if (isReadOnly()) {
-            throw new UnsupportedOperationException("shouldn't be called");
-        }
-        try {
-            blobStore().delete(basePath().add(testBlobPrefix(seed)));
-        } catch (IOException exp) {
-            throw new RepositoryVerificationException(metadata.name(), "cannot delete test data at " + basePath(), exp);
+        if (isReadOnly() == false) {
+            try {
+                blobStore().delete(basePath().add(testBlobPrefix(seed)));
+            } catch (IOException exp) {
+                throw new RepositoryVerificationException(metadata.name(), "cannot delete test data at " + basePath(), exp);
+            }
         }
     }
 
@@ -919,20 +915,29 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public void verify(String seed, DiscoveryNode localNode) {
         assertSnapshotOrGenericThread();
-        BlobContainer testBlobContainer = blobStore().blobContainer(basePath().add(testBlobPrefix(seed)));
-        if (testBlobContainer.blobExists("master.dat")) {
+        if (isReadOnly()) {
             try {
-                BytesArray bytes = new BytesArray(seed);
-                try (InputStream stream = bytes.streamInput()) {
-                    testBlobContainer.writeBlob("data-" + localNode.getId() + ".dat", stream, bytes.length(), true);
-                }
-            } catch (IOException exp) {
-                throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() + "] is not accessible on the node [" + localNode + "]", exp);
+                latestIndexBlobId();
+            } catch (IOException e) {
+                throw new RepositoryVerificationException(metadata.name(), "path " + basePath() +
+                                                                           " is not accessible on node " + localNode, e);
             }
         } else {
-            throw new RepositoryVerificationException(metadata.name(), "a file written by master to the store [" + blobStore() + "] cannot be accessed on the node [" + localNode + "]. "
-                + "This might indicate that the store [" + blobStore() + "] is not shared between this node and the master node or "
-                + "that permissions on the store don't allow reading files written by the master node");
+            BlobContainer testBlobContainer = blobStore().blobContainer(basePath().add(testBlobPrefix(seed)));
+            if (testBlobContainer.blobExists("master.dat")) {
+                try {
+                    BytesArray bytes = new BytesArray(seed);
+                    try (InputStream stream = bytes.streamInput()) {
+                        testBlobContainer.writeBlob("data-" + localNode.getId() + ".dat", stream, bytes.length(), true);
+                    }
+                } catch (IOException exp) {
+                    throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() + "] is not accessible on the node [" + localNode + "]", exp);
+                }
+            } else {
+                throw new RepositoryVerificationException(metadata.name(), "a file written by master to the store [" + blobStore() + "] cannot be accessed on the node [" + localNode + "]. "
+                                                                           + "This might indicate that the store [" + blobStore() + "] is not shared between this node and the master node or "
+                                                                           + "that permissions on the store don't allow reading files written by the master node");
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -112,7 +112,6 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -446,7 +445,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         indexMetaData = getSnapshotIndexMetaData(snapshotId, indexId);
                     } catch (ElasticsearchParseException | IOException ex) {
                         LOGGER.warn(() ->
-                            new ParameterizedMessage("[{}] [{}] failed to read metadata for index", snapshotId, index), ex);
+                                        new ParameterizedMessage("[{}] [{}] failed to read metadata for index", snapshotId, index), ex);
                     }
 
                     deleteIndexMetaDataBlobIgnoringErrors(snapshot, indexId);
@@ -458,7 +457,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             } catch (SnapshotException ex) {
                                 final int finalShardId = shardId;
                                 LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to delete shard data for shard [{}][{}]",
-                                    snapshotId, index, finalShardId), ex);
+                                                                           snapshotId, index, finalShardId), ex);
                             }
                         }
                     }
@@ -469,26 +468,21 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             final Collection<IndexId> indicesToCleanUp = Sets.newHashSet(repositoryData.getIndices().values());
             indicesToCleanUp.removeAll(updatedRepositoryData.getIndices().values());
             final BlobContainer indicesBlobContainer = blobStore().blobContainer(basePath().add("indices"));
-            for (final IndexId indexId : indicesToCleanUp) {
-                try {
-                    indicesBlobContainer.deleteBlob(indexId.getId());
-                } catch (DirectoryNotEmptyException dnee) {
-                    // if the directory isn't empty for some reason, it will fail to clean up;
-                    // we'll ignore that and accept that cleanup didn't fully succeed.
-                    // since we are using UUIDs for path names, this won't be an issue for
-                    // snapshotting indices of the same name
-                    LOGGER.debug(() -> new ParameterizedMessage("[{}] index [{}] no longer part of any snapshots in the repository, but failed to clean up " +
-                            "its index folder due to the directory not being empty.", metadata.name(), indexId), dnee);
-                } catch (IOException ioe) {
-                    // a different IOException occurred while trying to delete - will just log the issue for now
-                    LOGGER.debug(() -> new ParameterizedMessage("[{}] index [{}] no longer part of any snapshots in the repository, but failed to clean up " +
-                            "its index folder.", metadata.name(), indexId), ioe);
-                }
+            try {
+                indicesBlobContainer.deleteBlobsIgnoringIfNotExists(
+                    indicesToCleanUp.stream().map(IndexId::getId).collect(Collectors.toList()));
+            } catch (IOException ioe) {
+                // a different IOException occurred while trying to delete - will just log the issue for now
+                LOGGER.warn(() ->
+                                new ParameterizedMessage(
+                                    "[{}] indices {} are no longer part of any snapshots in the repository, " +
+                                    "but failed to clean up their index folders.", metadata.name(), indicesToCleanUp), ioe);
             }
         } catch (IOException | ResourceNotFoundException ex) {
             throw new RepositoryException(metadata.name(), "failed to delete snapshot [" + snapshotId + "]", ex);
         }
     }
+
 
     private void deleteSnapshotBlobIgnoringErrors(final SnapshotInfo snapshotInfo, final String blobId) {
         try {
@@ -1049,16 +1043,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             try {
                 // Delete temporary index files first, as we might otherwise fail in the next step creating the new index file if an earlier
                 // attempt to write an index file with this generation failed mid-way after creating the temporary file.
-                for (final String blobName : blobs.keySet()) {
-                    if (FsBlobContainer.isTempBlobName(blobName)) {
-                        try {
-                            blobContainer.deleteBlobIgnoringIfNotExists(blobName);
-                        } catch (IOException e) {
-                            LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete index blob [{}] during finalization",
-                                snapshotId, shardId, blobName), e);
-                            throw e;
-                        }
-                    }
+                final List<String> blobNames =
+                    blobs.keySet().stream().filter(FsBlobContainer::isTempBlobName).collect(Collectors.toList());
+                try {
+                    blobContainer.deleteBlobsIgnoringIfNotExists(blobNames);
+                } catch (IOException e) {
+                    LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete index blobs {} during finalization",
+                                                               snapshotId, shardId, blobNames), e);
+                    throw e;
                 }
 
                 // If we deleted all snapshots, we don't need to create a new index file
@@ -1067,28 +1059,26 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
 
                 // Delete old index files
-                for (final String blobName : blobs.keySet()) {
-                    if (blobName.startsWith(SNAPSHOT_INDEX_PREFIX)) {
-                        try {
-                            blobContainer.deleteBlobIgnoringIfNotExists(blobName);
-                        } catch (IOException e) {
-                            LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete index blob [{}] during finalization",
-                                snapshotId, shardId, blobName), e);
-                            throw e;
-                        }
-                    }
+                final List<String> indexBlobs =
+                    blobs.keySet().stream().filter(blob -> blob.startsWith(SNAPSHOT_INDEX_PREFIX)).collect(Collectors.toList());
+                try {
+                    blobContainer.deleteBlobsIgnoringIfNotExists(indexBlobs);
+                } catch (IOException e) {
+                    LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete index blobs {} during finalization",
+                                                               snapshotId, shardId, indexBlobs), e);
+                    throw e;
                 }
 
                 // Delete all blobs that don't exist in a snapshot
-                for (final String blobName : blobs.keySet()) {
-                    if (blobName.startsWith(DATA_BLOB_PREFIX) && (updatedSnapshots.findNameFile(canonicalName(blobName)) == null)) {
-                        try {
-                            blobContainer.deleteBlobIgnoringIfNotExists(blobName);
-                        } catch (IOException e) {
-                            LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete data blob [{}] during finalization",
-                                snapshotId, shardId, blobName), e);
-                        }
-                    }
+                final List<String> orphanedBlobs = blobs.keySet().stream()
+                    .filter(blobName ->
+                                blobName.startsWith(DATA_BLOB_PREFIX) && updatedSnapshots.findNameFile(canonicalName(blobName)) == null)
+                    .collect(Collectors.toList());
+                try {
+                    blobContainer.deleteBlobsIgnoringIfNotExists(orphanedBlobs);
+                } catch (IOException e) {
+                    LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to delete data blobs {} during finalization",
+                                                               snapshotId, shardId, orphanedBlobs), e);
                 }
             } catch (IOException e) {
                 String message = "Failed to finalize " + reason + " with shard index [" + currentIndexGen + "]";


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/40322 and depending 
https://github.com/elastic/elasticsearch/pull/35731

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
