### PR TITLE
Improve unknown function error for operators

### DIFF
--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -20,6 +20,7 @@ package io.crate.operation.aggregation;
 
 import io.crate.Streamer;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
@@ -74,13 +75,13 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
         // Return type is fixed to Long
         FunctionImplementation func = functions.resolveBuiltInFunctionBySignature(
             new FunctionName(null, HyperLogLogDistinctAggregation.NAME),
-            List.of(DataTypes.INTEGER),
+            List.of(Literal.of(1)),
             SearchPath.pathWithPGCatalogAndDoc()
         );
         assertEquals(DataTypes.LONG, func.info().returnType());
         func = functions.resolveBuiltInFunctionBySignature(
             new FunctionName(null, HyperLogLogDistinctAggregation.NAME),
-            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
+            List.of(Literal.of(1), Literal.of(2)),
             SearchPath.pathWithPGCatalogAndDoc()
         );
         assertEquals(DataTypes.LONG, func.info().returnType());

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -277,7 +277,6 @@ public class Function extends Symbol implements Cloneable {
                     printFunctionWithParenthesis(builder, style);
                 }
                 break;
-
             default:
                 if (name.startsWith(AnyOperator.OPERATOR_PREFIX)) {
                     printAnyOperator(builder, style);
@@ -390,13 +389,8 @@ public class Function extends Symbol implements Cloneable {
 
     private void printFunctionWithParenthesis(StringBuilder builder, Style style) {
         FunctionName functionName = info.ident().fqnName();
-        String schema = functionName.schema();
-        if (style == Style.QUALIFIED && schema != null) {
-            builder.append(schema).append(".");
-        }
-        builder
-            .append(functionName.name())
-            .append("(");
+        builder.append(functionName.toString(style));
+        builder.append("(");
         for (int i = 0; i < arguments.size(); i++) {
             Symbol argument = arguments.get(i);
             builder.append(argument.toString(style));

--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -23,6 +23,7 @@
 package io.crate.metadata;
 
 import com.google.common.collect.ComparisonChain;
+import io.crate.expression.symbol.format.Style;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -94,5 +95,14 @@ public final class FunctionName implements Comparable<FunctionName>, Writeable {
                "schema='" + schema + '\'' +
                ", name='" + name + '\'' +
                '}';
+    }
+
+    public String toString(Style style) {
+        String s = "";
+        String schema = schema();
+        if (style != Style.UNQUALIFIED && schema != null) {
+            s = s + schema + ".";
+        }
+        return s + name();
     }
 }

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -22,9 +22,11 @@
 
 package io.crate.metadata;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.functions.BoundVariables;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.functions.SignatureBinder;
@@ -42,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -102,7 +103,7 @@ public class Functions {
      */
     public FunctionImplementation get(@Nullable String suppliedSchema,
                                       String functionName,
-                                      List<? extends Symbol> arguments,
+                                      List<Symbol> arguments,
                                       SearchPath searchPath) {
         FunctionName fqnName = new FunctionName(suppliedSchema, functionName);
         FunctionImplementation func = getBuiltinByArgs(fqnName, arguments, searchPath);
@@ -110,7 +111,7 @@ public class Functions {
             func = resolveUserDefinedByArgs(fqnName, arguments, searchPath);
         }
         if (func == null) {
-            throw raiseUnknownFunction(suppliedSchema, functionName, arguments);
+            raiseUnknownFunction(suppliedSchema, functionName, arguments, List.of());
         }
         return func;
     }
@@ -137,23 +138,23 @@ public class Functions {
      * The types may be cast to match the built-in argument types.
      *
      * @param functionName The full qualified function name.
-     * @param argumentsTypes The function argument types.
+     * @param arguments The function argument.
      * @return a function implementation or null if it was not found.
      */
     @Nullable
     private FunctionImplementation getBuiltinByArgs(FunctionName functionName,
-                                                    List<? extends Symbol> argumentsTypes,
+                                                    List<Symbol> arguments,
                                                     SearchPath searchPath) {
         return resolveBuiltInFunctionBySignature(
             functionName,
-            Lists2.map(argumentsTypes, Symbol::valueType),
+            arguments,
             searchPath
         );
     }
 
     @Nullable
     public FunctionImplementation resolveBuiltInFunctionBySignature(FunctionName name,
-                                                                    List<DataType> arguments,
+                                                                    List<Symbol> arguments,
                                                                     SearchPath searchPath) {
         return resolveFunctionBySignature(name, arguments, searchPath, functionImplementations::get);
     }
@@ -161,7 +162,7 @@ public class Functions {
 
     @Nullable
     private static FunctionImplementation resolveFunctionBySignature(FunctionName name,
-                                                                     List<DataType> arguments,
+                                                                     List<Symbol> arguments,
                                                                      SearchPath searchPath,
                                                                      Function<FunctionName, List<FunctionProvider>> lookupFunction) {
         var candidates = lookupFunction.apply(name);
@@ -213,19 +214,24 @@ public class Functions {
             }
 
             // Last, try all candidates which allow coercion with full coercion.
-            return matchFunctionCandidates(candidatesAllowingCoercion, arguments, SignatureBinder.CoercionType.FULL);
+            match = matchFunctionCandidates(candidatesAllowingCoercion, arguments, SignatureBinder.CoercionType.FULL);
+
+            if (match == null) {
+                raiseUnknownFunction(name.schema(), name.name(), arguments, candidates);
+            }
+            return match;
         }
         return null;
     }
 
     @Nullable
     private static FunctionImplementation matchFunctionCandidates(List<FunctionProvider> candidates,
-                                                                  List<DataType> argumentTypes,
+                                                                  List<Symbol> arguments,
                                                                   SignatureBinder.CoercionType coercionType) {
         List<ApplicableFunction> applicableFunctions = new ArrayList<>();
         for (FunctionProvider candidate : candidates) {
             Signature boundSignature = new SignatureBinder(candidate.getSignature(), coercionType)
-                .bind(Lists2.map(argumentTypes, DataType::getTypeSignature));
+                .bind(Lists2.map(arguments, s -> s.valueType().getTypeSignature()));
             if (boundSignature != null) {
                 applicableFunctions.add(
                     new ApplicableFunction(
@@ -238,7 +244,7 @@ public class Functions {
         }
 
         if (coercionType != SignatureBinder.CoercionType.NONE) {
-            applicableFunctions = selectMostSpecificFunctions(applicableFunctions, argumentTypes);
+            applicableFunctions = selectMostSpecificFunctions(applicableFunctions, arguments);
             if (LOGGER.isDebugEnabled() && applicableFunctions.isEmpty()) {
                 LOGGER.debug("At least single function must be left after selecting most specific one");
             }
@@ -262,18 +268,18 @@ public class Functions {
      * The types may be cast to match the built-in argument types.
      *
      * @param functionName The full qualified function name.
-     * @param argumentsTypes The function arguments.
+     * @param arguments The function arguments.
      * @param searchPath The {@link SearchPath} against which to try to resolve the function if it is not identified by
      *                   a fully qualifed name (ie. `schema.functionName`)
      * @return a function implementation.
      */
     @Nullable
     private FunctionImplementation resolveUserDefinedByArgs(FunctionName functionName,
-                                                            List<? extends Symbol> argumentsTypes,
+                                                            List<Symbol> arguments,
                                                             SearchPath searchPath) throws UnsupportedOperationException {
         return resolveFunctionBySignature(
             functionName,
-            Lists2.map(argumentsTypes, Symbol::valueType),
+            arguments,
             searchPath,
             udfFunctionImplementations::get
         );
@@ -328,25 +334,59 @@ public class Functions {
         return impl;
     }
 
-    private static UnsupportedOperationException raiseUnknownFunction(@Nullable String suppliedSchema,
-                                                                      String name,
-                                                                      List<? extends Symbol> arguments) {
-        StringJoiner joiner = new StringJoiner(", ");
-        for (var arg : arguments) {
-            joiner.add(arg.valueType().toString());
+    @VisibleForTesting
+    static void raiseUnknownFunction(@Nullable String suppliedSchema,
+                                             String name,
+                                             List<Symbol> arguments,
+                                             List<FunctionProvider> candidates) {
+        List<DataType> argumentTypes = Symbols.typeView(arguments);
+        var function = new io.crate.expression.symbol.Function(
+            new FunctionInfo(
+                new FunctionIdent(suppliedSchema, name, argumentTypes),
+                DataTypes.UNDEFINED
+            ),
+            Signature.builder()
+                .name(new FunctionName(suppliedSchema, name))
+                .argumentTypes(Lists2.map(argumentTypes, DataType::getTypeSignature))
+                .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                .kind(FunctionInfo.Type.SCALAR)
+                .build(),
+            arguments
+        );
+
+        var message = "Unknown function: " + function.toString(Style.QUALIFIED);
+        if (candidates.isEmpty() == false) {
+            if (arguments.isEmpty() == false) {
+                message = message + ", no overload found for matching argument types: "
+                          + "(" + Lists2.joinOn(", ", argumentTypes, DataType::toString) + ").";
+            } else {
+                message = message + ".";
+            }
+            message = message + " Possible candidates: "
+                      + Lists2.joinOn(
+                          ", ",
+                          candidates,
+                          c -> c.getSignature().getName().toString(Style.QUALIFIED)
+                               + "("
+                               + Lists2.joinOn(
+                              ", ",
+                              c.getSignature().getArgumentTypes(),
+                              TypeSignature::toString)
+                               + "):" + c.getSignature().getReturnType().toString())
+                      ;
         }
-        String prefix = suppliedSchema == null ? "" : suppliedSchema + '.';
-        throw new UnsupportedOperationException("unknown function: " + prefix + name + '(' + joiner.toString() + ')');
+
+        throw new UnsupportedOperationException(message);
     }
 
     private static List<ApplicableFunction> selectMostSpecificFunctions(List<ApplicableFunction> applicableFunctions,
-                                                                        List<DataType> argumentTypes) {
+                                                                        List<Symbol> arguments) {
         if (applicableFunctions.isEmpty()) {
             return applicableFunctions;
         }
 
         // Find most specific by number of exact argument type matches
-        List<TypeSignature> argumentTypeSignatures = Lists2.map(argumentTypes, DataType::getTypeSignature);
+        List<TypeSignature> argumentTypeSignatures = Lists2.map(arguments, s -> s.valueType().getTypeSignature());
         List<ApplicableFunction> mostSpecificFunctions = selectMostSpecificFunctions(
             applicableFunctions,
             (l, r) -> hasMoreExactTypeMatches(l, r, argumentTypeSignatures));
@@ -374,14 +414,13 @@ public class Functions {
         //     `concat(array(E), array(E)):array(E)`
         //
         if (returnTypeIsTheSame(mostSpecificFunctions)
-            || argumentTypes.stream().allMatch(d -> d.id() == DataTypes.UNDEFINED.id())) {
+            || arguments.stream().allMatch(s -> s.valueType().id() == DataTypes.UNDEFINED.id())) {
             ApplicableFunction selectedFunction = mostSpecificFunctions.stream()
                 .sorted(Comparator.comparing(Objects::toString))
                 .iterator().next();
 
             return List.of(selectedFunction);
         }
-
         return mostSpecificFunctions;
     }
 

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -98,7 +98,8 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testWhereClauseObjectArrayField() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_=(bigint_array, integer)");
+        expectedException.expectMessage("Unknown function: (doc.users.friends['id'] = 5)," +
+                                        " no overload found for matching argument types: (bigint_array, integer).");
         e.analyze("delete from users where friends['id'] = 5");
     }
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -667,7 +667,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testNotTimestamp() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_not(timestamp with time zone)");
+        expectedException.expectMessage("Unknown function: (NOT doc.parted.date)," +
+                                        " no overload found for matching argument types: (timestamp with time zone).");
         analyze("select id, name from parted where not date");
     }
 
@@ -804,7 +805,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArrayCompareInvalidArray() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: any_=(text, text)");
+        expectedException.expectMessage("Unknown function: ('George' = ANY(doc.users.name))," +
+                                        " no overload found for matching argument types: (text, text).");
         analyze("select * from users where 'George' = ANY (name)");
     }
 
@@ -847,7 +849,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_=(bigint_array, integer)");
+        expectedException.expectMessage("Unknown function: (doc.users.friends['id'] = 5)," +
+                                        " no overload found for matching argument types: (bigint_array, integer).");
         analyze("select * from users where 5 = friends['id']");
     }
 
@@ -985,7 +988,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAnyLikeInvalidArray() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("any_like(text, text)");
+        expectedException.expectMessage("Unknown function: ('awesome' LIKE ANY(doc.users.name))," +
+                                        " no overload found for matching argument types: (text, text).");
         analyze("select * from users where 'awesome' LIKE ANY (name)");
     }
 
@@ -1276,14 +1280,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRegexpMatchInvalidArg() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_~(real, text)");
+        expectedException.expectMessage("Unknown function: (doc.users.floats ~ 'foo')," +
+                                        " no overload found for matching argument types: (real, text).");
         analyze("select * from users where floats ~ 'foo'");
     }
 
     @Test
     public void testRegexpMatchCaseInsensitiveInvalidArg() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_~*(real, text)");
+        expectedException.expectMessage("Unknown function: (doc.users.floats ~* 'foo')," +
+                                        " no overload found for matching argument types: (real, text).");
         analyze("select * from users where floats ~* 'foo'");
     }
 
@@ -1720,7 +1726,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectStarFromUnnestWithInvalidArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: unnest(integer, text)");
+        expectedException.expectMessage("Unknown function: unnest(1, 'foo')," +
+                                        " no overload found for matching argument types: (integer, text).");
         analyze("select * from unnest(1, 'foo')");
     }
 

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -372,7 +372,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testWhereClauseObjectArrayField() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_=(bigint_array, integer)");
+        expectedException.expectMessage("Unknown function: (doc.users.friends['id'] = 5)," +
+                                        " no overload found for matching argument types: (bigint_array, integer).");
         analyze("update users set awesome=true where friends['id'] = 5");
     }
 

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -33,7 +33,6 @@ import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
 import io.crate.analyze.relations.ParentRelations;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.auth.user.User;
-import io.crate.exceptions.ConversionException;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.LtOperator;
@@ -369,13 +368,14 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
-        expectedException.expectMessage("unknown function: any_=(integer_array, integer_array)");
+        expectedException.expectMessage("Unknown function: (doc.tarr.xs = ANY(_array(10, 20)))," +
+                                        " no overload found for matching argument types: (integer_array, integer_array).");
         executor.analyze("select * from tarr where xs = ANY([10, 20])");
     }
 
     @Test
     public void testCallingUnknownFunctionWithExplicitSchemaRaisesNiceError() {
-        expectedException.expectMessage("unknown function: foo.bar(integer)");
+        expectedException.expectMessage("Unknown function: foo.bar(1)");
         executor.analyze("select foo.bar(1)");
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -105,7 +105,8 @@ public class ArbitraryAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: arbitrary(object)");
+        expectedException.expectMessage("Unknown function: arbitrary(INPUT(0))," +
+                                        " no overload found for matching argument types: (object).");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -84,7 +84,8 @@ public class AverageAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: avg(geo_point)");
+        expectedException.expectMessage("Unknown function: avg(INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -98,7 +98,8 @@ public class GeometricMeanAggregationtest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: geometric_mean(boolean)");
+        expectedException.expectMessage("Unknown function: geometric_mean(INPUT(0))," +
+                                        " no overload found for matching argument types: (boolean).");
         executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -90,7 +90,8 @@ public class MaximumAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: max(object)");
+        expectedException.expectMessage("Unknown function: max(INPUT(0))," +
+                                        " no overload found for matching argument types: (object).");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -90,7 +90,8 @@ public class MinimumAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: min(object)");
+        expectedException.expectMessage("Unknown function: min(INPUT(0))," +
+                                        " no overload found for matching argument types: (object).");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -148,7 +148,8 @@ public class PercentileAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: percentile(geo_point, double precision)");
+        expectedException.expectMessage("Unknown function: percentile(INPUT(0), INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point, double precision).");
         execSingleFractionPercentile(DataTypes.GEO_POINT, new Object[][]{});
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -106,7 +106,8 @@ public class StdDevAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: stddev(geo_point)");
+        expectedException.expectMessage("Unknown function: stddev(INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -110,7 +110,8 @@ public class SumAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: sum(geo_point)");
+        expectedException.expectMessage("Unknown function: sum(INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -103,7 +103,8 @@ public class VarianceAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: variance(geo_point)");
+        expectedException.expectMessage("Unknown function: variance(INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -76,7 +76,8 @@ public class CIDROperatorTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_both_operands_are_of_wrong_type() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_<<(double precision, object)");
+        expectedException.expectMessage("Unknown function: (1.2 << _map('cidr', '192.168.0.0/24'))," +
+                                        " no overload found for matching argument types: (double precision, object).");
         assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -54,21 +54,24 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat()");
+        expectedException.expectMessage("Unknown function: array_cat()." +
+                                        " Possible candidates: array_cat(array(E), array(E)):array(E)");
         assertEvaluate("array_cat()", null);
     }
 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(integer_array)");
+        expectedException.expectMessage("Unknown function: array_cat(_array(1))," +
+                                        " no overload found for matching argument types: (integer_array).");
         assertEvaluate("array_cat([1])", null);
     }
 
     @Test
     public void testThreeArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_cat(integer_array, integer_array, integer_array)");
+        expectedException.expectMessage("Unknown function: array_cat(_array(1), _array(2), _array(3))," +
+                                        " no overload found for matching argument types: (integer_array, integer_array, integer_array).");
         assertEvaluate("array_cat([1], [2], [3])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -85,14 +85,16 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_difference()");
+        expectedException.expectMessage("Unknown function: array_difference()." +
+                                        " Possible candidates: array_difference(array(E), array(E)):array(E)");
         assertNormalize("array_difference()", null);
     }
 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_difference(integer_array)");
+        expectedException.expectMessage("Unknown function: array_difference(_array(1))," +
+                                        " no overload found for matching argument types: (integer_array).");
         assertNormalize("array_difference([1])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -59,28 +59,32 @@ public class ArrayLowerFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower()");
+        expectedException.expectMessage("Unknown function: array_lower()." +
+                                        " Possible candidates: array_lower(array(E), integer):integer");
         assertEvaluate("array_lower()", null);
     }
 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(integer_array)");
+        expectedException.expectMessage("Unknown function: array_lower(_array(1))," +
+                                        " no overload found for matching argument types: (integer_array).");
         assertEvaluate("array_lower([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(integer_array, integer, integer_array)");
+        expectedException.expectMessage("Unknown function: array_lower(_array(1), 2, _array(3))," +
+                                        " no overload found for matching argument types: (integer_array, integer, integer_array).");
         assertEvaluate("array_lower([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_lower(integer_array, integer_array)");
+        expectedException.expectMessage("Unknown function: array_lower(_array(1), _array(2))," +
+                                        " no overload found for matching argument types: (integer_array, integer_array).");
         assertEvaluate("array_lower([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -81,7 +81,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_unique()");
+        expectedException.expectMessage("Unknown function: array_unique().");
         assertEvaluate("array_unique()", null);
     }
 
@@ -112,7 +112,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_unique(geo_point_array, boolean_array)");
+        expectedException.expectMessage("Unknown function: array_unique(_array(doc.users.geopoint), _array(true))," +
+                                        " no overload found for matching argument types: (geo_point_array, boolean_array).");
         assertEvaluate("array_unique([geopoint], [true])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -64,28 +64,32 @@ public class ArrayUpperFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper()");
+        expectedException.expectMessage("Unknown function: array_upper()." +
+                                        " Possible candidates: array_upper(array(E), integer):integer");
         assertEvaluate("array_upper()", null);
     }
 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(integer_array)");
+        expectedException.expectMessage("Unknown function: array_upper(_array(1))," +
+                                        " no overload found for matching argument types: (integer_array).");
         assertEvaluate("array_upper([1])", null);
     }
 
     @Test
     public void testThreeArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(integer_array, integer, integer_array)");
