### PR TITLE
Use COMPLETE_NO_SCORES ScoreMode in GroupByOptimizedIterator

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -297,7 +297,7 @@ final class GroupByOptimizedIterator {
                                                                        AtomicReference<Throwable> killed,
                                                                        AtomicBoolean closed) throws IOException {
         final HashMap<BytesRef, Object[]> statesByKey = new HashMap<>();
-        final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE, 1f);
+        final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
         final List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
         Object[] nullStates = null;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits.


- We don't need scores there
- Use killed reference also for close checks in GroupByOptimizedIterator


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)