### PR TITLE
Limit line_numbers to 50 in the presence of errors when using  COPY FROM RETURN SUMMARY

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Limit the output of COPY FROM RETURN SUMMARY in the presence of errors to
+  display up to 50 ``line_numbers`` to avoid buffer pressure at clients and
+  to improve readability.
+
 - The ``array_unique`` scalar function use a common element type based on the
   type precedence if given arrays have different element types instead of always
   casting to the element type of the first array argument.

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -368,7 +368,8 @@ inserted records.
 | ``errors[ERROR_MSG]['count']``        | The number records failed with this error.     | ``BIGINT``    |
 +---------------------------------------+------------------------------------------------+---------------+
 | ``errors[ERROR_MSG]['line_numbers']`` | The line numbers of the source URI where the   | ``ARRAY``     |
-|                                       | error occurred.                                |               |
+|                                       | error occurred, limited to the first 50        |               |
+|                                       | errors, to avoid buffer pressure on clients.   |               |
 +---------------------------------------+------------------------------------------------+---------------+
 
 .. _AWS documentation: http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html

--- a/server/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
@@ -119,6 +119,7 @@ class UpsertResults {
 
         private static final String ERROR_COUNT_KEY = "count";
         private static final String LINE_NUMBERS_KEY = "line_numbers";
+        private static final int MAX_LINE_NUMBERS_ALLOWED = 50;
 
         private long successRowCount = 0;
         private long errorRowCount = 0;
@@ -150,12 +151,16 @@ class UpsertResults {
             if (errorEntry == null) {
                 errorEntry = new HashMap<>(1);
                 errors.put(msg, errorEntry);
-                currentLineNumbers = new ArrayList<>(lineNumbers);
+                int lineNumbersTopIndex = Math.min(lineNumbers.size(), MAX_LINE_NUMBERS_ALLOWED);
+                currentLineNumbers = new ArrayList<>(lineNumbers.subList(0, lineNumbersTopIndex));
             } else {
                 cnt = (Long) errorEntry.get(ERROR_COUNT_KEY);
                 //noinspection unchecked
                 currentLineNumbers = (List<Long>) errorEntry.get(LINE_NUMBERS_KEY);
-                currentLineNumbers.addAll(lineNumbers);
+                int allowedLineNumbersCount = MAX_LINE_NUMBERS_ALLOWED - currentLineNumbers.size();
+                if (lineNumbers.size() <= allowedLineNumbersCount) {
+                    currentLineNumbers.addAll(lineNumbers);
+                }
             }
             errorEntry.put(ERROR_COUNT_KEY, cnt + increaseBy);
             errorEntry.put(LINE_NUMBERS_KEY, currentLineNumbers);

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -706,6 +706,38 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
+    public void test_copy_from_return_summary_with_failed_rows_line_numers_limitted_to_50() throws Exception {
+        execute("create table tmp_t1 (v integer)");
+        Path tmpDir = newTempDir(LifecycleScope.TEST);
+        Path target = Files.createDirectories(tmpDir.resolve("target"));
+        String fileName = "uzulo.json";
+
+        // two correct inserts
+        tmpFileWithLines(Arrays.asList(
+            "{\"v\": 100}",
+            "{\"v\": 200}"
+        ), fileName, target);
+
+        int numBrokenInserts = 60;
+        String [] brokenInserts = new String[numBrokenInserts];
+        for (int i=0; i < numBrokenInserts; i++) {
+            brokenInserts[i] = String.format("{ \"v\": %d, \"bob\": 42", i); // bob is unexpected
+        }
+        tmpFileWithLines(Arrays.asList(brokenInserts), fileName, target);
+
+        execute("copy tmp_t1 from ? return summary", new Object[]{target.toUri().toString() + "*"});
+
+        String result = printedTable(response.rows());
+        assertThat(result, containsString(
+            "0| 60| {mapping set to strict, dynamic introduction of [bob] within [default] is not allowed"));
+
+        for (Map<String, Object> mappingError: ((Map<String, Map<String, Object>>) response.rows()[1][4]).values()) {
+            assertThat(((List<Long>) mappingError.get("line_numbers")).size(), is(50));
+            break;
+        }
+    }
+
+    @Test
     public void testCopyFromReturnSummaryWithFailedRows() throws Exception {
         execute("create table t1 (id int primary key, ts timestamp with time zone)");
 


### PR DESCRIPTION
Issue https://github.com/crate/crate/issues/9890

Limits the output of COPY FROM RETURN SUMMARY in the presence of errors to 50 `line_numbers` per error, to avoid crashing the Admin UI and crash.