+        expectedException.expectMessage("Unknown function: array_upper(_array(1), 2, _array(3))," +
+                                        " no overload found for matching argument types: (integer_array, integer, integer_array).");
         assertEvaluate("array_upper([1], 2, [3])", null);
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: array_upper(integer_array, integer_array)");
+        expectedException.expectMessage("Unknown function: array_upper(_array(1), _array(2))," +
+                                        " no overload found for matching argument types: (integer_array, integer_array).");
         assertEvaluate("array_upper([1], [2])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -39,7 +39,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testArgumentThatHasNoStringRepr() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(text, integer_array)");
+        expectedException.expectMessage("Unknown function: concat('foo', _array(1))," +
+                                        " no overload found for matching argument types: (text, integer_array).");
         assertNormalize("concat('foo', [1])", null);
     }
 
@@ -87,7 +88,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: concat(integer_array, integer_array_array)");
+        expectedException.expectMessage("Unknown function: concat(_array(1, 2), _array(_array(1, 2)))," +
+                                        " no overload found for matching argument types: (integer_array, integer_array_array).");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
@@ -38,14 +38,15 @@ public class StringToArrayFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: string_to_array()");
+        expectedException.expectMessage("Unknown function: string_to_array()");
         assertEvaluate("string_to_array()", null);
     }
 
     @Test
     public void testOneArgument() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: string_to_array(text)");
