### PR TITLE
Add a tables column to sys.snapshots

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1893,6 +1893,10 @@ repositories (see :ref:`snapshot-restore`).
 |                      | how they are represented         |                              |
 |                      | as ES index names.               |                              |
 +----------------------+----------------------------------+------------------------------+
+| ``tables``           | Contains the fully qualified     | ``ARRAY(TEXT)``              |
+|                      | names of all tables within the   |                              |
+|                      | snapshot.                        |                              |
++----------------------+----------------------------------+------------------------------+
 | ``started``          | The point in time when the       | ``TIMESTAMP WITH TIME ZONE`` |
 |                      | creation of the snapshot         |                              |
 |                      | started. Changes made after      |                              |

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -88,6 +88,10 @@ Administration
 - Increased the default interval to detect ``keystore`` or ``truststore``
   changes to five minutes.
 
+- Added a ``tables`` column to the :ref:`sys.snapshots <sys-snapshots>` table
+  which lists the fully qualified name of all tables contained within the
+  snapshot.
+
 
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------

--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
@@ -22,6 +22,9 @@
 package io.crate.expression.reference.sys.snapshot;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
+import io.crate.metadata.RelationName;
 
 public class SysSnapshot {
 
@@ -83,5 +86,12 @@ public class SysSnapshot {
 
     public List<String> failures() {
         return snapshotShardFailures;
+    }
+
+    public List<String> tables() {
+        return concreteIndices.stream()
+            .map(RelationName::fqnFromIndexName)
+            .distinct()
+            .collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
@@ -45,6 +45,7 @@ public class SysSnapshotsTableInfo {
             .add("name", STRING, SysSnapshot::name)
             .add("repository", STRING, SysSnapshot::repository)
             .add("concrete_indices", STRING_ARRAY, SysSnapshot::concreteIndices)
+            .add("tables", STRING_ARRAY, SysSnapshot::tables)
             .add("started", TIMESTAMPZ, SysSnapshot::started)
             .add("finished", TIMESTAMPZ, SysSnapshot::finished)
             .add("version", STRING, SysSnapshot::version)

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -516,7 +516,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(785, response.rowCount());
+        assertEquals(786, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -139,15 +139,17 @@ public class SysSnapshotsTest extends SQLTransportIntegrationTest {
     public void testQueryAllColumns() {
         execute("select * from sys.snapshots");
         assertThat(response.rowCount(), is(1L));
-        assertThat(response.cols(), arrayContaining("concrete_indices", "failures", "finished", "name", "repository", "started", "state", "version"));
+        assertThat(response.cols(), arrayContaining("concrete_indices", "failures", "finished", "name", "repository", "started", "state", "tables", "version"));
+        ArrayType<String> stringArray = new ArrayType<>(DataTypes.STRING);
         assertThat(response.columnTypes(), arrayContaining(
-            new ArrayType<>(DataTypes.STRING),
-            new ArrayType<>(DataTypes.STRING),
+            stringArray,
+            stringArray,
             TimestampType.INSTANCE_WITH_TZ,
             StringType.INSTANCE,
             StringType.INSTANCE,
             TimestampType.INSTANCE_WITH_TZ,
             StringType.INSTANCE,
+            stringArray,
             StringType.INSTANCE
         ));
         Object[] firstRow = response.rows()[0];
@@ -158,7 +160,8 @@ public class SysSnapshotsTest extends SQLTransportIntegrationTest {
         assertThat(firstRow[4], is(REPOSITORY_NAME));
         assertThat((Long) firstRow[5], greaterThanOrEqualTo(createdTime));
         assertThat(firstRow[6], is(SnapshotState.SUCCESS.name()));
-        assertThat(firstRow[7], is(Version.CURRENT.toString()));
+        assertThat((List<Object>) firstRow[7], Matchers.contains(getFqn("test_table")));
+        assertThat(firstRow[8], is(Version.CURRENT.toString()));
 
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

More useful to users than the `concrete_indices` column.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)