### PR TITLE
Add recursive deletes for blobs

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -10,6 +10,7 @@ tqdm==4.24.0
 sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
+minio>=5.0.0
 
 # packages for local dev
 

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -119,6 +119,16 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         }
     }
 
+    public void delete() throws IOException {
+        var children = children();
+        if (!children.isEmpty()) {
+            // TODO: Upgrade to newer non-blocking Azure SDK 11 and execute delete requests in parallel that way
+            for (Map.Entry<String, BlobContainer> entry : children.entrySet()) {
+                entry.getValue().deleteBlobIgnoringIfNotExists(entry.getKey());
+            }
+        }
+    }
+
     @Override
     public Map<String, BlobMetadata> listBlobsByPrefix(@Nullable String prefix) throws IOException {
         logger.trace("listBlobsByPrefix({})", prefix);

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -79,6 +79,11 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void delete() throws IOException {
+        store.execute(fileContext -> fileContext.delete(path, true));
+    }
+
+    @Override
     public InputStream readBlob(String blobName) throws IOException {
         // FSDataInputStream does buffering internally
         // FSDataInputStream can open connections on read() or skip() so we wrap in

--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -96,6 +96,11 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository is read only");
     }
 
+    @Override
+    public void delete() {
+        throw new UnsupportedOperationException("URL repository is read only");
+    }
+
     /**
      * This operation is not supported by URLBlobContainer
      */

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -115,6 +115,12 @@ public interface BlobContainer {
     void deleteBlob(String blobName) throws IOException;
 
     /**
+     * Deletes this container and all its contents from the repository.
+     * @throws IOException on failure
+     */
+    void delete() throws IOException;
+
+    /**
      * Deletes the blobs with given names. Unlike {@link #deleteBlob(String)} this method will not throw an exception
      * when one or multiple of the given blobs don't exist and simply ignore this case.
      *

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.blobstore;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -66,6 +67,20 @@ public class BlobPath implements Iterable<String> {
             return p;
         }
         return p + SEPARATOR;
+    }
+
+    /**
+     * Returns this path's parent path.
+     *
+     * @return Parent path or {@code null} if there is none
+     */
+    @Nullable
+    public BlobPath parent() {
+        if (paths.isEmpty()) {
+            return null;
+        } else {
+            return new BlobPath(List.copyOf(paths.subList(0, paths.size() - 1)));
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -124,6 +124,11 @@ public class FsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void delete() throws IOException {
+        IOUtils.rm(path);
+    }
+
+    @Override
     public boolean blobExists(String blobName) {
         return Files.exists(path.resolve(blobName));
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -581,11 +581,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 try {
                     if (survivingIndexIds.contains(indexSnId) == false) {
                         LOGGER.debug("[{}] Found stale index [{}]. Cleaning it up", metadata.name(), indexSnId);
-                        BlobContainer blobContainer = indexEntry.getValue();
-                        for (var blobNames : blobContainer.listBlobs().keySet()) {
-                            deleteResult++;
-                            blobContainer.deleteBlobIgnoringIfNotExists(blobNames);
-                        }
+                        var blobContainer = indexEntry.getValue();
+                        deleteResult += blobContainer.listBlobs().keySet().size();
+                        blobContainer.delete();
                         LOGGER.debug("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of elastic/elasticsearch#43281, this adds `BlobContainer.delete()` which performs recursive deletes.

This is a prerequisite for further optimizations. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
