### PR TITLE
Allow ORDER BY on aggregations shadowed by alias

### DIFF
--- a/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
+++ b/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
@@ -67,9 +67,14 @@ public class OrderByWithAggregationValidator {
 
         @Override
         public Void visitFunction(Function symbol, ValidatorContext context) {
-            if (context.outputSymbols.contains(symbol)) {
-                return null;
-            } else if (context.isDistinct) {
+            for (var output : context.outputSymbols) {
+                if (output.equals(symbol)) {
+                    return null;
+                } else if (output instanceof AliasSymbol && ((AliasSymbol) output).symbol().equals(symbol)) {
+                    return null;
+                }
+            }
+            if (context.isDistinct) {
                 throw new UnsupportedOperationException(Symbols.format(INVALID_FIELD_IN_DISTINCT_TEMPLATE, symbol));
             }
             if (symbol.info().type() == FunctionInfo.Type.SCALAR) {

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -958,4 +958,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat(collect.collectPhase().projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
     }
+
+    @Test
+    public void test_order_by_on_aggregation_with_alias_in_select_list() throws Exception {
+        String stmt = "SELECT count(id) as cnt FROM users GROUP BY name ORDER BY count(id) DESC";
+        LogicalPlan plan = e.logicalPlan(stmt);
+        String expectedPlan =
+            "Eval[count(id) AS cnt]\n" +
+            "  └ OrderBy[count(id) DESC]\n" +
+            "    └ GroupHashAggregate[name | count(id)]\n" +
+            "      └ Collect[doc.users | [id, name] | true]";
+        assertThat(plan, isPlan(expectedPlan));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression in master.
Detected running the crate-python tests against the latest nightly. They
failed with:

    UnsupportedFeatureException: ORDER BY function 'count(id)' is not allowed. Only scalar functions can be used]
        [SQL: SELECT count(characters.id) AS count_1, characters.name AS characters_name
        FROM characters GROUP BY characters.name ORDER BY count(characters.id) DESC, characters.name


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)