### PR TITLE
Add scalar function CURRENT_TIME returning current time UTC with microsecond precision

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/TimePrecisionIncreaseTest.java
+++ b/benchmarks/src/test/java/io/crate/execution/TimePrecisionIncreaseTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution;
+
+import org.joda.time.DateTimeUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Measurement(iterations = 4)
+@Timeout(time=30000, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 10000, timeUnit = TimeUnit.MILLISECONDS)
+public class TimePrecisionIncreaseTest {
+
+    @Benchmark
+    public void currentTimeMillisOriginal(Blackhole blackhole) {
+        blackhole.consume(DateTimeUtils.currentTimeMillis());
+    }
+
+    @Benchmark
+    public void currentTimeMillisNextGen(Blackhole blackhole) {
+        Supplier<Long> currentTimeMillis = () -> {
+            Instant i = Clock.systemUTC().instant();
+            return (i.getEpochSecond() * 1000_000_000L + i.getNano()) / 1000_000L;
+        };
+        blackhole.consume(currentTimeMillis.get());
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Benchmark                                            Mode  Cnt  Score   Error  Units
+        // TimeIncreasePrecisionTest.currentTimeMillisNextGen   avgt    4  0.039 ± 0.001  us/op
+        // TimeIncreasePrecisionTest.currentTimeMillisOriginal  avgt    4  0.028 ± 0.001  us/op
+        new Runner(
+            new OptionsBuilder()
+                .include(TimePrecisionIncreaseTest.class.getSimpleName())
+                .build())
+            .run();
+    }
+}

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -130,6 +130,11 @@ Administration
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------
 
+- Added scalar function :ref:`CURRENT_TIME <current_time>`, that returns
+  the system's time as microseconds since midnight UTC, at the time the SQL
+  statement is handled. The actual return type is the new data type
+  :ref:`timetz <time-data-type>`.
+
 - Added new type :ref:`time with time zone <time-data-type>`, a.k.a `timetz`,
   which is to be used as return type for time related functions such as the
   future `current_time`.

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -805,6 +805,30 @@ The following fields are supported:
 .. _`available time zones`: http://www.joda.org/joda-time/timezones.html
 .. _`Joda-Time`: http://www.joda.org/joda-time/
 
+.. _current_time:
+
+``CURRENT_TIME``
+----------------
+
+The ``CURRENT_TIME`` expression returns the time in microseconds
+since midnight UTC at the time the SQL statement was handled. Clock
+time is looked up at most once within the scope of a single query, to
+ensure that multiple occurrences of ``CURRENT_TIME`` evaluate to the
+same value.
+
+synopsis::
+
+    CURRENT_TIME [ ( precision ) ]
+
+``precision`` must be a positive integer between 0 and 6. The default value is
+6. It determines the number of fractional seconds to output. A value of 0 means
+the time will have second precision, no fractional seconds (microseconds)
+are given.
+
+.. NOTE::
+   No guarantee is provided about the accuracy of the underlying clock,
+   results may be limited to millisecond precision, depending on the
+   system.
 
 .. _current_timestamp:
 
@@ -833,9 +857,8 @@ are given.
 
 .. NOTE::
 
-   The ``CURRENT_TIMESTAMP`` will be evaluated  using javas
-   ``System.currentTimeMillis()``. So its actual result depends on the
-   underlying operating system.
+   The return value of expressions ``CURRENT_TIMESTAMP`` and ``CURRENT_TIME``
+   depends on the system clock and the JVM implementation.
 
 .. _now:
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -448,7 +448,7 @@ equivalent to the SQL-conforming construct timestamp AT TIME ZONE zone.
 time with time zone
 -------------------
 
-The time type consist of time followed by an optional time zone.
+The time type consists of time followed by an optional time zone.
 
 ``timetz`` is an alias for `time with time zone`.
 

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -77,6 +77,7 @@ import io.crate.expression.scalar.systeminformation.ObjDescriptionFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
 import io.crate.expression.scalar.systeminformation.VersionFunction;
+import io.crate.expression.scalar.timestamp.CurrentTimeFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.scalar.timestamp.NowFunction;
 import io.crate.expression.scalar.timestamp.TimezoneFunction;
@@ -124,6 +125,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
 
         DateTruncFunction.register(this);
         ExtractFunctions.register(this);
