### PR TITLE
Convert all operators to new signature based function registry

### DIFF
--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -175,8 +175,8 @@ public class EqualityExtractor {
 
         private void initProxies(Map<Function, EqProxy> existingProxies) {
             Symbol left = origin.arguments().get(0);
-            DataType leftType = origin.info().ident().argumentTypes().get(0);
-            DataType rightType = ((ArrayType) origin.info().ident().argumentTypes().get(1)).innerType();
+            DataType<?> leftType = origin.info().ident().argumentTypes().get(0);
+            DataType<?> rightType = ((ArrayType<?>) origin.info().ident().argumentTypes().get(1)).innerType();
             FunctionInfo eqInfo = new FunctionInfo(
                 new FunctionIdent(
                     EqOperator.NAME,
@@ -184,10 +184,11 @@ public class EqualityExtractor {
                 ),
                 DataTypes.BOOLEAN
             );
-            Literal arrayLiteral = (Literal) origin.arguments().get(1);
+            Literal<?> arrayLiteral = (Literal<?>) origin.arguments().get(1);
+
             proxies = new HashMap<>();
-            for (Literal arrayElem : Literal.explodeCollection(arrayLiteral)) {
-                Function f = new Function(eqInfo, Arrays.asList(left, arrayElem));
+            for (Literal<?> arrayElem : Literal.explodeCollection(arrayLiteral)) {
+                Function f = new Function(eqInfo, EqOperator.SIGNATURE, Arrays.asList(left, arrayElem));
                 EqProxy existingProxy = existingProxies.get(f);
                 if (existingProxy == null) {
                     existingProxy = new ChildEqProxy(f, this);

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -22,24 +22,22 @@
 
 package io.crate.expression.operator;
 
+import io.crate.common.collections.Tuple;
 import io.crate.data.Input;
-import io.crate.metadata.BaseFunctionResolver;
-import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.functions.params.FuncParams;
-import io.crate.metadata.functions.params.Param;
-import io.crate.types.DataType;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.common.collections.Tuple;
 import org.elasticsearch.common.network.InetAddresses;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Locale;
 
 public final class CIDROperator {
@@ -48,8 +46,20 @@ public final class CIDROperator {
 
     private static final int IPV4_ADDRESS_LEN = 4;
 
+    private static final FunctionInfo INFO = new FunctionInfo(
+        new FunctionIdent(CONTAINED_WITHIN, Arrays.asList(DataTypes.IP, DataTypes.STRING)),
+        DataTypes.BOOLEAN);
+
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(CONTAINED_WITHIN, new CIDRResolver());
+        module.register(
+            Signature.scalar(
+                CONTAINED_WITHIN,
+                DataTypes.IP.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ),
+            (signature, dataTypes) -> new ContainedWithinOperator(signature)
+        );
     }
 
     public static boolean containedWithin(String ipStr, String cidrStr) {
@@ -93,53 +103,37 @@ public final class CIDROperator {
         return new BigInteger(1, maskBuffer.array()).not().shiftRight(prefixLength);
     }
 
-    private static class CIDRResolver extends BaseFunctionResolver {
+    public static class ContainedWithinOperator extends Scalar<Boolean, Object> {
 
-        private CIDRResolver() {
-            super(
-                FuncParams.builder(
-                    Param.of(DataTypes.IP, DataTypes.STRING),
-                    Param.of(DataTypes.STRING)
-                ).build());
+        private final Signature signature;
+
+        public ContainedWithinOperator(Signature signature) {
+            this.signature = signature;
         }
 
         @Override
-        public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            return new ContainedWithinOperator(
-                FunctionInfo.of(
-                    CONTAINED_WITHIN,
-                    dataTypes,
-                    DataTypes.BOOLEAN
-                )
-            );
+        public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+            assert args.length == 2 : "number of args must be 2";
+            String left = (String) args[0].value();
+            if (null == left) {
+                return null;
+            }
+            String right = (String) args[1].value();
+            if (null == right) {
+                return null;
+            }
+            return containedWithin(left, right);
         }
 
-        private static class ContainedWithinOperator extends Scalar<Boolean, Object> {
+        @Override
+        public FunctionInfo info() {
+            return INFO;
+        }
 
-            private final FunctionInfo info;
-
-            private ContainedWithinOperator(FunctionInfo info) {
-                this.info = info;
-            }
-
-            @Override
-            public FunctionInfo info() {
-                return info;
-            }
-
-            @Override
-            public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
-                assert args.length == 2 : "number of args must be 2";
-                String left = (String) args[0].value();
-                if (null == left) {
-                    return null;
-                }
-                String right = (String) args[1].value();
-                if (null == right) {
-                    return null;
-                }
-                return containedWithin(left, right);
-            }
+        @Nullable
+        @Override
+        public Signature signature() {
+            return signature;
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -21,48 +21,52 @@
 
 package io.crate.expression.operator;
 
-import io.crate.common.collections.MapComparator;
 import io.crate.data.Input;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.BaseFunctionResolver;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.functions.params.FuncParams;
-import io.crate.metadata.functions.params.Param;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
+import io.crate.metadata.functions.Signature;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import javax.annotation.Nullable;
 
-import static io.crate.expression.operator.CmpOperator.CmpResolver.createInfo;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public final class EqOperator extends Operator<Object> {
 
     public static final String NAME = "op_=";
 
-    private final FunctionInfo info;
+    public static final Signature SIGNATURE = Signature.scalar(
+        NAME,
+        parseTypeSignature("E"),
+        parseTypeSignature("E"),
+        Operator.RETURN_TYPE.getTypeSignature()
+    ).withTypeVariableConstraints(typeVariable("E"));
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new EqOperatorResolver());
+        module.register(
+            SIGNATURE,
+            (signature, dataTypes) ->
+                new EqOperator(
+                    new FunctionInfo(
+                        new FunctionIdent(NAME, dataTypes),
+                        Operator.RETURN_TYPE
+                    ),
+                    signature
+                )
+        );
     }
 
-    public static Function createFunction(Symbol left, Symbol right) {
-        return new Function(createInfo(NAME, Arrays.asList(left.valueType(), right.valueType())),
-            Arrays.asList(left, right));
-    }
+    private final FunctionInfo info;
+    private final Signature signature;
 
-    private EqOperator(FunctionInfo info) {
+    public EqOperator(FunctionInfo info, Signature signature) {
         this.info = info;
+        this.signature = signature;
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
         assert args.length == 2 : "number of args must be 2";
         Object left = args[0].value();
         if (left == null) {
@@ -80,46 +84,9 @@ public final class EqOperator extends Operator<Object> {
         return info;
     }
 
-    private static class ObjectEqOperator extends Operator<Object> {
-
-        private final FunctionInfo info;
-
-        ObjectEqOperator(FunctionInfo info) {
-            this.info = info;
-        }
-
-        @Override
-        @SafeVarargs
-        public final Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
-            Object left = args[0].value();
-            Object right = args[1].value();
-            if (left == null || right == null) {
-                return null;
-            }
-            return MapComparator.compareMaps(((Map) left), ((Map) right)) == 0;
-        }
-
-        @Override
-        public FunctionInfo info() {
-            return info;
-        }
-    }
-
-    private static class EqOperatorResolver extends BaseFunctionResolver {
-
-        EqOperatorResolver() {
-            super(FuncParams.builder(Param.ANY, Param.ANY).build());
-        }
-
-        @Override
-        public FunctionImplementation getForTypes(List<DataType> argumentTypes) throws IllegalArgumentException {
-            DataType leftType = argumentTypes.get(0);
-            DataType rightType = argumentTypes.get(1);
-            FunctionInfo info = new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.BOOLEAN);
-            if (leftType.id() == ObjectType.ID && rightType.id() == ObjectType.ID) {
-                return new ObjectEqOperator(info);
-            }
-            return new EqOperator(info);
-        }
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -22,15 +22,30 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import static io.crate.expression.operator.Operator.generateInfo;
+
 public final class GtOperator {
 
     public static final String NAME = "op_>";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, GtOperator::cmpMatches));
-    }
-
-    private static boolean cmpMatches(int cmpResult) {
-        return cmpResult > 0;
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    supportedType.getTypeSignature(),
+                    supportedType.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ),
+                (signature, args) -> new CmpOperator(
+                    generateInfo(NAME, args.get(0)),
+                    signature,
+                    cmpResult -> cmpResult > 0
+                )
+            );
+        }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -22,16 +22,30 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import static io.crate.expression.operator.Operator.generateInfo;
+
 public final class GteOperator {
 
     public static final String NAME = "op_>=";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, GteOperator::cmpMatches));
-
-    }
-
-    private static boolean cmpMatches(int cmpResult) {
-        return cmpResult >= 0;
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    supportedType.getTypeSignature(),
+                    supportedType.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ),
+                (signature, args) -> new CmpOperator(
+                    generateInfo(NAME, args.get(0)),
+                    signature,
+                    cmpResult -> cmpResult >= 0
+                )
+            );
+        }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -22,15 +22,30 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import static io.crate.expression.operator.Operator.generateInfo;
+
 public final class LtOperator {
 
     public static final String NAME = "op_<";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, LtOperator::cmpMatches));
-    }
-
-    private static boolean cmpMatches(int cmpResult) {
-        return cmpResult < 0;
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    supportedType.getTypeSignature(),
+                    supportedType.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ),
+                (signature, args) -> new CmpOperator(
+                    generateInfo(NAME, args.get(0)),
+                    signature,
+                    cmpResult -> cmpResult < 0
+                )
+            );
+        }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -22,15 +22,30 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import static io.crate.expression.operator.Operator.generateInfo;
+
 public final class LteOperator {
 
     public static final String NAME = "op_<=";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, LteOperator::cmpMatches));
