### PR TITLE
Fix NPE in createTableStats that occurred on primitive array types.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -221,5 +221,9 @@ Performance improvements
 Fixes
 =====
 
+- Fixed an issue that caused a ``NullPointerException`` if the :ref:`ANALYZE
+  <analyze>` statement was executed on tables with primitive array type columns
+  that contain ``NULL`` values.
+
 - Fixed an issue that caused the ``OFFSET`` clause to be ignored in ``SELECT
   DISTINCT`` queries.

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -24,6 +24,7 @@ package io.crate.statistics;
 
 import io.crate.Streamer;
 import io.crate.action.FutureActionListener;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.data.Row;
 import io.crate.execution.ddl.AnalyzeRequest;
@@ -39,8 +40,6 @@ import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -65,7 +64,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 @Singleton
 public final class TransportAnalyzeAction {
 
-    private static final Logger LOGGER = LogManager.getLogger(TransportAnalyzeAction.class);
     private static final String INVOKE_ANALYZE = "internal:crate:sql/analyze/invoke";
     private static final String FETCH_SAMPLES = "internal:crate:sql/analyze/fetch_samples";
     private static final String RECEIVE_TABLE_STATS = "internal:crate:sql/analyze/receive_stats";
@@ -180,7 +178,8 @@ public final class TransportAnalyzeAction {
         return listener;
     }
 
-    private static Stats createTableStats(Samples samples, List<Reference> primitiveColumns) {
+    @VisibleForTesting
+    static Stats createTableStats(Samples samples, List<Reference> primitiveColumns) {
         List<Row> records = samples.records;
         List<Object> columnValues = new ArrayList<>(records.size());
         Map<ColumnIdent, ColumnStats> statsByColumn = new HashMap<>(primitiveColumns.size());

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -173,7 +174,7 @@ public class ArrayType<T> extends DataType<List<T>> {
             return -1;
         }
         for (int i = 0; i < val1.size(); i++) {
-            int cmp = innerType.compare(val1.get(i), val2.get(i));
+            int cmp = Comparator.nullsFirst(innerType).compare(val1.get(i), val2.get(i));
             if (cmp != 0) {
                 return cmp;
             }

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1596,7 +1596,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("REFRESH TABLE t1");
 
         assertThat(
-            printedTable(execute("SELECT * FROM t1").rows()),
+            printedTable(execute("SELECT * FROM t1 ORDER BY str").rows()),
             is("abc\n" +
                "abc\n" +
                "bcd\n" +

--- a/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
+++ b/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.statistics;
+
+import io.crate.breaker.SizeEstimatorFactory;
+import io.crate.data.Row1;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+
+public class TransportAnalyzeActionTest extends CrateUnitTest {
+
+    @Test
+    public void test_create_stats_for_tables_with_array_columns_with_nulls() {
+        var rows = new ArrayList<String>();
+        rows.add(null);
+
+        var samples = new Samples(
+            List.of(new Row1(rows), new Row1(rows)),
+            List.of(DataTypes.STRING_ARRAY.streamer()),
+            2,
+            SizeEstimatorFactory.create(DataTypes.STRING_ARRAY).estimateSize(rows)
+        );
+        var references = List.of(
+            new Reference(
+                new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummy"), "dummy"),
+                RowGranularity.DOC,
+                DataTypes.STRING_ARRAY,
+                null,
+                null)
+        );
+        var stats = TransportAnalyzeAction.createTableStats(samples, references);
+        assertThat(stats.numDocs, is(2L));
+    }
+}

--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -105,4 +105,13 @@ public class ArrayTypeTest extends CrateUnitTest {
         in = out.bytes().streamInput();
         assertThat(streamer.readValueFrom(in), contains(nullValue()));
     }
+
+    @Test
+    public void test_compare_arrays_of_string_that_contain_nulls() {
+        int cmp = DataTypes.STRING_ARRAY.compare(
+            DataTypes.STRING_ARRAY.value("{'a', null}"),
+            DataTypes.STRING_ARRAY.value("{'a', 'b'}")
+        );
+        assertThat(cmp, is(-1));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
