### PR TITLE
Delay writes on channel until execute is finished

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -353,7 +353,8 @@ public class Session implements AutoCloseable {
         }
     }
 
-    public void execute(String portalName, int maxRows, ResultReceiver<?> resultReceiver) {
+    @Nullable
+    public CompletableFuture<?> execute(String portalName, int maxRows, ResultReceiver<?> resultReceiver) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("method=execute portalName={} maxRows={}", portalName, maxRows);
         }
@@ -413,7 +414,9 @@ public class Session implements AutoCloseable {
                 activeExecution = activeExecution
                     .thenCompose(ignored -> singleExec(portal, resultReceiver, maxRows));
             }
+            return activeExecution;
         }
+        return null;
     }
 
     public CompletableFuture<?> sync() {

--- a/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
+++ b/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import java.net.SocketAddress;
+import java.util.ArrayDeque;
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+/**
+ * Channel implementation that allows to delay writes with `blockWritesUntil`
+ **/
+public class DelayableWriteChannel implements Channel {
+
+    private final Channel delegate;
+    private volatile DelayedWrites delay;
+
+    public DelayableWriteChannel(Channel channel) {
+        this.delegate = channel;
+    }
+
+    @Override
+    public <T> Attribute<T> attr(AttributeKey<T> key) {
+        return delegate.attr(key);
+    }
+
+    @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return delegate.hasAttr(key);
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress) {
+        return delegate.bind(localAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress) {
+        return delegate.connect(remoteAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return delegate.connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return delegate.disconnect();
+    }
+
+    @Override
+    public ChannelFuture close() {
+        return delegate.close();
+    }
+
+    @Override
+    public ChannelFuture deregister() {
+        return delegate.deregister();
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.bind(localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture disconnect(ChannelPromise promise) {
+        return delegate.disconnect(promise);
+    }
+
+    @Override
+    public ChannelFuture close(ChannelPromise promise) {
+        return delegate.close(promise);
+    }
+
+    @Override
+    public ChannelFuture deregister(ChannelPromise promise) {
+        return delegate.deregister(promise);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        if (delay != null) {
+            ChannelPromise newPromise = newPromise();
+            delay.add(() -> delegate.write(msg, newPromise));
+            return newPromise;
+        }
+        return delegate.write(msg);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        if (delay != null) {
+            delay.add(() -> delegate.write(msg, promise));
+            return promise;
+        }
+        return delegate.write(msg, promise);
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        if (delay != null) {
+            delay.add(() -> delegate.writeAndFlush(msg, promise));
+            return promise;
+        }
+        return delegate.writeAndFlush(msg, promise);
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        if (delay != null) {
+            ChannelPromise promise = newPromise();
+            delay.add(() -> delegate.writeAndFlush(msg, promise));
+            return promise;
+        }
+        return delegate.writeAndFlush(msg);
+    }
+
+    @Override
+    public ChannelPromise newPromise() {
+        return delegate.newPromise();
+    }
+
+    @Override
+    public ChannelProgressivePromise newProgressivePromise() {
+        return delegate.newProgressivePromise();
+    }
+
+    @Override
+    public ChannelFuture newSucceededFuture() {
+        return delegate.newSucceededFuture();
+    }
+
+    @Override
+    public ChannelFuture newFailedFuture(Throwable cause) {
+        return delegate.newFailedFuture(cause);
+    }
+
+    @Override
+    public ChannelPromise voidPromise() {
+        return delegate.voidPromise();
+    }
+
+    @Override
+    public int compareTo(Channel o) {
+        return delegate.compareTo(o);
+    }
+
+    @Override
+    public ChannelId id() {
+        return delegate.id();
+    }
+
+    @Override
+    public EventLoop eventLoop() {
+        return delegate.eventLoop();
+    }
+
+    @Override
+    public Channel parent() {
+        return delegate.parent();
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return delegate.config();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return delegate.isRegistered();
+    }
+
+    @Override
+    public boolean isActive() {
+        return delegate.isActive();
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return delegate.metadata();
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+        return delegate.localAddress();
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        return delegate.remoteAddress();
+    }
+
+    @Override
+    public ChannelFuture closeFuture() {
+        return delegate.closeFuture();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return delegate.isWritable();
+    }
+
+    @Override
+    public long bytesBeforeUnwritable() {
+        return delegate.bytesBeforeUnwritable();
+    }
+
+    @Override
+    public long bytesBeforeWritable() {
+        return delegate.bytesBeforeWritable();
+    }
+
+    @Override
+    public Unsafe unsafe() {
+        return delegate.unsafe();
+    }
+
+    @Override
+    public ChannelPipeline pipeline() {
+        return delegate.pipeline();
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+        return delegate.alloc();
+    }
+
+    @Override
+    public Channel read() {
+        return delegate.read();
+    }
+
+    @Override
+    public Channel flush() {
+        return delegate.flush();
+    }
+
+    public Channel bypassDelay() {
+        return delegate;
+    }
+
+    public void delayWritesUntil(CompletableFuture<?> future) {
+        DelayedWrites delayedWrites;
+        if (delay == null) {
+            delayedWrites = new DelayedWrites(future);
+        } else {
+            delayedWrites = new DelayedWrites(delay.future.thenCompose(ignored -> future));
+        }
+        this.delay = delayedWrites;
+        future.whenComplete((res, err) -> {
+            delayedWrites.runDelayed();
+            if (delay == delayedWrites) {
+                delay = null;
+            }
+        });
+    }
+
+    static class DelayedWrites {
+
+        private final ArrayDeque<Runnable> delayed = new ArrayDeque<>();
+        private final CompletableFuture<?> future;
+
+        public DelayedWrites(CompletableFuture<?> future) {
+            this.future = future;
+        }
+
+        public void add(Runnable runnable) {
+            synchronized (delayed) {
+                delayed.add(runnable);
+            }
+        }
+
+        private void runDelayed() {
+            Runnable runnable;
+            synchronized (delayed) {
+                while ((runnable = delayed.poll()) != null) {
+                    runnable.run();
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -195,6 +195,7 @@ public class PostgresWireProtocol {
     private final Authentication authService;
     private final SslReqHandler sslReqHandler;
 
+    private DelayableWriteChannel channel;
     private int msgLength;
     private byte msgType;
     private Session session;
@@ -289,9 +290,13 @@ public class PostgresWireProtocol {
     private class MessageHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
         @Override
-        public void channelRead0(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
-            final Channel channel = ctx.channel();
+        public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+            channel = new DelayableWriteChannel(ctx.channel());
+        }
 
+        @Override
+        public void channelRead0(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
+            assert channel != null : "Channel must be initialized";
             try {
                 dispatchState(buffer, channel);
             } catch (Throwable t) {
@@ -311,7 +316,7 @@ public class PostgresWireProtocol {
             }
         }
 
-        private void dispatchState(ByteBuf buffer, Channel channel) {
+        private void dispatchState(ByteBuf buffer, DelayableWriteChannel channel) {
             switch (state) {
                 case STARTUP_HEADER:
                 case MSG_HEADER:
@@ -336,7 +341,7 @@ public class PostgresWireProtocol {
             }
         }
 
-        private void dispatchMessage(ByteBuf buffer, Channel channel) {
+        private void dispatchMessage(ByteBuf buffer, DelayableWriteChannel channel) {
             switch (msgType) {
                 case 'Q': // Query (simple)
                     handleSimpleQuery(buffer, channel);
@@ -390,6 +395,7 @@ public class PostgresWireProtocol {
         @Override
         public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
             LOGGER.trace("channelDisconnected");
+            channel = null;
             closeSession();
             super.channelUnregistered(ctx);
         }
@@ -608,7 +614,7 @@ public class PostgresWireProtocol {
      * | string portalName
      * | int32 maxRows (0 = unlimited)
      */
-    private void handleExecute(ByteBuf buffer, Channel channel) {
+    private void handleExecute(ByteBuf buffer, DelayableWriteChannel channel) {
         String portalName = readCString(buffer);
         int maxRows = buffer.readInt();
         String query = session.getQuery(portalName);
@@ -625,20 +631,39 @@ public class PostgresWireProtocol {
             maxRows = 0;
             resultReceiver = new RowCountReceiver(
                 query,
-                channel,
+                channel.bypassDelay(),
                 SQLExceptions.forWireTransmission(getAccessControl.apply(session.sessionContext()))
             );
         } else {
             // query with resultSet
             resultReceiver = new ResultSetReceiver(
                 query,
-                channel,
+                channel.bypassDelay(),
                 SQLExceptions.forWireTransmission(getAccessControl.apply(session.sessionContext())),
                 Lists2.map(outputTypes, PGTypes::get),
                 session.getResultFormatCodes(portalName)
             );
         }
-        session.execute(portalName, maxRows, resultReceiver);
+        // .execute is going async and may execute the query in another thread-pool.
+        // The results are later sent to the clients via the `ResultReceiver` created
+        // above, The `channel.write` calls - which the `ResultReceiver` makes - may
+        // happen in a thread which is *not* a netty thread.
+        // If that is the case, netty schedules the writes intead of running them
+        // immediately. A consequence of that is that *this* thread can continue
+        // processing other messages from the client, and if this thread then sends messages to the
+        // client, these are sent immediately, overtaking the result messages of the
+        // execute that is triggered here.
+        //
+        // This would lead to out-of-order messages. For example, we could send a
+        // `parseComplete` before the `commandComplete` of the previous statement has
+        // been transmitted.
+        //
+        // To ensure clients receive messages in the correct order we delay all writes
+        // on the channel until the future below is finished.
+        CompletableFuture<?> execute = session.execute(portalName, maxRows, resultReceiver);
+        if (execute != null) {
+            channel.delayWritesUntil(execute);
+        }
     }
 
     private void handleSync(final Channel channel) {
@@ -677,7 +702,7 @@ public class PostgresWireProtocol {
     }
 
     @VisibleForTesting
-    void handleSimpleQuery(ByteBuf buffer, final Channel channel) {
+    void handleSimpleQuery(ByteBuf buffer, final DelayableWriteChannel channel) {
         String queryString = readCString(buffer);
         assert queryString != null : "query must not be nulL";
 
@@ -690,7 +715,7 @@ public class PostgresWireProtocol {
         composedFuture.whenComplete(new ReadyForQueryCallback(channel));
     }
 
-    private CompletableFuture<?> handleSingleQuery(String query, Channel channel) {
+    private CompletableFuture<?> handleSingleQuery(String query, DelayableWriteChannel channel) {
 
         CompletableFuture<?> result = new CompletableFuture<>();
 

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -127,7 +127,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         ByteBuf buffer = Unpooled.buffer();
         try {
             Messages.writeCString(buffer, ";".getBytes(StandardCharsets.UTF_8));
-            ctx.handleSimpleQuery(buffer, channel);
+            ctx.handleSimpleQuery(buffer, new DelayableWriteChannel(channel));
         } finally {
             buffer.release();
         }
@@ -521,7 +521,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         try {
             // the actual statements don't have to be valid as they are not executed
             Messages.writeCString(query, statements.getBytes(StandardCharsets.UTF_8));
-            ctx.handleSimpleQuery(query, channel);
+            ctx.handleSimpleQuery(query, new DelayableWriteChannel(channel));
         } finally {
             query.release();
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We must make sure that the client receives the rows and the
`commandComplete` message before it receives a `parseComplete` for a
second query that the client may have sent as well.

We send the query results and the `commandComplete` from the `SEARCH`
threadpool instead of from the netty worker thread, which causes netty
to schedule them for later execution. (When the worker thread can pick
it up)

Meanwhile it was the case that the netty-loop continued processing more
messages.

This fixes https://github.com/crate/crate/issues/10068


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)