### PR TITLE
De-duplicate aggregation functions used with GROUP BY

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
@@ -112,9 +113,9 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
     public GroupHashAggregate(LogicalPlan source, List<Symbol> groupKeys, List<Function> aggregates, long numExpectedRows) {
         super(source);
         this.numExpectedRows = numExpectedRows;
-        this.outputs = Lists2.concat(groupKeys, aggregates);
+        this.aggregates = List.copyOf(new LinkedHashSet<>(aggregates));
+        this.outputs = Lists2.concat(groupKeys, this.aggregates);
         this.groupKeys = groupKeys;
-        this.aggregates = aggregates;
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes an unreleased regression which caused incorrect results.
See https://github.com/crate/crate/issues/10075

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)