+        expectedException.expectMessage("Unknown function: string_to_array('xyz')," +
+                                        " no overload found for matching argument types: (text).");
         assertEvaluate("string_to_array('xyz')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -58,7 +58,8 @@ public class IntervalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_unsupported_arithmetic_operator_on_interval_types() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: multiply(undefined, interval)");
+        expectedException.expectMessage("Unknown function: (NULL * cast('1 second' AS interval))," +
+                                        " no overload found for matching argument types: (undefined, interval).");
         assertEvaluate("null * interval '1 second'", Matchers.nullValue());
     }
 
@@ -75,7 +76,8 @@ public class IntervalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void test_unallowed_operations() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("subtract(interval, timestamp with time zone)");
+        expectedException.expectMessage("Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone))," +
+                                        " no overload found for matching argument types: (interval, timestamp with time zone).");
         assertEvaluate("interval '1 second' - '86401000'::timestamp", Matchers.is(86400000L));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
@@ -34,7 +34,8 @@ public class MapFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testMapWithWrongNumOfArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _map(text, integer, text)");
+        expectedException.expectMessage("Unknown function: _map('foo', 1, 'bar')," +
+                                        " no overload found for matching argument types: (text, integer, text).");
         assertEvaluate("_map('foo', 1, 'bar')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
@@ -40,7 +40,8 @@ public class NegateFunctionsTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNegateOnStringResultsInError() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _negate(text)");
+        expectedException.expectMessage("Unknown function: _negate(doc.users.name)," +
+                                        " no overload found for matching argument types: (text).");
         assertEvaluate("- name", nullValue(), Literal.of("foo"));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -64,7 +64,8 @@ public class PowerFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidNumberOfArguments() {
-        expectedException.expectMessage("unknown function: power(integer)");
+        expectedException.expectMessage("Unknown function: power(2)," +
+                                        " no overload found for matching argument types: (integer).");
         assertEvaluate("power(2)", null);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -64,7 +64,8 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNullIfInvalidArgsLength() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: nullif(integer, integer, integer)");
+        expectedException.expectMessage("Unknown function: nullif(1, 2, 3)," +
+                                        " no overload found for matching argument types: (integer, integer, integer).");
         assertEvaluate("nullif(1, 2, 3)", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
@@ -61,7 +61,8 @@ public class CoordinateFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWithTooManyArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: latitude(text, text)");
+        expectedException.expectMessage("Unknown function: latitude('POINT (10 20)', 'foo')," +
+                                        " no overload found for matching argument types: (text, text).");
         assertNormalize("latitude('POINT (10 20)', 'foo')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -37,14 +37,16 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testResolveWithTooManyArguments() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: distance(text, text, text)");
+        expectedException.expectMessage("Unknown function: distance('POINT (10 20)', 'POINT (11 21)', 'foo')," +
+                                        " no overload found for matching argument types: (text, text, text).");
         assertNormalize("distance('POINT (10 20)', 'POINT (11 21)', 'foo')", null);
     }
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: distance(integer, text)");
+        expectedException.expectMessage("Unknown function: distance(1, 'POINT (11 21)')," +
+                                        " no overload found for matching argument types: (integer, text).");
         assertNormalize("distance(1, 'POINT (11 21)')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
@@ -55,7 +55,8 @@ public class GeoHashFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWithTooManyArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: geohash(text, text)");
+        expectedException.expectMessage("Unknown function: geohash('POINT (10 20)', 'foo')," +
+                                        " no overload found for matching argument types: (text, text).");
         assertNormalize("geohash('POINT (10 20)', 'foo')", null);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -95,14 +95,16 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testFirstArgumentWithInvalidType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: within(bigint, geo_point)");
+        expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
+                                        " no overload found for matching argument types: (bigint, geo_point).");
         getFunction(FNAME, DataTypes.LONG, DataTypes.GEO_POINT);
     }
 
     @Test
     public void testSecondArgumentWithInvalidType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: within(geo_point, bigint)");
+        expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
+                                        " no overload found for matching argument types: (geo_point, bigint).");
         getFunction(FNAME, DataTypes.GEO_POINT, DataTypes.LONG);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
