### PR TITLE
Fix ORDER BY handling on table functions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that caused ``ORDER BY`` expressions referencing table
+  functions used in the ``SELECT`` list to fail.
+
 - Fixed an issue that prevented an optimization for ``SELECT DISTINCT
   <single_text_column> FROM <table>`` from working if used within a ``INSERT
   INTO`` statement.

--- a/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -146,4 +146,15 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()),
             is("fo| [1, 2, 3]\n"));
     }
+
+    @Test
+    public void test_unnest_can_be_used_in_selectlist_on_children_of_object_arrays() throws Exception {
+        execute("create table test (a string, b string, c array(object as (d string, e string)))");
+        execute("insert into test (a, b, c) values ('x', 'y', [ { d = '1', e = '2' }, { d = '3', e = '4' } ])");
+        execute("refresh table test");
+        execute("select a, b, unnest(c['d']), unnest(c['e']) from test order by 1, 3");
+        assertThat(printedTable(response.rows()),
+            is("x| y| 1| 2\n" +
+               "x| y| 3| 4\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/10122

This got already fixed in master with the changes to how the operator
tree is built.

In 4.1 the standalone outputs contained the table-function un-evaluated
(which is an `Iterable<Row>` value - for which there is no type and no
size estimator, which led to a runtime exception)

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)