### PR TITLE
Re-enable IAM Roles for s3 repositories

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -225,6 +225,9 @@ Performance improvements
 Fixes
 =====
 
+- Re-enabled the IAM role authentication for
+  :ref:`s3 repositories <ref-create-repository-types-s3>`
+
 - Changed the required privileges to execute ``RESET`` statements to include
   the ``AL`` privilege. Users with ``AL`` could change settings using ``SET
   GLOBAL`` already.
@@ -235,3 +238,4 @@ Fixes
 
 - Fixed an issue that caused the ``OFFSET`` clause to be ignored in ``SELECT
   DISTINCT`` queries.
+

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -196,13 +196,17 @@ A repository that stores its snapshot inside an HDFS file-system.
 ``s3``
 ------
 
-A repository that stores its snapshot on the Amazon S3 service.
+A repository that stores its snapshot on the Amazon S3 service. When used in
+conjunction with Amazon IAM Roles, ``access_key`` and ``secret_key`` must be
+undefined and these credentials will then be loaded from the Amazon Container
+(e.g. EC2).
+
 
 .. rubric:: Parameters
 
 **access_key**
   | *Type:*    ``text``
-  | *Required:* ``true``
+  | *Required:* ``false``
 
   Access key used for authentication against AWS. Note that this setting is
   masked and thus will not be visible when querying the ``sys.repositories``
@@ -210,7 +214,7 @@ A repository that stores its snapshot on the Amazon S3 service.
 
 **secret_key**
   | *Type:*    ``text``
-  | *Required:* ``true``
+  | *Required:* ``false``
 
   Secret key used for authentication against AWS. Note that this setting is
   masked and thus will not be visible when querying the ``sys.repositories``

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -69,12 +69,10 @@ public class S3Repository extends BlobStoreRepository {
 
     static final String TYPE = "s3";
 
-    public static List<Setting<?>> mandatorySettings() {
-        return List.of(ACCESS_KEY_SETTING, SECRET_KEY_SETTING);
-    }
-
     public static List<Setting<?>> optionalSettings() {
-        return List.of(BASE_PATH_SETTING,
+        return List.of(ACCESS_KEY_SETTING,
+                       SECRET_KEY_SETTING,
+                       BASE_PATH_SETTING,
                        BUCKET_SETTING,
                        BUFFER_SIZE_SETTING,
                        CANNED_ACL_SETTING,

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -21,7 +21,6 @@ package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.util.json.Jackson;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
@@ -36,9 +35,6 @@ import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static org.elasticsearch.repositories.s3.S3RepositorySettings.ACCESS_KEY_SETTING;
-import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 
 /**
  * A plugin to add a repository type that writes to and from the AWS S3.
@@ -67,11 +63,6 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     }
 
     @Override
-    public List<Setting<?>> getSettings() {
-        return List.of(ACCESS_KEY_SETTING, SECRET_KEY_SETTING);
-    }
-
-    @Override
     public Map<String, Repository.Factory> getRepositories(final Environment env, final NamedXContentRegistry registry, ThreadPool threadPool) {
         return Collections.singletonMap(
             S3Repository.TYPE,
@@ -79,7 +70,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
                 @Override
                 public TypeSettings settings() {
-                    return new TypeSettings(S3Repository.mandatorySettings(), S3Repository.optionalSettings());
+                    return new TypeSettings(List.of(), S3Repository.optionalSettings());
                 }
 
                 @Override

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -29,6 +30,7 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.internal.Constants;
+import io.crate.exceptions.InvalidArgumentException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
@@ -123,7 +125,17 @@ class S3Service implements Closeable {
         final AWSCredentials credentials = clientSettings.credentials;
         if (credentials == null) {
             logger.debug("Using instance profile credentials");
-            return new EC2ContainerCredentialsProviderWrapper();
+            var ec2ContainerCredentialsProviderWrapper = new EC2ContainerCredentialsProviderWrapper();
+            try {
+                // Check if credentials are available
+                ec2ContainerCredentialsProviderWrapper.getCredentials();
+                return ec2ContainerCredentialsProviderWrapper;
+            } catch (SdkClientException e) {
+                throw new InvalidArgumentException(
+                    "Cannot find required credentials to create a repository of type s3. " +
+                    "Credentials must be provided either as repository options access_key and secret_key or AWS IAM roles."
+                    );
+            }
         } else {
             logger.debug("Using basic key/secret credentials");
             return new AWSStaticCredentialsProvider(credentials);

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -24,6 +24,7 @@ package org.elasticsearch.repositories.s3;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -77,7 +78,7 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
         e = SQLExecutor.builder(clusterService).build();
         plannerContext = e.getPlannerContext(clusterService.state());
         repositoryParamValidator = new RepositoryParamValidator(
-            Map.of("s3", new TypeSettings(S3Repository.mandatorySettings(), S3Repository.optionalSettings()))
+            Map.of("s3", new TypeSettings(List.of(), S3Repository.optionalSettings()))
         );
     }
 
@@ -168,14 +169,6 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
                 Matchers.hasEntry("readonly", "false")
             )
         );
-    }
-
-    @Test
-    public void testCreateS3RepoWithMissingMandatorySettings() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The following required parameters are missing to" +
-                                        " create a repository of type \"s3\": [secret_key]");
-        analyze(e, "CREATE REPOSITORY foo TYPE s3 WITH (access_key='test')");
     }
 
     private static Settings toSettings(GenericProperties<Expression> genericProperties) {

--- a/server/src/main/java/io/crate/exceptions/InvalidArgumentException.java
+++ b/server/src/main/java/io/crate/exceptions/InvalidArgumentException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.exceptions;
+
+public class InvalidArgumentException extends ValidationException {
+
+    public InvalidArgumentException(String message) {
+        super(message);
+    }
+
+    public <C, R> R accept(CrateExceptionVisitor<C, R> exceptionVisitor, C context) {
+        return exceptionVisitor.visitCrateException(this, context);
+    }
+
+    @Override
+    public int errorCode() {
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will re-enable the IAM role authentication on ec2 for s3 repositories when no aws credentials are provided. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
