### PR TITLE
Add the ip type support for the right CIDR operand.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -131,6 +131,9 @@ SQL Standard and PostgreSQL compatibility improvements
 Functions and operators
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+- Added the :ref:`ip <ip-type>` data type support for the right operand of
+  the ``CIDR`` operator.
+
 - Replaced the ``Nashorn`` JavaScript engine with ``GraalVM`` for JavaScript
   :ref:`user-defined functions <sql_administration_udf>`. This change upgrades
   ``ECMAScript`` support from ``5.1`` to ``10.0``.

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -202,8 +202,8 @@ Example::
     SQLActionException[SQLParseException: Cannot cast `'not.a.real.ip'` of type `text` to type `ip`]
 
 Ip addresses support the binary operator `<<`, which checks for subnet inclusion
-using `CIDR notation`_ [ip address/prefix_length]. The left operand must be of
-type ``ip`` and the right of ``text`` e.g. `'192.168.1.5' << '192.168.1/24'`.
+using `CIDR notation`_ [ip address/prefix_length]. The left and right operands
+must be of type ``ip``.
 
 .. _date-time-types:
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See ``<<`` in PostgreSQL https://www.postgresql.org/docs/10/functions-net.html

This would make it possible to base `IpType` on `DataType` instead of `StringType`. https://github.com/crate/crate/pull/10018

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