-    }
-
-    private static boolean cmpMatches(int cmpResult) {
-        return cmpResult <= 0;
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    supportedType.getTypeSignature(),
+                    supportedType.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ),
+                (signature, args) -> new CmpOperator(
+                    generateInfo(NAME, args.get(0)),
+                    signature,
+                    cmpResult -> cmpResult <= 0
+                )
+            );
+        }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/Operator.java
+++ b/server/src/main/java/io/crate/expression/operator/Operator.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.operator;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -34,6 +33,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.types.BooleanType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+
+import java.util.List;
 
 public abstract class Operator<I> extends Scalar<Boolean, I> {
 
@@ -53,6 +54,6 @@ public abstract class Operator<I> extends Scalar<Boolean, I> {
     }
 
     static FunctionInfo generateInfo(String name, DataType<?> type) {
-        return new FunctionInfo(new FunctionIdent(name, ImmutableList.of(type, type)), RETURN_TYPE);
+        return new FunctionInfo(new FunctionIdent(name, List.of(type, type)), RETURN_TYPE);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/Operators.java
+++ b/server/src/main/java/io/crate/expression/operator/Operators.java
@@ -21,16 +21,17 @@
 
 package io.crate.expression.operator;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.expression.predicate.NotPredicate;
+
+import java.util.Set;
 
 public class Operators {
 
-    public static final ImmutableSet<String> LOGICAL_OPERATORS = ImmutableSet.of(
+    public static final Set<String> LOGICAL_OPERATORS = Set.of(
         AndOperator.NAME, OrOperator.NAME, NotPredicate.NAME
     );
 
-    public static final ImmutableSet<String> COMPARISON_OPERATORS = ImmutableSet.of(
+    public static final Set<String> COMPARISON_OPERATORS = Set.of(
         EqOperator.NAME,
         GtOperator.NAME, GteOperator.NAME,
         LtOperator.NAME, LteOperator.NAME,

--- a/server/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -28,15 +28,41 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
+
+import javax.annotation.Nullable;
 
 public class OrOperator extends Operator<Boolean> {
 
     public static final String NAME = "op_or";
     public static final FunctionInfo INFO = generateInfo(NAME, DataTypes.BOOLEAN);
 
+    public static final Signature SIGNATURE = Signature.scalar(
+        NAME,
+        DataTypes.BOOLEAN.getTypeSignature(),
+        DataTypes.BOOLEAN.getTypeSignature(),
+        DataTypes.BOOLEAN.getTypeSignature()
+    );
+
+
     public static void register(OperatorModule module) {
-        module.registerOperatorFunction(new OrOperator());
+        module.register(
+            SIGNATURE,
+            (signature, dataTypes) -> new OrOperator(signature)
+        );
+    }
+
+    private final Signature signature;
+
+    public OrOperator(Signature signature) {
+        this.signature = signature;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -24,11 +24,14 @@ package io.crate.expression.operator;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
 
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static io.crate.expression.scalar.regex.RegexMatcher.isPcrePattern;
 
@@ -39,12 +42,30 @@ public class RegexpMatchOperator extends Operator<String> {
     public static final FunctionInfo INFO = generateInfo(NAME, DataTypes.STRING);
 
     public static void register(OperatorModule module) {
-        module.registerOperatorFunction(new RegexpMatchOperator());
+        var supportedArgumentTypes = List.of(DataTypes.STRING, DataTypes.UNDEFINED);
+        for (var left : supportedArgumentTypes) {
+            for (var right : supportedArgumentTypes) {
+                module.register(
+                    Signature.scalar(
+                        NAME,
+                        left.getTypeSignature(),
+                        right.getTypeSignature(),
+                        Operator.RETURN_TYPE.getTypeSignature()
+                    ).withForbiddenCoercion(),
+                    (signature, dataTypes) -> new RegexpMatchOperator(signature)
+                );
+            }
+        }
     }
 
+    private final Signature signature;
+
+    public RegexpMatchOperator(Signature signature) {
+        this.signature = signature;
+    }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, Input<String>[] args) {
         assert args.length == 2 : "invalid number of arguments";
         String source = args[0].value();
         if (source == null) {
@@ -67,5 +88,11 @@ public class RegexpMatchOperator extends Operator<String> {
     @Override
     public FunctionInfo info() {
         return INFO;
+    }
+
+    @Nullable
+    @Override
+    public Signature signature() {
+        return signature;
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -83,16 +83,6 @@ public class Function extends Symbol implements Cloneable {
     @Nullable
     private final Symbol filter;
 
-    public static Function of(String name, List<Symbol> arguments, DataType<?> returnType) {
-        return new Function(
-            new FunctionInfo(
-                new FunctionIdent(name, Symbols.typeView(arguments)),
-                returnType
-            ),
-            arguments
-        );
-    }
-
     public Function(StreamInput in) throws IOException {
         info = new FunctionInfo(in);
         if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
@@ -108,6 +98,7 @@ public class Function extends Symbol implements Cloneable {
         }
     }
 
+    @Deprecated
     public Function(FunctionInfo info, List<Symbol> arguments) {
         this(info, null, arguments);
     }

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -143,11 +143,14 @@ public final class WhereClauseOptimizer {
     public static DetailedQuery optimize(EvaluatingNormalizer normalizer,
                                          Symbol query,
                                          DocTableInfo table,
-                                         TransactionContext txnCtx) {
+                                         TransactionContext txnCtx,
+                                         Functions functions) {
         Symbol queryGenColsProcessed = GeneratedColumnExpander.maybeExpand(
             query,
             table.generatedColumns(),
-            Lists2.concat(table.partitionedByColumns(), Lists2.map(table.primaryKey(), table::getReference)));
+            Lists2.concat(table.partitionedByColumns(), Lists2.map(table.primaryKey(), table::getReference)),
+            functions
+        );
         if (!query.equals(queryGenColsProcessed)) {
             query = normalizer.normalize(queryGenColsProcessed, txnCtx);
         }

--- a/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -134,7 +134,7 @@ public final class UpdatePlanner {
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
         DocTableInfo tableInfo = docTable.tableInfo();
         WhereClauseOptimizer.DetailedQuery detailedQuery = WhereClauseOptimizer.optimize(
-            normalizer, query, tableInfo, plannerCtx.transactionContext());
+            normalizer, query, tableInfo, plannerCtx.transactionContext(), functions);
 
         if (detailedQuery.docKeys().isPresent()) {
             return new UpdateById(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
@@ -86,7 +86,8 @@ public final class RewriteCollectToGet implements Rule<Collect> {
             normalizer,
             where.queryOrFallback(),
             relation.tableInfo(),
-            txnCtx
+            txnCtx,
+            functions
         );
         Optional<DocKeys> docKeys = detailedQuery.docKeys();
         //noinspection OptionalIsPresent no capturing lambda allocation

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -91,7 +91,7 @@ public final class DeletePlanner {
         DocTableInfo table = tableRel.tableInfo();
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
         WhereClauseOptimizer.DetailedQuery detailedQuery = WhereClauseOptimizer.optimize(
-            normalizer, delete.query(), table, context.transactionContext());
+            normalizer, delete.query(), table, context.transactionContext(), context.functions());
 
         if (!detailedQuery.partitions().isEmpty()) {
             return new DeletePartitions(table.ident(), detailedQuery.partitions());

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -95,8 +95,10 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(actualStatement.query(), equalTo(expectedStatement.query()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWhereClauseObjectArrayField() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_=(bigint_array, integer)");
         e.analyze("delete from users where friends['id'] = 5");
     }
 

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -369,8 +369,10 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         analyze("update users set friends[1] = 2");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWhereClauseObjectArrayField() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_=(bigint_array, integer)");
         analyze("update users set awesome=true where friends['id'] = 5");
     }
 

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -369,7 +369,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("Cannot cast `xs` of type `integer_array` to type `integer`");
+        expectedException.expectMessage("unknown function: any_=(integer_array, integer_array)");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -378,4 +378,18 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
             contains(isLiteral(0L))
         ));
     }
+
+    @Test
+    public void test_primary_key_extraction_on_subscript_with_any() {
+        Map<RelationName, AnalyzedRelation> sources = T3.sources(List.of(T3.T4), clusterService);
+        DocTableRelation tr4 = (DocTableRelation) sources.get(T3.T4);
+        var expressionsT4 = new SqlExpressions(sources, tr4);
+        var pkCol = new ColumnIdent("obj");
+
+        var query = expressionsT4.normalize(expressionsT4.asSymbol("obj = any([{i = 1}])"));
+        List<List<Symbol>> matches = analyzeExact(query, List.of(pkCol));
+        assertThat(matches, contains(
+            contains(isLiteral(Map.of("i", 1)))
+        ));
+    }
 }

--- a/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -150,7 +150,8 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                     new EvaluatingNormalizer(getFunctions(), RowGranularity.CLUSTER, null, docTableRelation),
                     queriedRelation.where(),
                     docTableRelation.tableInfo(),
-                    coordinatorTxnCtx
+                    coordinatorTxnCtx,
+                    e.functions()
                 );
                 return detailedQuery.toBoundWhereClause(
                     docTableRelation.tableInfo(),

--- a/server/src/test/java/io/crate/execution/dsl/projection/FilterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/FilterProjectionTest.java
@@ -21,9 +21,12 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.expression.symbol.InputColumn;
-import io.crate.metadata.RowGranularity;
 import io.crate.expression.operator.EqOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -31,13 +34,25 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 public class FilterProjectionTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
+        var eqFunction =  new Function(
+            new FunctionInfo(
+                new FunctionIdent(EqOperator.NAME, List.of(DataTypes.INTEGER, DataTypes.INTEGER)),
+                DataTypes.BOOLEAN
+            ),
+            List.of(
+                new InputColumn(0, DataTypes.INTEGER),
+                new InputColumn(1, DataTypes.INTEGER)
+            )
+        );
+
         FilterProjection p = new FilterProjection(
-            EqOperator.createFunction(new InputColumn(0, DataTypes.INTEGER), new InputColumn(1, DataTypes.INTEGER)),
+            eqFunction,
             Collections.singletonList(new InputColumn(0))
         );
         p.requiredGranularity(RowGranularity.SHARD);

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -177,9 +177,8 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         EqOperator op =
             (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
         List<Symbol> toCollect = Collections.singletonList(testDocLevelReference);
-        WhereClause whereClause = new WhereClause(new Function(
-            op.info(),
-            arguments)
+        WhereClause whereClause = new WhereClause(
+            new Function(op.info(), op.signature(), arguments)
         );
         RoutedCollectPhase collectNode = getCollectNode(toCollect, whereClause);
 

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -152,7 +152,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         List<Symbol> arguments = Arrays.asList(tableNameRef, Literal.of("shards"));
         FunctionImplementation eqImpl
             = functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
-        Function whereClause = new Function(eqImpl.info(), arguments);
+        Function whereClause = new Function(eqImpl.info(), eqImpl.signature(),  arguments);
 
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC, new WhereClause(whereClause));
         Bucket result = collect(collectNode);

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -130,7 +130,7 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
         List<Symbol> arguments = Arrays.asList(Literal.of(2), new InputColumn(1, DataTypes.INTEGER));
         EqOperator op =
             (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
-        Function function = new Function(op.info(), arguments);
+        Function function = new Function(op.info(), op.signature(), arguments);
         FilterProjection filterProjection = new FilterProjection(function,
             Arrays.asList(new InputColumn(0), new InputColumn(1)));
 

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -270,8 +270,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         List<Symbol> arguments = Arrays.asList(Literal.of(2), new InputColumn(1));
         EqOperator op =
             (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
-        Function function = new Function(
-            op.info(), arguments);
+        Function function = new Function(op.info(), op.signature(), arguments);
         FilterProjection projection = new FilterProjection(function,
             Arrays.asList(new InputColumn(0), new InputColumn(1)));
 

--- a/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
@@ -48,7 +48,7 @@ public class AndOperatorTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_get_conjunctions_of_predicate_with_2_ands() {
-        Symbol query = sqlExpressions.asSymbol("(a = 1 or a = 2) AND x = 2 AND name = 'foo'");
+        Symbol query = sqlExpressions.asSymbol("(a = 1::int or a = 2::int) AND x = 2::int AND name = 'foo'");
         List<Symbol> split = AndOperator.split(query);
         assertThat(split, contains(
             isSQL("((doc.users.a = 1) OR (doc.users.a = 2))"),
@@ -59,7 +59,7 @@ public class AndOperatorTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_get_conjunctions_of_predicate_without_any_ands() {
-        Symbol query = sqlExpressions.asSymbol("a = 1");
+        Symbol query = sqlExpressions.asSymbol("a = 1::int");
         List<Symbol> split = AndOperator.split(query);
         assertThat(split, contains(
             isSQL("(doc.users.a = 1)")

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.operator;
 
-import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Literal;
 import org.junit.Rule;
@@ -76,7 +75,8 @@ public class CIDROperatorTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_both_operands_are_of_wrong_type() {
-        expectedException.expect(ConversionException.class);
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_<<(double precision, object)");
         assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false);
     }
 

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -69,6 +69,7 @@ public class EqOperatorTest extends AbstractScalarFunctionsTest {
     public void testEvaluateEqOperator() {
         assertNormalize("{l=1, b=true} = {l=1, b=true}", isLiteral(true));
         assertNormalize("{l=2, b=true} = {l=1, b=true}", isLiteral(false));
+        assertNormalize("{l=2, b=true} = {}", isLiteral(false));
 
         assertNormalize("1.2 = null", isLiteral(null));
         assertNormalize("'foo' = null", isLiteral(null));

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -372,8 +372,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     public void testRangeQueryOnDocThrowsException() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `_doc` of type `object` to any of the types: [double precision, ");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_>(object, object)");
         convert("_doc > {\"name\"='foo'}");
     }
 

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -82,7 +82,8 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
             normalizer,
             queriedTable.where(),
             table.tableInfo(),
-            e.getPlannerContext(clusterService.state()).transactionContext()
+            e.getPlannerContext(clusterService.state()).transactionContext(),
+            e.functions()
         );
     }
 

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -28,9 +28,12 @@ import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.NestedLoopPhase;
 import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.expression.operator.EqOperator;
+import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.test.integration.CrateUnitTest;
@@ -44,6 +47,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -82,8 +86,16 @@ public class JoinPhaseTest extends CrateUnitTest {
             ImmutableList.of(),
             DistributionInfo.DEFAULT_BROADCAST,
             null);
-        joinCondition = EqOperator.createFunction(
-            new InputColumn(0, DataTypes.STRING), new InputColumn(1, DataTypes.STRING));
+        joinCondition = new Function(
+            new FunctionInfo(
+                new FunctionIdent(EqOperator.NAME, List.of(DataTypes.STRING, DataTypes.STRING)),
+                DataTypes.BOOLEAN
+            ),
+            List.of(
+                new InputColumn(0, DataTypes.STRING),
+                new InputColumn(1, DataTypes.STRING)
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Refactored all operator registration to use the new signature based function registry.

Regex operators are now only registered to `text` and `undefined`(null) data types to prevent casting of a `text` argument to an argument type of higher precedence which would then later fail anyway on evaluation as only `text` types can be used.
This results in a different exception when used with non-text, non-null values; `UnsupportedOperationException` instead of a `ConversionException`.
