### PR TITLE
Fallback to last applied settings when updating settings with dependencies

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -202,6 +202,9 @@ Performance improvements
 Fixes
 =====
 
+- Fixed an issue that could prevent updating settings that depend on other
+  settings. For example ``"cluster.routing.allocation.disk.watermark.low"``
+
 - Fixed an issue that caused the ``ANALYZE`` statement to fail if there are
   tables with object arrays in the cluster.
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -552,6 +552,10 @@ public class Setting<T> implements ToXContentObject {
         return Collections.emptySet();
     }
 
+    public Iterator<Setting<T>> getValidationDependencies() {
+        return validator.settings();
+    }
+
     /**
      * Build a new updater with a noop validator.
      */


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The validation of changes to settings like `...watermark.low` didn't
consider the active values of it's dependencies if they weren't changed
within the same request.

The following worked:

    set global "cluster.routing.allocation.disk.watermark.low" = '91%', "cluster.routing.allocation.disk.watermark.high" = '95%';

But doing the same in two steps didn't:

    set global "cluster.routing.allocation.disk.watermark.high" = '95%';
    set global "cluster.routing.allocation.disk.watermark.low" = '91%';

`low` depends on `high`, and it validated against the *default*
value if the `high` value wasn't submitted within the same request
instead of the last applied value.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)