+        CurrentTimeFunction.register(this);
         CurrentTimestampFunction.register(this);
         NowFunction.register(this);
         TimezoneFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -29,6 +29,9 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 public final class NowFunction extends Scalar<Long, Object> {
 
     public static final String NAME = "now";
@@ -54,7 +57,7 @@ public final class NowFunction extends Scalar<Long, Object> {
     @Override
     @SafeVarargs
     public final Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
-        return txnCtx.currentTimeMillis();
+        return ChronoUnit.MILLIS.between(Instant.EPOCH, txnCtx.currentInstant());
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -41,6 +41,7 @@ import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.scalar.cast.TryCastFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
+import io.crate.expression.scalar.timestamp.CurrentTimeFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.symbol.format.MatchPrinter;
 import io.crate.expression.symbol.format.Style;
@@ -336,6 +337,15 @@ public class Function extends Symbol implements Cloneable {
                     printFunctionWithParenthesis(builder, style);
                 }
                 break;
+
+            case CurrentTimeFunction.NAME:
+                if (arguments.isEmpty()) {
+                    builder.append("CURRENT_TIME");
+                } else {
+                    printFunctionWithParenthesis(builder, style);
+                }
+                break;
+
             default:
                 if (name.startsWith(AnyOperator.OPERATOR_PREFIX)) {
                     printAnyOperator(builder, style);

--- a/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -24,8 +24,8 @@ package io.crate.metadata;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.metadata.settings.SessionSettings;
-import org.joda.time.DateTimeUtils;
 
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -37,7 +37,7 @@ import java.util.Objects;
 public final class CoordinatorTxnCtx implements TransactionContext {
 
     private final SessionContext sessionContext;
-    private Long currentTimeMillis = null;
+    private Instant currentInstant;
 
     public static CoordinatorTxnCtx systemTransactionContext() {
         return new CoordinatorTxnCtx(SessionContext.systemSessionContext());
@@ -48,15 +48,15 @@ public final class CoordinatorTxnCtx implements TransactionContext {
     }
 
     /**
-     * @return current timestamp in ms. Subsequent calls will always return the same value. (Not thread-safe)
+     * @return current Instant. Subsequent calls will always return the same value. (Not thread-safe)
      */
     @Override
-    public long currentTimeMillis() {
-        if (currentTimeMillis == null) {
-            // no synchronization because StmtCtx is mostly used during single-threaded analysis phase
-            currentTimeMillis = DateTimeUtils.currentTimeMillis();
+    public Instant currentInstant() {
+        // no synchronization because StmtCtx is mostly used during single-threaded analysis phase
+        if (currentInstant == null) {
+            currentInstant = SystemClock.currentInstant();
         }
-        return currentTimeMillis;
+        return currentInstant;
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1052,13 +1052,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void testCreateTableWithCurrentTimestampAsGeneratedColumnIsntNormalized() {
         BoundCreateTable analysis = analyze(
-            "create table foo (ts timestamp with time zone GENERATED ALWAYS as current_timestamp)");
+            "create table foo (ts timestamp with time zone GENERATED ALWAYS as current_timestamp(3))");
 
         Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
         Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
         assertThat(generatedColumnsMapping.size(), is(1));
         // current_timestamp used to get evaluated and then this contained the actual timestamp instead of the function name
-        assertThat(generatedColumnsMapping.get("ts"), is("current_timestamp(3)")); // 3 is the default precision
+        assertThat(generatedColumnsMapping.get("ts"), is("current_timestamp(3)"));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1563,12 +1563,12 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void selectCurrentTimeStamp() {
+    public void selectCurrentTimestamp() {
         AnalyzedRelation relation = analyze("select CURRENT_TIMESTAMP from sys.cluster");
         assertThat(
             relation.outputs(),
             contains(
-                isFunction("current_timestamp", isLiteral(3))
+                isFunction("current_timestamp")
             )
         );
     }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -115,7 +115,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUnsupportedExpressionCurrentDate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported expression current_time");
+        expectedException.expectMessage("Unsupported expression current_date");
         SessionContext sessionContext = SessionContext.systemSessionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions, coordinatorTxnCtx, paramTypeHints,
@@ -126,7 +126,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
-        expressionAnalyzer.convert(SqlParser.createExpression("current_time"), expressionAnalysisContext);
+        expressionAnalyzer.convert(SqlParser.createExpression("current_date"), expressionAnalysisContext);
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
     protected SqlExpressions sqlExpressions;
     protected Functions functions;
     protected Map<RelationName, AnalyzedRelation> tableSources;
-    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    protected TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private InputFactory inputFactory;
 
     protected static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.timestamp;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.SystemClock;
+import io.crate.types.TimeTZ;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class CurrentTimeFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final long CURRENT_TIME_MILLIS = (10 * 3600 + 57 * 60 + 12) * 1000L; // 10:57:12 UTC
+
+    @Before
+    public void prepare() {
+        SystemClock.setCurrentMillisFixedUTC(CURRENT_TIME_MILLIS);
+    }
+
+    @After
+    public void cleanUp() {
+        SystemClock.setCurrentMillisSystemUTC();
+    }
+
+    private static TimeTZ microsFromMidnightUTC(Instant i) {
+        long dateTimeMicros = (i.getEpochSecond() * 1000_000_000L + i.getNano()) / 1000L;
+        long dateMicros = i.truncatedTo(ChronoUnit.DAYS).toEpochMilli() * 1000L;
+        return new TimeTZ(dateTimeMicros - dateMicros, 0);
+    }
+
+    @Test
+    public void time_is_created_correctly() {
+        TimeTZ expected = microsFromMidnightUTC(txnCtx.currentInstant());
+        assertEvaluate("current_time", expected);
+        assertEvaluate("current_time(6)", expected);
+    }
+
+    @Test
+    public void test_calls_within_statement_are_idempotent() {
+        assertEvaluate("current_time = current_time", true);
+    }
+
+    @Test
+    public void time_zero_precission() {
+        assertEvaluate("current_time(0)", microsFromMidnightUTC(txnCtx.currentInstant()));
+    }
+
+    @Test
+    public void precision_larger_than_6_raises_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("precision must be between [0..6]");
+        assertEvaluate("current_time(14)", null);
+    }
+
+    @Test
+    public void integerIsNormalizedToLiteral() {
+        assertNormalize("current_time(1)", instanceOf(Literal.class));
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -2,7 +2,7 @@ package io.crate.expression.scalar.timestamp;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.joda.time.DateTimeUtils;
+import io.crate.metadata.SystemClock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,12 +15,12 @@ public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepare() {
-        DateTimeUtils.setCurrentMillisFixed(EXPECTED_TIMESTAMP);
+        SystemClock.setCurrentMillisFixedUTC(EXPECTED_TIMESTAMP);
     }
 
     @After
     public void cleanUp() {
-        DateTimeUtils.setCurrentMillisSystem();
+        SystemClock.setCurrentMillisSystemUTC();
     }
 
     @Test
@@ -53,6 +53,11 @@ public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Precision must be between 0 and 3");
         assertEvaluate("current_timestamp(4)", null);
+    }
+
+    @Test
+    public void test_calls_within_statement_are_idempotent() {
+        assertEvaluate("current_timestamp(3) = current_timestamp(3)", true);
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
@@ -23,7 +23,7 @@
 package io.crate.expression.scalar.timestamp;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.joda.time.DateTimeUtils;
+import io.crate.metadata.SystemClock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,12 +34,12 @@ public class NowFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepare() {
-        DateTimeUtils.setCurrentMillisFixed(EXPECTED_TIMESTAMP);
+        SystemClock.setCurrentMillisFixedUTC(EXPECTED_TIMESTAMP);
     }
 
     @After
     public void cleanUp() {
-        DateTimeUtils.setCurrentMillisSystem();
+        SystemClock.setCurrentMillisSystemUTC();
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -1472,7 +1472,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
                                                                " ts timestamp with time zone default current_timestamp)");
         Reference reference = md.references().get(new ColumnIdent("ts"));
         assertThat(reference.valueType(), is(DataTypes.TIMESTAMPZ));
-        assertThat(reference.defaultExpression(), isFunction("current_timestamp", List.of(DataTypes.INTEGER)));
+        assertThat(reference.defaultExpression(), isFunction("current_timestamp"));
     }
 
     @Test


### PR DESCRIPTION
As per https://github.com/crate/crate/issues/9662 

scalar function that returns the new type `time with time zone`.