### PR TITLE
Fix contribution attribution (mailcap)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,9 +1,10 @@
 <christian.haudum@gmail.com> <christian@rjdj.me>
-<matthias@crate.io> <matthiasfelsche@m7f6.de>
-<matthias@crate.io> <matthiaswahl@m7w3.de>
-<matthias@crate.io> <mfelsche@users.noreply.github.com>
-<matthias@crate.io> <wahl@crate-technology.com>
-<matthias@crate.io> <wahl@crate.io>
+Matthias Wahl <matthias@crate.io>
+Matthias Wahl <matthias@crate.io> <matthiasfelsche@m7f6.de>
+Matthias Wahl <matthias@crate.io> <matthiaswahl@m7w3.de>
+Matthias Wahl <matthias@crate.io> <mfelsche@users.noreply.github.com>
+Matthias Wahl <matthias@crate.io> <wahl@crate-technology.com>
+Matthias Wahl <matthias@crate.io> <wahl@crate.io>
 Bernd Dorn <bernddorn@gmail.com>
 Bernhard Kuzel <bernhard.kuzel@gmail.com>
 Lukas Ender <hello@lukasender.at>


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The email got re-used and contributions got attributed to the wrong person.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)