@@ -42,7 +42,8 @@ public class PgBackendPidFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testInvalidType() throws Exception {
-        expectedException.expectMessage("unknown function: pg_backend_pid(undefined)");
+        expectedException.expectMessage("Unknown function: pg_backend_pid(NULL)," +
+                                        " no overload found for matching argument types: (undefined).");
         sqlExpressions.asSymbol("pg_backend_pid(null)");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/regex/MatchesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/MatchesFunctionTest.java
@@ -98,7 +98,8 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidNumberOfArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_matches(text)");
+        expectedException.expectMessage("Unknown function: regexp_matches('foobar')," +
+                                        " no overload found for matching argument types: (text).");
         assertNormalize("regexp_matches('foobar')", null);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -73,7 +73,8 @@ public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_replace(text, text, integer_array)");
+        expectedException.expectMessage("Unknown function: regexp_replace('foobar', '.*', _array(1, 2))," +
+                                        " no overload found for matching argument types: (text, text, integer_array).");
 
         assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
     }

--- a/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
@@ -61,7 +61,7 @@ public class ChrFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void test_empty_value_throws_exception() throws Exception {
-        expectedException.expectMessage("unknown function: chr()");
+        expectedException.expectMessage("Unknown function: chr(). Possible candidates: chr(integer):text");
         expectedException.expect(Exception.class);
         assertEvaluate("chr()", "");
     }

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -37,7 +37,8 @@ public class QuoteIdentFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testZeroArguments() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: quote_ident()");
+        expectedException.expectMessage("Unknown function: quote_ident()." +
+                                        " Possible candidates: quote_ident(text):text");
         assertEvaluate("quote_ident()", null);
     }
 

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -105,7 +105,8 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_function_arguments_must_have_array_types() {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: _values(integer)");
+        expectedException.expectMessage("Unknown function: _values(200)," +
+                                        " no overload found for matching argument types: (integer).");
         assertExecute("_values(200)", "");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -623,7 +623,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                         assertThat(func.info().ident().argumentTypes(), not(equalTo(Symbols.typeView(arguments))));
                     }
                 } catch (UnsupportedOperationException e) {
-                    assertThat(e.getMessage().startsWith("unknown function"), is(true));
+                    assertThat(e.getMessage().startsWith("Unknown function"), is(true));
                 }
 
             }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -373,7 +373,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
 
     public void testRangeQueryOnDocThrowsException() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: op_>(object, object)");
+        expectedException.expectMessage("Unknown function: (doc.users._doc > _map('name', 'foo'))," +
+                                        " no overload found for matching argument types: (object, object).");
         convert("_doc > {\"name\"='foo'}");
     }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -121,7 +121,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(functions.get("my_schema", "valid", ImmutableList.of(), pathWithPGCatalogAndDoc()), Matchers.notNullValue());
 
-        expectedException.expectMessage("unknown function: my_schema.invalid()");
+        expectedException.expectMessage("Unknown function: my_schema.invalid()");
         functions.get("my_schema", "invalid", ImmutableList.of(), pathWithPGCatalogAndDoc());
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Format the unknown operator in operator style, not function style.
Example:
  `unknown function: bool = ANY(integer)`



## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
