### PR TITLE
Fix flaky test_copy_from_return_summary_with_failed_rows_line_numers_limitted_to_50

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import io.crate.data.Row;
+import io.crate.testing.TestingHelpers;
+
+public class UpsertResultsTest {
+
+    @Test
+    public void test_error_line_numbers_are_limited_to_50() throws Exception {
+        UpsertResults upsertResults = new UpsertResults();
+        for (int i = 0; i < 60; i++) {
+            upsertResults.addResult("dummyUri", "some failure", i);
+        }
+
+        Iterable<Row> rows = upsertResults.rowsIterable();
+        assertThat(TestingHelpers.printedTable(rows), is(
+            "NULL| dummyUri| 0| 60| {some failure={count=60, line_numbers=[" +
+            "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, " +
+            "19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, " +
+            "36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]}}\n"
+        ));
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -706,38 +706,6 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
-    public void test_copy_from_return_summary_with_failed_rows_line_numers_limitted_to_50() throws Exception {
-        execute("create table tmp_t1 (v integer)");
-        Path tmpDir = newTempDir(LifecycleScope.TEST);
-        Path target = Files.createDirectories(tmpDir.resolve("target"));
-        String fileName = "uzulo.json";
-
-        // two correct inserts
-        tmpFileWithLines(Arrays.asList(
-            "{\"v\": 100}",
-            "{\"v\": 200}"
-        ), fileName, target);
-
-        int numBrokenInserts = 60;
-        String [] brokenInserts = new String[numBrokenInserts];
-        for (int i=0; i < numBrokenInserts; i++) {
-            brokenInserts[i] = String.format("{ \"v\": %d, \"bob\": 42", i); // bob is unexpected
-        }
-        tmpFileWithLines(Arrays.asList(brokenInserts), fileName, target);
-
-        execute("copy tmp_t1 from ? return summary", new Object[]{target.toUri().toString() + "*"});
-
-        String result = printedTable(response.rows());
-        assertThat(result, containsString(
-            "0| 60| {mapping set to strict, dynamic introduction of [bob] within [default] is not allowed"));
-
-        for (Map<String, Object> mappingError: ((Map<String, Map<String, Object>>) response.rows()[1][4]).values()) {
-            assertThat(((List<Long>) mappingError.get("line_numbers")).size(), is(50));
-            break;
-        }
-    }
-
-    @Test
     public void testCopyFromReturnSummaryWithFailedRows() throws Exception {
         execute("create table t1 (id int primary key, ts timestamp with time zone)");
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Rewrites it as a unit test to fix the flakyness and also because it's
faster.

See https://github.com/crate/crate/pull/10109#issuecomment-647424509 for
a failure


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)