### PR TITLE
Insert into support for `varchar(length)`

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/StringUtils.java
+++ b/libs/shared/src/main/java/io/crate/common/StringUtils.java
@@ -23,10 +23,9 @@
 package io.crate.common;
 
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.annotation.Nullable;
 
 public final class StringUtils {
 
@@ -52,5 +51,21 @@ public final class StringUtils {
             return null;
         }
         return value.toString();
+    }
+
+    /**
+     * Checks if a string is blank within the specified range.
+     * {@code start} index is inclusive, {@code end} is exclusive.
+     *
+     * @return {@code false} if any character within the range is not
+     * an unicode space character, otherwise, {@code false}.
+     */
+    public static boolean isBlank(String string, int start, int end) {
+        for (int i = start; i < end; i++) {
+            if (!Character.isSpaceChar(string.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -57,5 +57,4 @@ public interface InsertSourceGen {
         }
         return new InsertSourceFromCells(txnCtx, functions, table, indexName, validation, targets);
     }
-
 }

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -31,6 +31,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
+import io.crate.types.StringType;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -140,6 +141,9 @@ public class PGTypes {
 
             case RowType.ID:
                 return new RecordType(Lists2.map(((RowType) type).fieldTypes(), PGTypes::get));
+
+            case StringType.ID:
+                return VarCharType.INSTANCE;
 
             default: {
                 PGType pgType = CRATE_TO_PG_TYPES.get(type);

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -105,6 +105,16 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
         return implicitCast(value);
     }
 
+    /**
+     * To prepare a value of the same {@link DataType<T>} for insertion.
+     *
+     * @param value The value of the {@link DataType<T>}.
+     * @return The prepared for insertion value of the {@link DataType<T>}.
+     */
+    public T valueForInsert(Object value) {
+        return (T) value;
+    }
+
     public abstract T value(Object value) throws IllegalArgumentException, ClassCastException;
 
     public TypeSignature getTypeSignature() {

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -141,7 +141,7 @@ public final class DataTypes {
             entry(NotSupportedType.ID, in -> NOT_SUPPORTED),
             entry(ByteType.ID, in -> BYTE),
             entry(BooleanType.ID, in -> BOOLEAN),
-            entry(StringType.ID, in -> STRING),
+            entry(StringType.ID, StringType::new),
             entry(IpType.ID, in -> IP),
             entry(DoubleType.ID, in -> DOUBLE),
             entry(FloatType.ID, in -> FLOAT),

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -39,6 +39,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.crate.common.StringUtils.isBlank;
+
 public class StringType extends DataType<String> implements Streamer<String> {
 
     public static final int ID = 4;
@@ -148,6 +150,29 @@ public class StringType extends DataType<String> implements Streamer<String> {
             return string;
         } else {
             return string.substring(0, lengthLimit);
+        }
+    }
+
+    @Override
+    public String valueForInsert(Object value) {
+        if (value == null) {
+            return null;
+        }
+        assert value instanceof String
+            : "valueForInsert must be called only on objects of String type";
+        var string = (String) value;
+        if (unbound() || string.length() <= lengthLimit) {
+            return string;
+        } else {
+            if (isBlank(string, lengthLimit, string.length())) {
+                return string.substring(0, lengthLimit);
+            } else {
+                if (string.length() > 20) {
+                    string = string.substring(0, 20) + "...";
+                }
+                throw new IllegalArgumentException(
+                    "'" + string + "' is too long for the text type of length: " + lengthLimit);
+            }
         }
     }
 

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -67,6 +68,14 @@ public class StringType extends DataType<String> implements Streamer<String> {
 
     private StringType(int lengthLimit) {
         this.lengthLimit = lengthLimit;
+    }
+
+    public StringType(StreamInput in) throws IOException {
+        if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
+            lengthLimit = in.readInt();
+        } else {
+            lengthLimit = Integer.MAX_VALUE;
+        }
     }
 
     protected StringType() {
@@ -205,6 +214,13 @@ public class StringType extends DataType<String> implements Streamer<String> {
     @Override
     public void writeValueTo(StreamOutput out, String v) throws IOException {
         out.writeOptionalString(v);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (out.getVersion().onOrAfter(Version.V_4_2_0)) {
+            out.writeInt(lengthLimit);
+        }
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1585,6 +1585,21 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
         assertThat(response.rows()[1][0], is(3));
         assertThat(response.rows()[1][1], is("new"));
+    }
 
+    @Test
+    public void test_insert_from_values_and_subquery_into_varchar_with_length_column() {
+        execute("CREATE TABLE t1 (str varchar(3)) CLUSTERED INTO 1 SHARDS");
+
+        execute("INSERT INTO t1 (str) VALUES ('abc'), ('abc   ')");
+        execute("INSERT INTO t1 (str) (SELECT UNNEST(['bcd', 'bcd   ']))");
+        execute("REFRESH TABLE t1");
+
+        assertThat(
+            printedTable(execute("SELECT * FROM t1").rows()),
+            is("abc\n" +
+               "abc\n" +
+               "bcd\n" +
+               "bcd\n"));
     }
 }

--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -51,22 +51,21 @@ public class ArrayTypeTest extends CrateUnitTest {
     @Test
     public void testArrayTypeSerialization() throws Exception {
         // nested string array: [ ["x"], ["y"] ]
-        ArrayType arrayType = new ArrayType<>(new ArrayType<>(StringType.INSTANCE));
+        ArrayType<?> arrayType = new ArrayType<>(new ArrayType<>(StringType.INSTANCE));
         BytesStreamOutput out = new BytesStreamOutput();
 
         DataTypes.toStream(arrayType, out);
 
         StreamInput in = out.bytes().streamInput();
 
-        DataType readType = DataTypes.fromStream(in);
+        DataType<?> readType = DataTypes.fromStream(in);
         assertThat(readType, instanceOf(ArrayType.class));
 
-        ArrayType readArrayType = (ArrayType) readType;
+        ArrayType<?> readArrayType = (ArrayType<?>) readType;
         assertThat(readArrayType.innerType(), instanceOf(ArrayType.class));
 
-        ArrayType readInnerArrayType = (ArrayType) readArrayType.innerType();
-        assertThat(readInnerArrayType.innerType(), instanceOf(StringType.class));
-        assertSame(readInnerArrayType.innerType(), StringType.INSTANCE);
+        ArrayType<?> readInnerArrayType = (ArrayType<?>) readArrayType.innerType();
+        assertThat(readInnerArrayType.innerType(), is(StringType.INSTANCE));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -110,6 +110,30 @@ public class StringTypeTest extends CrateUnitTest {
     }
 
     @Test
+    public void test_value_for_insert_text_with_length_on_literals_of_length_lte_length() {
+        assertThat(StringType.of(4).valueForInsert("abcd"), is("abcd"));
+        assertThat(StringType.of(3).valueForInsert("a"), is("a"));
+    }
+
+    @Test
+    public void test_value_for_insert_text_without_length_does_not_change_input_value() {
+        assertThat(StringType.INSTANCE.valueForInsert("abcd"), is("abcd"));
+    }
+
+    @Test
+    public void test_value_for_insert_text_with_length_trims_exceeding_chars_if_they_are_whitespaces() {
+        assertThat(StringType.of(2).valueForInsert("a    "), is("a "));
+        assertThat(StringType.of(2).valueForInsert("ab  "), is("ab"));
+    }
+
+    @Test
+    public void test_value_for_insert_text_with_length_for_literal_exceeding_length_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("'abcd' is too long for the text type of length: 3");
+        StringType.of(3).valueForInsert("abcd");
+    }
+
+    @Test
     public void test_create_text_type_with_negative_length_limit_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("The text type length must be at least 1, received: -1");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
