### PR TITLE
Add optimized global aggregates using doc-values

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -29,6 +29,9 @@ import io.crate.metadata.FunctionImplementation;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -110,5 +113,11 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                                               Input[] stateToRemove) {
         throw new UnsupportedOperationException("Cannot remove state from the aggregated state as the function is " +
                                                 "not removable cumulative");
+    }
+
+    @Nullable
+    @SuppressWarnings("rawtypes")
+    public DocValueAggregator<?> getDocValueAggregator(List<DataType> argumentTypes, List<MappedFieldType> fieldTypes) {
+        return null;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.LeafReader;
+
+public interface DocValueAggregator<T> {
+
+    public T initialState();
+
+    public void loadDocValues(LeafReader reader) throws IOException;
+
+    public void apply(T state, int doc) throws IOException;
+
+    // Aggregations are executed on shard level,
+    // that means there is always a final reduce step necessary
+    // → never return final value, but always partial result
+    @Nullable
+    public Object partialResult(T state);
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.index.engine.Engine.Searcher;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+
+import io.crate.common.collections.Lists2;
+import io.crate.data.BatchIterator;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.exceptions.Exceptions;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.AggregationProjection;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.dsl.projection.Projections;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.jobs.SharedShardContext;
+import io.crate.expression.symbol.Aggregation;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
+
+public class DocValuesAggregates {
+
+    @Nullable
+    public static BatchIterator<Row> tryOptimize(Functions functions,
+                                                 IndexShard indexShard,
+                                                 DocTableInfo table,
+                                                 LuceneQueryBuilder luceneQueryBuilder,
+                                                 FieldTypeLookup fieldTypeLookup,
+                                                 RoutedCollectPhase phase,
+                                                 CollectTask collectTask) {
+        var shardProjections = Projections.shardProjections(phase.projections());
+        AggregationProjection aggregateProjection = aggregateProjection(shardProjections);
+        if (aggregateProjection == null) {
+            return null;
+        }
+        var aggregators = createAggregators(
+            functions,
+            aggregateProjection,
+            fieldTypeLookup,
+            phase.toCollect()
+        );
+        if (aggregators == null) {
+            return null;
+        }
+        ShardId shardId = indexShard.shardId();
+        SharedShardContext shardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
+        Searcher searcher = shardContext.acquireSearcher(LuceneShardCollectorProvider.formatSource(phase));
+        try {
+            QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
+            collectTask.addSearcher(shardContext.readerId(), searcher);
+            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+                phase.where(),
+                collectTask.txnCtx(),
+                indexShard.mapperService(),
+                indexShard.shardId().getIndexName(),
+                queryShardContext,
+                table,
+                shardContext.indexService().cache()
+            );
+
+            AtomicReference<Throwable> killed = new AtomicReference<>();
+            return CollectingBatchIterator.newInstance(
+                () -> killed.set(BatchIterator.CLOSED),
+                killed::set,
+                () -> {
+                    try {
+                        return CompletableFuture.completedFuture(getRow(
+                            killed,
+                            searcher,
+                            queryContext.query(),
+                            aggregators
+                        ));
+                    } catch (Throwable t) {
+                        return CompletableFuture.failedFuture(t);
+                    }
+                },
+                true
+            );
+        } catch (Throwable t) {
+            searcher.close();
+            throw t;
+        }
+    }
+
+    @Nullable
+    private static MappedFieldType resolveInputToFieldType(FieldTypeLookup fieldTypeLookup,
+                                                           List<Symbol> toCollect,
+                                                           Symbol input) {
+        if (!(input instanceof InputColumn)) {
+            return null;
+        }
+        Symbol collectSymbol = toCollect.get(((InputColumn) input).index());
+        if (!(collectSymbol instanceof Reference)) {
+            return null;
+        }
+        MappedFieldType mappedFieldType = fieldTypeLookup.get(((Reference) collectSymbol).column().fqn());
+        if (mappedFieldType != null && !mappedFieldType.hasDocValues()) {
+            return null;
+        }
+        return mappedFieldType;
+    }
+
+    @Nullable
+    @SuppressWarnings("rawtypes")
+    private static List<DocValueAggregator> createAggregators(Functions functions,
+                                                              AggregationProjection aggregateProjection,
+                                                              FieldTypeLookup fieldTypeLookup,
+                                                              List<Symbol> toCollect) {
+        List<Aggregation> aggregations = aggregateProjection.aggregations();
+        ArrayList<DocValueAggregator> aggregator = new ArrayList<>(aggregations.size());
+        Function<Symbol, MappedFieldType> resolveFieldType =
+            symbol -> resolveInputToFieldType(fieldTypeLookup, toCollect, symbol);
+
+        for (int i = 0; i < aggregations.size(); i++) {
+            Aggregation aggregation = aggregations.get(i);
+            if (!aggregation.filter().equals(Literal.BOOLEAN_TRUE)) {
+                return null;
+            }
+            List<MappedFieldType> fieldTypes = Lists2.map(aggregation.inputs(), resolveFieldType);
+            if (fieldTypes.stream().anyMatch(Objects::isNull)) {
+                // We can extend this to instead return an adapter to the normal aggregation implementation
+                return null;
+            }
+
+            FunctionIdent functionIdent = aggregation.functionIdent();
+            FunctionImplementation func = functions.getQualified(
+                aggregation.signature(),
+                functionIdent.argumentTypes()
+            );
+            if (!(func instanceof AggregationFunction)) {
+                throw new IllegalStateException(
+                    "Expected an aggregationFunction for " + aggregation + " got: " + func);
+            }
+            DocValueAggregator<?> docValueAggregator = ((AggregationFunction<?, ?>) func).getDocValueAggregator(
+                functionIdent.argumentTypes(),
+                fieldTypes
+            );
+            if (docValueAggregator == null) {
+                return null;
+            } else {
+                aggregator.add(docValueAggregator);
+            }
+        }
+        return aggregator;
+    }
+
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Iterable<Row> getRow(AtomicReference<Throwable> killed,
+                                        Searcher searcher,
+                                        Query query,
+                                        List<DocValueAggregator> aggregators) throws IOException {
+        IndexSearcher indexSearcher = searcher.searcher();
+        Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+        Object[] cells = new Object[aggregators.size()];
+        for (int i = 0; i < aggregators.size(); i++) {
+            cells[i] = aggregators.get(i).initialState();
+        }
+        for (var leaf : leaves) {
+            Scorer scorer = weight.scorer(leaf);
+            if (scorer == null) {
+                continue;
+            }
+            for (int i = 0; i < aggregators.size(); i++) {
+                aggregators.get(i).loadDocValues(leaf.reader());
+            }
+            DocIdSetIterator docs = scorer.iterator();
+            Bits liveDocs = leaf.reader().getLiveDocs();
+            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                if (liveDocs != null && !liveDocs.get(doc)) {
+                    continue;
+                }
+                Throwable killCause = killed.get();
+                if (killCause != null) {
+                    Exceptions.rethrowUnchecked(killCause);
+                }
+                for (int i = 0; i < aggregators.size(); i++) {
+                    aggregators.get(i).apply(cells[i], doc);
+                }
+            }
+        }
+        for (int i = 0; i < aggregators.size(); i++) {
+            cells[i] = aggregators.get(i).partialResult(cells[i]);
+        }
+        return List.of(new RowN(cells));
+    }
+
+
+    @Nullable
+    private static AggregationProjection aggregateProjection(Collection<? extends Projection> shardProjections) {
+        if (shardProjections.size() != 1) {
+            return null;
+        }
+        var projection = shardProjections.iterator().next();
+        if (!(projection instanceof AggregationProjection)) {
+            return null;
+        }
+        return (AggregationProjection) projection;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -155,7 +155,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     @Nullable
     @Override
     protected BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase, CollectTask collectTask) {
-        return GroupByOptimizedIterator.tryOptimizeSingleStringKey(
+        var it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
             indexShard,
             table,
             luceneQueryBuilder,
@@ -163,6 +163,18 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             bigArrays,
             new InputFactory(functions),
             docInputFactory,
+            normalizedPhase,
+            collectTask
+        );
+        if (it != null) {
+            return it;
+        }
+        return DocValuesAggregates.tryOptimize(
+            functions,
+            indexShard,
+            table,
+            luceneQueryBuilder,
+            fieldTypeLookup,
             normalizedPhase,
             collectTask
         );

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -24,10 +24,24 @@ package io.crate.integrationtests;
 
 import org.junit.Test;
 
+import io.crate.testing.TestingHelpers;
+
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.CoreMatchers.is;
 
 public class AggregateExpressionIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void test_sum_int() throws Exception {
+        execute("create table tbl (x int)");
+        execute("insert into tbl (x) values (1), (2), (3)");
+        execute("refresh table tbl");
+
+        execute("select sum(x) from tbl");
+        assertThat(TestingHelpers.printedTable(response.rows()),
+            is("6\n")
+        );
+    }
 
     @Test
     public void test_filter_in_aggregate_expr_with_group_by() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    Q: select avg("adRevenue") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       80.198 ±   32.376 |     46.869 |     78.789 |     80.146 |    789.931 |
    |   V2    |       27.888 ±   20.782 |     23.429 |     25.451 |     26.543 |    480.902 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  96.79%                           - 102.34%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 96.79%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |    8    23.13    26.17 |    0     0.00     0.00 |     8590     2319 |   777.04      31413
     V2 |    0     0.00     0.00 |    0     0.00     0.00 |     8590        0 |    14.71        198

    V1 top allocation frames
      Float.valueOf(float):30818982785
      CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int):287010080
      169079530.get$Lambda(...):78850440
      291374498.get$Lambda(...):57452096
      MatchAllDocsQuery.createWeight(...):26222072
    V2 top allocation frames
      CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int):46133248
      ParserATNSimulator.getEpsilonTarget(...):12582912
      IndexInput.getFullSliceDescription(String):10487808
      Weight.scorerSupplier(...):1047961


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)