### PR TITLE
Fix use of parameter symbols in join conditions

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -193,10 +193,11 @@ public class NestedLoopJoin implements LogicalPlan {
             configureExecution(left, right, plannerContext, isDistributed);
 
         List<Symbol> joinOutputs = Lists2.concat(leftLogicalPlan.outputs(), rightLogicalPlan.outputs());
+        SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
 
         Symbol joinInput = null;
         if (joinCondition != null) {
-            joinInput = InputColumns.create(joinCondition, joinOutputs);
+            joinInput = InputColumns.create(paramBinder.apply(joinCondition), joinOutputs);
         }
 
         NestedLoopPhase nlPhase = new NestedLoopPhase(

--- a/server/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLExecutor.java
@@ -734,11 +734,15 @@ public class SQLExecutor {
     }
 
     public <T> T plan(String statement, UUID jobId, int fetchSize) {
-        AnalyzedStatement analyzedStatement = analyze(statement, ParamTypeHints.EMPTY);
-        return planInternal(analyzedStatement, jobId, fetchSize);
+        return plan(statement, jobId, fetchSize, Row.EMPTY);
     }
 
-    private <T> T planInternal(AnalyzedStatement analyzedStatement, UUID jobId, int fetchSize) {
+    public <T> T plan(String statement, UUID jobId, int fetchSize, Row params) {
+        AnalyzedStatement analyzedStatement = analyze(statement, ParamTypeHints.EMPTY);
+        return planInternal(analyzedStatement, jobId, fetchSize, params);
+    }
+
+    private <T> T planInternal(AnalyzedStatement analyzedStatement, UUID jobId, int fetchSize, Row params) {
         RoutingProvider routingProvider = new RoutingProvider(random.nextInt(), emptyList());
         PlannerContext plannerContext = new PlannerContext(
             planner.currentClusterState(),
@@ -758,7 +762,7 @@ public class SQLExecutor {
                 0,
                 null,
                 null,
-                Row.EMPTY,
+                params,
                 new SubQueryResults(emptyMap()) {
                     @Override
                     public Object getSafe(SelectSymbol key) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression in master that prevented the use of parameter symbols within
join conditions.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)