### PR TITLE
Increase SSL trust/keystore poll interval to 5m by default

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -85,6 +85,9 @@ Administration
   built. It means that ``CrateDB`` doesn't rely on ``JAVA_HOME`` of the host
   system any longer.
 
+- Increased the default interval to detect ``keystore`` or ``truststore``
+  changes to five minutes.
+
 
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -526,10 +526,10 @@ Layer Security (TLS).
 
 **ssl.resource_poll_interval**
   | *Runtime:* ``no``
-  | *Default:* ``10s``
+  | *Default:* ``5m``
 
   The frequency at which SSL files such as keystore and truststore are polled
-  for changes. Possible effective values are ``2s``, ``10s`` or ``30s``.
+  for changes.
 
 Cross-origin resource sharing (CORS)
 ====================================

--- a/server/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
+++ b/server/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
@@ -22,7 +22,6 @@
 
 package io.crate.protocols.ssl;
 
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
 import org.apache.logging.log4j.LogManager;
@@ -82,7 +81,7 @@ public final class SslConfigSettings {
     public static final CrateSetting<TimeValue> SSL_RESOURCE_POLL_INTERVAL = CrateSetting.of(
         new Setting<>(
             SSL_RESOURCE_POLL_INTERVAL_NAME,
-            TimeValue.timeValueSeconds(SensitivityWatchEventModifier.MEDIUM.sensitivityValueInSeconds()).getStringRep(),
+            TimeValue.timeValueMinutes(5).getStringRep(),
             new SslResourcePollIntervalParser(LOGGER),
             Setting.Property.NodeScope),
         DataTypes.STRING);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

An update to the keystore or truststore doesn't occur often. Usually it
is done to replace a certificate that is about to expire.

Polling every 10s seems a like waste of CPU cycles. It shouldn't matter
too much whether the reload happens within 10s or a couple of minutes,
as long as somebody doing the replacement gets some feedback eventually, without waiting too long.

5m seems like a good compromise.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)