### PR TITLE
Base data type comparison on its IDs in relevant places.

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -304,10 +304,10 @@ public class AnalyzedColumnDefinition<T> {
         Settings storageSettings = GenericPropertiesConverter.genericPropertiesToSettings(definition.storageProperties);
         for (String property : storageSettings.names()) {
             if (property.equals(COLUMN_STORE_PROPERTY)) {
-                DataType dataType = definition.dataType();
+                DataType<?> dataType = definition.dataType();
                 boolean val = storageSettings.getAsBoolean(property, true);
                 if (val == false) {
-                    if (dataType != DataTypes.STRING) {
+                    if (!DataTypes.isSameType(dataType, DataTypes.STRING)) {
                         throw new IllegalArgumentException(
                             String.format(Locale.ENGLISH, "Invalid storage option \"columnstore\" for data type \"%s\"",
                                           dataType.getName()));

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -542,7 +542,7 @@ public class AnalyzedTableElements<T> {
             }
             throw new ColumnUnknownException(partitionedByIdent.sqlFqn(), relationName);
         }
-        DataType columnType = columnDefinition.dataType();
+        DataType<?> columnType = columnDefinition.dataType();
         if (!DataTypes.isPrimitive(columnType)) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                              "Cannot use column %s of type %s in PARTITIONED BY clause",

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -235,7 +235,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         for (int i = 0; i < leftOutputs.size(); i++) {
             var leftType = leftOutputs.get(i).valueType();
             var rightType = rightOutputs.get(i).valueType();
-            if (!DataTypes.compareTypesById(leftType, rightType)) {
+            if (!DataTypes.isSameType(leftType, rightType)) {
                 throw new UnsupportedOperationException(
                     "Corresponding output columns at position: " + (i + 1) +
                     " must be compatible for all parts of a UNION");

--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -67,7 +67,7 @@ public class SemanticSortValidator {
 
         @Override
         public Void visitFunction(Function symbol, SortContext context) {
-            if (!context.inFunction && !DataTypes.PRIMITIVE_TYPES.contains(symbol.valueType())) {
+            if (!context.inFunction && !DataTypes.isPrimitive(symbol.valueType())) {
                 throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH,
                                   "Cannot %s '%s': invalid return type '%s'.",
@@ -98,7 +98,7 @@ public class SemanticSortValidator {
         public Void visitSymbol(Symbol symbol, SortContext context) {
             // if we are in a function, we do not need to check the data type.
             // the function will do that for us.
-            if (!context.inFunction && !DataTypes.PRIMITIVE_TYPES.contains(symbol.valueType())) {
+            if (!context.inFunction && !DataTypes.isPrimitive(symbol.valueType())) {
                 throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH,
                                   "Cannot %s '%s': invalid data type '%s'.",

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -99,10 +99,11 @@ public class FileCollectSource implements CollectSource {
                                                       Functions functions,
                                                       Symbol targetUri) {
         Object value = SymbolEvaluator.evaluate(txnCtx, functions, targetUri, Row.EMPTY, SubQueryResults.EMPTY);
-        if (targetUri.valueType() == DataTypes.STRING) {
+        if (DataTypes.isSameType(targetUri.valueType(), DataTypes.STRING)) {
             String uri = (String) value;
             return Collections.singletonList(uri);
-        } else if (targetUri.valueType() instanceof ArrayType && ((ArrayType) targetUri.valueType()).innerType() == DataTypes.STRING) {
+        } else if (DataTypes.isArray(targetUri.valueType()) &&
+                   DataTypes.isSameType(ArrayType.unnest(targetUri.valueType()), DataTypes.STRING)) {
             //noinspection unchecked
             return (List<String>) value;
         }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -346,7 +346,7 @@ public class ProjectionToProjectorVisitor
         StringBuilder sb = new StringBuilder(uri);
         Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME, context.txnCtx);
         assert resolvedFileName instanceof Literal : "resolvedFileName must be a Literal, but is: " + resolvedFileName;
-        assert resolvedFileName.valueType() == StringType.INSTANCE :
+        assert DataTypes.isSameType(resolvedFileName.valueType(), StringType.INSTANCE) :
             "resolvedFileName.valueType() must be " + StringType.INSTANCE;
 
         String fileName = (String) ((Literal) resolvedFileName).value();

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -21,15 +21,6 @@
 
 package io.crate.metadata.information;
 
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.BOOLEAN;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.NUMERIC_PRIMITIVE_TYPES;
-import static io.crate.types.DataTypes.TIMESTAMPZ;
-import static io.crate.types.DataTypes.TIMESTAMP;
-
-import java.util.Map;
-
 import io.crate.expression.reference.information.ColumnContext;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -37,11 +28,20 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.types.ByteType;
+import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
+
+import java.util.Map;
+
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.TIMESTAMP;
+import static io.crate.types.DataTypes.TIMESTAMPZ;
 
 
 public class InformationColumnsTableInfo {
@@ -85,7 +85,7 @@ public class InformationColumnsTableInfo {
             .add("character_octet_length", INTEGER, ignored -> null)
             .add("numeric_precision", INTEGER, r -> PRECISION_BY_TYPE_ID.get(r.info.valueType().id()))
             .add("numeric_precision_radix", INTEGER, r -> {
-                if (NUMERIC_PRIMITIVE_TYPES.contains(r.info.valueType())) {
+                if (DataTypes.isNumericPrimitive(r.info.valueType())) {
                     return NUMERIC_PRECISION_RADIX;
                 }
                 return null;

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -209,7 +209,7 @@ public class LogicalPlanner {
             OrderBy relationOrderBy = queriedRelation.orderBy();
             Symbol firstOutput = queriedRelation.outputs().get(0);
             if ((relationOrderBy == null || relationOrderBy.orderBySymbols().get(0).equals(firstOutput) == false)
-                && DataTypes.PRIMITIVE_TYPES.contains(firstOutput.valueType())) {
+                && DataTypes.isPrimitive(firstOutput.valueType())) {
 
                 return Order.create(planBuilder, new OrderBy(Collections.singletonList(firstOutput)));
             }

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -105,7 +105,7 @@ public class Union implements LogicalPlan {
         ResultDescription leftResultDesc = left.resultDescription();
         ResultDescription rightResultDesc = right.resultDescription();
 
-        assert DataTypes.compareTypesById(leftResultDesc.streamOutputs(), rightResultDesc.streamOutputs())
+        assert DataTypes.isSameType(leftResultDesc.streamOutputs(), rightResultDesc.streamOutputs())
             : "Left and right must output the same types, got " +
               "lhs=" + leftResultDesc.streamOutputs() + ", rhs=" + rightResultDesc.streamOutputs();
 

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -140,7 +140,7 @@ public final class TransportAnalyzeAction {
             for (TableInfo table : schema.getTables()) {
                 List<Reference> primitiveColumns = StreamSupport.stream(table.spliterator(), false)
                     .filter(x -> !x.column().isSystemColumn())
-                    .filter(x -> DataTypes.PRIMITIVE_TYPES.contains(x.valueType()))
+                    .filter(x -> DataTypes.isPrimitive(x.valueType()))
                     .map(x -> table.getReadReference(x.column()))
                     .collect(Collectors.toList());
 

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -108,6 +108,12 @@ public final class DataTypes {
         TIMESTAMP
     );
 
+    private static final Set<Integer> PRIMITIVE_TYPE_IDS =
+        PRIMITIVE_TYPES.stream()
+            .map(DataType::id)
+            .collect(toSet());
+
+
     public static final Set<DataType> STORAGE_UNSUPPORTED = Set.of(
         INTERVAL
     );
@@ -120,6 +126,11 @@ public final class DataTypes {
         INTEGER,
         LONG
     );
+
+    private static final Set<Integer> NUMERIC_PRIMITIVE_TYPE_IDS =
+        NUMERIC_PRIMITIVE_TYPES.stream()
+            .map(DataType::id)
+            .collect(toSet());
 
     /**
      * Type registry mapping type ids to the according data type instance.
@@ -407,8 +418,20 @@ public final class DataTypes {
         return MAPPING_NAMES_TO_TYPES.get(name);
     }
 
-    public static boolean isPrimitive(DataType type) {
-        return PRIMITIVE_TYPES.contains(type);
+    /**
+     * Checks if the {@link DataType} is a primitive data type.
+     * The parameters of the data type are ignored.
+     */
+    public static boolean isPrimitive(DataType<?> type) {
+        return PRIMITIVE_TYPE_IDS.contains(type.id());
+    }
+
+    /**
+     * Checks if the {@link DataType} is a numeric primitive data type.
+     * The parameters of the data type are ignored.
+     */
+    public static boolean isNumericPrimitive(DataType<?> type) {
+        return NUMERIC_PRIMITIVE_TYPE_IDS.contains(type.id());
     }
 
     /**
@@ -434,26 +457,34 @@ public final class DataTypes {
         return streamer;
     }
 
-    public static boolean compareTypesById(DataType<?> left, DataType<?> right) {
+    /**
+     * Compares any two {@link DataType} by their IDs.
+     * The parameters of the data types, if they have any, are ignored.
+     */
+    public static boolean isSameType(DataType<?> left, DataType<?> right) {
         if (left.id() != right.id()) {
             return false;
         } else if (isArray(left)) {
-            return compareTypesById(
-                ((ArrayType) left).innerType(),
-                ((ArrayType) right).innerType());
+            return isSameType(
+                ((ArrayType<?>) left).innerType(),
+                ((ArrayType<?>) right).innerType());
         } else {
             return true;
         }
     }
 
-    public static boolean compareTypesById(List<DataType> left, List<DataType> right) {
+    /**
+     * Compares two {@link List<DataType>} by their IDs.
+     * The parameters of the data types, if they have any, are ignored.
+     */
+    public static boolean isSameType(List<DataType> left, List<DataType> right) {
         if (left.size() != right.size()) {
             return false;
         }
         assert left instanceof RandomAccess && right instanceof RandomAccess
             : "data type lists should support RandomAccess for fast lookups";
         for (int i = 0; i < left.size(); i++) {
-            if (!compareTypesById(left.get(i), right.get(i))) {
+            if (!isSameType(left.get(i), right.get(i))) {
                 return false;
             }
         }

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static io.crate.types.DataTypes.compareTypesById;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
@@ -295,33 +294,33 @@ public class DataTypesTest extends CrateUnitTest {
     }
 
     @Test
-    public void test_compare_by_id_primitive_types() {
-        assertThat(compareTypesById(DataTypes.STRING, DataTypes.STRING), is(true));
-        assertThat(compareTypesById(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
+    public void test_is_same_type_on_primitive_types() {
+        assertThat(DataTypes.isSameType(DataTypes.STRING, DataTypes.STRING), is(true));
+        assertThat(DataTypes.isSameType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
     }
 
     @Test
-    public void test_compare_by_id_complex_types() {
-        assertThat(compareTypesById(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY), is(false));
-        assertThat(compareTypesById(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT), is(false));
+    public void test_is_same_type_on_complex_types() {
+        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY), is(false));
+        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT), is(false));
     }
 
     @Test
-    public void test_compare_by_id_primitive_and_complex_types() {
-        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
-        assertThat(compareTypesById(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE), is(false));
+    public void test_is_same_type_on_primitive_and_complex_types() {
+        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
+        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE), is(false));
     }
 
     @Test
-    public void test_compare_by_id_array_types_of_the_same_dimension() {
-        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
-        assertThat(compareTypesById(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
+    public void test_is_same_type_on_array_types_of_the_same_dimension() {
+        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
+        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
     }
 
     @Test
-    public void test_compare_by_id_array_types_of_not_equal_dimension_and_same_inner_type() {
+    public void test_is_same_type_on_array_types_of_not_equal_dimension_and_same_inner_type() {
         assertThat(
-            compareTypesById(
+            DataTypes.isSameType(
                 new ArrayType<>(DataTypes.STRING_ARRAY),
                 DataTypes.STRING_ARRAY),
             is(false));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Some of the data types might contain parameters. At some places
e.g. SemanticSortValidator while comparing data types we are
not interested in checking for the strict equality, but rather
only whether the type IDs are the same.


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
