### PR TITLE
Ensure GroupByOptimizedIterator can be used in insert-from-query cases

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -225,6 +225,10 @@ Performance improvements
 Fixes
 =====
 
+- Fixed an issue that prevented an optimization for ``SELECT DISTINCT
+  <single_text_column> FROM <table>`` from working if used within a ``INSERT
+  INTO`` statement.
+
 - Re-enabled the IAM role authentication for
   :ref:`s3 repositories <ref-create-repository-types-s3>`
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -85,6 +85,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
@@ -129,6 +130,7 @@ final class GroupByOptimizedIterator {
         if (keyRef == null) {
             return null; // group by on non-reference
         }
+        keyRef = (Reference) DocReferences.inverseSourceLookup(keyRef);
         MappedFieldType keyFieldType = fieldTypeLookup.get(keyRef.column().fqn());
         if (keyFieldType == null || !keyFieldType.hasDocValues()) {
             return null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In `insert-from-query` we prefer using source lookups (`_doc['col']`).
This prevented the optimization from kicking in.

Closes https://github.com/crate/crate/issues/10082

    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |    15878.168 ±    0.000 |  15878.168 |  15878.168 |  15878.168 |  15878.168 |
    |   V2    |      510.232 ±    0.000 |    510.232 |    510.232 |    510.232 |    510.232 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 187.55%                           - 187.55%
    There is a nan% probability that the observed difference is not random, and the best estimate of that difference is 187.55%
    The test has no statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |   18    10.65     3.24 |    0     0.00     0.00 |     4295     3205 |  2751.76      42438
     V2 |    0     0.00     0.00 |    0     0.00     0.00 |     4295        0 |    56.19         16


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)