### PR TITLE
Exclude warmer.enabled setting from new tables

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1663,7 +1663,6 @@ How to reindex
     |    "translog.flush_threshold_size" = 536870912,     |
     |    "translog.sync_interval" = 5000,                 |
     |    "unassigned.node_left.delayed_timeout" = 60000,  |
-    |    "warmer.enabled" = true,                         |
     |    "write.wait_for_active_shards" = '1'             |
     | )                                                   |
     +-----------------------------------------------------+

--- a/docs/general/ddl/show-create-table.rst
+++ b/docs/general/ddl/show-create-table.rst
@@ -54,7 +54,6 @@ existing user-created doc table in the cluster::
     |    "translog.flush_threshold_size" = 536870912,     |
     |    "translog.sync_interval" = 5000,                 |
     |    "unassigned.node_left.delayed_timeout" = 60000,  |
-    |    "warmer.enabled" = true,                         |
     |    "write.wait_for_active_shards" = '1'             |
     | )                                                   |
     +-----------------------------------------------------+

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -112,6 +112,7 @@ public class TableParameters {
      */
     static final Set<Setting> SETTINGS_NOT_INCLUDED_IN_DEFAULT = Set.of(
         IndexMetaData.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,
+        IndexSettings.INDEX_WARMER_ENABLED_SETTING,
         IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING,
         MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING
     );

--- a/server/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/server/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -114,7 +114,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -166,7 +165,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -220,7 +218,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -270,7 +267,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
                      SqlFormatter.formatSql(node));
@@ -323,7 +319,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -401,7 +396,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -451,7 +445,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
             SqlFormatter.formatSql(node));
@@ -500,7 +493,6 @@ public class MetaDataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"translog.flush_threshold_size\" = 536870912,\n" +
                      "   \"translog.sync_interval\" = 5000,\n" +
                      "   \"unassigned.node_left.delayed_timeout\" = 60000,\n" +
-                     "   \"warmer.enabled\" = true,\n" +
                      "   \"write.wait_for_active_shards\" = '1'\n" +
                      ")",
                      SqlFormatter.formatSql(node));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The setting is deprecated. If we include it by default it results in a
warning if users create a new table.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)