### PR TITLE
Add query optimizer incl. rules for cast optimizations

### DIFF
--- a/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -126,6 +126,7 @@ public final class GeneratedColumnExpander {
                 Symbol otherSide = null;
                 for (int i = 0; i < function.arguments().size(); i++) {
                     Symbol arg = function.arguments().get(i);
+                    arg = Symbols.unwrapReferenceFromCast(arg);
                     if (arg instanceof Reference) {
                         reference = (Reference) arg;
                     } else {

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -165,7 +165,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class ExpressionAnalyzer {
 
-    private static final Map<ComparisonExpression.Type, ComparisonExpression.Type> SWAP_OPERATOR_TABLE = Map.of(
+    public static final Map<ComparisonExpression.Type, ComparisonExpression.Type> SWAP_OPERATOR_TABLE = Map.of(
         ComparisonExpression.Type.GREATER_THAN, ComparisonExpression.Type.LESS_THAN,
         ComparisonExpression.Type.LESS_THAN, ComparisonExpression.Type.GREATER_THAN,
         ComparisonExpression.Type.GREATER_THAN_OR_EQUAL, ComparisonExpression.Type.LESS_THAN_OR_EQUAL,

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -341,7 +341,7 @@ public class EqualityExtractor {
             }
 
             public EqProxy add(Function compared) {
-                if (compared.info().ident().name().equals(AnyOperators.Names.EQ)) {
+                if (compared.info().ident().name().equals(AnyOperators.Type.EQ.opName())) {
                     AnyEqProxy anyEqProxy = new AnyEqProxy(compared, proxies);
                     for (EqProxy proxiedProxy : anyEqProxy) {
                         if (!proxies.containsKey(proxiedProxy.origin())) {
@@ -411,6 +411,7 @@ public class EqualityExtractor {
             Symbol firstArg = arguments.get(0);
 
             if (functionName.equals(EqOperator.NAME)) {
+                firstArg = Symbols.unwrapReferenceFromCast(firstArg);
                 if (firstArg instanceof Reference && SymbolVisitors.any(Symbols.IS_COLUMN, arguments.get(1)) == false) {
                     Comparison comparison = context.comparisons.get(
                         ((Reference) firstArg).column());
@@ -419,8 +420,9 @@ public class EqualityExtractor {
                         return comparison.add(function);
                     }
                 }
-            } else if (functionName.equals(AnyOperators.Names.EQ) && arguments.get(1).symbolType().isValueSymbol()) {
+            } else if (functionName.equals(AnyOperators.Type.EQ.opName()) && arguments.get(1).symbolType().isValueSymbol()) {
                 // ref = any ([1,2,3])
+                firstArg = Symbols.unwrapReferenceFromCast(firstArg);
                 if (firstArg instanceof Reference) {
                     Reference reference = (Reference) firstArg;
                     Comparison comparison = context.comparisons.get(reference.column());

--- a/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -38,6 +38,9 @@ import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class CastFunctionResolver {
 
+    public static final List<String> CAST_FUNCTION_NAMES = List.of(
+        ExplicitCastFunction.NAME, ImplicitCastFunction.NAME, TryCastFunction.NAME);
+
     public static Symbol generateCastFunction(Symbol sourceSymbol,
                                               DataType<?> targetType,
                                               CastMode... castModes) {

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -41,6 +41,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+
 public class Symbols {
 
     private static final HasColumnVisitor HAS_COLUMN_VISITOR = new HasColumnVisitor();
@@ -168,6 +170,14 @@ public class Symbols {
             }
         }
         return String.format(Locale.ENGLISH, messageTmpl, formattedSymbols);
+    }
+
+    public static Symbol unwrapReferenceFromCast(Symbol symbol) {
+        if (symbol instanceof Function
+            && CAST_FUNCTION_NAMES.contains(((Function) symbol).info().ident().name())) {
+            return ((Function) symbol).arguments().get(0);
+        }
+        return symbol;
     }
 
     private static class HasColumnVisitor extends SymbolVisitor<ColumnIdent, Boolean> {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -21,35 +21,6 @@
 
 package io.crate.lucene;
 
-import static io.crate.expression.eval.NullEliminator.eliminateNullsIfPossible;
-import static io.crate.metadata.DocReferences.inverseSourceLookup;
-import static java.util.Map.entry;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.Query;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.cache.IndexCache;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
-
 import io.crate.data.Input;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.VersioninigValidationException;
@@ -96,6 +67,33 @@ import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataTypes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.cache.IndexCache;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.crate.expression.eval.NullEliminator.eliminateNullsIfPossible;
+import static io.crate.metadata.DocReferences.inverseSourceLookup;
+import static java.util.Map.entry;
 
 
 @Singleton
@@ -299,12 +297,12 @@ public class LuceneQueryBuilder {
             entry(Ignore3vlFunction.NAME, new Ignore3vlQuery()),
             entry(IsNullPredicate.NAME, new IsNullQuery()),
             entry(MatchPredicate.NAME, new ToMatchQuery()),
-            entry(AnyOperators.Names.EQ, new AnyEqQuery()),
-            entry(AnyOperators.Names.NEQ, new AnyNeqQuery()),
-            entry(AnyOperators.Names.LT, new AnyRangeQuery("gt", "lt")),
-            entry(AnyOperators.Names.LTE, new AnyRangeQuery("gte", "lte")),
-            entry(AnyOperators.Names.GTE, new AnyRangeQuery("lte", "gte")),
-            entry(AnyOperators.Names.GT, new AnyRangeQuery("lt", "gt")),
+            entry(AnyOperators.Type.EQ.opName(), new AnyEqQuery()),
+            entry(AnyOperators.Type.NEQ.opName(), new AnyNeqQuery()),
+            entry(AnyOperators.Type.LT.opName(), new AnyRangeQuery("gt", "lt")),
+            entry(AnyOperators.Type.LTE.opName(), new AnyRangeQuery("gte", "lte")),
+            entry(AnyOperators.Type.GTE.opName(), new AnyRangeQuery("lte", "gte")),
+            entry(AnyOperators.Type.GT.opName(), new AnyRangeQuery("lt", "gt")),
             entry(LikeOperators.ANY_LIKE, new AnyLikeQuery(false)),
             entry(LikeOperators.ANY_NOT_LIKE, new AnyNotLikeQuery(false)),
             entry(LikeOperators.ANY_ILIKE, new AnyLikeQuery(true)),

--- a/server/src/main/java/io/crate/lucene/NotQuery.java
+++ b/server/src/main/java/io/crate/lucene/NotQuery.java
@@ -74,12 +74,12 @@ final class NotQuery implements FunctionToQuery {
          */
         private final Set<String> STRICT_3VL_FUNCTIONS =
             Set.of(
-                AnyOperators.Names.EQ,
-                AnyOperators.Names.NEQ,
-                AnyOperators.Names.GTE,
-                AnyOperators.Names.GT,
-                AnyOperators.Names.LTE,
-                AnyOperators.Names.LT,
+                AnyOperators.Type.EQ.opName(),
+                AnyOperators.Type.NEQ.opName(),
+                AnyOperators.Type.GTE.opName(),
+                AnyOperators.Type.GT.opName(),
+                AnyOperators.Type.LTE.opName(),
+                AnyOperators.Type.LT.opName(),
                 LikeOperators.ANY_LIKE,
                 LikeOperators.ANY_NOT_LIKE,
                 CoalesceFunction.NAME

--- a/server/src/main/java/io/crate/metadata/functions/params/Param.java
+++ b/server/src/main/java/io/crate/metadata/functions/params/Param.java
@@ -292,24 +292,13 @@ public final class Param {
             lowerPrecedenceArg = arg1;
         }
 
-        final DataType lowerPrecedenceType = lowerPrecedenceArg.valueType();
-        final DataType higherPrecedenceType = higherPrecedenceArg.valueType();
+        final DataType<?> lowerPrecedenceType = lowerPrecedenceArg.valueType();
+        final DataType<?> higherPrecedenceType = higherPrecedenceArg.valueType();
 
-        final boolean lowerPrecedenceCastable =
-            lowerPrecedenceArg.canBeCasted() && lowerPrecedenceType.isConvertableTo(higherPrecedenceType, false) &&
-            isTypeValid(higherPrecedenceType);
-        final boolean higherPrecedenceCastable =
-            higherPrecedenceArg.canBeCasted() && higherPrecedenceType.isConvertableTo(lowerPrecedenceType, false) &&
-            isTypeValid(lowerPrecedenceType);
-
-        // Check if one of the two arguments is a value symbol which can be converted easily, e.g. Literal
-        // We also allow downcasts in this case because we can check during analyzing the statement if
-        // the downcast succeeds.
-        if (lowerPrecedenceCastable && lowerPrecedenceArg.isValueSymbol()) {
-            return higherPrecedenceArg;
-        } else if (higherPrecedenceCastable && higherPrecedenceArg.isValueSymbol()) {
-            return lowerPrecedenceArg;
-        }
+        final boolean lowerPrecedenceCastable = lowerPrecedenceType.isConvertableTo(higherPrecedenceType, false)
+            && isTypeValid(higherPrecedenceType);
+        final boolean higherPrecedenceCastable = higherPrecedenceType.isConvertableTo(lowerPrecedenceType, false)
+            && isTypeValid(lowerPrecedenceType);
 
         if (lowerPrecedenceCastable) {
             return higherPrecedenceArg;
@@ -317,18 +306,10 @@ public final class Param {
             return lowerPrecedenceArg;
         }
 
-        // if neither the source, nor the target can be casted, yet either one *IS* convertible to the other, we will
-        // try to do the conversion (comparing two columns will never utilize the index anyway)
-        if (lowerPrecedenceType.isConvertableTo(higherPrecedenceType, false)) {
-            return higherPrecedenceArg;
-        } else if (higherPrecedenceType.isConvertableTo(lowerPrecedenceType, false)) {
-            return lowerPrecedenceArg;
-        }
-
         return null;
     }
 
-    private boolean isTypeValid(DataType dataType) {
+    private boolean isTypeValid(DataType<?> dataType) {
         return validTypes.isEmpty() || validTypes.contains(dataType);
     }
 

--- a/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -66,6 +66,7 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryAndParamBinder;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.symbol.Optimizer;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 
@@ -332,7 +333,7 @@ public final class UpdatePlanner {
             tableInfo.rowGranularity(),
             List.of(idReference),
             singletonList(updateProjection),
-            where.queryOrFallback(),
+            Optimizer.optimizeCasts(where.queryOrFallback(), plannerCtx),
             DistributionInfo.DEFAULT_BROADCAST
         );
         Collect collect = new Collect(collectPhase, TopN.NO_LIMIT, 0, numOutPuts, maxRowsPerNode, null);

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -43,6 +43,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
+import io.crate.planner.optimizer.symbol.Optimizer;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RoutingProvider;
@@ -243,6 +244,7 @@ public class Collect implements LogicalPlan {
         } else if (where.hasSeqNoAndPrimaryTerm()) {
             throw VersioninigValidationException.seqNoAndPrimaryTermUsage();
         }
+
         List<Symbol> boundOutputs = Lists2.map(outputs, binder);
         return new RoutedCollectPhase(
             plannerContext.jobId(),
@@ -258,7 +260,7 @@ public class Collect implements LogicalPlan {
                 ? Lists2.map(boundOutputs, DocReferences::toSourceLookup)
                 : boundOutputs,
             Collections.emptyList(),
-            where.queryOrFallback(),
+            Optimizer.optimizeCasts(where.queryOrFallback(), plannerContext),
             DistributionInfo.DEFAULT_BROADCAST
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/FunctionSymbolResolver.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/FunctionSymbolResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol;
+
+import io.crate.expression.symbol.Symbol;
+
+import java.util.List;
+
+public interface FunctionSymbolResolver {
+
+    Symbol apply(String name, List<Symbol> arguments);
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol;
+
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.common.collections.Lists2;
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.symbol.FunctionCopyVisitor;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Functions;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.planner.optimizer.symbol.rule.MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators;
+import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastInsideOperators;
+import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference;
+import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference;
+import io.crate.planner.optimizer.symbol.rule.MoveSubscriptOnReferenceCastToLiteralCastInsideOperators;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class Optimizer {
+
+    public static Symbol optimizeCasts(Symbol query, PlannerContext plannerContext) {
+        Optimizer optimizer = new Optimizer(
+            plannerContext.functions(),
+            plannerContext.transactionContext(),
+            () -> plannerContext.clusterState().nodes().getMinNodeVersion(),
+            List.of(
+                MoveReferenceCastToLiteralCastInsideOperators::new,
+                MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference::new,
+                MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference::new,
+                MoveSubscriptOnReferenceCastToLiteralCastInsideOperators::new,
+                MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators::new
+            )
+        );
+        return optimizer.optimize(query);
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(Optimizer.class);
+
+    private final List<Rule<?>> rules;
+    private final Supplier<Version> minNodeVersionInCluster;
+    private final Functions functions;
+    private final Visitor visitor = new Visitor();
+
+    public Optimizer(Functions functions,
+                     CoordinatorTxnCtx coordinatorTxnCtx,
+                     Supplier<Version> minNodeVersionInCluster,
+                     List<Function<FunctionSymbolResolver, Rule<?>>> rules) {
+        FunctionSymbolResolver functionResolver =
+            (f, args) -> {
+                try {
+                    return ExpressionAnalyzer.allocateFunction(
+                        f,
+                        args,
+                        null,
+                        null,
+                        functions,
+                        coordinatorTxnCtx
+                    );
+                } catch (ConversionException e) {
+                    return null;
+                }
+            };
+
+        this.rules = Lists2.map(rules, r -> r.apply(functionResolver));
+        this.minNodeVersionInCluster = minNodeVersionInCluster;
+        this.functions = functions;
+    }
+
+    public Symbol optimize(Symbol node) {
+        return node.accept(visitor, null);
+    }
+
+    public Symbol tryApplyRules(Symbol node) {
+        final boolean isTraceEnabled = LOGGER.isTraceEnabled();
+        // Some rules may only become applicable after another rule triggered, so we keep
+        // trying to re-apply the rules as long as at least one plan was transformed.
+        boolean done = false;
+        int numIterations = 0;
+        while (!done && numIterations < 10_000) {
+            done = true;
+            Version minVersion = minNodeVersionInCluster.get();
+            for (Rule rule : rules) {
+                if (minVersion.before(rule.requiredVersion())) {
+                    continue;
+                }
+                Match<?> match = rule.pattern().accept(node, Captures.empty());
+                if (match.isPresent()) {
+                    if (isTraceEnabled) {
+                        LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
+                    }
+                    Symbol transformedNode = rule.apply(match.value(), match.captures(), functions);
+                    if (transformedNode != null) {
+                        if (isTraceEnabled) {
+                            LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the symbol");
+                        }
+                        node = transformedNode;
+                        done = false;
+                    }
+                }
+            }
+            numIterations++;
+        }
+        assert numIterations < 10_000
+            : "Optimizer reached 10_000 iterations safety guard. This is an indication of a broken rule that matches again and again";
+        return node;
+    }
+
+    private class Visitor extends FunctionCopyVisitor<Void> {
+
+        @Override
+        public Symbol visitFunction(io.crate.expression.symbol.Function symbol, Void context) {
+            var maybeTransformedSymbol = tryApplyRules(symbol);
+            if (symbol.equals(maybeTransformedSymbol) == false) {
+                return maybeTransformedSymbol;
+            }
+            return super.visitFunction(symbol, context);
+        }
+    }
+
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import org.elasticsearch.Version;
+
+public interface Rule<T> {
+
+    Pattern<T> pattern();
+
+    Symbol apply(T symbol, Captures captures, Functions functions);
+
+    /**
+     * @return The version all nodes in the cluster must have to be able to use this optimization.
+     */
+    default Version requiredVersion() {
+        return Version.V_4_0_0;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import io.crate.expression.scalar.ArrayUpperFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+
+public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implements Rule<Function> {
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+    private final FunctionSymbolResolver functionResolver;
+
+    public MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators(FunctionSymbolResolver functionResolver) {
+        this.functionResolver = functionResolver;
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> COMPARISON_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
+                    .with(f -> f.info().ident().name().equals(ArrayUpperFunction.ARRAY_LENGTH)
+                               || f.info().ident().name().equals(ArrayUpperFunction.ARRAY_UPPER))
+                    .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+                )
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        Functions functions) {
+        var literal = operator.arguments().get(1);
+        var castFunction = captures.get(castCapture);
+        var function = castFunction.arguments().get(0);
+        DataType<?> targetType = function.valueType();
+
+        return functionResolver.apply(
+            operator.info().ident().name(),
+            List.of(function, literal.cast(targetType))
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import io.crate.common.collections.Lists2;
+import io.crate.expression.operator.LikeOperators;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+
+public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Function> {
+
+    private static List<String> MATCHING_OPERATORS = Lists2.concat(
+        COMPARISON_OPERATORS,
+        List.of(
+            LikeOperators.OP_LIKE,
+            LikeOperators.OP_ILIKE
+        )
+    );
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+    private final FunctionSymbolResolver functionResolver;
+
+    public MoveReferenceCastToLiteralCastInsideOperators(FunctionSymbolResolver functionResolver) {
+        this.functionResolver = functionResolver;
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> MATCHING_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        Functions functions) {
+        var literal = operator.arguments().get(1);
+        var castFunction = captures.get(castCapture);
+        var reference = castFunction.arguments().get(0);
+        DataType<?> targetType = reference.valueType();
+
+        return functionResolver.apply(
+            operator.info().ident().name(),
+            List.of(reference, literal.cast(targetType))
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+
+public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference implements Rule<Function> {
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+    private final FunctionSymbolResolver functionResolver;
+
+    public MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference(FunctionSymbolResolver functionResolver) {
+        this.functionResolver = functionResolver;
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.info().ident().name()))
+            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        Functions functions) {
+        var literal = operator.arguments().get(1);
+        var castFunction = captures.get(castCapture);
+        var reference = castFunction.arguments().get(0);
+        DataType<?> targetType = new ArrayType<>(reference.valueType());
+
+        return functionResolver.apply(
+            operator.info().ident().name(),
+            List.of(reference, literal.cast(targetType))
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+
+public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference implements Rule<Function> {
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+    private final FunctionSymbolResolver functionResolver;
+
+    public MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference(FunctionSymbolResolver functionResolver) {
+        this.functionResolver = functionResolver;
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.info().ident().name()))
+            .with(f -> f.arguments().get(0).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(1)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        Functions functions) {
+        var literal = operator.arguments().get(0);
+        var castFunction = captures.get(castCapture);
+        var reference = castFunction.arguments().get(0);
+        DataType<?> targetType = reference.valueType();
+        if (targetType.id() != ArrayType.ID) {
+            return null;
+        }
+        targetType = ((ArrayType<?>) targetType).innerType();
+
+        var operatorName = operator.info().ident().name();
+        if (List.of(AnyOperators.Type.EQ.opName(), AnyOperators.Type.NEQ.opName()).contains(operatorName) == false
+            && literal.valueType().id() == ArrayType.ID) {
+            // this is not supported and will fail later on with more verbose error than a cast error
+            return null;
+        }
+
+        return functionResolver.apply(
+            operator.info().ident().name(),
+            List.of(literal.cast(targetType), reference)
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import io.crate.expression.scalar.SubscriptFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Functions;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+
+public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements Rule<Function> {
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+    private final FunctionSymbolResolver functionResolver;
+
+    public MoveSubscriptOnReferenceCastToLiteralCastInsideOperators(FunctionSymbolResolver functionResolver) {
+        this.functionResolver = functionResolver;
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> COMPARISON_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
+                    .with(f -> f.info().ident().name().equals(SubscriptFunction.NAME))
+                    .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+                )
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        Functions functions) {
+        var literal = operator.arguments().get(1);
+        var castFunction = captures.get(castCapture);
+        var subscript = castFunction.arguments().get(0);
+        DataType<?> targetType = subscript.valueType();
+
+        return functionResolver.apply(
+            operator.info().ident().name(),
+            List.of(subscript, literal.cast(targetType))
+        );
+    }
+}

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -82,7 +82,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDeleteWherePartitionedByColumn() throws Exception {
-        AnalyzedDeleteStatement delete = e.analyze("delete from parted where date = 1395874800000");
+        AnalyzedDeleteStatement delete = e.analyze("delete from parted where date = 1395874800000::timestamp");
         assertThat(delete.query(), isFunction(EqOperator.NAME, isReference("date"), isLiteral(1395874800000L)));
     }
 

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -364,7 +364,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testGroupByHavingOtherColumnInAggregate() throws Exception {
-        QueriedSelectRelation relation = analyze("select sum(floats), name from users group by name having max(bytes) = 4");
+        QueriedSelectRelation relation = analyze("select sum(floats), name from users group by name having max(bytes) = 4::char");
         assertThat(relation.having(), isFunction("op_="));
         Function havingFunction = (Function) relation.having();
         assertThat(havingFunction.arguments().size(), is(2));

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -431,7 +431,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testWhereInSelect() throws Exception {
         QueriedSelectRelation relation = analyze("select load from sys.nodes where load['1'] in (1.0, 2.0, 4.0, 8.0, 16.0)");
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(AnyOperators.Names.EQ));
+        assertThat(whereClause.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
     }
 
     @Test
@@ -855,7 +855,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze(
             "select * from users where 5 = ANY (friends['id'])");
         Function anyFunction = (Function) relation.where();
-        assertThat(anyFunction.info().ident().name(), is(AnyOperators.Names.EQ));
+        assertThat(anyFunction.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
         assertThat(anyFunction.arguments().get(1), isReference("friends['id']", new ArrayType<>(DataTypes.LONG)));
         assertThat(anyFunction.arguments().get(0), isLiteral(5L));
     }
@@ -1218,7 +1218,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         Function havingFunction = (Function) relation.having();
 
         // assert that the in was converted to or
-        assertThat(havingFunction.info().ident().name(), is(AnyOperators.Names.EQ));
+        assertThat(havingFunction.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -134,8 +134,8 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select * from " +
                                                  " (select a, i from t1 order by a limit 5) t1 " +
                                                  "left join" +
-                                                 " (select b, i from t2 where b > 10) t2 " +
-                                                 "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
+                                                 " (select b, i from t2 where b > '10') t2 " +
+                                                 "on t1.i = t2.i where t1.a > '50' and t2.b > '100' " +
                                                  "limit 10");
         assertThat(relation,
                    isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) LIMIT 10::bigint"));
@@ -152,8 +152,8 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select * from " +
                                                  " (select a, i from t1 order by a limit 5) t1 " +
                                                  "left join" +
-                                                 " (select b, i from t2 where b > 10) t2 " +
-                                                 "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
+                                                 " (select b, i from t2 where b > '10') t2 " +
+                                                 "on t1.i = t2.i where t1.a > '50' and t2.b > '100' " +
                                                  "order by 2 limit 10");
         assertThat(relation,
             isSQL("SELECT t1.a, t1.i, t2.b, t2.i WHERE ((t1.a > '50') AND (t2.b > '100')) ORDER BY t1.i LIMIT 10::bigint"));
@@ -172,7 +172,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                                  "     select * from t1 order by a desc limit 5) a" +
                                                  "  order by a limit 10) t1 " +
                                                  "join" +
-                                                 " (select b, i from t2 where b > 10) t2 " +
+                                                 " (select b, i from t2 where b > '10') t2 " +
                                                  "on t1.i = t2.i " +
                                                  "order by 1 limit 10");
         assertThat(relation.outputs(), contains(isFunction("count")));
@@ -201,8 +201,8 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testJoinOnSubSelectsWithOrder() throws Exception {
         QueriedSelectRelation relation = analyze("select * from " +
                                                  " (select a, i from t1 order by a) t1, " +
-                                                 " (select b, i from t2 where b > 10) t2 " +
-                                                 "where t1.a > 50 and t2.b > 100 " +
+                                                 " (select b, i from t2 where b > '10') t2 " +
+                                                 "where t1.a > '50' and t2.b > '100' " +
                                                  "order by 2 limit 10");
         assertThat(relation.outputs(), contains(isField("a"), isField("i"), isField("b"), isField("i")));
         assertThat(relation.where(), isSQL("((t1.a > '50') AND (t2.b > '100'))"));
@@ -225,8 +225,8 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select * from " +
                                                  " (select max(a) ma, i from t1 group by i) t1 " +
                                                  "left join" +
-                                                 " (select max(b) mb, i from t2 group by i having i > 10) t2 " +
-                                                 "on t1.i = t2.i where t1.ma > 50 and t2.mb > 100");
+                                                 " (select max(b) mb, i from t2 group by i having i > 10::int) t2 " +
+                                                 "on t1.i = t2.i where t1.ma > '50' and t2.mb > '100'");
         assertThat(relation.outputs(), isSQL("t1.ma, t1.i, t2.mb, t2.i"));
         assertThat(relation.joinPairs().get(0).condition(), isSQL("(t1.i = t2.i)"));
         assertThat(relation.where(), isSQL("((t1.ma > '50') AND (t2.mb > '100'))"));

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -56,7 +56,7 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSplitWithQueryMerge() throws Exception {
-        Symbol symbol = asSymbol("t1.a = 10 and (t2.b = 30 or t2.b = 20) and t1.x = 1");
+        Symbol symbol = asSymbol("t1.a = '10' and (t2.b = '30' or t2.b = '20') and t1.x = 1");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
         assertThat(split.get(Sets.newHashSet(tr1)), isSQL("((doc.t1.a = '10') AND (doc.t1.x = 1))"));
@@ -66,16 +66,16 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_query_splitter_retains_literals() {
         expressions.context().allowEagerNormalize(false);
-        Symbol symbol = asSymbol("t1.a = 10 and t1.x = t2.y and (false)");
+        Symbol symbol = asSymbol("t1.a = 10::text and t1.x = t2.y and (false)");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
-        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = _cast(10, 'text'))"));
+        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = cast(10 AS text))"));
         assertThat(split.get(Set.of(tr1, tr2)), isSQL("((doc.t1.x = doc.t2.y) AND false)"));
     }
 
     @Test
     public void testSplitDownTo1Relation() throws Exception {
-        Symbol symbol = asSymbol("t1.a = 10 and (t2.b = 30 or t2.b = 20)");
+        Symbol symbol = asSymbol("t1.a = '10' and (t2.b = '30' or t2.b = '20')");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
         assertThat(split.get(Sets.newHashSet(tr1)), isSQL("(doc.t1.a = '10')"));
@@ -84,7 +84,7 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMixedSplit() throws Exception {
-        Symbol symbol = asSymbol("t1.a = 10 and (t2.b = t3.c)");
+        Symbol symbol = asSymbol("t1.a = '10' and (t2.b = t3.c)");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
         assertThat(split.get(Sets.newHashSet(tr1)), isSQL("(doc.t1.a = '10')"));

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -368,4 +368,14 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
         List<List<Symbol>> matches = analyzeExactX(query("x = abs(x)"));
         assertThat(matches, nullValue());
     }
+
+    @Test
+    public void test_primary_key_comparison_is_detected_inside_cast_function() throws Exception {
+        Symbol query = query("cast(x as bigint) = 0");
+        List<List<Symbol>> matches = analyzeExactX(query);
+        assertThat(matches.size(), is(1));
+        assertThat(matches, contains(
+            contains(isLiteral(0L))
+        ));
+    }
 }

--- a/server/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/builder/SplitPointsTest.java
@@ -51,7 +51,7 @@ public class SplitPointsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSplitPointsCreationWithFunctionInAggregation() throws Exception {
-        QueriedSelectRelation relation = e.analyze("select sum(coalesce(x, 0::integer)) + 10 from t1");
+        QueriedSelectRelation relation = e.analyze("select sum(coalesce(x, 0)) + 10 from t1");
 
         SplitPoints splitPoints = SplitPointsBuilder.create(relation);
 

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -311,7 +311,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFormatOperatorWithStaticInstance() throws Exception {
-        Symbol comparisonOperator = sqlExpressions.asSymbol("bar = 1 and foo = 2");
+        Symbol comparisonOperator = sqlExpressions.asSymbol("bar = 1 and foo = '2'");
         String printed = comparisonOperator.toString(Style.QUALIFIED);
         assertThat(
             printed,

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -542,7 +542,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("insert into stuff (id, type, content) values(?, ?, ?)",
             new Object[]{3, 126, "Now panic"});
         ensureYellow();
-        refresh();
 
         execute("select id, type, content from stuff where id=2 and type=126");
         assertThat(response.rowCount(), is(1L));

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -214,10 +214,10 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast `'a'` of type `text` to type `char`");
+        expectedException.expectMessage("Cannot cast `[129]` of type `integer_array` to type `char_array`");
 
         setUpSimple();
-        execute("update t1 set byte_field=0 where byte_field in ('a')");
+        execute("update t1 set byte_field=0 where byte_field in (129)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.lucene.match.CrateRegexQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+import org.junit.Test;
+
+import static io.crate.lucene.LikeQuery.convertSqlLikeToLuceneWildcard;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
+
+    @Test
+    public void testLikeAnyOnArrayLiteral() throws Exception {
+        Query likeQuery = convert("name like any (['a', 'b', 'c'])");
+        assertThat(likeQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery likeBQuery = (BooleanQuery) likeQuery;
+        assertThat(likeBQuery.clauses().size(), is(3));
+        for (int i = 0; i < 2; i++) {
+            // like --> ConstantScoreQuery with regexp-filter
+            Query filteredQuery = likeBQuery.clauses().get(i).getQuery();
+            assertThat(filteredQuery, instanceOf(WildcardQuery.class));
+        }
+    }
+
+    @Test
+    public void testILikeAnyOnArrayLiteral() throws Exception {
+        Query likeQuery = convert("name ilike any (['A', 'B', 'B'])");
+        assertThat(likeQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery likeBQuery = (BooleanQuery) likeQuery;
+        assertThat(likeBQuery.clauses().size(), is(3));
+        for (int i = 0; i < 2; i++) {
+            Query filteredQuery = likeBQuery.clauses().get(i).getQuery();
+            assertThat(filteredQuery, instanceOf(CrateRegexQuery.class));
+        }
+    }
+
+    @Test
+    public void testNotLikeAnyOnArrayLiteral() throws Exception {
+        Query notLikeQuery = convert("name not like any (['a', 'b', 'c'])");
+        assertThat(notLikeQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
+        assertThat(notLikeBQuery.clauses(), hasSize(2));
+        BooleanClause clause = notLikeBQuery.clauses().get(1);
+        assertThat(clause.getOccur(), is(BooleanClause.Occur.MUST_NOT));
+        assertThat(((BooleanQuery) clause.getQuery()).clauses(), hasSize(3));
+        for (BooleanClause innerClause : ((BooleanQuery) clause.getQuery()).clauses()) {
+            assertThat(innerClause.getOccur(), is(BooleanClause.Occur.MUST));
+            assertThat(innerClause.getQuery(), instanceOf(WildcardQuery.class));
+        }
+    }
+
+    @Test
+    public void testNotILikeAnyOnArrayLiteral() throws Exception {
+        Query notLikeQuery = convert("name not ilike any (['A', 'B', 'C'])");
+        assertThat(notLikeQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
+        assertThat(notLikeBQuery.clauses(), hasSize(2));
+        BooleanClause clause = notLikeBQuery.clauses().get(1);
+        assertThat(clause.getOccur(), is(BooleanClause.Occur.MUST_NOT));
+        assertThat(((BooleanQuery) clause.getQuery()).clauses(), hasSize(3));
+        for (BooleanClause innerClause : ((BooleanQuery) clause.getQuery()).clauses()) {
+            assertThat(innerClause.getOccur(), is(BooleanClause.Occur.MUST));
+            assertThat(innerClause.getQuery(), instanceOf(CrateRegexQuery.class));
+        }
+    }
+
+    @Test
+    public void testLikeWithBothSidesReferences() throws Exception {
+        Query query = convert("name ilike name");
+        assertThat(query, instanceOf(GenericFunctionQuery.class));
+    }
+
+
+    @Test
+    public void testSqlLikeToLuceneWildcard() throws Exception {
+        assertThat(convertSqlLikeToLuceneWildcard("%\\\\%"), is("*\\\\*"));
+        assertThat(convertSqlLikeToLuceneWildcard("%\\\\_"), is("*\\\\?"));
+        assertThat(convertSqlLikeToLuceneWildcard("%\\%"), is("*%"));
+
+        assertThat(convertSqlLikeToLuceneWildcard("%me"), is("*me"));
+        assertThat(convertSqlLikeToLuceneWildcard("\\%me"), is("%me"));
+        assertThat(convertSqlLikeToLuceneWildcard("*me"), is("\\*me"));
+
+        assertThat(convertSqlLikeToLuceneWildcard("_me"), is("?me"));
+        assertThat(convertSqlLikeToLuceneWildcard("\\_me"), is("_me"));
+        assertThat(convertSqlLikeToLuceneWildcard("?me"), is("\\?me"));
+    }
+}

--- a/server/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
@@ -173,31 +173,6 @@ public class FuncParamsTest extends CrateUnitTest {
         assertThat(signature, is(list(DataTypes.LONG, new ArrayType(DataTypes.LONG))));
     }
 
-    @Test
-    public void testRespectCastableArgumentsWithInnerType() {
-        FuncArg castableArg = new Arg(DataTypes.LONG, true);
-        ArrayType integerArrayType = new ArrayType(DataTypes.INTEGER);
-        FuncArg nonCastableArg = new Arg(integerArrayType, false);
-        FuncParams params = FuncParams.builder(Param.ANY, Param.ANY_ARRAY.withInnerType(Param.ANY)).build();
-
-        List<DataType> signature = params.match(list(castableArg, nonCastableArg));
-        assertThat(signature, is(list(DataTypes.INTEGER, integerArrayType)));
-    }
-
-    @Test
-    public void testLosslessConversionResultingInDowncast() {
-        FuncArg highPrecedenceType = Literal.of(DataTypes.LONG, 5L);
-        FuncArg lowerPrecedenceType = new Arg(DataTypes.INTEGER, true);
-        FuncParams params = FuncParams.builder(Param.NUMERIC, Param.NUMERIC).build();
-
-        List<DataType> signature;
-        signature = params.match(list(highPrecedenceType, lowerPrecedenceType));
-        assertThat(signature, is(list(DataTypes.INTEGER, DataTypes.INTEGER)));
-
-        signature = params.match(list(lowerPrecedenceType, highPrecedenceType));
-        assertThat(signature, is(list(DataTypes.INTEGER, DataTypes.INTEGER)));
-    }
-
     private static class Arg implements FuncArg {
 
         private final DataType dataType;

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -305,8 +305,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = plan("select * from " +
                                 " (select a, i from t1 order by a limit 5) t1 " +
                                 "inner join" +
-                                " (select b, i from t2 where b > 10) t2 " +
-                                "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
+                                " (select b, i from t2 where b > '10') t2 " +
+                                "on t1.i = t2.i where t1.a > '50' and t2.b > '100' " +
                                 "limit 10");
         assertThat(plan, isPlan(
             "Limit[10::bigint;0]\n" +

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -47,7 +47,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
     public void testFilterAndOuterJoinIsRewrittenToInnerJoinIfFilterEliminatesNullRow() {
         var plan = sqlExecutor.logicalPlan(
             "SELECT * FROM t1 LEFT JOIN t2 ON t1.x = t2.x " +
-            "WHERE t2.x = 10"
+            "WHERE t2.x = '10'"
         );
         var expectedPlan =
             "NestedLoopJoin[INNER | (x = x)]\n" +

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -157,7 +157,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFilterIsMovedBeneathOrder() {
-        LogicalPlan plan = plan("select * from (select * from t1 order by a) tt where a > 10");
+        LogicalPlan plan = plan("select * from (select * from t1 order by a) tt where a > '10'");
         assertThat(plan, isPlan(
             "Rename[a, x, i] AS tt\n" +
             "  └ OrderBy[a ASC]\n" +

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.symbol;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.TableRelation;
+import io.crate.data.Row;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
+import io.crate.expression.operator.Operator;
+import io.crate.expression.operator.Operators;
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.ComparisonExpression;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.is;
+
+public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest {
+
+    private SqlExpressions e;
+    private Functions functions = getFunctions();
+    private AbstractTableRelation<?> tr1;
+    private PlannerContext plannerContext;
+
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        String createTableStmt =
+            "create table t1 (" +
+            "  id integer," +
+            "  name text," +
+            "  d_array array(double)," +
+            "  y_array array(bigint)," +
+            "  text_array array(text)," +
+            "  ts_array array(timestamp with time zone)," +
+            "  o_array array(object as (xs array(integer)))," +
+            "  addr ip" +
+            ")";
+        RelationName name = new RelationName(DocSchemaInfo.NAME, "t1");
+        DocTableInfo tableInfo = SQLExecutor.tableInfo(
+            name,
+            createTableStmt,
+            clusterService);
+        Map<RelationName, AnalyzedRelation> sources = Map.of(name, new TableRelation(tableInfo));
+        e = new SqlExpressions(sources);
+        tr1 = (AbstractTableRelation<?>) sources.get(tableInfo.ident());
+        plannerContext = SQLExecutor.builder(clusterService).build().getPlannerContext(clusterService.state());
+    }
+
+    private void assertCollectQuery(String query, String expected) {
+        var collect = new Collect(
+            false,
+            tr1,
+            Collections.emptyList(),
+            new WhereClause(e.asSymbol(query)),
+            100,
+            10
+        );
+        var plan = (io.crate.planner.node.dql.Collect) collect.build(
+            plannerContext,
+            new ProjectionBuilder(functions),
+            TopN.NO_LIMIT,
+            0,
+            null,
+            null,
+            Row.EMPTY,
+            new SubQueryResults(emptyMap()) {
+                @Override
+                public Object getSafe(SelectSymbol key) {
+                    return Literal.of(key.valueType(), null);
+                }
+            }
+
+        );
+        assertThat(((RoutedCollectPhase) plan.collectPhase()).where().toString(), is(expected));
+    }
+
+
+    @Test
+    public void test_any_operator_cast_on_left_reference_is_moved_to_cast_on_literal() {
+        for (var op : AnyOperators.Type.operatorSymbols()) {
+            assertCollectQuery(
+                "name " + op + " ANY([1, 2, 2])",
+                "(name " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
+            );
+        }
+        for (var op : List.of("LIKE", "ILIKE")) {
+            assertCollectQuery(
+                "name " + op + " ANY([1, 2, 2])",
+                "(name " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
+            );
+
+            assertCollectQuery(
+                "name NOT " + op + " ANY([1, 2, 2])",
+                "(name NOT " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
+            );
+        }
+    }
+
+    @Test
+    public void test_any_operator_cast_on_right_reference_is_moved_to_cast_on_literal() {
+        for(var op : AnyOperators.Type.operatorSymbols()) {
+            assertCollectQuery(
+                "'1' " + op + " ANY(d_array)",
+                "(1.0 " + op + " ANY(d_array))"
+            );
+        }
+        for (var op : List.of("LIKE", "ILIKE")) {
+            assertCollectQuery(
+                "1 " + op + " ANY(text_array)",
+                "(_cast(1, 'text') " + op + " ANY(text_array))"
+            );
+            assertCollectQuery(
+                "1 NOT " + op + " ANY(text_array)",
+                "(_cast(1, 'text') NOT " + op + " ANY(text_array))"
+            );
+        }
+    }
+
+    @Test
+    public void test_any_operator_cast_on_nested_array_referewence_is_moved_to_cast_on_literal() {
+        assertCollectQuery(
+            "[1.0, 2.0, 3.0] = any(o_array['xs'])",
+            "(_cast([1.0, 2.0, 3.0], 'array(integer)') = ANY(o_array['xs']))"
+        );
+    }
+
+    private String getSwappedOperator(String op) {
+        for (var comp : ComparisonExpression.Type.values()) {
+            if (comp.getValue().equals(op)) {
+                var swappedComp = ExpressionAnalyzer.SWAP_OPERATOR_TABLE.get(comp);
+                if (swappedComp == null) {
+                    return op;
+                }
+                return swappedComp.getValue();
+            }
+        }
+        return op;
+    }
+
+    @Test
+    public void test_operator_cast_on_reference_is_moved_to_cast_on_literal() {
+        for (var op : Operators.COMPARISON_OPERATORS) {
+            op = op.replace(Operator.PREFIX, "");
+            if (op.equals(ComparisonExpression.Type.CONTAINED_WITHIN.getValue())) {
+                assertCollectQuery(
+                    "addr " + op + " '192.168.0.1/24'",
+                    "(addr << '192.168.0.1/24')"
+                );
+            } else {
+                assertCollectQuery(
+                    "id " + op + " 1.0",
+                    "(id " + op + " _cast(1.0, 'integer'))"
+                );
+                assertCollectQuery(
+                    "1.0 " + op + " id",
+                    "(id " + getSwappedOperator(op) + " _cast(1.0, 'integer'))"
+                );
+            }
+        }
+    }
+
+    @Test
+    public void test_operator_subscript_on_reference_cast_is_moved_to_literal_cast() {
+        assertCollectQuery(
+            "ts_array[1] = 1129224512000",
+            "(ts_array[1] = _cast(1129224512000::bigint, 'timestamp with time zone'))"
+        );
+    }
+
+    @Test
+    public void test_operator_cast_on_array_length_with_reference_is_moved_to_literal_cast() {
+        assertCollectQuery(
+            "array_length(y_array, 1) < 1.0",
+            "(array_length(y_array, 1) < _cast(1.0, 'integer'))"
+        );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This replaces the special literal downcast logic inside the deprecated/old function matching which caused bugs on arithmetic.

The optimizer runs before creating any `RoutedCollectPhase` while building execution plans and thus only runs once per query.

Relates https://github.com/crate/crate/issues/9901.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
