### PR TITLE
Adapt exception handling in repository creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.repositories.blobstore;
 
+import io.crate.exceptions.InvalidArgumentException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -354,7 +355,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     }
                     try {
                         store = createBlobStore();
-                    } catch (RepositoryException e) {
+                    } catch (RepositoryException | InvalidArgumentException e) {
                         throw e;
                     } catch (Exception e) {
                         throw new RepositoryException(metadata.name(), "cannot create blob store: " + e.getMessage() , e);


### PR DESCRIPTION
This change will make sure invalid arguments in the repository
creation will be return as error code 400 and not 500.

I found this by manually testing the backport to 4.1 and realised this yield also to the wrong behaviour in master.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
