### PR TITLE
Add primitive type value getters to Input and Row

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/Input.java
+++ b/libs/dex/src/main/java/io/crate/data/Input.java
@@ -25,4 +25,16 @@ package io.crate.data;
 public interface Input<T> {
 
     T value();
+
+    default boolean hasValue() {
+        return value() != null;
+    }
+
+    default long getLong() {
+        return ((Number) value()).longValue();
+    }
+
+    default double getDouble() {
+        return ((Number) value()).doubleValue();
+    }
 }

--- a/libs/shared/src/main/java/io/crate/data/Row.java
+++ b/libs/shared/src/main/java/io/crate/data/Row.java
@@ -67,6 +67,19 @@ public interface Row {
      */
     Object get(int index);
 
+    default boolean hasValue(int index) {
+        return get(index) != null;
+    }
+
+    default long getLong(int index) {
+        return ((Number) get(index)).longValue();
+    }
+
+    default double getDouble(int index) {
+        return ((Number) get(index)).doubleValue();
+    }
+
+
     /**
      * Returns a materialized view of this row.
      */

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -183,10 +183,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                                 AverageState state,
                                 Input... args) {
         if (state != null) {
-            Number value = (Number) args[0].value();
-            if (value != null) {
+            Input input = args[0];
+            if (input.hasValue()) {
                 state.count++;
-                state.sum += value.doubleValue();
+                state.sum += input.getDouble();
             }
         }
         return state;

--- a/server/src/main/java/io/crate/execution/engine/collect/InputCollectExpression.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/InputCollectExpression.java
@@ -26,7 +26,7 @@ import io.crate.data.Row;
 public class InputCollectExpression implements CollectExpression<Row, Object> {
 
     private final int position;
-    private Object value;
+    private Row row = null;
 
     public InputCollectExpression(int position) {
         this.position = position;
@@ -36,12 +36,33 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
     public void setNextRow(Row row) {
         assert row.numColumns() > position
             : "Wanted to retrieve value for column at position=" + position + " from row=" + row + " but row has only " + row.numColumns() + " columns";
-        value = row.get(position);
+        this.row = row;
     }
 
     @Override
     public Object value() {
-        return value;
+        if (row == null) {
+            return null;
+        }
+        return row.get(position);
+    }
+
+    @Override
+    public double getDouble() {
+        return row.getDouble(position);
+    }
+
+    @Override
+    public long getLong() {
+        return row.getLong(position);
+    }
+
+    @Override
+    public boolean hasValue() {
+        if (row == null) {
+            return false;
+        }
+        return row.hasValue(position);
     }
 
     @Override
@@ -52,7 +73,7 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
         InputCollectExpression that = (InputCollectExpression) o;
 
         if (position != that.position) return false;
-        if (value != null ? !value.equals(that.value) : that.value != null) return false;
+        if (row != null ? !row.equals(that.row) : that.row != null) return false;
 
         return true;
     }
@@ -60,7 +81,7 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
     @Override
     public int hashCode() {
         int result = position;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (row != null ? row.hashCode() : 0);
         return result;
     }
 

--- a/server/src/main/java/io/crate/expression/InputRow.java
+++ b/server/src/main/java/io/crate/expression/InputRow.java
@@ -47,6 +47,21 @@ public class InputRow implements Row {
     }
 
     @Override
+    public boolean hasValue(int index) {
+        return inputs.get(index).hasValue();
+    }
+
+    @Override
+    public double getDouble(int index) {
+        return inputs.get(index).getDouble();
+    }
+
+    @Override
+    public long getLong(int index) {
+        return inputs.get(index).getLong();
+    }
+
+    @Override
     public String toString() {
         return "InputRow{" +
                "inputs=" + inputs +

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
@@ -62,6 +62,34 @@ public class DoubleColumnReference extends LuceneCollectorExpression<Double> {
     }
 
     @Override
+    public double getDouble() {
+        try {
+            if (values.advanceExact(docId)) {
+                switch (values.docValueCount()) {
+                    case 1:
+                        return values.nextValue();
+
+                    default:
+                        throw new GroupByOnArrayUnsupportedException(columnName);
+                }
+            } else {
+                throw new NullPointerException("No value for docId: " + docId);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public boolean hasValue() {
+        try {
+            return values.advanceExact(docId) && values.docValueCount() == 1;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
     public void setNextDocId(int docId) {
         this.docId = docId;
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -76,6 +76,14 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void test_foo() throws Exception {
+        execute("create table tbl (x float)");
+        execute("insert into tbl (x) values (1.3), (4.3)");
+        execute("refresh table tbl");
+        execute("select avg(x) from tbl");
+    }
+
+    @Test
     public void testSelectResultContainsColumnsInTheOrderOfTheSelectListInTheQuery() throws Exception {
         execute("create table test (id string primary key)");
         execute("insert into test (id) values ('id1')");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Can be used to avoid boxing, reducing GC pressure:

    Q: select avg("adRevenue") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       79.766 ±   33.954 |     59.834 |     77.306 |     79.315 |    827.139 |
    |   V2    |       78.867 ±   45.859 |     60.119 |     75.772 |     77.997 |   1088.908 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   1.13%                           -   2.01%
    There is a 27.53% probability that the observed difference is not random, and the best estimate of that difference is 1.13%
    The test has no statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |    8    25.69    25.87 |    0     0.00     0.00 |     8590     2302 |   779.49      31376
     V2 |    0     0.00     0.00 |    0     0.00     0.00 |     8590        0 |     5.15        204

    V1 top allocation frames
      Float.valueOf(float):30764719292
      CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int):308680281
      899821166.get$Lambda(...):71253024
      1473265863.get$Lambda(...):57404392
      MatchAllDocsQuery.createWeight(...):30122432
    V2 top allocation frames
      CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int):46139392
      ParserATNSimulator.getEpsilonTarget(...):19663880
      Lucene80DocValuesProducer.getNumeric(...):12578816
      1029211416.get$Lambda(...):10461240
      1960783837.get$Lambda(...):8392704


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)