### PR TITLE
Detect Integer literal values at the sql parser

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -61,6 +61,12 @@ Breaking Changes
   execution is only available via the ``results`` array represented by a
   row count for each bulk operation.
 
+- Numeric literals fitting into the ``integer`` range will be detected now as
+  ``integer`` literals instead of ``bigint`` literals. Thus a statement like
+  ``select 1`` will return an ``integer`` column type. This shouldn't be an
+  issue for most clients as the ``HTTP`` endpoint uses ``JSON`` for
+  serialization and PostgreSQL clients usually use a typed ``getLong``.
+
 Deprecations
 ============
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -2711,11 +2711,11 @@ Example:
 ::
 
     cr> select pg_typeof([1, 2, 3]) as typeof;
-    +--------------+
-    | typeof       |
-    +--------------+
-    | bigint_array |
-    +--------------+
+    +---------------+
+    | typeof        |
+    +---------------+
+    | integer_array |
+    +---------------+
     SELECT 1 row in set (... sec)
 
 .. _version:

--- a/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -101,7 +101,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagWithDefaultValueAndEmptyOver() throws Throwable {
         assertEvaluate(
             "lag(x, 1, -1) over()",
-            contains(new Object[]{-1L, 1L, 2L, 3L}),
+            contains(new Object[]{-1, 1, 2, 3}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},
@@ -114,7 +114,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagWithExpressionAsArgumentAndEmptyOver() throws Throwable {
         assertEvaluate(
             "lag(coalesce(x, 1), 1, -1) over()",
-            contains(new Object[]{-1L, 1L, 1L}),
+            contains(new Object[]{-1, 1, 1}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{null},
@@ -204,7 +204,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLeadOverCurrentRowUnboundedFollowingWithDefaultValue() throws Throwable {
         assertEvaluate(
             "lead(x, 2, 42) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
-            contains(new Object[]{2L, 3L, 4L, 42L, 42L}),
+            contains(new Object[]{2, 3, 4, 42, 42}),
             List.of(new ColumnIdent("x")),
             new Object[]{1},
             new Object[]{2},

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -46,6 +46,7 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
@@ -243,6 +244,11 @@ public final class ExpressionFormatter {
         @Override
         protected String visitLongLiteral(LongLiteral node, @Nullable List<Expression> parameters) {
             return Long.toString(node.getValue());
+        }
+
+        @Override
+        protected String visitIntegerLiteral(IntegerLiteral node, @Nullable List<Expression> parameters) {
+            return Integer.toString(node.getValue());
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -60,6 +60,7 @@ import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.IndexColumnConstraint;
 import io.crate.sql.tree.IndexDefinition;
 import io.crate.sql.tree.Insert;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.Join;
 import io.crate.sql.tree.JoinCriteria;
@@ -675,7 +676,13 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitLongLiteral(LongLiteral node, Integer indent) {
-            builder.append(String.format(Locale.ENGLISH, "%d", node.getValue()));
+            builder.append(node.getValue());
+            return null;
+        }
+
+        @Override
+        protected Void visitIntegerLiteral(IntegerLiteral node, Integer indent) {
+            builder.append(node.getValue());
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -200,6 +200,10 @@ public abstract class AstVisitor<R, C> {
         return visitLiteral(node, context);
     }
 
+    protected R visitIntegerLiteral(IntegerLiteral node, C context) {
+        return visitLiteral(node, context);
+    }
+
     protected R visitLogicalBinaryExpression(LogicalBinaryExpression node, C context) {
         return visitExpression(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
@@ -86,8 +86,8 @@ public class FrameBound extends Node {
                                     @Nullable Comparator<T> cmp,
                                     List<T> rows) {
                 if (mode == ROWS) {
-                    assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
-                    return Math.max(pStart, currentRowIdx - ((Long) offset).intValue());
+                    assert offset instanceof Number : "In ROWS mode the offset must be a non-null, non-negative number";
+                    return Math.max(pStart, currentRowIdx - ((Number) offset).intValue());
                 } else {
                     int firstGTEProbeValue = findFirstGTEProbeValue(rows, pStart, currentRowIdx, offsetProbeValue, cmp);
                     if (firstGTEProbeValue == -1) {
@@ -199,8 +199,8 @@ public class FrameBound extends Node {
                                   List<T> rows) {
                 // end index is exclusive so we increment it by one when finding the interval end index
                 if (mode == ROWS) {
-                    assert offset instanceof Long : "In ROWS mode the offset must be a non-null, non-negative number";
-                    return Math.min(pEnd, currentRowIdx + ((Long) offset).intValue() + 1);
+                    assert offset instanceof Number : "In ROWS mode the offset must be a non-null, non-negative number";
+                    return Math.min(pEnd, currentRowIdx + ((Number) offset).intValue() + 1);
                 } else {
                     return findFirstLTEProbeValue(rows, pEnd, currentRowIdx, offsetProbeValue, cmp) + 1;
                 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/IntegerLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/IntegerLiteral.java
@@ -20,38 +20,39 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.sql.tree;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import org.junit.Test;
+public class IntegerLiteral extends Literal {
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+    private final int value;
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
-
-    @Test
-    public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, integer, text)");
-        assertEvaluate("_map('foo', 1, 'bar')", null);
+    public IntegerLiteral(int value) {
+        this.value = value;
     }
 
-    @Test
-    public void testKeyNotOfTypeString() {
-        assertEvaluate("_map(10, 2)", Collections.singletonMap("10", 2));
+    public int getValue() {
+        return value;
     }
 
-    @Test
-    public void testEvaluation() {
-        Map<String, Object> m = new HashMap<>();
-        m.put("foo", 10);
-        // minimum args
-        assertEvaluate("_map('foo', 10)", m);
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitIntegerLiteral(this, context);
+    }
 
-        // variable args
-        m.put("bar", "some");
-        assertEvaluate("_map('foo', 10, 'bar', 'some')", m);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntegerLiteral that = (IntegerLiteral) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value;
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
@@ -41,8 +41,10 @@ public abstract class Literal
         } else if (value instanceof Number) {
             if (value instanceof Float || value instanceof Double) {
                 literal = new DoubleLiteral(value.toString());
-            } else if (value instanceof Short || value instanceof Integer || value instanceof Long) {
-                literal = new LongLiteral(value.toString());
+            } else if (value instanceof Short || value instanceof Integer) {
+                literal = new IntegerLiteral(((Number) value).intValue());
+            } else if (value instanceof Long) {
+                literal = new LongLiteral((Long) value);
             }
         } else if (value instanceof Boolean) {
             literal = (Boolean) value ? BooleanLiteral.TRUE_LITERAL : BooleanLiteral.FALSE_LITERAL;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/LongLiteral.java
@@ -21,14 +21,12 @@
 
 package io.crate.sql.tree;
 
-import static java.util.Objects.requireNonNull;
-
 public class LongLiteral extends Literal {
 
     private final long value;
 
-    public LongLiteral(String value) {
-        this.value = Long.parseLong(requireNonNull(value, "value is null"));
+    public LongLiteral(long value) {
+        this.value = value;
     }
 
     public long getValue() {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicateColumnIdent.java
@@ -33,6 +33,7 @@ public class MatchPredicateColumnIdent extends Expression {
         this.ident = ident;
         if (boost != null) {
             if (!(boost instanceof LongLiteral ||
+                  boost instanceof IntegerLiteral ||
                   boost instanceof DoubleLiteral ||
                   boost instanceof ParameterExpression)) {
                 throw new IllegalArgumentException("'boost' value must be a numeric literal or a parameter expression");

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -23,6 +23,8 @@
 package io.crate.sql;
 
 
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.IntegerLiteral;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -283,5 +285,11 @@ public class LiteralsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
         Literals.replaceEscapedChars("\\U0000006G");
+    }
+
+    @Test
+    public void test_integer_literal() {
+        var literal = SqlParser.createExpression("2147483647");
+        assertThat(literal, is(new IntegerLiteral(Integer.MAX_VALUE)));
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -50,8 +50,8 @@ import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.GCDanglingArtifacts;
 import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.Insert;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.KillStatement;
-import io.crate.sql.tree.LongLiteral;
 import io.crate.sql.tree.MatchPredicate;
 import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.ObjectLiteral;
@@ -69,7 +69,6 @@ import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.SwapTable;
 import io.crate.sql.tree.Update;
 import io.crate.sql.tree.Window;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1228,8 +1227,8 @@ public class TestStatementBuilder {
         expression = SqlParser.createExpression("[1,2,3][1]");
         assertThat(expression, instanceOf(SubscriptExpression.class));
         subscript = (SubscriptExpression) expression;
-        assertThat(subscript.index(), instanceOf(LongLiteral.class));
-        assertThat(((LongLiteral) subscript.index()).getValue(), is(1L));
+        assertThat(subscript.index(), instanceOf(IntegerLiteral.class));
+        assertThat(((IntegerLiteral) subscript.index()).getValue(), is(1));
         assertThat(subscript.base(), instanceOf(ArrayLiteral.class));
     }
 
@@ -1268,14 +1267,14 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(IntegerLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(QualifiedNameReference.class));
 
         Expression someExpression = SqlParser.createExpression("1 = SOME (arrayColumnRef)");
         assertThat(someExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression someArrayComparison = (ArrayComparisonExpression) someExpression;
         assertThat(someArrayComparison.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(someArrayComparison.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(someArrayComparison.getLeft(), instanceOf(IntegerLiteral.class));
         assertThat(someArrayComparison.getRight(), instanceOf(QualifiedNameReference.class));
 
         Expression allExpression = SqlParser.createExpression("'StringValue' = ALL (arrayColumnRef)");
@@ -1292,7 +1291,7 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         ArrayComparisonExpression arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(IntegerLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
 
         // It's possible to omit the parenthesis
@@ -1300,7 +1299,7 @@ public class TestStatementBuilder {
         assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
         arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
         assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
-        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(IntegerLiteral.class));
         assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
     }
 
@@ -1358,7 +1357,7 @@ public class TestStatementBuilder {
 
         ObjectLiteral objectLiteral = (ObjectLiteral) SqlParser.createExpression("{a=1, aa=-1, b='str', c=[], d={}}");
         assertThat(objectLiteral.values().size(), is(5));
-        assertThat(objectLiteral.values().get("a"), instanceOf(LongLiteral.class));
+        assertThat(objectLiteral.values().get("a"), instanceOf(IntegerLiteral.class));
         assertThat(objectLiteral.values().get("aa"), instanceOf(NegativeExpression.class));
         assertThat(objectLiteral.values().get("b"), instanceOf(StringLiteral.class));
         assertThat(objectLiteral.values().get("c"), instanceOf(ArrayLiteral.class));
@@ -1366,7 +1365,7 @@ public class TestStatementBuilder {
 
         ObjectLiteral quotedObjectLiteral = (ObjectLiteral) SqlParser.createExpression("{\"AbC\"=123}");
         assertThat(quotedObjectLiteral.values().size(), is(1));
-        assertThat(quotedObjectLiteral.values().get("AbC"), instanceOf(LongLiteral.class));
+        assertThat(quotedObjectLiteral.values().get("AbC"), instanceOf(IntegerLiteral.class));
         assertThat(quotedObjectLiteral.values().get("abc"), CoreMatchers.nullValue());
         assertThat(quotedObjectLiteral.values().get("ABC"), CoreMatchers.nullValue());
 
@@ -1383,7 +1382,7 @@ public class TestStatementBuilder {
 
         ArrayLiteral singleArrayLiteral = (ArrayLiteral) SqlParser.createExpression("[1]");
         assertThat(singleArrayLiteral.values().size(), is(1));
-        assertThat(singleArrayLiteral.values().get(0), instanceOf(LongLiteral.class));
+        assertThat(singleArrayLiteral.values().get(0), instanceOf(IntegerLiteral.class));
 
         ArrayLiteral multipleArrayLiteral = (ArrayLiteral) SqlParser.createExpression(
             "['str', -12.56, {}, ['another', 'array']]");

--- a/server/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -246,7 +246,7 @@ public class MetaDataToASTNodeResolver {
             Expression clusteredBy = clusteredByColumn == null || clusteredByColumn.isSystemColumn()
                 ? null
                 : expressionFromColumn(clusteredByColumn);
-            Expression numShards = new LongLiteral(Integer.toString(tableInfo.numberOfShards()));
+            Expression numShards = new LongLiteral(tableInfo.numberOfShards());
             return Optional.of(new ClusteredBy<>(Optional.ofNullable(clusteredBy), Optional.of(numShards)));
         }
 

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -48,6 +48,7 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.LongLiteral;
 import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.Update;
@@ -213,12 +214,21 @@ public final class UpdateAnalyzer {
             return super.visitSubscriptExpression(node, childOfSubscript);
         }
 
-        @Override
-        protected Void visitLongLiteral(LongLiteral node, Boolean childOfSubscript) {
+        private Void validateLiteral(Boolean childOfSubscript) {
             if (childOfSubscript) {
                 throw new IllegalArgumentException("Updating a single element of an array is not supported");
             }
             return null;
+        }
+
+        @Override
+        protected Void visitLongLiteral(LongLiteral node, Boolean childOfSubscript) {
+            return validateLiteral(childOfSubscript);
+        }
+
+        @Override
+        protected Void visitIntegerLiteral(IntegerLiteral node, Boolean childOfSubscript) {
+            return validateLiteral(childOfSubscript);
         }
     }
 }

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -100,6 +100,7 @@ import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.IfExpression;
 import io.crate.sql.tree.InListExpression;
 import io.crate.sql.tree.InPredicate;
+import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.IntervalLiteral;
 import io.crate.sql.tree.IsNotNullPredicate;
 import io.crate.sql.tree.IsNullPredicate;
@@ -909,6 +910,11 @@ public class ExpressionAnalyzer {
 
         @Override
         protected Symbol visitLongLiteral(LongLiteral node, ExpressionAnalysisContext context) {
+            return Literal.of(node.getValue());
+        }
+
+        @Override
+        protected Symbol visitIntegerLiteral(IntegerLiteral node, ExpressionAnalysisContext context) {
             return Literal.of(node.getValue());
         }
 

--- a/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
+++ b/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
@@ -53,6 +53,11 @@ public class LiteralValueFormatter {
             formatArray(value, builder);
         } else if (value instanceof String || value instanceof Point || value instanceof Period) {
             builder.append(Literals.quoteStringLiteral(value.toString()));
+        } else if (value instanceof Long
+                   && ((Long) value <= Integer.MAX_VALUE
+                   || (Long) value >= Integer.MIN_VALUE)) {
+            builder.append(value.toString());
+            builder.append("::bigint");
         } else {
             builder.append(value.toString());
         }

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -136,10 +136,10 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         assertThat(session.getParamType("S_1", 2), is(DataTypes.UNDEFINED));
 
         DescribeResult describe = session.describe('S', "S_1");
-        assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.LONG, DataTypes.LONG }));
+        assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER }));
 
-        assertThat(session.getParamType("S_1", 0), is(DataTypes.LONG));
-        assertThat(session.getParamType("S_1", 1), is(DataTypes.LONG));
+        assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
+        assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Requested parameter index exceeds the number of parameters");

--- a/server/src/test/java/io/crate/analyze/CompoundLiteralTest.java
+++ b/server/src/test/java/io/crate/analyze/CompoundLiteralTest.java
@@ -84,7 +84,7 @@ public class CompoundLiteralTest extends CrateDummyClusterServiceUnitTest {
     public void testObjectConstructionWithExpressionsAsValues() throws Exception {
         Literal objectLiteral = (Literal) expressions.normalize(expressions.asSymbol("{name = 1 + 2}"));
         assertThat(objectLiteral.symbolType(), is(SymbolType.LITERAL));
-        assertThat(objectLiteral.value(), is(Map.<String, Object>of("name", 3L)));
+        assertThat(objectLiteral.value(), is(Map.<String, Object>of("name", 3)));
 
         Literal nestedObjectLiteral = (Literal) expressions.normalize(expressions.asSymbol("{a = {name = concat('foo', 'bar')}}"));
         @SuppressWarnings("unchecked") Map<String, Object> values = (Map<String, Object>) nestedObjectLiteral.value();
@@ -109,17 +109,17 @@ public class CompoundLiteralTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testArrayConstructionWithOnlyLiterals() throws Exception {
-        Literal emptyArray = (Literal) analyzeExpression("[]");
+        Literal<?> emptyArray = (Literal<?>) analyzeExpression("[]");
         assertThat((List<Object>) emptyArray.value(), Matchers.empty());
         assertThat(emptyArray.valueType(), is(new ArrayType<>(UndefinedType.INSTANCE)));
 
-        Literal singleArray = (Literal) analyzeExpression("[1]");
-        assertThat(singleArray.valueType(), is(new ArrayType<>(LongType.INSTANCE)));
-        assertThat(((List<Long>) singleArray.value()), contains(1L));
+        Literal<?> singleArray = (Literal<?>) analyzeExpression("[1]");
+        assertThat(singleArray.valueType(), is(new ArrayType<>(DataTypes.INTEGER)));
+        assertThat(((List<Long>) singleArray.value()), contains(1));
 
-        Literal multiArray = (Literal) analyzeExpression("[1, 2, 3]");
-        assertThat(multiArray.valueType(), is(new ArrayType<>(LongType.INSTANCE)));
-        assertThat(((List<Long>) multiArray.value()), contains(1L, 2L, 3L));
+        Literal<?> multiArray = (Literal<?>) analyzeExpression("[1, 2, 3]");
+        assertThat(multiArray.valueType(), is(new ArrayType<>(DataTypes.INTEGER)));
+        assertThat(((List<Long>) multiArray.value()), contains(1, 2, 3));
     }
 
     @Test
@@ -132,7 +132,7 @@ public class CompoundLiteralTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testArrayDifferentTypes() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'string'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'string'` of type `text` to type `integer`");
         analyzeExpression("[1, 'string']");
     }
 
@@ -140,7 +140,7 @@ public class CompoundLiteralTest extends CrateDummyClusterServiceUnitTest {
     public void testNestedArrayLiteral() throws Exception {
         Map<String, DataType<?>> expected = ImmutableMap.<String, DataType<?>>builder()
             .put("'string'", DataTypes.STRING)
-            .put("0", DataTypes.LONG)
+            .put("0", DataTypes.INTEGER)
             .put("1.8", DataTypes.DOUBLE)
             .put("TRUE", DataTypes.BOOLEAN)
             .build();

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -347,7 +347,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testObjectWithInvalidValueTypeAsNodeFiltersArgument() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("node_filters argument 'name' must be a String, not 20 (Long)");
+        expectedException.expectMessage("node_filters argument 'name' must be a String, not 20 (Integer)");
         analyze("COPY users FROM '/' WITH (node_filters={name=20})");
     }
 }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1027,7 +1027,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
         assertThat(
             generatedColumnsMapping.get("day"),
-            is("_cast((_cast(ts, 'bigint') + 1), 'timestamp with time zone')"));
+            is("_cast((_cast(ts, 'bigint') + 1::bigint), 'timestamp with time zone')"));
 
         Map<String, Object> mappingProperties = analysis.mappingProperties();
         Map<String, Object> dayMapping = (Map<String, Object>) mappingProperties.get("day");
@@ -1294,13 +1294,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testGeneratedColumnInsideObjectIsProcessed() {
         BoundCreateTable stmt = analyze("create table t (obj object as (c as 1 + 1))");
         AnalyzedColumnDefinition<Object> obj = stmt.analyzedTableElements().columns().get(0);
-        AnalyzedColumnDefinition c = obj.children().get(0);
+        AnalyzedColumnDefinition<?> c = obj.children().get(0);
 
-        assertThat(c.dataType(), is(DataTypes.LONG));
+        assertThat(c.dataType(), is(DataTypes.INTEGER));
         assertThat(c.formattedGeneratedExpression(), is("2"));
         assertThat(AnalyzedTableElements.toMapping(stmt.analyzedTableElements()).toString(),
                    is("{_meta={generated_columns={obj.c=2}}, " +
-                      "properties={obj={dynamic=true, position=1, type=object, properties={c={type=long}}}}}"));
+                      "properties={obj={dynamic=true, position=1, type=object, properties={c={type=integer}}}}}"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -168,7 +168,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select 58 as fiftyEight from foo.users group by fiftyEight;");
         assertThat(relation.groupBy().isEmpty(), is(false));
         List<Symbol> groupBySymbols = relation.groupBy();
-        assertThat(groupBySymbols.get(0), isAlias("fiftyeight", isLiteral(58L)));
+        assertThat(groupBySymbols.get(0), isAlias("fiftyeight", isLiteral(58)));
     }
 
     @Test
@@ -248,7 +248,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.isDistinct(), is(true));
         assertThat(relation,
             isSQL("SELECT max(doc.users.id) GROUP BY doc.users.name " +
-                  "ORDER BY max(doc.users.id) LIMIT 5 OFFSET 10"));
+                  "ORDER BY max(doc.users.id) LIMIT 5::bigint OFFSET 10::bigint"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -458,7 +458,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testWhereInSelectDifferentDataTypeValueIncompatibleDataTypes() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         analyze("select 'found' from users where 1 in (1, 'foo', 2)");
     }
 
@@ -485,7 +485,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectDistinctWithFunction() {
         QueriedSelectRelation relation = analyze("select distinct id + 1 from users");
         assertThat(relation.isDistinct(), is(true));
-        assertThat(relation.outputs(), isSQL("(doc.users.id + 1)"));
+        assertThat(relation.outputs(), isSQL("(doc.users.id + 1::bigint)"));
     }
 
     @Test
@@ -846,7 +846,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `friends['id']` of type `bigint_array` to type `integer`");
         analyze("select * from users where 5 = friends['id']");
     }
 
@@ -935,15 +935,15 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testPrefixedNumericLiterals() throws Exception {
         AnalyzedRelation relation = analyze("select - - - 10");
         List<Symbol> outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(-10L)));
+        assertThat(outputs.get(0), is(Literal.of(-10)));
 
         relation = analyze("select - + - 10");
         outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(10L)));
+        assertThat(outputs.get(0), is(Literal.of(10)));
 
         relation = analyze("select - (- 10 - + 10) * - (+ 10 + - 10)");
         outputs = relation.outputs();
-        assertThat(outputs.get(0), is(Literal.of(0L)));
+        assertThat(outputs.get(0), is(Literal.of(0)));
     }
 
     @Test
@@ -1095,7 +1095,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testMatchPredicateWithWrongQueryTerm() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast expressions from type `bigint_array` to type `text`");
+        expectedException.expectMessage("Cannot cast expressions from type `integer_array` to type `text`");
         analyze("select name from users order by match(name, [10, 20])");
     }
 
@@ -1191,15 +1191,15 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(match.options(), isLiteral(Map.ofEntries(
             Map.entry("analyzer", "german"),
             Map.entry("boost", 4.6),
-            Map.entry("cutoff_frequency", 5L),
-            Map.entry("fuzziness", 12L),
+            Map.entry("cutoff_frequency", 5),
+            Map.entry("fuzziness", 12),
             Map.entry("fuzzy_rewrite", "top_terms_20"),
-            Map.entry("max_expansions", 3L),
-            Map.entry("minimum_should_match", 4L),
+            Map.entry("max_expansions", 3),
+            Map.entry("minimum_should_match", 4),
             Map.entry("operator", "or"),
-            Map.entry("prefix_length", 4L),
+            Map.entry("prefix_length", 4),
             Map.entry("rewrite", "constant_score_boolean"),
-            Map.entry("slop", 3L),
+            Map.entry("slop", 3),
             Map.entry("tie_breaker", 0.75),
             Map.entry("zero_terms_query", "all")
         )));
@@ -1712,7 +1712,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: unnest(bigint, text)");
+        expectedException.expectMessage("unknown function: unnest(integer, text)");
         analyze("select * from unnest(1, 'foo')");
     }
 
@@ -1846,7 +1846,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testColumnOutputWithSingleRowSubselect() {
         AnalyzedRelation relation = analyze("select 1 = \n (select \n 2\n)\n");
         assertThat(relation.outputs(), contains(
-            isFunction("op_=", isLiteral(1L), instanceOf(SelectSymbol.class)))
+            isFunction("op_=", isLiteral(1), instanceOf(SelectSymbol.class)))
         );
     }
 
@@ -1987,7 +1987,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation rel = analyze("select ({x=10}).x");
         assertThat(
             rel.outputs(),
-            contains(isLiteral(10L))
+            contains(isLiteral(10))
         );
     }
 

--- a/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -57,14 +57,14 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analysis.scope(), is(SetStatement.Scope.GLOBAL));
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1)))));
 
         analysis = analyze("SET GLOBAL TRANSIENT stats.jobs_log_size=2");
         assertThat(analysis.isPersistent(), is(false));
         assertThat(analysis.scope(), is(SetStatement.Scope.GLOBAL));
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(2)))));
 
 
         analysis = analyze("SET GLOBAL TRANSIENT stats.enabled=false, stats.operations_log_size=0, stats.jobs_log_size=0");
@@ -77,11 +77,11 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(1),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(0L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(0)))));
 
         assertThat(
             analysis.settings().get(2),
-            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(0L)))));
+            is(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(0)))));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2)))));
 
 
         analysis = analyze("SET LOCAL something TO DEFAULT");
@@ -121,14 +121,14 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2)))));
 
         analysis = analyze("SET SESSION something = 1,2,3");
         assertThat(analysis.scope(), is(SetStatement.Scope.SESSION));
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(1L), Literal.of(2L), Literal.of(3L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(1), Literal.of(2), Literal.of(3)))));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2L)))));
+            is(new Assignment<>(Literal.of("something"), List.of(Literal.of(2)))));
 
         analysis = analyze("SET something = DEFAULT");
         assertThat(analysis.scope(), is(SetStatement.Scope.SESSION));
@@ -162,7 +162,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(
             analysis.settings().get(0),
-            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1L)))));
+            is(new Assignment<>(Literal.of("stats.operations_log_size"), List.of(Literal.of(1)))));
     }
 //
     @Test

--- a/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -138,11 +138,11 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                                  "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
                                                  "limit 10");
         assertThat(relation,
-                   isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) LIMIT 10"));
+                   isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) LIMIT 10::bigint"));
         assertThat(relation.joinPairs().get(0).condition(),
                    isSQL("(t1.i = t2.i)"));
         assertThat(((AliasedAnalyzedRelation) relation.from().get(0)).relation(),
-                   isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
+                   isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5::bigint"));
         assertThat(((AliasedAnalyzedRelation) relation.from().get(1)).relation(),
                    isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '10')"));
     }
@@ -156,11 +156,11 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                                  "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
                                                  "order by 2 limit 10");
         assertThat(relation,
-            isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) ORDER BY t1.i LIMIT 10"));
+            isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) ORDER BY t1.i LIMIT 10::bigint"));
         assertThat(relation.joinPairs().get(0).condition(),
             isSQL("(t1.i = t2.i)"));
         assertThat(((AliasedAnalyzedRelation) relation.from().get(0)).relation(),
-            isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
+            isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5::bigint"));
         assertThat(((AliasedAnalyzedRelation) relation.from().get(1)).relation(),
             isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '10')"));
     }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -168,14 +168,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNumericTypeOutOfRange() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for shorts: Cannot cast expression `-100000` of type `bigint` to `smallint`");
+        expectedException.expectMessage("Validation failed for shorts: Cannot cast expression `-100000` of type `integer` to `smallint`");
         analyze("update users set shorts=-100000");
     }
 
     @Test
     public void testNumericOutOfRangeFromFunction() {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for bytes: Cannot cast expression `1234` of type `bigint` to `char`");
+        expectedException.expectMessage("Validation failed for bytes: Cannot cast expression `1234` of type `integer` to `char`");
         analyze("update users set bytes=abs(-1234)");
     }
 
@@ -201,7 +201,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         Reference ref = update.assignmentByTargetCol().keySet().iterator().next();
         assertThat(ref, instanceOf(DynamicReference.class));
-        Assert.assertEquals(DataTypes.LONG, ref.valueType());
+        Assert.assertEquals(DataTypes.INTEGER, ref.valueType());
         assertThat(ref.column().isTopLevel(), is(false));
         assertThat(ref.column().fqn(), is("details.arms"));
     }

--- a/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -53,7 +53,7 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_error_is_raised_if_the_types_of_the_rows_are_not_compatible() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         e.analyze("VALUES (1), ('foo')");
     }
 
@@ -69,7 +69,7 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_nulls_in_column_values_must_not_fail_type_validation() {
         AnalyzedRelation relation = e.analyze("VALUES (1), (null), (2), (null)");
-        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.LONG)));
+        assertThat(relation.outputs(), contains(isReference("col1", DataTypes.INTEGER)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -192,7 +192,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new QualifiedName("subscript"),
             ImmutableList.of(
                 new ArrayLiteral(ImmutableList.of(new StringLiteral("obj"))),
-                new LongLiteral("1")));
+                new LongLiteral(1)));
 
         Symbol symbol = expressionAnalyzer.convert(subscriptFunctionCall, expressionAnalysisContext);
         assertThat(symbol, isLiteral("obj"));
@@ -317,8 +317,8 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testIncompatibleLiteralThrowsException() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `2147483648` of type `bigint` to type `integer`");
-        executor.asSymbol("doc.t2.i = 1 + " + Integer.MAX_VALUE);
+        expectedException.expectMessage("Cannot cast `2.147483648E9` of type `double precision` to type `integer`");
+        executor.asSymbol("doc.t2.i = 1.0 + " + Integer.MAX_VALUE);
     }
 
     @Test
@@ -376,24 +376,24 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testParameterExpressionInAny() throws Exception {
         Symbol s = expressions.asSymbol("5 = ANY(?)");
-        assertThat(s, isFunction(AnyOperators.Names.EQ, isLiteral(5L), instanceOf(ParameterSymbol.class)));
+        assertThat(s, isFunction(AnyOperators.Names.EQ, isLiteral(5), instanceOf(ParameterSymbol.class)));
     }
 
     @Test
     public void testParameterExpressionInLikeAny() throws Exception {
         Symbol s = expressions.asSymbol("5 LIKE ANY(?)");
-        assertThat(s, isFunction(LikeOperators.ANY_LIKE, isLiteral(5L), instanceOf(ParameterSymbol.class)));
+        assertThat(s, isFunction(LikeOperators.ANY_LIKE, isLiteral(5), instanceOf(ParameterSymbol.class)));
     }
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `integer`");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 
     @Test
     public void testCallingUnknownFunctionWithExplicitSchemaRaisesNiceError() {
-        expectedException.expectMessage("unknown function: foo.bar(bigint)");
+        expectedException.expectMessage("unknown function: foo.bar(integer)");
         executor.analyze("select foo.bar(1)");
     }
 

--- a/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -36,12 +36,12 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     @Test
     public void testValidGroupByWithScalar() throws Exception {
         AnalyzedRelation relation = executor.analyze("select id * 2 from users group by id");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn(), is("(id * 2)"));
+        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn(), is("(id * 2::bigint)"));
     }
 
     @Test
     public void testValidGroupByWithMultipleScalarFunctions() throws Exception {
         AnalyzedRelation relation = executor.analyze("select abs(id * 2) from users group by id");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn(), is("abs((id * 2))"));
+        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn(), is("abs((id * 2::bigint))"));
     }
 }

--- a/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -67,20 +67,20 @@ public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
         assertReplaced("null and x = null", "(_cast(NULL, 'boolean') AND (x = _cast(NULL, 'integer')))");
         assertReplaced(
             "null or x = 1 or null",
-            "((_cast(NULL, 'boolean') OR (x = _cast(1, 'integer'))) OR _cast(NULL, 'boolean'))");
+            "((_cast(NULL, 'boolean') OR (x = 1)) OR _cast(NULL, 'boolean'))");
         assertReplaced(
             "not(null and x = 1)",
-            "(NOT (_cast(NULL, 'boolean') AND (x = _cast(1, 'integer'))))");
+            "(NOT (_cast(NULL, 'boolean') AND (x = 1)))");
         assertReplaced(
             "not(null or not(null and x = 1))",
-            "(NOT (_cast(NULL, 'boolean') OR (NOT (_cast(NULL, 'boolean') AND (x = _cast(1, 'integer'))))))");
+            "(NOT (_cast(NULL, 'boolean') OR (NOT (_cast(NULL, 'boolean') AND (x = 1)))))");
         assertReplaced(
             "not(null and x = 1) and not(null or x = 2)",
-            "((NOT (_cast(NULL, 'boolean') AND (x = _cast(1, 'integer')))) AND " +
-            "(NOT (_cast(NULL, 'boolean') OR (x = _cast(2, 'integer')))))");
+            "((NOT (_cast(NULL, 'boolean') AND (x = 1))) AND " +
+            "(NOT (_cast(NULL, 'boolean') OR (x = 2))))");
         assertReplaced(
             "null or coalesce(null or x = 1, true)",
-            "(_cast(NULL, 'boolean') OR coalesce((_cast(NULL, 'boolean') OR (x = _cast(1, 'integer'))), true))");
+            "(_cast(NULL, 'boolean') OR coalesce((_cast(NULL, 'boolean') OR (x = 1)), true))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -273,7 +273,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             ".partitioned.parted.04732cpp6ksjcc9i60o30c1g",
             ".partitioned.parted.04732cpp6ks3ed1o60o30c1g"
         ));
-        assertThat(whereClause.queryOrFallback(), isSQL("((doc.parted.date = 1395961200000) OR (doc.parted.id = 1))"));
+        assertThat(whereClause.queryOrFallback(), isSQL("((doc.parted.date = 1395961200000::bigint) OR (doc.parted.id = 1))"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
@@ -52,7 +52,7 @@ public class AndOperatorTest extends AbstractScalarFunctionsTest {
         List<Symbol> split = AndOperator.split(query);
         assertThat(split, contains(
             isSQL("((doc.users.a = 1) OR (doc.users.a = 2))"),
-            isSQL("(doc.users.x = 2)"),
+            isSQL("(doc.users.x = 2::bigint)"),
             isSQL("(doc.users.name = 'foo')")
         ));
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -38,7 +38,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeWithValueSymbols() throws Exception {
-        assertNormalize("array_cat([10, 20], [10, 30])", isLiteral(Arrays.asList(10L, 20L, 10L, 30L)));
+        assertNormalize("array_cat([10, 20], [10, 30])", isLiteral(Arrays.asList(10, 20, 10, 30)));
     }
 
     @Test
@@ -48,7 +48,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        assertNormalize("array_cat([1, 2, 3], null)", isLiteral(Arrays.asList(1L, 2L, 3L)));
+        assertNormalize("array_cat([1, 2, 3], null)", isLiteral(Arrays.asList(1, 2, 3)));
     }
 
     @Test
@@ -61,14 +61,14 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(bigint_array)");
+        expectedException.expectMessage("unknown function: array_cat(integer_array)");
         assertEvaluate("array_cat([1])", null);
     }
 
     @Test
     public void testThreeArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(bigint_array, bigint_array, bigint_array)");
+        expectedException.expectMessage("unknown function: array_cat(integer_array, integer_array, integer_array)");
         assertEvaluate("array_cat([1], [2], [3])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -55,25 +55,25 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testArrayDifferenceRemovesTheNestedArraysInTheFirstArrayThatAreContainedWithinTheSecondArray() {
         assertEvaluate(
             "array_difference([[1, 2], [1, 3]], [[1, 2]])",
-            Matchers.contains(Matchers.contains(1L, 3L)));
+            Matchers.contains(Matchers.contains(1, 3)));
     }
 
     @Test
     public void testArrayDifferenceRemovesTheObjectsInTheFirstArrayThatAreContainedInTheSecond() {
         assertEvaluate(
             "array_difference([{x=[1, 2]}, {x=[1, 3]}], [{x=[1, 3]}])",
-            Matchers.contains(Matchers.hasEntry(is("x"), Matchers.contains(1L, 2L))));
+            Matchers.contains(Matchers.hasEntry(is("x"), Matchers.contains(1, 2))));
     }
 
     @Test
     public void testNormalize() throws Exception {
-        assertNormalize("array_difference([10, 20], [10, 30])", isLiteral(List.of(20L)));
+        assertNormalize("array_difference([10, 20], [10, 30])", isLiteral(List.of(20)));
         assertNormalize("array_difference([], [10, 30])", isLiteral(List.of()));
     }
 
     @Test
     public void testNormalizeNullArguments() throws Exception {
-        assertNormalize("array_difference([1], null)", isLiteral(List.of(1L)));
+        assertNormalize("array_difference([1], null)", isLiteral(List.of(1)));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_difference(bigint_array)");
+        expectedException.expectMessage("unknown function: array_difference(integer_array)");
         assertNormalize("array_difference([1])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -66,21 +66,21 @@ public class ArrayLowerFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array)");
+        expectedException.expectMessage("unknown function: array_lower(integer_array)");
         assertEvaluate("array_lower([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array, bigint, bigint_array)");
+        expectedException.expectMessage("unknown function: array_lower(integer_array, integer, integer_array)");
         assertEvaluate("array_lower([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(bigint_array, bigint_array)");
+        expectedException.expectMessage("unknown function: array_lower(integer_array, integer_array)");
         assertEvaluate("array_lower([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -41,7 +41,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeWithValueSymbols() throws Exception {
-        assertNormalize("array_unique([10, 20], [10, 30])", isLiteral(Arrays.asList(10L, 20L, 30L)));
+        assertNormalize("array_unique([10, 20], [10, 30])", isLiteral(Arrays.asList(10, 20, 30)));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        assertNormalize("array_unique([1], null)", isLiteral(List.of(1L)));
+        assertNormalize("array_unique([1], null)", isLiteral(List.of(1)));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testArrayUniqueOnNestedArrayReturnsUniqueInnerArrays() {
         assertEvaluate("array_unique([[0, 0], [1, 1]], [[0, 0], [1, 1]])",
-            List.of(List.of(0L, 0L), List.of(1L, 1L)));
+            List.of(List.of(0, 0), List.of(1, 1)));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate(
             "array_unique([{x=[1, 1]}], [{x=[1, 1]}])",
              Matchers.contains(
-               Matchers.hasEntry(is("x"), Matchers.contains(is(1L), is(1L)))
+               Matchers.hasEntry(is("x"), Matchers.contains(is(1), is(1)))
            )
         );
     }
@@ -105,7 +105,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testConvertNonNumericStringToNumber() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 
@@ -118,12 +118,12 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullElements() throws Exception {
-        assertEvaluate("array_unique([1, null, 3], [null, 2, 3])", Arrays.asList(1L, null, 3L, 2L));
+        assertEvaluate("array_unique([1, null, 3], [null, 2, 3])", Arrays.asList(1, null, 3, 2));
     }
 
     @Test
-    public void testEmptyArrayAndLongArray() throws Exception {
-        assertEvaluate("array_unique([], [111, 222, 333])", Arrays.asList(111L, 222L, 333L));
+    public void testEmptyArrayAndInterArray() throws Exception {
+        assertEvaluate("array_unique([], [111, 222, 333])", Arrays.asList(111, 222, 333));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -71,21 +71,21 @@ public class ArrayUpperFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array)");
+        expectedException.expectMessage("unknown function: array_upper(integer_array)");
         assertEvaluate("array_upper([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array, bigint, bigint_array)");
+        expectedException.expectMessage("unknown function: array_upper(integer_array, integer, integer_array)");
         assertEvaluate("array_upper([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(bigint_array, bigint_array)");
+        expectedException.expectMessage("unknown function: array_upper(integer_array, integer_array)");
         assertEvaluate("array_upper([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -39,7 +39,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testArgumentThatHasNoStringRepr() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(text, bigint_array)");
+        expectedException.expectMessage("unknown function: concat(text, integer_array)");
         assertNormalize("concat('foo', [1])", null);
     }
 
@@ -76,18 +76,18 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTwoArrays() throws Exception {
-        assertNormalize("concat([1, 2], [2, 3])", isLiteral(List.of(1L, 2L, 2L, 3L)));
+        assertNormalize("concat([1, 2], [2, 3])", isLiteral(List.of(1, 2, 2, 3)));
     }
 
     @Test
     public void testArrayWithAUndefinedInnerType() throws Exception {
-        assertNormalize("concat([], [1, 2])", isLiteral(List.of(1L, 2L)));
+        assertNormalize("concat([], [1, 2])", isLiteral(List.of(1, 2)));
     }
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(bigint_array, bigint_array_array)");
+        expectedException.expectMessage("unknown function: concat(integer_array, integer_array_array)");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 
@@ -101,7 +101,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluate() throws Exception {
-        assertEvaluate("concat([1], [2::integer, 3::integer])", List.of(1L, 2L, 3L));
+        assertEvaluate("concat([1::bigint], [2, 3])", List.of(1L, 2L, 3L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -41,7 +41,7 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_subscript_can_retrieve_items_of_objects_within_array() {
-        assertEvaluate("[{x=10}, {x=2}]['x']", List.of(10L, 2L));
+        assertEvaluate("[{x=10}, {x=2}]['x']", List.of(10, 2));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -33,8 +33,8 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluate() throws Exception {
-        assertEvaluate("subscript_obj({x=10}, 'x')", 10L);
-        assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'x'), 'y')", 10L);
+        assertEvaluate("subscript_obj({x=10}, 'x')", 10);
+        assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'x'), 'y')", 10);
     }
 
     @Test
@@ -62,11 +62,11 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testFunctionCanBeUsedAsIndexInSubscript() {
-        assertNormalize("{\"x\" = 10}['x' || '']", isLiteral(10L));
+        assertNormalize("{\"x\" = 10}['x' || '']", isLiteral(10));
     }
 
     @Test
     public void testSubscriptOnObjectWithPath() {
-        assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", 10L);
+        assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", 10);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
@@ -40,7 +40,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("'1' = 1", true);
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         assertEvaluate("'foo' = 1", true);
     }
 
@@ -66,7 +66,7 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         assertEvaluate("case 1 when 1.0 then 'foo' else 'bar' end", "foo");
 
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         assertEvaluate("case 1 when 'foo' then 'foo' else 'bar' end", "bar");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -33,9 +33,9 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testAbs() throws Exception {
-        assertEvaluate("abs(-2)", 2L);
+        assertEvaluate("abs(-2)", 2);
         assertEvaluate("abs(-2.0)", 2.0);
-        assertEvaluate("abs(cast(-2 as integer))", 2);
+        assertEvaluate("abs(cast(-2 as bigint))", 2L);
         assertEvaluate("abs(cast(-2.0 as float))", 2.0f);
         assertEvaluate("abs(null)", null);
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
@@ -37,21 +37,21 @@ public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTypeValidation() {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `bigint`");
+        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         assertEvaluate("ARRAY[1, 'foo']", null);
     }
 
     @Test
     public void testEvaluateArrayWithExpr() {
-        assertEvaluate("ARRAY[1 + 2]", List.of(3L));
-        assertEvaluate("[1 + 1]", List.of(2L));
+        assertEvaluate("ARRAY[1 + 2]", List.of(3));
+        assertEvaluate("[1 + 1]", List.of(2));
     }
 
     @Test
     public void testEvaluateNestedArrays() {
         assertEvaluate("ARRAY[[]]", List.of(List.of()));
         assertEvaluate("[ARRAY[]]", List.of(List.of()));
-        assertEvaluate("[[1 + 1], ARRAY[1 + 2]]", List.of(List.of(2L), List.of(3L)));
+        assertEvaluate("[[1 + 1], ARRAY[1 + 2]]", List.of(List.of(2), List.of(3)));
     }
 
     public void testEvaluateArrayOnColumnIdents() {
@@ -64,8 +64,8 @@ public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeArrays() {
-        assertNormalize("ARRAY[1 + 2]", isLiteral(List.of(3L)));
-        assertNormalize("[ARRAY[1 + 2]]", isLiteral(List.of(List.of(3L))));
+        assertNormalize("ARRAY[1 + 2]", isLiteral(List.of(3)));
+        assertNormalize("[ARRAY[1 + 2]]", isLiteral(List.of(List.of(3))));
         assertNormalize("[[null is null], ARRAY[4 is not null], [false]]",
             isLiteral(List.of(List.of(true), List.of(true), List.of(false))));
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -49,10 +49,10 @@ public class CeilFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateOnIntAndLong() throws Exception {
-        assertNormalize("ceil(cast(20 as integer))", isLiteral(20));
+        assertNormalize("ceil(20)", isLiteral(20));
         assertNormalize("ceil(cast(null as integer))", isLiteral(null, DataTypes.INTEGER));
 
-        assertNormalize("ceil(20)", isLiteral(20L));
+        assertNormalize("ceil(20::bigint)", isLiteral(20L));
         assertNormalize("ceil(cast(null as long))", isLiteral(null, DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -31,8 +31,8 @@ public class ExpFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_exp_scalar() {
-        assertNormalize("exp(1)", isLiteral(2L));
-        assertNormalize("exp(1::int)", isLiteral(2));
+        assertNormalize("exp(1)", isLiteral(2));
+        assertNormalize("exp(1::bigint)", isLiteral(2L));
         assertNormalize("exp(1.0)", isLiteral(2.718281828459045));
         assertNormalize("exp(1.0::real)", isLiteral(2.7182817F));
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
@@ -44,11 +44,11 @@ public class FloorFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateOnIntAndLong() throws Exception {
-        assertNormalize("floor(cast(20 as integer))", isLiteral(20));
+        assertNormalize("floor(20)", isLiteral(20));
         assertNormalize("floor(cast(null as integer))", isLiteral(null, DataTypes.INTEGER));
         assertNormalize("floor(42.9)", isLiteral(42L));
 
-        assertNormalize("floor(20)", isLiteral(20L));
+        assertNormalize("floor(20::bigint)", isLiteral(20L));
         assertNormalize("floor(cast(null as long))", isLiteral(null, DataTypes.LONG));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
@@ -31,19 +31,19 @@ public class ModulusFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_modulus_scalar() {
-        assertNormalize("modulus(3, 2)", isLiteral(1L));
-        assertNormalize("modulus(3::int, 2::int)", isLiteral(1));
+        assertNormalize("modulus(3, 2)", isLiteral(1));
+        assertNormalize("modulus(3::bigint, 2::bigint)", isLiteral(1L));
         assertNormalize("modulus(3.5, 2)", isLiteral(1.5d));
         assertNormalize("modulus(3.5::real, 2)", isLiteral(1.5f));
     }
 
     @Test
     public void test_modulus_operator() {
-        assertNormalize("3 % 2", isLiteral(1L));
+        assertNormalize("3 % 2", isLiteral(1));
     }
 
     @Test
     public void test_mod_works_as_alias_for_modulus() {
-        assertNormalize("mod(3, 2)", isLiteral(1L));
+        assertNormalize("mod(3, 2)", isLiteral(1));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -64,7 +64,7 @@ public class PowerFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidNumberOfArguments() {
-        expectedException.expectMessage("unknown function: power(bigint)");
+        expectedException.expectMessage("unknown function: power(integer)");
         assertEvaluate("power(2)", null);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -33,8 +33,8 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testRound() throws Exception {
         assertEvaluate("round(42.2)", 42L);
-        assertEvaluate("round(42)", 42L);
-        assertEvaluate("round(cast(42 as integer))", 42);
+        assertEvaluate("round(42)", 42);
+        assertEvaluate("round(42::bigint)", 42L);
         assertEvaluate("round(cast(42.2 as float))", 42);
         assertEvaluate("round(null)", null);
 

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -136,7 +136,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     public void testDoubleColonOperatorCast() {
         assertEvaluate("10.4::string", "10.4");
         assertEvaluate("[1, 2, 0]::array(boolean)", List.of(true, true, false));
-        assertEvaluate("(1+3)/2::string", 2L);
+        assertEvaluate("(1+3)/2::string", 2);
         assertEvaluate("((1+3)/2)::string", "2");
         assertEvaluate("'10'::long + 5", 15L);
         assertEvaluate("(-4)::string", "-4");

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -32,15 +32,15 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCoalesce() throws Exception {
         assertEvaluate("coalesce(null)", null);
-        assertEvaluate("coalesce(10, null, 20)", 10L);
+        assertEvaluate("coalesce(10, null, 20)", 10);
         assertEvaluate("coalesce(name, 'foo')", "foo", Literal.NULL);
     }
 
     @Test
     public void testGreatest() throws Exception {
         assertEvaluate("greatest(null, null)", null);
-        assertEvaluate("greatest(10)", 10L);
-        assertEvaluate("greatest(10, 20, null, 30)", 30L);
+        assertEvaluate("greatest(10)", 10);
+        assertEvaluate("greatest(10, 20, null, 30)", 30);
         assertEvaluate("greatest(11.1, 22.2, null)", 22.2);
         assertEvaluate("greatest('foo', name, 'bar')", "foo", Literal.NULL);
     }
@@ -48,15 +48,15 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testLeast() throws Exception {
         assertEvaluate("least(null, null)", null);
-        assertEvaluate("least(10)", 10L);
-        assertEvaluate("least(10, 20, null, 30)", 10L);
+        assertEvaluate("least(10)", 10);
+        assertEvaluate("least(10, 20, null, 30)", 10);
         assertEvaluate("least(11.1, 22.2, null)", 11.1);
         assertEvaluate("least('foo', name, 'bar')", "bar", Literal.NULL);
     }
 
     @Test
     public void testNullIf() throws Exception {
-        assertEvaluate("nullif(10, 12)", 10L);
+        assertEvaluate("nullif(10, 12)", 10);
         assertEvaluate("nullif(name, 'foo')", null, Literal.of("foo"));
         assertEvaluate("nullif(null, 'foo')", null);
     }
@@ -64,7 +64,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNullIfInvalidArgsLength() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: nullif(bigint, bigint, bigint)");
+        expectedException.expectMessage("unknown function: nullif(integer, integer, integer)");
         assertEvaluate("nullif(1, 2, 3)", null);
     }
 
@@ -105,7 +105,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     public void testCaseIncompatibleTypes() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Data types of all result expressions of a CASE statement must be equal, " +
-                                        "found: [text, bigint]");
+                                        "found: [text, integer]");
         assertEvaluate("case name when 'foo' then 'hello foo' when 'bar' then 1 end",
             "hello foo",
             Literal.of("foo"), Literal.of("foo"));
@@ -129,7 +129,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
         // x = long
         // a = integer
         String expression = "case x + 1 when a::long then 111 end";
-        assertEvaluate(expression, 111L,
+        assertEvaluate(expression, 111,
             Literal.of(110L),    // x
             Literal.of(111));    // a
     }
@@ -137,7 +137,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCaseWithNullArgument() throws Exception {
         String expression = "CASE 68 WHEN 38 THEN NULL ELSE 1 END";
-        assertEvaluate(expression, 1L);
+        assertEvaluate(expression, 1);
     }
 
     @Test
@@ -155,25 +155,25 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testCaseWithNullArgumentIfReturnsLong() throws Exception {
         String expression = "CASE 38 WHEN 38 THEN 1 ELSE NULL END";
-        assertEvaluate(expression, 1L);
+        assertEvaluate(expression, 1);
     }
 
     @Test
     public void testCaseWithDifferentResultTypesReturnsLong() throws Exception {
-        String expression1 = "CASE 47 WHEN 38 THEN 1 ELSE 12::integer END";
+        String expression1 = "CASE 47 WHEN 38 THEN 1 ELSE 12::bigint END";
         assertEvaluate(expression1, 12L);
-        String expression2 = "CASE 34 WHEN 38 THEN 1::integer ELSE 12 END";
+        String expression2 = "CASE 34 WHEN 38 THEN 1::bigint ELSE 12 END";
         assertEvaluate(expression2, 12L);
     }
 
     @Test
     public void testCaseWithStringAndLongResultTypesReturnsLong() throws Exception {
-        assertEvaluate("CASE 38 WHEN 38 THEN '38' ELSE 40 END",38L);
+        assertEvaluate("CASE 38 WHEN 38 THEN '38' ELSE 40 END",38);
     }
 
     @Test
     public void testCaseWithStringDefaultTypeReturnsLong() throws Exception {
-        assertEvaluate("CASE 45 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",40L);
-        assertEvaluate("CASE 34 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",34L);
+        assertEvaluate("CASE 45 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",40);
+        assertEvaluate("CASE 34 WHEN 38 THEN 38 WHEN 34 THEN 34 WHEN 80 THEN 80 ELSE '40' END",34);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -44,7 +44,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testResolveWithInvalidType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: distance(bigint, text)");
+        expectedException.expectMessage("unknown function: distance(integer, text)");
         assertNormalize("distance(1, 'POINT (11 21)')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -73,7 +73,7 @@ public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_replace(text, text, bigint_array)");
+        expectedException.expectMessage("unknown function: regexp_replace(text, text, integer_array)");
 
         assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
     }

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -39,7 +39,7 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_expressions() {
-        assertEvaluate("pg_typeof(1 + 1::short)", DataTypes.LONG.getName());
+        assertEvaluate("pg_typeof(1 + 1::short)", DataTypes.INTEGER.getName());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("pg_typeof(['Hello', 'World'])", DataTypes.STRING_ARRAY.getName());
         assertEvaluate("pg_typeof([1::smallint, 2::smallint])", DataTypes.SHORT_ARRAY.getName());
         assertEvaluate("pg_typeof([1::integer, 2::integer])", DataTypes.INTEGER_ARRAY.getName());
-        assertEvaluate("pg_typeof([1, 2])", DataTypes.BIGINT_ARRAY.getName());
+        assertEvaluate("pg_typeof([1, 2])", DataTypes.INTEGER_ARRAY.getName());
         assertEvaluate("pg_typeof([1.0::double precision, 2.0::double precision])",
                        DataTypes.DOUBLE_ARRAY.getName());
 
@@ -126,7 +126,7 @@ public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
                        Literal.of(List.of(1L, 2L), DataTypes.BIGINT_ARRAY));
         assertEvaluate("pg_typeof(double_array)",
                        DataTypes.DOUBLE_ARRAY.getName(),
-                       Literal.of(List.of((double) 1.0, (double) 2.0), DataTypes.DOUBLE_ARRAY));
+                       Literal.of(List.of(1.0, 2.0), DataTypes.DOUBLE_ARRAY));
     }
 }
 

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -304,9 +304,9 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testStyles() throws Exception {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(bar+cast(\"select\" as long)+1+1+1+1+1+1)))");
         assertThat(nestedFn.toString(Style.QUALIFIED),
-            is("abs(sqrt(ln(_cast((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1), 'double precision'))))"));
+            is("abs(sqrt(ln(_cast((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint), 'double precision'))))"));
         assertThat(nestedFn.toString(Style.UNQUALIFIED),
-            is("abs(sqrt(ln(_cast((((((((bar + cast(\"select\" AS bigint)) + 1) + 1) + 1) + 1) + 1) + 1), 'double precision'))))"));
+            is("abs(sqrt(ln(_cast((((((((bar + cast(\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint), 'double precision'))))"));
     }
 
     @Test
@@ -315,7 +315,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         String printed = comparisonOperator.toString(Style.QUALIFIED);
         assertThat(
             printed,
-            is("((doc.formatter.bar = 1) AND (doc.formatter.foo = '2'))")
+            is("((doc.formatter.bar = 1::bigint) AND (doc.formatter.foo = '2'))")
         );
     }
 

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -105,7 +105,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_function_arguments_must_have_array_types() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _values(bigint)");
+        expectedException.expectMessage("unknown function: _values(integer)");
         assertExecute("_values(200)", "");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1285,7 +1285,7 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         execute("explain select distinct id from m.tbl limit 2");
         assertThat(
             printedTable(response.rows()),
-            is("TopNDistinct[2 | [id]]\n" +
+            is("TopNDistinct[2::bigint | [id]]\n" +
                "  └ Collect[m.tbl | [id] | true]\n")
         );
         execute("select distinct id from m.tbl limit 2");

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -21,27 +21,6 @@
 
 package io.crate.integrationtests;
 
-import static io.crate.testing.TestingHelpers.printRows;
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.After;
-import org.junit.Test;
-
 import io.crate.data.CollectionBucket;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.engine.join.RamBlockSizeCalculator;
@@ -51,6 +30,26 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseHashJoins;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static io.crate.testing.TestingHelpers.printRows;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class JoinIntegrationTest extends SQLTransportIntegrationTest {
@@ -401,7 +400,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("explain select * from doc.t as t1, doc.t as t2 order by t1.x, t2.x limit 3");
         assertThat(printedTable(response.rows()), is(
             "Fetch[x, y, x, y]\n" +
-            "  └ Limit[3;0]\n" +
+            "  └ Limit[3::bigint;0]\n" +
             "    └ OrderBy[x ASC x ASC]\n" +
             "      └ NestedLoopJoin[CROSS]\n" +
             "        ├ Rename[t1._fetchid, x] AS t1\n" +

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -205,7 +205,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast `129` of type `bigint` to type `char`");
+        expectedException.expectMessage("Cannot cast `129` of type `integer` to type `char`");
 
         setUpSimple();
         execute("delete from t1 where byte_field=129");

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -228,9 +228,9 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                   "   \"day2\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\") INDEX OFF,\n" +
                   "   \"day3\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
                   "   \"day4\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
-                  "   \"col1\" BIGINT GENERATED ALWAYS AS _cast(\"ts\", 'bigint') + 1,\n" +
-                  "   \"col2\" TEXT GENERATED ALWAYS AS _cast((_cast(\"ts\", 'bigint') + 1), 'text'),\n" +
-                  "   \"col3\" TEXT GENERATED ALWAYS AS _cast((_cast(\"ts\", 'bigint') + 1), 'text'),\n" +
+                  "   \"col1\" BIGINT GENERATED ALWAYS AS _cast(\"ts\", 'bigint') + CAST(1 AS bigint),\n" +
+                  "   \"col2\" TEXT GENERATED ALWAYS AS _cast((_cast(\"ts\", 'bigint') + CAST(1 AS bigint)), 'text'),\n" +
+                  "   \"col3\" TEXT GENERATED ALWAYS AS _cast((_cast(\"ts\", 'bigint') + CAST(1 AS bigint)), 'text'),\n" +
                   "   \"name\" TEXT GENERATED ALWAYS AS concat(\"user\"['name'], 'foo'),\n" +
                   "   \"ts\" TIMESTAMP WITH TIME ZONE,\n" +
                   "   \"user\" OBJECT(DYNAMIC) AS (\n" +

--- a/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -58,7 +58,7 @@ public class SysClusterTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
         assertThat(
             printedTable(response.rows()),
-            is("Limit[2;0]\n" +
+            is("Limit[2::bigint;0]\n" +
                "  └ Collect[sys.cluster | [id, license, master_node, name, settings] | true]\n")
         );
     }

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -77,7 +77,7 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testGlobalAggregationFromUnnest() {
-        assertThat(execute("select max(col1) from unnest([1, 2, 3, 4])").rows()[0][0], is(4L));
+        assertThat(execute("select max(col1) from unnest([1, 2, 3, 4])").rows()[0][0], is(4));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
     @Test
     public void testAggregationOnResultOfTableFunctionWithinSubQuery() {
         execute("select max(x) from (select unnest([1, 2, 3, 4]) as x) as t");
-        assertThat(response.rows()[0][0], is(4L));
+        assertThat(response.rows()[0][0], is(4));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -396,13 +396,13 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     public void testArithmeticFunctions() throws Exception {
         execute("select ((2 * 4 - 2 + 1) / 2) % 3 from sys.cluster");
         assertThat(response.cols()[0], is("0"));
-        assertThat(response.rows()[0][0], is(0L));
+        assertThat(response.rows()[0][0], is(0));
 
         execute("select ((2 * 4.0 - 2 + 1) / 2) % 3 from sys.cluster");
         assertThat(response.rows()[0][0], is(0.5));
 
         execute("select ? + 2 from sys.cluster", $(1));
-        assertThat(response.rows()[0][0], is(3L));
+        assertThat(response.rows()[0][0], is(3));
 
         if (!Constants.WINDOWS) {
             response = execute("select load['1'] + load['5'], load['1'], load['5'] from sys.nodes limit 1");

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -65,12 +65,12 @@ public class UnionIntegrationTest extends SQLTransportIntegrationTest {
                 "union all " +
                 "select * from unnest([4, 5, 6], ['4', '5', '6'])");
         assertThat(response.rows(), arrayContainingInAnyOrder(
-            new Object[] {1L, "1"},
-            new Object[] {2L, "2"},
-            new Object[] {3L, "3"},
-            new Object[] {4L, "4"},
-            new Object[] {5L, "5"},
-            new Object[] {6L, "6"}
+            new Object[] {1, "1"},
+            new Object[] {2, "2"},
+            new Object[] {3, "3"},
+            new Object[] {4, "4"},
+            new Object[] {5, "5"},
+            new Object[] {6, "6"}
         ));
     }
 
@@ -238,7 +238,7 @@ public class UnionIntegrationTest extends SQLTransportIntegrationTest {
     public void testUnionAllArrayAndObjectColumns() {
         execute("select * from (select t1.id, t1.text, t3.arr, t3.obj from t1 join t3 on arr is not null) a " +
                 "union all " +
-                "select id, text, [1,2], {custom = true} from t3 where arr is not null " +
+                "select id, text, [1::bigint, 2::bigint], {custom = true} from t3 where arr is not null " +
                 "order by id");
         assertThat(printedTable(response.rows()), is(
             "1| text| [1, 2, 3]| {temperature=42}\n" +

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -474,27 +474,27 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(
             convert("ts_array[1] = 1129224512000").toString(),
             is("+ts_array:[1129224512000 TO 1129224512000] " +
-                "#(ts_array[1] = 1129224512000)")
+                "#(ts_array[1] = 1129224512000::bigint)")
         );
         assertThat(
             convert("ts_array[1] >= 1129224512000").toString(),
             is("+ts_array:[1129224512000 TO 9223372036854775807] " +
-                "#(ts_array[1] >= 1129224512000)")
+                "#(ts_array[1] >= 1129224512000::bigint)")
         );
         assertThat(
             convert("ts_array[1] > 1129224512000").toString(),
             is("+ts_array:[1129224512001 TO 9223372036854775807] " +
-                "#(ts_array[1] > 1129224512000)")
+                "#(ts_array[1] > 1129224512000::bigint)")
         );
         assertThat(
             convert("ts_array[1] <= 1129224512000").toString(),
             is("+ts_array:[-9223372036854775808 TO 1129224512000] " +
-                "#(ts_array[1] <= 1129224512000)")
+                "#(ts_array[1] <= 1129224512000::bigint)")
         );
         assertThat(
             convert("ts_array[1] < 1129224512000").toString(),
             is("+ts_array:[-9223372036854775808 TO 1129224511999] " +
-                "#(ts_array[1] < 1129224512000)")
+                "#(ts_array[1] < 1129224512000::bigint)")
         );
     }
 

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -33,7 +33,7 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     public void testNotAnyEqWith3vl() {
         assertThat(
             convert("NOT 10 = ANY(y_array)").toString(),
-            is("+(+*:* -y_array:[10 TO 10]) +(+*:* -((10 = ANY(y_array)) IS NULL))")
+            is("+(+*:* -y_array:[10 TO 10]) +(+*:* -((10::bigint = ANY(y_array)) IS NULL))")
         );
         assertThat
             (

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -367,12 +367,12 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         Reference integerIndexed = md.references().get(new ColumnIdent("integerIndexed"));
         assertThat(integerIndexed.indexType(), is(Reference.IndexType.NOT_ANALYZED));
-        assertThat(integerIndexed.defaultExpression(), isLiteral(1L));
+        assertThat(integerIndexed.defaultExpression(), isLiteral(1));
 
 
         Reference integerNotIndexed = md.references().get(new ColumnIdent("integerNotIndexed"));
         assertThat(integerNotIndexed.indexType(), is(Reference.IndexType.NO));
-        assertThat(integerNotIndexed.defaultExpression(), isLiteral(1L));
+        assertThat(integerNotIndexed.defaultExpression(), isLiteral(1));
 
         Reference stringNotIndexed = md.references().get(new ColumnIdent("stringNotIndexed"));
         assertThat(stringNotIndexed.indexType(), is(Reference.IndexType.NO));
@@ -1463,7 +1463,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
     public void testArrayAsGeneratedColumn() throws Exception {
         DocIndexMetaData md = getDocIndexMetaDataFromStatement("create table t1 (x as ([10, 20]))");
         GeneratedReference generatedReference = md.generatedColumnReferences().get(0);
-        assertThat(generatedReference.valueType(), is(new ArrayType(DataTypes.LONG)));
+        assertThat(generatedReference.valueType(), is(new ArrayType<>(DataTypes.INTEGER)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -33,7 +33,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testSetPlan() throws Exception {
         UpdateSettingsPlan plan = e.plan("set GLOBAL PERSISTENT stats.jobs_log_size=1024");
 
-        assertThat(plan.settings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024L)))));
+        assertThat(plan.settings(), contains(new Assignment<>(Literal.of("stats.jobs_log_size"), List.of(Literal.of(1024)))));
         assertThat(plan.isPersistent(), is(true));
 
         plan = e.plan("set GLOBAL TRANSIENT stats.enabled=false,stats.jobs_log_size=0");

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -104,7 +104,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
     public void testFilterOnPartitionColumnAndPrimaryKeyResultsInDocKeys() {
         WhereClauseOptimizer.DetailedQuery query = optimize(
             "select * from parted_pk where id = 1 and date = 1395874800000");
-        assertThat(query.docKeys().toString(), is("Optional[DocKeys{1, 1395874800000}]"));
+        assertThat(query.docKeys().toString(), is("Optional[DocKeys{1, 1395874800000::bigint}]"));
         assertThat(query.partitions(), empty());
     }
 
@@ -152,6 +152,6 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
     public void testFilterOnPKAndVersionResultsInDocKeys() {
         WhereClauseOptimizer.DetailedQuery query = optimize(
             "select * from bystring where name = 'foo' and _version = 2");
-        assertThat(query.docKeys().toString(), is("Optional[DocKeys{'foo', 2}]"));
+        assertThat(query.docKeys().toString(), is("Optional[DocKeys{'foo', 2::bigint}]"));
     }
 }

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -378,7 +378,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
             "select id from users group by id having id > 0");
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
-        assertThat(collectPhase.where(), isSQL("(doc.users.id > 0)"));
+        assertThat(collectPhase.where(), isSQL("(doc.users.id > 0::bigint)"));
         assertThat(collectPhase.projections(), contains(
             instanceOf(GroupProjection.class)
         ));

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -71,8 +71,8 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
             Literal.of(7L)
         );
         assertThat(plan, isPlan(
-            "Limit[20;7]\n" +
-            "  └ Limit[10;5]\n" +
+            "Limit[20::bigint;7::bigint]\n" +
+            "  └ Limit[10::bigint;5::bigint]\n" +
             "    └ Collect[doc.users | [name] | true]"));
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -63,7 +63,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10"
         );
         var expectedPlan =
-            "Filter[(coalesce(_cast(x, 'bigint'), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | true]";
@@ -77,7 +77,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10 AND t1.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(_cast(x, 'bigint'), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | (x > 5)]\n" +
             "    └ Collect[doc.t2 | [x] | true]";
@@ -91,7 +91,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(_cast(x, 'bigint'), 10) = 10)]\n" +
+            "Filter[(coalesce(x, 10) = 10)]\n" +
             "  └ NestedLoopJoin[RIGHT | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | (x > 5)]";
@@ -105,7 +105,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[((coalesce(_cast(x, 'bigint'), 10) = 10) AND (x > 5))]\n" +
+            "Filter[((coalesce(x, 10) = 10) AND (x > 5))]\n" +
             "  └ NestedLoopJoin[FULL | (x = x)]\n" +
             "    ├ Collect[doc.t1 | [x] | true]\n" +
             "    └ Collect[doc.t2 | [x] | (x > 5)]";

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -350,7 +350,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "SELECT x, count(*) FROM t1 GROUP BY 1 HAVING count(*) > 10 AND x > 1"
         );
         var expectedPlan =
-            "Filter[(count(*) > 10)]\n" +
+            "Filter[(count(*) > 10::bigint)]\n" +
             "  └ GroupHashAggregate[x | count(*)]\n" +
             "    └ Collect[doc.t1 | [x] | (x > 1)]";
         assertThat(plan, isPlan(expectedPlan));
@@ -396,7 +396,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "Rename[id, name] AS u\n" +
             "  └ OrderBy[id ASC name ASC]\n" +
             "    └ OrderBy[id ASC name ASC]\n" +
-            "      └ Get[doc.users | id, name | DocKeys{1}]";
+            "      └ Get[doc.users | id, name | DocKeys{1::bigint}]";
         assertThat(plan, isPlan(expectedPlan));
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -226,7 +226,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             ClientMessages.sendParseMessage(buffer,
                 "S1",
                 "select ? in (1, 2, 3)",
-                new int[] { PGTypes.get(DataTypes.LONG).oid() });
+                new int[] { PGTypes.get(DataTypes.INTEGER).oid() });
                 ClientMessages.sendBindMessage(buffer,
                     "P1",
                     "S1",
@@ -302,7 +302,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(response.readByte(), is((byte) 't'));
                 assertThat(response.readInt(), is(10));
                 assertThat(response.readShort(), is((short) 1));
-                assertThat(response.readInt(), is(PGTypes.get(DataTypes.LONG).oid()));
+                assertThat(response.readInt(), is(PGTypes.get(DataTypes.INTEGER).oid()));
             } finally {
                 response.release();
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Introduce an integer literal object which will be used instead of a 
long literal if the value fits into the integer range.
Queries like ``select 1`` will now return ``integer`` instead of ``long``.

This allows us to later remove the special literal downcast logic on 
function matching while keeping the existing behaviour of 
``int_col + 1 -> integer``.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
