### PR TITLE
Remove the cast function per data type mapping.

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -57,7 +57,6 @@ import io.crate.expression.scalar.SubscriptFunctions;
 import io.crate.expression.scalar.arithmetic.ArrayFunction;
 import io.crate.expression.scalar.arithmetic.MapFunction;
 import io.crate.expression.scalar.arithmetic.NegateFunctions;
-import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.symbol.Function;
@@ -574,16 +573,11 @@ public class ExpressionAnalyzer {
         @Override
         protected Symbol visitTryCast(TryCast node, ExpressionAnalysisContext context) {
             DataType<?> returnType = DataTypeAnalyzer.convert(node.getType());
-
-            if (CastFunctionResolver.supportsExplicitConversion(returnType)) {
-                try {
-                    return node.getExpression().accept(this, context).cast(returnType, true, true);
-                } catch (ConversionException e) {
-                    return Literal.NULL;
-                }
+            try {
+                return node.getExpression().accept(this, context).cast(returnType, true, true);
+            } catch (ConversionException e) {
+                return Literal.NULL;
             }
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "No cast function found for return type %s", returnType.getName()));
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -21,55 +21,22 @@
 
 package io.crate.expression.scalar.cast;
 
-import io.crate.common.collections.Lists2;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.ArrayType;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
-import io.crate.types.TypeSignature;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
+import static io.crate.expression.scalar.cast.CastFunction.CAST_NAME;
+import static io.crate.expression.scalar.cast.CastFunction.TRY_CAST_NAME;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.DataTypes.GEO_POINT;
-import static io.crate.types.DataTypes.GEO_SHAPE;
-import static io.crate.types.DataTypes.PRIMITIVE_TYPES;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class CastFunctionResolver {
-
-    public static final String TRY_CAST_PREFIX = "try_";
-    private static final String TO_PREFIX = "to_";
-
-    static final Map<String, DataType> CAST_SIGNATURES; // cast function name -> data type
-
-    static {
-        List<DataType> CAST_FUNC_TYPES = Lists2.concat(
-            PRIMITIVE_TYPES,
-            List.of(GEO_SHAPE, GEO_POINT, DataTypes.UNTYPED_OBJECT, DataTypes.UNDEFINED));
-
-        CAST_SIGNATURES = new HashMap<>((CAST_FUNC_TYPES.size()) * 2);
-        for (var type : CAST_FUNC_TYPES) {
-            CAST_SIGNATURES.put(castFuncName(type), type);
-
-            var arrayType = new ArrayType<>(type);
-            CAST_SIGNATURES.put(castFuncName(arrayType), arrayType);
-        }
-    }
-
-    static String castFuncName(DataType type) {
-        return TO_PREFIX + type.getName();
-    }
 
     public static Symbol generateCastFunction(Symbol sourceSymbol,
                                               DataType<?> targetType,
@@ -79,13 +46,18 @@ public class CastFunctionResolver {
         if (!sourceType.isConvertableTo(targetType, explicitCast)) {
             throw new ConversionException(sourceType, targetType);
         }
+
         // Currently, it is not possible to resolve a function based on
         // its return type. For instance, it is not possible to generate
         // an object cast function with the object return type which inner
         // types have to be considered as well. Therefore, to bypass this
         // limitation we encode the return type info as the second function
         // argument.
-        var info = functionInfo(List.of(sourceType, targetType), targetType, tryCast);
+        var info = FunctionInfo.of(
+            tryCast ? TRY_CAST_NAME : CAST_NAME,
+            List.of(sourceType, targetType),
+            targetType
+        );
         return new Function(
             info,
             createSignature(info),
@@ -94,39 +66,12 @@ public class CastFunctionResolver {
             null);
     }
 
-    /**
-     * resolve the needed conversion function info based on the wanted return data type
-     */
-    static FunctionInfo functionInfo(List<DataType> dataTypes, DataType returnType, boolean tryCast) {
-        var castFunctionName = castFuncName(returnType);
-        if (CAST_SIGNATURES.get(castFunctionName) == null) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "No cast function found for return type %s",
-                    returnType.getName()));
-        }
-        castFunctionName = tryCast ? TRY_CAST_PREFIX + castFunctionName : castFunctionName;
-        return new FunctionInfo(new FunctionIdent(castFunctionName, dataTypes), returnType);
-    }
-
     static Signature createSignature(FunctionInfo functionInfo) {
-        DataType<?> returnType = functionInfo.returnType();
-        TypeSignature returnTypeSignature = returnType.getTypeSignature();
-        if (returnType.id() == ObjectType.ID) {
-            returnTypeSignature = DataTypes.UNTYPED_OBJECT.getTypeSignature();
-        }
         return Signature.scalar(
             functionInfo.ident().fqnName(),
             parseTypeSignature("E"),
-            parseTypeSignature("E"),
-            returnTypeSignature
-        ).withTypeVariableConstraints(typeVariable("E"));
-    }
-
-    public static boolean supportsExplicitConversion(DataType returnType) {
-        return CAST_SIGNATURES.containsKey(castFuncName(returnType));
-    }
-
-    public static boolean isCastFunction(String name) {
-        return name.startsWith(TRY_CAST_PREFIX) || name.startsWith(TO_PREFIX);
+            parseTypeSignature("V"),
+            parseTypeSignature("V")
+        ).withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -35,7 +35,6 @@ import io.crate.expression.scalar.SubscriptObjectFunction;
 import io.crate.expression.scalar.SubscriptRecordFunction;
 import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
 import io.crate.expression.scalar.arithmetic.ArrayFunction;
-import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
@@ -61,9 +60,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static io.crate.expression.scalar.cast.CastFunction.CAST_SQL_NAME;
-import static io.crate.expression.scalar.cast.CastFunction.TRY_CAST_SQL_NAME;
-import static io.crate.expression.scalar.cast.CastFunctionResolver.TRY_CAST_PREFIX;
+import static io.crate.expression.scalar.cast.CastFunction.CAST_NAME;
+import static io.crate.expression.scalar.cast.CastFunction.TRY_CAST_NAME;
 import static java.util.Objects.requireNonNull;
 
 public class Function extends Symbol implements Cloneable {
@@ -311,7 +309,8 @@ public class Function extends Symbol implements Cloneable {
             default:
                 if (name.startsWith(AnyOperator.OPERATOR_PREFIX)) {
                     printAnyOperator(builder, style);
-                } else if (CastFunctionResolver.isCastFunction(name)) {
+                } else if (name.equalsIgnoreCase(CAST_NAME) ||
+                           name.equalsIgnoreCase(TRY_CAST_NAME)) {
                     printCastFunction(builder, style);
                 } else if (name.startsWith(Operator.PREFIX)) {
                     printOperator(builder, style, null);
@@ -353,9 +352,6 @@ public class Function extends Symbol implements Cloneable {
     }
 
     private void printCastFunction(StringBuilder builder, Style style) {
-        String prefix = info.ident().name().startsWith(TRY_CAST_PREFIX)
-            ? TRY_CAST_SQL_NAME
-            : CAST_SQL_NAME;
         final String asTypeName;
         DataType<?> dataType = info.returnType();
         if (DataTypes.isArray(dataType)) {
@@ -368,7 +364,7 @@ public class Function extends Symbol implements Cloneable {
         } else {
             asTypeName = " AS " + dataType.getName();
         }
-        builder.append(prefix)
+        builder.append(info.ident().name())
             .append("(");
         builder.append(arguments().get(0).toString(style));
         builder

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -39,6 +39,7 @@ import io.crate.expression.operator.GtOperator;
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.LtOperator;
 import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.scalar.cast.CastFunction;
 import io.crate.expression.scalar.conditional.CoalesceFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -325,16 +326,26 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Function symbol2 = (Function) executor.asSymbol("doc.t5.w = doc.t2.i + 1.2");
         assertThat(symbol2, isFunction(EqOperator.NAME));
         assertThat(symbol2.arguments().get(0), isReference("w"));
-        assertThat(symbol2.arguments().get(1), isFunction("to_bigint"));
-        assertThat(symbol2.arguments().get(1).valueType(), is(DataTypes.LONG));
+        assertThat(
+            symbol2.arguments().get(1),
+            isFunction(
+                CastFunction.CAST_NAME,
+                List.of(DataTypes.INTEGER, DataTypes.LONG)
+            )
+        );
     }
 
     @Test
     public void testColumnsCanBeCastedWhenOnBothSidesOfOperator() {
         Function symbol = (Function) executor.asSymbol("doc.t5.i < doc.t5.w");
         assertThat(symbol, isFunction(LtOperator.NAME));
-        assertThat(symbol.arguments().get(0), isFunction("to_bigint"));
-        assertThat(symbol.arguments().get(0).valueType(), is(DataTypes.LONG));
+        assertThat(
+            symbol.arguments().get(0),
+            isFunction(
+                CastFunction.CAST_NAME,
+                List.of(DataTypes.INTEGER, DataTypes.LONG)
+            )
+        );
         assertThat(symbol.arguments().get(1).valueType(), is(DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -34,7 +34,6 @@ import org.locationtech.spatial4j.shape.Point;
 import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
-import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
 public class LiteralTest extends CrateUnitTest {
@@ -111,8 +110,14 @@ public class LiteralTest extends CrateUnitTest {
     }
 
     @Test
-    public void testCasting() {
+    public void test_cast_on_literal_returns_cast_function() {
         Symbol intLiteral = Literal.of(1);
-        assertThat(intLiteral.cast(DataTypes.LONG), isFunction("to_bigint"));
+        assertThat(
+            intLiteral.cast(DataTypes.LONG),
+            isFunction(
+                CastFunction.CAST_NAME,
+                List.of(intLiteral.valueType(), DataTypes.LONG)
+            )
+        );
     }
 }

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -35,6 +35,7 @@ import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.TopNProjection;
+import io.crate.expression.scalar.cast.CastFunction;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.PartitionName;
@@ -356,7 +357,16 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             instanceOf(EvalProjection.class),
             instanceOf(ColumnIndexWriterProjection.class)));
         EvalProjection collectTopN = (EvalProjection) collectPhase.projections().get(1);
-        assertThat(collectTopN.outputs(), contains(isInputColumn(0), isFunction("to_text")));
+        assertThat(
+            collectTopN.outputs(),
+            contains(
+                isInputColumn(0),
+                isFunction(
+                    CastFunction.CAST_NAME,
+                    List.of(DataTypes.LONG, DataTypes.STRING)
+                )
+            )
+        );
 
         ColumnIndexWriterProjection columnIndexWriterProjection = (ColumnIndexWriterProjection) collectPhase.projections().get(2);
         assertThat(columnIndexWriterProjection.columnReferencesExclPartition(), contains(isReference("id"), isReference("name")));
@@ -421,7 +431,10 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat(projections.get(0).outputs(),
             contains(
-                isFunction("to_bigint"),
+                isFunction(
+                    CastFunction.CAST_NAME,
+                    List.of(DataTypes.INTEGER, DataTypes.LONG)
+                ),
                 isInputColumn(1)
             )
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently, we maintained the cast function per data type mapping.
The name of the target data type is part of the cast function name,
it looks as following `to_<type>` or for the try cast `try_<type>`.
Each cast function has the following signature:

    `try_<target_type>(source_type, target_type):target_type`

or

    `to_<target_type>(source_type, target_type):target_type`

that obviously duplicates information about the target type.

This commit replaces the cast function per data type mapping with
the two cast function with the following signatures:

    `cast(source_type, target_type):target_type`
    `try_cast(source_type, target_type):target_type`

instead of **~70** registered cast functions.

This is a backwards-compatible change. The cast functions were never
stored in the metadata with names under which they were registered,
e.g. `to_bigint`, etc. The symbol printer was always converting them
into the following format:

    `cast(source as target_type)`
or

    `try_cast(source as target_type)`

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
