### PR TITLE
Allow users with AL privileges to execute RESET statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -221,6 +221,10 @@ Performance improvements
 Fixes
 =====
 
+- Changed the required privileges to execute ``RESET`` statements to include
+  the ``AL`` privilege. Users with ``AL`` could change settings using ``SET
+  GLOBAL`` already.
+
 - Fixed an issue that caused a ``NullPointerException`` if the :ref:`ANALYZE
   <analyze>` statement was executed on tables with primitive array type columns
   that contain ``NULL`` values.

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -535,7 +535,13 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitResetAnalyzedStatement(AnalyzedResetStatement resetAnalyzedStatement, User user) {
-            throwRequiresSuperUserPermission(user.name());
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema
+            );
             return null;
         }
 

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -190,11 +190,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testResetNotAllowedAsNormalUser() throws Exception {
-        expectedException.expect(UnauthorizedException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement. " +
-                                        "Superuser permissions are required");
+    public void test_reset_requires_AL_privileges() throws Exception {
         analyze("reset global stats.enabled");
+        assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

They can use `SET GLOBAL` so it makes sense to be able to RESET settings
as well.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)