### PR TITLE
Track Shard-Snapshot Index Generation at Repository Root

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -247,4 +247,27 @@ public interface ActionListener<Response> {
             }
         };
     }
+
+    /**
+     * Creates a listener that delegates all responses it receives to another listener.
+     *
+     * @param delegate ActionListener to wrap and delegate any exception to
+     * @param bc BiConsumer invoked with delegate listener and exception
+     * @param <T> Type of the listener
+     * @return Delegating listener
+     */
+    static <T> ActionListener<T> delegateResponse(ActionListener<T> delegate, BiConsumer<ActionListener<T>, Exception> onFailure) {
+        return new ActionListener<T>() {
+
+            @Override
+            public void onResponse(T r) {
+                delegate.onResponse(r);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                onFailure.accept(delegate, e);
+            }
+        };
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.action;
 
+import io.crate.common.CheckedSupplier;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 
 /**
@@ -29,6 +31,32 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 public abstract class ActionRunnable<Response> extends AbstractRunnable {
 
     protected final ActionListener<Response> listener;
+
+    /**
+     * Creates a {@link Runnable} that invokes the given listener with {@code null} after the given runnable has executed.
+     * @param listener Listener to invoke
+     * @param runnable Runnable to execute
+     * @return Wrapped {@code Runnable}
+     */
+    public static <T> ActionRunnable<T> run(ActionListener<T> listener, CheckedRunnable<Exception> runnable) {
+        return new ActionRunnable<>(listener) {
+            @Override
+            protected void doRun() throws Exception {
+                runnable.run();
+                listener.onResponse(null);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link Runnable} that invokes the given listener with the return of the given supplier.
+     * @param listener Listener to invoke
+     * @param supplier Supplier that provides value to pass to listener
+     * @return Wrapped {@code Runnable}
+     */
+    public static <T> ActionRunnable<T> supply(ActionListener<T> listener, CheckedSupplier<T, Exception> supplier) {
+        return ActionRunnable.wrap(listener, l -> l.onResponse(supplier.get()));
+    }
 
     /**
      * Creates a {@link Runnable} that wraps the given listener and a consumer of it that is executed when the {@link Runnable} is run.

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -93,11 +93,12 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         private final ImmutableOpenMap<String, List<ShardId>> waitingIndices;
         private final long startTime;
         private final long repositoryStateId;
+        private final boolean useShardGenerations;
         @Nullable private final String failure;
 
         public Entry(Snapshot snapshot, boolean includeGlobalState, boolean partial, State state, List<IndexId> indices,
                      long startTime, long repositoryStateId, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards,
-                     String failure) {
+                     String failure, boolean useShardGenerations) {
             this.state = state;
             this.snapshot = snapshot;
             this.includeGlobalState = includeGlobalState;
@@ -114,21 +115,22 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             this.repositoryStateId = repositoryStateId;
             this.failure = failure;
+            this.useShardGenerations = useShardGenerations;
         }
 
         public Entry(Snapshot snapshot, boolean includeGlobalState, boolean partial, State state, List<IndexId> indices,
-                     long startTime, long repositoryStateId, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards) {
-            this(snapshot, includeGlobalState, partial, state, indices, startTime, repositoryStateId, shards, null);
+                     long startTime, long repositoryStateId, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, boolean useShardGenerations) {
+            this(snapshot, includeGlobalState, partial, state, indices, startTime, repositoryStateId, shards, null, useShardGenerations);
         }
 
         public Entry(Entry entry, State state, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards) {
             this(entry.snapshot, entry.includeGlobalState, entry.partial, state, entry.indices, entry.startTime,
-                entry.repositoryStateId, shards, entry.failure);
+                entry.repositoryStateId, shards, entry.failure, entry.useShardGenerations);
         }
 
         public Entry(Entry entry, State state, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, String failure) {
             this(entry.snapshot, entry.includeGlobalState, entry.partial, state, entry.indices, entry.startTime,
-                entry.repositoryStateId, shards, failure);
+                entry.repositoryStateId, shards, failure, entry.useShardGenerations);
         }
 
         public Entry(Entry entry, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards) {
@@ -188,6 +190,16 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             return failure;
         }
 
+        /**
+         * Whether to write to the repository in a format only understood by versions newer than
+         * {@link SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION}.
+         *
+         * @return true if writing to repository in new format
+         */
+        public boolean useShardGenerations() {
+            return useShardGenerations;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -203,6 +215,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (!snapshot.equals(entry.snapshot)) return false;
             if (state != entry.state) return false;
             if (repositoryStateId != entry.repositoryStateId) return false;
+            if (useShardGenerations != entry.useShardGenerations) return false;
 
             return true;
         }
@@ -217,6 +230,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             result = 31 * result + indices.hashCode();
             result = 31 * result + Long.hashCode(startTime);
             result = 31 * result + Long.hashCode(repositoryStateId);
+            result = 31 * result + (useShardGenerations ? 1 : 0);
+
             return result;
         }
 
@@ -445,24 +460,30 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
     public SnapshotsInProgress(StreamInput in) throws IOException {
         Entry[] entries = new Entry[in.readVInt()];
         for (int i = 0; i < entries.length; i++) {
-            Snapshot snapshot = new Snapshot(in);
-            boolean includeGlobalState = in.readBoolean();
-            boolean partial = in.readBoolean();
-            State state = State.fromValue(in.readByte());
+            final Snapshot snapshot = new Snapshot(in);
+            final boolean includeGlobalState = in.readBoolean();
+            final boolean partial = in.readBoolean();
+            final State state = State.fromValue(in.readByte());
             int indices = in.readVInt();
             List<IndexId> indexBuilder = new ArrayList<>();
             for (int j = 0; j < indices; j++) {
                 indexBuilder.add(new IndexId(in.readString(), in.readString()));
             }
-            long startTime = in.readLong();
+            final long startTime = in.readLong();
             ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
-            int shards = in.readVInt();
+            final int shards = in.readVInt();
             for (int j = 0; j < shards; j++) {
                 ShardId shardId = new ShardId(in);
                 builder.put(shardId, new ShardSnapshotStatus(in));
             }
-            long repositoryStateId = in.readLong();
+            final long repositoryStateId = in.readLong();
             final String failure = in.readOptionalString();
+            final boolean useShardGenerations;
+            if (in.getVersion().onOrAfter(SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION)) {
+                useShardGenerations = in.readBoolean();
+            } else {
+                useShardGenerations = false;
+            }
             entries[i] = new Entry(snapshot,
                 includeGlobalState,
                 partial,
@@ -471,7 +492,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 startTime,
                 repositoryStateId,
                 builder.build(),
-                failure);
+                failure,
+                useShardGenerations);
         }
         this.entries = Arrays.asList(entries);
     }
@@ -496,6 +518,9 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             out.writeLong(entry.repositoryStateId);
             out.writeOptionalString(entry.failure);
+            if (out.getVersion().onOrAfter(SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION)) {
+                out.writeBoolean(entry.useShardGenerations);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotInProgressException;
 import org.elasticsearch.snapshots.SnapshotsService;
 
 import java.util.Arrays;
@@ -93,9 +94,15 @@ public class MetaDataDeleteIndexService {
      */
     public ClusterState deleteIndices(ClusterState currentState, Set<Index> indices) {
         final MetaData meta = currentState.metaData();
-        final Set<IndexMetaData> metaDatas = indices.stream().map(i -> meta.getIndexSafe(i)).collect(toSet());
+        final Set<Index> indicesToDelete = indices.stream().map(i -> meta.getIndexSafe(i).getIndex()).collect(toSet());
+
         // Check if index deletion conflicts with any running snapshots
-        SnapshotsService.checkIndexDeletion(currentState, metaDatas);
+        Set<Index> snapshottingIndices = SnapshotsService.snapshottingIndices(currentState, indicesToDelete);
+        if (snapshottingIndices.isEmpty() == false) {
+            throw new SnapshotInProgressException("Cannot delete indices that are being snapshotted: " + snapshottingIndices +
+                                                  ". Try again after snapshot finishes or cancel the currently running snapshot.");
+        }
+
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
         MetaData.Builder metaDataBuilder = MetaData.builder(meta);
         ClusterBlocks.Builder clusterBlocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -133,36 +133,39 @@ public interface Repository extends LifecycleComponent {
      * <p>
      * This method is called on master after all shards are snapshotted.
      *
-     * @param snapshotId            snapshot id
-     * @param indices               list of indices in the snapshot
-     * @param startTime             start time of the snapshot
-     * @param failure               global failure reason or null
-     * @param totalShards           total number of shards
-     * @param shardFailures         list of shard failures
-     * @param repositoryStateId     the unique id identifying the state of the repository when the snapshot began
-     * @param includeGlobalState    include cluster global state
-     * @param clusterMetaData       cluster metadata
-     * @param listener              listener to be called on completion of the snapshot
+     * @param snapshotId         snapshot id
+     * @param shardGenerations   updated shard generations
+     * @param startTime          start time of the snapshot
+     * @param failure            global failure reason or null
+     * @param totalShards        total number of shards
+     * @param shardFailures      list of shard failures
+     * @param repositoryStateId  the unique id identifying the state of the repository when the snapshot began
+     * @param includeGlobalState include cluster global state
+     * @param clusterMetaData    cluster metadata
+     * @param writeShardGens     if shard generations should be written to the repository
+     * @param listener           listener to be called on completion of the snapshot
      */
     void finalizeSnapshot(SnapshotId snapshotId,
-                                  List<IndexId> indices,
-                                  long startTime,
-                                  String failure,
-                                  int totalShards,
-                                  List<SnapshotShardFailure> shardFailures,
-                                  long repositoryStateId,
-                                  boolean includeGlobalState,
-                                  MetaData clusterMetaData,
-                                  ActionListener<SnapshotInfo> listener);
+                          ShardGenerations shardGenerations,
+                          long startTime,
+                          String failure,
+                          int totalShards,
+                          List<SnapshotShardFailure> shardFailures,
+                          long repositoryStateId,
+                          boolean includeGlobalState,
+                          MetaData clusterMetaData,
+                          boolean writeShardGens,
+                          ActionListener<SnapshotInfo> listener);
 
     /**
      * Deletes snapshot
      *
-     * @param snapshotId snapshot id
+     * @param snapshotId        snapshot id
      * @param repositoryStateId the unique id identifying the state of the repository when the snapshot deletion began
-     * @param listener completion listener
+     * @param writeShardGens    if shard generations should be written to the repository
+     * @param listener          completion listener
      */
-    void deleteSnapshot(SnapshotId snapshotId, long repositoryStateId, ActionListener<Void> listener);
+    void deleteSnapshot(SnapshotId snapshotId, long repositoryStateId, boolean writeShardGens, ActionListener<Void> listener);
 
     /**
      * Verifies repository on the master node and returns the verification token.
@@ -213,7 +216,7 @@ public interface Repository extends LifecycleComponent {
      * @param listener            listener invoked on completion
      */
     void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit,
-                       IndexShardSnapshotStatus snapshotStatus, ActionListener<String> listener);
+                       IndexShardSnapshotStatus snapshotStatus, boolean writeShardGens, ActionListener<String> listener);
 
     /**
      * Restores snapshot of the shard.
@@ -228,5 +231,15 @@ public interface Repository extends LifecycleComponent {
      */
     void restoreShard(Store store, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId,
                              RecoveryState recoveryState);
+
+    /**
+     * Retrieve shard snapshot status for the stored snapshot
+     *
+     * @param snapshotId snapshot id
+     * @param indexId    the snapshotted index id for the shard to get status for
+     * @param shardId    shard id
+     * @return snapshot status
+     */
+    IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, IndexId indexId, ShardId shardId);
 
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -21,13 +21,14 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ResourceNotFoundException;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotState;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +56,7 @@ public final class RepositoryData {
      * An instance initialized for an empty repository.
      */
     public static final RepositoryData EMPTY = new RepositoryData(EMPTY_REPO_GEN,
-        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), ShardGenerations.EMPTY);
 
     /**
      * The generational id of the index file from which the repository data was read.
@@ -78,20 +79,30 @@ public final class RepositoryData {
      */
     private final Map<IndexId, Set<SnapshotId>> indexSnapshots;
 
+    private final ShardGenerations shardGenerations;
+
     public RepositoryData(long genId,
                           Map<String, SnapshotId> snapshotIds,
                           Map<String, SnapshotState> snapshotStates,
-                          Map<IndexId, Set<SnapshotId>> indexSnapshots) {
+                          Map<IndexId, Set<SnapshotId>> indexSnapshots,
+                          ShardGenerations shardGenerations) {
         this.genId = genId;
         this.snapshotIds = Collections.unmodifiableMap(snapshotIds);
         this.snapshotStates = Collections.unmodifiableMap(snapshotStates);
         this.indices = Collections.unmodifiableMap(indexSnapshots.keySet().stream()
             .collect(Collectors.toMap(IndexId::getName, Function.identity())));
         this.indexSnapshots = Collections.unmodifiableMap(indexSnapshots);
+        this.shardGenerations = Objects.requireNonNull(shardGenerations, "shardGenerations must not be null");
+        assert indices.values().containsAll(shardGenerations.indices()) :
+            "ShardGenerations contained indices " + shardGenerations.indices() + " but snapshots only reference indices " + indices.values();
     }
 
     protected RepositoryData copy() {
-        return new RepositoryData(genId, snapshotIds, snapshotStates, indexSnapshots);
+        return new RepositoryData(genId, snapshotIds, snapshotStates, indexSnapshots, shardGenerations);
+    }
+
+    public ShardGenerations shardGenerations() {
+        return shardGenerations;
     }
 
     /**
@@ -135,12 +146,31 @@ public final class RepositoryData {
     }
 
     /**
+     * Returns the list of {@link IndexId} that have their snapshots updated but not removed (because they are still referenced by other
+     * snapshots) after removing the given snapshot from the repository.
+     *
+     * @param snapshotId SnapshotId to remove
+     * @return List of indices that are changed but not removed
+     */
+    public List<IndexId> indicesToUpdateAfterRemovingSnapshot(SnapshotId snapshotId) {
+        return indexSnapshots.entrySet().stream()
+            .filter(entry -> entry.getValue().size() > 1 && entry.getValue().contains(snapshotId))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Add a snapshot and its indices to the repository; returns a new instance.  If the snapshot
      * already exists in the repository data, this method throws an IllegalArgumentException.
+     *
+     * @param snapshotId       Id of the new snapshot
+     * @param snapshotState    State of the new snapshot
+     * @param shardGenerations Updated shard generations in the new snapshot. For each index contained in the snapshot an array of new
+     *                         generations indexed by the shard id they correspond to must be supplied.
      */
     public RepositoryData addSnapshot(final SnapshotId snapshotId,
                                       final SnapshotState snapshotState,
-                                      final List<IndexId> snapshottedIndices) {
+                                      final ShardGenerations shardGenerations) {
         if (snapshotIds.containsKey(snapshotId.getUUID())) {
             // if the snapshot id already exists in the repository data, it means an old master
             // that is blocked from the cluster is trying to finalize a snapshot concurrently with
@@ -152,16 +182,35 @@ public final class RepositoryData {
         Map<String, SnapshotState> newSnapshotStates = new HashMap<>(snapshotStates);
         newSnapshotStates.put(snapshotId.getUUID(), snapshotState);
         Map<IndexId, Set<SnapshotId>> allIndexSnapshots = new HashMap<>(indexSnapshots);
-        for (final IndexId indexId : snapshottedIndices) {
+        for (final IndexId indexId : shardGenerations.indices()) {
             allIndexSnapshots.computeIfAbsent(indexId, k -> new LinkedHashSet<>()).add(snapshotId);
         }
-        return new RepositoryData(genId, snapshots, newSnapshotStates, allIndexSnapshots);
+        return new RepositoryData(genId, snapshots, newSnapshotStates, allIndexSnapshots,
+                                  ShardGenerations.builder().putAll(this.shardGenerations).putAll(shardGenerations).build());
+    }
+
+    /**
+     * Create a new instance with the given generation and all other fields equal to this instance.
+     *
+     * @param newGeneration New Generation
+     * @return New instance
+     */
+    public RepositoryData withGenId(long newGeneration) {
+        if (newGeneration == genId) {
+            return this;
+        }
+        return new RepositoryData(newGeneration, this.snapshotIds, this.snapshotStates, this.indexSnapshots, this.shardGenerations);
     }
 
     /**
      * Remove a snapshot and remove any indices that no longer exist in the repository due to the deletion of the snapshot.
+     *
+     * @param snapshotId              Snapshot Id
+     * @param updatedShardGenerations Shard generations that changed as a result of removing the snapshot.
+     *                                The {@code String[]} passed for each {@link IndexId} contains the new shard generation id for each
+     *                                changed shard indexed by its shardId
      */
-    public RepositoryData removeSnapshot(final SnapshotId snapshotId) {
+    public RepositoryData removeSnapshot(final SnapshotId snapshotId, final ShardGenerations updatedShardGenerations) {
         Map<String, SnapshotId> newSnapshotIds = snapshotIds.values().stream()
             .filter(id -> !snapshotId.equals(id))
             .collect(Collectors.toMap(SnapshotId::getUUID, Function.identity()));
@@ -189,7 +238,10 @@ public final class RepositoryData {
             indexSnapshots.put(indexId, set);
         }
 
-        return new RepositoryData(genId, newSnapshotIds, newSnapshotStates, indexSnapshots);
+        return new RepositoryData(genId, newSnapshotIds, newSnapshotStates, indexSnapshots,
+                                  ShardGenerations.builder().putAll(shardGenerations).putAll(updatedShardGenerations)
+                                      .retainIndicesAndPruneDeletes(indexSnapshots.keySet()).build()
+        );
     }
 
     /**
@@ -211,16 +263,17 @@ public final class RepositoryData {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        @SuppressWarnings("unchecked") RepositoryData that = (RepositoryData) obj;
+        RepositoryData that = (RepositoryData) obj;
         return snapshotIds.equals(that.snapshotIds)
-                   && snapshotStates.equals(that.snapshotStates)
-                   && indices.equals(that.indices)
-                   && indexSnapshots.equals(that.indexSnapshots);
+               && snapshotStates.equals(that.snapshotStates)
+               && indices.equals(that.indices)
+               && indexSnapshots.equals(that.indexSnapshots)
+               && shardGenerations.equals(that.shardGenerations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotIds, snapshotStates, indices, indexSnapshots);
+        return Objects.hash(snapshotIds, snapshotStates, indices, indexSnapshots, shardGenerations);
     }
 
     /**
@@ -228,15 +281,7 @@ public final class RepositoryData {
      * throwing an exception if the index could not be resolved.
      */
     public IndexId resolveIndexId(final String indexName) {
-        if (indices.containsKey(indexName)) {
-            return indices.get(indexName);
-        } else {
-            // on repositories created before 5.0, there was no indices information in the index
-            // blob, so if the repository hasn't been updated with new snapshots, no new index blob
-            // would have been written, so we only have old snapshots without the index information.
-            // in this case, the index id is just the index name
-            return new IndexId(indexName, indexName);
-        }
+        return Objects.requireNonNull(indices.get(indexName), () -> "Tried to resolve unknown index [" + indexName + "]");
     }
 
     /**
@@ -268,6 +313,7 @@ public final class RepositoryData {
         return snapshotIndices;
     }
 
+    private static final String SHARD_GENERATIONS = "shard_generations";
     private static final String SNAPSHOTS = "snapshots";
     private static final String INDICES = "indices";
     private static final String INDEX_ID = "id";
@@ -278,7 +324,10 @@ public final class RepositoryData {
     /**
      * Writes the snapshots metadata and the related indices metadata to x-content.
      */
-    public XContentBuilder snapshotsToXContent(final XContentBuilder builder) throws IOException {
+    public XContentBuilder snapshotsToXContent(final XContentBuilder builder, final boolean shouldWriteShardGens) throws IOException {
+        assert shouldWriteShardGens || shardGenerations.indices().isEmpty() :
+            "Should not build shard generations in BwC mode but saw generations [" + shardGenerations + "]";
+
         builder.startObject();
         // write the snapshots list
         builder.startArray(SNAPSHOTS);
@@ -304,6 +353,13 @@ public final class RepositoryData {
                 builder.value(snapshotId.getUUID());
             }
             builder.endArray();
+            if (shouldWriteShardGens) {
+                builder.startArray(SHARD_GENERATIONS);
+                for (String gen : shardGenerations.getGens(indexId)) {
+                    builder.value(gen);
+                }
+                builder.endArray();
+            }
             builder.endObject();
         }
         builder.endObject();
@@ -318,6 +374,7 @@ public final class RepositoryData {
         final Map<String, SnapshotId> snapshots = new HashMap<>();
         final Map<String, SnapshotState> snapshotStates = new HashMap<>();
         final Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
+        final ShardGenerations.Builder shardGenerations = ShardGenerations.builder();
 
         if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
@@ -325,31 +382,23 @@ public final class RepositoryData {
                 if (SNAPSHOTS.equals(field)) {
                     if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
                         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                            final SnapshotId snapshotId;
-                            // the new format from 5.0 which contains the snapshot name and uuid
-                            if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-                                String name = null;
-                                String uuid = null;
-                                SnapshotState state = null;
-                                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                                    String currentFieldName = parser.currentName();
-                                    parser.nextToken();
-                                    if (NAME.equals(currentFieldName)) {
-                                        name = parser.text();
-                                    } else if (UUID.equals(currentFieldName)) {
-                                        uuid = parser.text();
-                                    } else if (STATE.equals(currentFieldName)) {
-                                        state = SnapshotState.fromValue(parser.numberValue().byteValue());
-                                    }
+                            String name = null;
+                            String uuid = null;
+                            SnapshotState state = null;
+                            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                                String currentFieldName = parser.currentName();
+                                parser.nextToken();
+                                if (NAME.equals(currentFieldName)) {
+                                    name = parser.text();
+                                } else if (UUID.equals(currentFieldName)) {
+                                    uuid = parser.text();
+                                } else if (STATE.equals(currentFieldName)) {
+                                    state = SnapshotState.fromValue(parser.numberValue().byteValue());
                                 }
-                                snapshotId = new SnapshotId(name, uuid);
-                                if (state != null) {
-                                    snapshotStates.put(uuid, state);
-                                }
-                            } else {
-                                // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
-                                final String name = parser.text();
-                                snapshotId = new SnapshotId(name, name);
+                            }
+                            final SnapshotId snapshotId = new SnapshotId(name, uuid);
+                            if (state != null) {
+                                snapshotStates.put(uuid, state);
                             }
                             snapshots.put(snapshotId.getUUID(), snapshotId);
                         }
@@ -363,6 +412,7 @@ public final class RepositoryData {
                     while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                         final String indexName = parser.currentName();
                         final Set<SnapshotId> snapshotIds = new LinkedHashSet<>();
+                        final List<String> gens = new ArrayList<>();
 
                         IndexId indexId = null;
                         if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
@@ -405,10 +455,20 @@ public final class RepositoryData {
                                             + " references an unknown snapshot uuid [" + uuid + "]");
                                     }
                                 }
+                            } else if (SHARD_GENERATIONS.equals(indexMetaFieldName)) {
+                                XContentParserUtils.ensureExpectedToken(
+                                    XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
+                                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                                    gens.add(parser.textOrNull());
+                                }
+
                             }
                         }
                         assert indexId != null;
                         indexSnapshots.put(indexId, snapshotIds);
+                        for (int i = 0; i < gens.size(); i++) {
+                            shardGenerations.put(indexId, i, gens.get(i));
+                        }
                     }
                 } else {
                     throw new ElasticsearchParseException("unknown field name  [" + field + "]");
@@ -417,7 +477,7 @@ public final class RepositoryData {
         } else {
             throw new ElasticsearchParseException("start object expected");
         }
-        return new RepositoryData(genId, snapshots, snapshotStates, indexSnapshots);
+        return new RepositoryData(genId, snapshots, snapshotStates, indexSnapshots, shardGenerations.build());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/repositories/ShardGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/ShardGenerations.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class ShardGenerations {
+
+    public static final ShardGenerations EMPTY = new ShardGenerations(Collections.emptyMap());
+
+    /**
+     * Special generation that signifies that a shard is new and the repository does not yet contain a valid
+     * {@link org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots} blob for it.
+     */
+    public static final String NEW_SHARD_GEN = "_new";
+
+    /**
+     * Special generation that signifies that the shard has been deleted from the repository.
+     * This generation is only used during computations. It should never be written to disk.
+     */
+    public static final String DELETED_SHARD_GEN = "_deleted";
+
+    private final Map<IndexId, List<String>> shardGenerations;
+
+    private ShardGenerations(Map<IndexId, List<String>> shardGenerations) {
+        this.shardGenerations = shardGenerations;
+    }
+
+    /**
+     * Returns all indices for which shard generations are tracked.
+     *
+     * @return indices for which shard generations are tracked
+     */
+    public Collection<IndexId> indices() {
+        return Collections.unmodifiableSet(shardGenerations.keySet());
+    }
+
+    /**
+     * Computes the obsolete shard index generations that can be deleted once this instance was written to the repository.
+     * Note: This method should only be used when finalizing a snapshot and we can safely assume that data has only been added but not
+     * removed from shard paths.
+     *
+     * @param previous Previous {@code ShardGenerations}
+     * @return Map of obsolete shard index generations in indices that are still tracked by this instance
+     */
+    public Map<IndexId, Map<Integer, String>> obsoleteShardGenerations(ShardGenerations previous) {
+        final Map<IndexId, Map<Integer, String>> result = new HashMap<>();
+        previous.shardGenerations.forEach(((indexId, oldGens) -> {
+            final List<String> updatedGenerations = shardGenerations.get(indexId);
+            final Map<Integer, String> obsoleteShardIndices = new HashMap<>();
+            assert updatedGenerations != null
+                : "Index [" + indexId + "] present in previous shard generations, but missing from updated generations";
+            for (int i = 0; i < Math.min(oldGens.size(), updatedGenerations.size()); i++) {
+                final String oldGeneration = oldGens.get(i);
+                final String updatedGeneration = updatedGenerations.get(i);
+                // If we had a previous generation that is different from an updated generation it's obsolete
+                // Since this method assumes only additions and no removals of shards, a null updated generation means no update
+                if (updatedGeneration != null && oldGeneration != null && oldGeneration.equals(updatedGeneration) == false) {
+                    obsoleteShardIndices.put(i, oldGeneration);
+                }
+            }
+            result.put(indexId, Collections.unmodifiableMap(obsoleteShardIndices));
+        }));
+        return Collections.unmodifiableMap(result);
+    }
+
+    /**
+     * Get the generation of the {@link org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots} blob for a given index
+     * and shard.
+     * There are three special kinds of generations that can be returned here.
+     * <ul>
+     *     <li>{@link #DELETED_SHARD_GEN} a deleted shard that isn't referenced by any snapshot in the repository any longer</li>
+     *     <li>{@link #NEW_SHARD_GEN} a new shard that we know doesn't hold any valid data yet in the repository</li>
+     *     <li>{@code null} unknown state. The shard either does not exist at all or it was created by a node older than
+     *     {@link org.elasticsearch.snapshots.SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION}. If a caller expects a shard to exist in the
+     *     repository but sees a {@code null} return, it should try to recover the generation by falling back to listing the contents
+     *     of the respective shard directory.</li>
+     * </ul>
+     *
+     * @param indexId IndexId
+     * @param shardId Shard Id
+     * @return generation of the {@link org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots} blob
+     */
+    @Nullable
+    public String getShardGen(IndexId indexId, int shardId) {
+        final List<String> generations = shardGenerations.get(indexId);
+        if (generations == null || generations.size() < shardId + 1) {
+            return null;
+        }
+        return generations.get(shardId);
+    }
+
+    public List<String> getGens(IndexId indexId) {
+        final List<String> existing = shardGenerations.get(indexId);
+        return existing == null ? Collections.emptyList() : Collections.unmodifiableList(existing);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ShardGenerations that = (ShardGenerations) o;
+        return shardGenerations.equals(that.shardGenerations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shardGenerations);
+    }
+
+    @Override
+    public String toString() {
+        return "ShardGenerations{generations:" + this.shardGenerations + "}";
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private final Map<IndexId, Map<Integer, String>> generations = new HashMap<>();
+
+        /**
+         * Filters out all generations that don't belong to any of the supplied {@code indices} and prunes all {@link #DELETED_SHARD_GEN}
+         * entries from the builder.
+         *
+         * @param indices indices to filter for
+         * @return builder that contains only the given {@code indices} and no {@link #DELETED_SHARD_GEN} entries
+         */
+        public Builder retainIndicesAndPruneDeletes(Set<IndexId> indices) {
+            generations.keySet().retainAll(indices);
+            for (IndexId index : indices) {
+                final Map<Integer, String> shards = generations.getOrDefault(index, Collections.emptyMap());
+                final Iterator<Map.Entry<Integer, String>> iterator = shards.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<Integer, String> entry = iterator.next();
+                    final String generation = entry.getValue();
+                    if (generation.equals(DELETED_SHARD_GEN)) {
+                        iterator.remove();
+                    }
+                }
+                if (shards.isEmpty()) {
+                    generations.remove(index);
+                }
+            }
+            return this;
+        }
+
+        public Builder putAll(ShardGenerations shardGenerations) {
+            shardGenerations.shardGenerations.forEach((indexId, gens) -> {
+                for (int i = 0; i < gens.size(); i++) {
+                    final String gen = gens.get(i);
+                    if (gen != null) {
+                        put(indexId, i, gens.get(i));
+                    }
+                }
+            });
+            return this;
+        }
+
+        public Builder put(IndexId indexId, int shardId, String generation) {
+            generations.computeIfAbsent(indexId, i -> new HashMap<>()).put(shardId, generation);
+            return this;
+        }
+
+        public ShardGenerations build() {
+            return new ShardGenerations(generations.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> {
+                    final Set<Integer> shardIds = entry.getValue().keySet();
+                    assert shardIds.isEmpty() == false;
+                    final int size = shardIds.stream().mapToInt(i -> i).max().getAsInt() + 1;
+                    // Create a list that can hold the highest shard id as index and leave null values for shards that don't have
+                    // a map entry.
+                    final String[] gens = new String[size];
+                    entry.getValue().forEach((shardId, generation) -> gens[shardId] = generation);
+                    return Arrays.asList(gens);
+                }
+            )));
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.snapshots;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.common.io.IOUtils;
+import io.crate.common.unit.TimeValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -42,7 +43,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -50,7 +50,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
@@ -70,6 +69,7 @@ import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -88,7 +88,6 @@ import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
  * starting and stopping shard level snapshots
  */
 public class SnapshotShardsService extends AbstractLifecycleComponent implements ClusterStateListener, IndexEventListener {
-
     private static final Logger LOGGER = LogManager.getLogger(SnapshotShardsService.class);
 
     private static final String UPDATE_SNAPSHOT_STATUS_ACTION_NAME = "internal:cluster/snapshot/update_snapshot_status";
@@ -96,8 +95,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     private final ClusterService clusterService;
 
     private final IndicesService indicesService;
-
-    private final SnapshotsService snapshotsService;
 
     private final RepositoriesService repositoriesService;
 
@@ -115,13 +112,11 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     private final UpdateSnapshotStatusAction updateSnapshotStatusHandler;
 
     @Inject
-    public SnapshotShardsService(Settings settings, ClusterService clusterService, SnapshotsService snapshotsService,
-                                 RepositoriesService repositoriesService, ThreadPool threadPool,
-                                 TransportService transportService, IndicesService indicesService,
+    public SnapshotShardsService(Settings settings, ClusterService clusterService, RepositoriesService repositoriesService,
+                                 ThreadPool threadPool, TransportService transportService, IndicesService indicesService,
                                  IndexNameExpressionResolver indexNameExpressionResolver) {
         this.indicesService = indicesService;
         this.repositoriesService = repositoriesService;
-        this.snapshotsService = snapshotsService;
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
@@ -158,7 +153,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             if ((previousSnapshots == null && currentSnapshots != null)
                 || (previousSnapshots != null && previousSnapshots.equals(currentSnapshots) == false)) {
                 synchronized (shardSnapshots) {
-                    processIndexShardSnapshots(currentSnapshots);
+                    cancelRemoved(currentSnapshots);
+                    if (currentSnapshots != null) {
+                        startNewSnapshots(currentSnapshots);
+                    }
                 }
             }
 
@@ -181,7 +179,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 Map<ShardId, IndexShardSnapshotStatus> shards = snapshotShards.getValue();
                 if (shards.containsKey(shardId)) {
                     LOGGER.debug("[{}] shard closing, abort snapshotting for snapshot [{}]",
-                        shardId, snapshotShards.getKey().getSnapshotId());
+                                 shardId, snapshotShards.getKey().getSnapshotId());
                     shards.get(shardId).abortIfNotCompleted("shard is closing, aborting");
                 }
             }
@@ -201,18 +199,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         synchronized (shardSnapshots) {
             final Map<ShardId, IndexShardSnapshotStatus> current = shardSnapshots.get(snapshot);
             return current == null ? null : new HashMap<>(current);
-        }
-    }
-
-    /**
-     * Checks if any new shards should be snapshotted on this node
-     *
-     * @param snapshotsInProgress Current snapshots in progress in cluster state
-     */
-    private void processIndexShardSnapshots(SnapshotsInProgress snapshotsInProgress) {
-        cancelRemoved(snapshotsInProgress);
-        if (snapshotsInProgress != null) {
-            startNewSnapshots(snapshotsInProgress);
         }
     }
 
@@ -250,7 +236,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     // Add all new shards to start processing on
                     final ShardId shardId = shard.key;
                     final ShardSnapshotStatus shardSnapshotStatus = shard.value;
-                    if (localNodeId.equals(shardSnapshotStatus.nodeId()) && shardSnapshotStatus.state() == ShardState.INIT.INIT
+                    if (localNodeId.equals(shardSnapshotStatus.nodeId())
+                        && shardSnapshotStatus.state() == ShardState.INIT
                         && snapshotShards.containsKey(shardId) == false) {
                         LOGGER.trace("[{}] - Adding shard to the queue", shardId);
                         if (startedShards == null) {
@@ -293,9 +280,11 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 final IndexShardSnapshotStatus snapshotStatus = shardEntry.getValue();
                 final IndexId indexId = indicesMap.get(shardId.getIndexName());
                 assert indexId != null;
-                snapshot(shardId, snapshot, indexId, snapshotStatus, new ActionListener<>() {
+                assert entry.useShardGenerations() || snapshotStatus.generation() == null :
+                    "Found non-null shard generation [" + snapshotStatus.generation() + "] for snapshot with old-format compatibility";
+                snapshot(shardId, snapshot, indexId, snapshotStatus, entry.useShardGenerations(), new ActionListener<>() {
                     @Override
-                    public void onResponse(final String newGeneration) {
+                    public void onResponse(String newGeneration) {
                         assert newGeneration != null;
                         assert newGeneration.equals(snapshotStatus.generation());
                         if (LOGGER.isDebugEnabled()) {
@@ -309,7 +298,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     @Override
                     public void onFailure(Exception e) {
                         LOGGER.warn(() -> new ParameterizedMessage("[{}][{}] failed to snapshot shard", shardId, snapshot), e);
-                        notifyFailedSnapshotShard(snapshot, shardId, ExceptionsHelper.detailedMessage(e));
+                        notifyFailedSnapshotShard(snapshot, shardId, ExceptionsHelper.stackTrace(e));
                     }
                 });
             }
@@ -323,7 +312,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * @param snapshotStatus snapshot status
      */
     private void snapshot(final ShardId shardId, final Snapshot snapshot, final IndexId indexId,
-                          final IndexShardSnapshotStatus snapshotStatus, ActionListener<String> listener) {
+                          final IndexShardSnapshotStatus snapshotStatus, boolean writeShardGens, ActionListener<String> listener) {
         try {
             final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
             if (indexShard.routingEntry().primary() == false) {
@@ -346,7 +335,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 // we flush first to make sure we get the latest writes snapshotted
                 snapshotRef = indexShard.acquireLastIndexCommit(true);
                 repository.snapshotShard(indexShard.store(), indexShard.mapperService(), snapshot.getSnapshotId(), indexId,
-                                         snapshotRef.getIndexCommit(), snapshotStatus, ActionListener.runBefore(listener, snapshotRef::close));
+                                         snapshotRef.getIndexCommit(), snapshotStatus, writeShardGens, ActionListener.runBefore(listener, snapshotRef::close));
             } catch (Exception e) {
                 IOUtils.close(snapshotRef);
                 throw e;
@@ -400,7 +389,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * Internal request that is used to send changes in snapshot status to master
      */
     public static class UpdateIndexShardSnapshotStatusRequest extends MasterNodeRequest<UpdateIndexShardSnapshotStatusRequest> {
-
         private final Snapshot snapshot;
         private final ShardId shardId;
         private final ShardSnapshotStatus status;
@@ -448,12 +436,15 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
 
     /** Notify the master node that the given shard has been successfully snapshotted **/
     private void notifySuccessfulSnapshotShard(final Snapshot snapshot, final ShardId shardId, String generation) {
-        sendSnapshotShardUpdate(snapshot, shardId, new ShardSnapshotStatus(clusterService.localNode().getId(), ShardState.SUCCESS, generation));
+        assert generation != null;
+        sendSnapshotShardUpdate(snapshot, shardId,
+                                new ShardSnapshotStatus(clusterService.localNode().getId(), ShardState.SUCCESS, generation));
     }
 
     /** Notify the master node that the given shard failed to be snapshotted **/
     private void notifyFailedSnapshotShard(final Snapshot snapshot, final ShardId shardId, final String failure) {
-        sendSnapshotShardUpdate(snapshot, shardId, new ShardSnapshotStatus(clusterService.localNode().getId(), ShardState.FAILED, failure, null));
+        sendSnapshotShardUpdate(snapshot, shardId,
+                                new ShardSnapshotStatus(clusterService.localNode().getId(), ShardState.FAILED, failure, null));
     }
 
     /** Updates the shard snapshot status by sending a {@link UpdateIndexShardSnapshotStatusRequest} to the master node */
@@ -526,8 +517,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     private static class SnapshotStateExecutor implements ClusterStateTaskExecutor<UpdateIndexShardSnapshotStatusRequest> {
 
         @Override
-        public ClusterTasksResult<UpdateIndexShardSnapshotStatusRequest> execute(ClusterState currentState,
-                                                                                 List<UpdateIndexShardSnapshotStatusRequest> tasks) {
+        public ClusterTasksResult<UpdateIndexShardSnapshotStatusRequest> execute(ClusterState currentState, List<UpdateIndexShardSnapshotStatusRequest> tasks) {
             final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
             if (snapshots != null) {
                 int changedCount = 0;
@@ -539,7 +529,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     for (UpdateIndexShardSnapshotStatusRequest updateSnapshotState : tasks) {
                         if (entry.snapshot().equals(updateSnapshotState.snapshot())) {
                             LOGGER.trace("[{}] Updating shard [{}] with status [{}]", updateSnapshotState.snapshot(),
-                                updateSnapshotState.shardId(), updateSnapshotState.status().state());
+                                         updateSnapshotState.shardId(), updateSnapshotState.status().state());
                             if (updated == false) {
                                 shards.putAll(entry.shards());
                                 updated = true;
@@ -565,8 +555,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 if (changedCount > 0) {
                     LOGGER.trace("changed cluster state triggered by {} snapshot state updates", changedCount);
                     return ClusterTasksResult.<UpdateIndexShardSnapshotStatusRequest>builder().successes(tasks)
-                        .build(ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE,
-                            new SnapshotsInProgress(unmodifiableList(entries))).build());
+                        .build(ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, new SnapshotsInProgress(unmodifiableList(entries))).build());
                 }
             }
             return ClusterTasksResult.<UpdateIndexShardSnapshotStatusRequest>builder().successes(tasks).build(currentState);
@@ -575,25 +564,21 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
 
     static class UpdateIndexShardSnapshotStatusResponse extends TransportResponse {
 
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public UpdateIndexShardSnapshotStatusResponse() {
+
         }
 
-        public UpdateIndexShardSnapshotStatusResponse() {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
         }
     }
 
     private class UpdateSnapshotStatusAction
         extends TransportMasterNodeAction<UpdateIndexShardSnapshotStatusRequest, UpdateIndexShardSnapshotStatusResponse> {
         UpdateSnapshotStatusAction(TransportService transportService, ClusterService clusterService,
-                                   ThreadPool threadPool, IndexNameExpressionResolver indexNameExpressionResolver) {
+                                   ThreadPool threadPool,IndexNameExpressionResolver indexNameExpressionResolver) {
             super(
-                SnapshotShardsService.UPDATE_SNAPSHOT_STATUS_ACTION_NAME,
-                transportService,
-                clusterService,
-                threadPool,
-                UpdateIndexShardSnapshotStatusRequest::new,
-                indexNameExpressionResolver
+                SnapshotShardsService.UPDATE_SNAPSHOT_STATUS_ACTION_NAME, transportService, clusterService, threadPool, UpdateIndexShardSnapshotStatusRequest::new, indexNameExpressionResolver
             );
         }
 
@@ -618,4 +603,5 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             return null;
         }
     }
+
 }

--- a/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -55,7 +56,7 @@ public class SysSnapshotsTest extends CrateUnitTest {
         snapshots.put(s1.getUUID(), s1);
         snapshots.put(s2.getUUID(), s2);
         RepositoryData repositoryData = new RepositoryData(
-            1, snapshots, Collections.emptyMap(), Collections.emptyMap());
+            1, snapshots, Collections.emptyMap(), Collections.emptyMap(), ShardGenerations.EMPTY);
 
         Repository r1 = mock(Repository.class);
         when(r1.getRepositoryData()).thenReturn(repositoryData);

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -40,6 +40,7 @@ import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -345,6 +346,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     @Test
     public void testRestoreSnapshotSinglePartition() throws Exception {
         createTableAndSnapshot("my_parted_table", SNAPSHOT_NAME, true);
+        waitNoPendingTasksOnAll();
 
         execute("delete from my_parted_table");
         waitNoPendingTasksOnAll();
@@ -417,6 +419,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         createTable("my_table_1", false);
         createTable("my_table_2", false);
         createSnapshot(SNAPSHOT_NAME, "my_table_1", "my_table_2");
+        waitNoPendingTasksOnAll();
 
         execute("drop table my_table_1");
 
@@ -514,14 +517,14 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         var corruptedIndex = indexIds.entrySet().iterator().next().getValue();
         var shardIndexFile = defaultRepositoryLocation.toPath().resolve("indices")
             .resolve(corruptedIndex.getId()).resolve("0")
-            .resolve("index-0");
+            .resolve("index-" + repositoryData.shardGenerations().getShardGen(corruptedIndex, 0));
 
         // Truncating shard index file
         try (var outChan = Files.newByteChannel(shardIndexFile, StandardOpenOption.WRITE)) {
             outChan.truncate(randomInt(10));
         }
 
-        assertSnapShotState(snapShotName1);
+        assertSnapShotState(snapShotName1, SnapshotState.SUCCESS);
 
         execute("drop table t1");
         execute("RESTORE SNAPSHOT " +  fullSnapShotName1 + " TABLE t1 with (wait_for_completion=true)");
@@ -540,24 +543,15 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         var fullSnapShotName2 = REPOSITORY_NAME + ".s2";
 
         execute("CREATE SNAPSHOT " + fullSnapShotName2 + " ALL WITH (wait_for_completion=true)");
-
-        assertSnapShotState(snapShotName2);
-
-        execute("drop table t1");
-        execute("RESTORE SNAPSHOT " + fullSnapShotName2 + " TABLE t1 with (wait_for_completion=true)");
-        ensureYellow();
-
-        execute("SELECT COUNT(*) FROM t1");
-        assertThat(response.rows()[0][0], is(numberOfDocs + numberOfAdditionalDocs));
-
+        assertSnapShotState(snapShotName2, SnapshotState.PARTIAL);
     }
 
-    private void assertSnapShotState(String snapShotName) {
+    private void assertSnapShotState(String snapShotName, SnapshotState state) {
         execute(
             "SELECT state, array_length(concrete_indices, 1) FROM sys.snapshots where name = ? and repository = ?",
             new Object[]{snapShotName, REPOSITORY_NAME});
 
-        assertThat(response.rows()[0][0], is("SUCCESS"));
+        assertThat(response.rows()[0][0], is(state.name()));
         assertThat(response.rows()[0][1], is(1));
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/SnapshotsInProgressTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SnapshotsInProgressTests.java
@@ -65,7 +65,7 @@ public class SnapshotsInProgressTests extends ESTestCase {
         // test no waiting shards in an index
         shards.put(new ShardId(idx3Name, idx3UUID, 0), new ShardSnapshotStatus(randomAlphaOfLength(2), randomNonWaitingState(), "", "1"));
         Entry entry = new Entry(snapshot, randomBoolean(), randomBoolean(), State.INIT,
-                                indices, System.currentTimeMillis(), randomLong(), shards.build());
+                                indices, System.currentTimeMillis(), randomLong(), shards.build(), randomBoolean());
 
         ImmutableOpenMap<String, List<ShardId>> waitingIndices = entry.waitingIndices();
         assertEquals(2, waitingIndices.get(idx1Name).size());

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Tests for the {@link RepositoryData} class.
+ */
+public class RepositoryDataTests extends ESTestCase {
+
+    public void testEqualsAndHashCode() {
+        RepositoryData repositoryData1 = generateRandomRepoData();
+        RepositoryData repositoryData2 = repositoryData1.copy();
+        assertEquals(repositoryData1, repositoryData2);
+        assertEquals(repositoryData1.hashCode(), repositoryData2.hashCode());
+    }
+
+    public void testIndicesToUpdateAfterRemovingSnapshot() {
+        final RepositoryData repositoryData = generateRandomRepoData();
+        final List<IndexId> indicesBefore = List.copyOf(repositoryData.getIndices().values());
+        final SnapshotId randomSnapshot = randomFrom(repositoryData.getSnapshotIds());
+        final IndexId[] indicesToUpdate = indicesBefore.stream().filter(index -> {
+            final Set<SnapshotId> snapshotIds = repositoryData.getSnapshots(index);
+            return snapshotIds.contains(randomSnapshot) && snapshotIds.size() > 1;
+        }).toArray(IndexId[]::new);
+        assertThat(repositoryData.indicesToUpdateAfterRemovingSnapshot(randomSnapshot), containsInAnyOrder(indicesToUpdate));
+    }
+
+    public void testXContent() throws IOException {
+        RepositoryData repositoryData = generateRandomRepoData();
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        repositoryData.snapshotsToXContent(builder, true);
+        try (XContentParser parser = createParser(JsonXContent.JSON_XCONTENT, BytesReference.bytes(builder))) {
+            long gen = (long) randomIntBetween(0, 500);
+            RepositoryData fromXContent = RepositoryData.snapshotsFromXContent(parser, gen);
+            assertEquals(repositoryData, fromXContent);
+            assertEquals(gen, fromXContent.getGenId());
+        }
+    }
+
+    public void testAddSnapshots() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        // test that adding the same snapshot id to the repository data throws an exception
+        Map<String, IndexId> indexIdMap = repositoryData.getIndices();
+        // test that adding a snapshot and its indices works
+        SnapshotId newSnapshot = new SnapshotId(randomAlphaOfLength(7), UUIDs.randomBase64UUID());
+        List<IndexId> indices = new ArrayList<>();
+        Set<IndexId> newIndices = new HashSet<>();
+        int numNew = randomIntBetween(1, 10);
+        final ShardGenerations.Builder builder = ShardGenerations.builder();
+        for (int i = 0; i < numNew; i++) {
+            IndexId indexId = new IndexId(randomAlphaOfLength(7), UUIDs.randomBase64UUID());
+            newIndices.add(indexId);
+            indices.add(indexId);
+            builder.put(indexId, 0, "1");
+        }
+        int numOld = randomIntBetween(1, indexIdMap.size());
+        List<String> indexNames = new ArrayList<>(indexIdMap.keySet());
+        for (int i = 0; i < numOld; i++) {
+            final IndexId indexId = indexIdMap.get(indexNames.get(i));
+            indices.add(indexId);
+            builder.put(indexId, 0, "2");
+        }
+        RepositoryData newRepoData = repositoryData.addSnapshot(newSnapshot,
+                                                                randomFrom(SnapshotState.SUCCESS, SnapshotState.PARTIAL, SnapshotState.FAILED), builder.build());
+        // verify that the new repository data has the new snapshot and its indices
+        assertTrue(newRepoData.getSnapshotIds().contains(newSnapshot));
+        for (IndexId indexId : indices) {
+            Set<SnapshotId> snapshotIds = newRepoData.getSnapshots(indexId);
+            assertTrue(snapshotIds.contains(newSnapshot));
+            if (newIndices.contains(indexId)) {
+                assertEquals(snapshotIds.size(), 1); // if it was a new index, only the new snapshot should be in its set
+            }
+        }
+        assertEquals(repositoryData.getGenId(), newRepoData.getGenId());
+    }
+
+    public void testInitIndices() {
+        final int numSnapshots = randomIntBetween(1, 30);
+        final Map<String, SnapshotId> snapshotIds = new HashMap<>(numSnapshots);
+        final Map<String, SnapshotState> snapshotStates = new HashMap<>(numSnapshots);
+        for (int i = 0; i < numSnapshots; i++) {
+            final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
+            snapshotIds.put(snapshotId.getUUID(), snapshotId);
+            snapshotStates.put(snapshotId.getUUID(), randomFrom(SnapshotState.values()));
+        }
+        RepositoryData repositoryData = new RepositoryData(EMPTY_REPO_GEN, snapshotIds,
+                                                           Collections.emptyMap(), Collections.emptyMap(), ShardGenerations.EMPTY);
+        // test that initializing indices works
+        Map<IndexId, Set<SnapshotId>> indices = randomIndices(snapshotIds);
+        RepositoryData newRepoData =
+            new RepositoryData(repositoryData.getGenId(), snapshotIds, snapshotStates, indices, ShardGenerations.EMPTY);
+        List<SnapshotId> expected = new ArrayList<>(repositoryData.getSnapshotIds());
+        Collections.sort(expected);
+        List<SnapshotId> actual = new ArrayList<>(newRepoData.getSnapshotIds());
+        Collections.sort(actual);
+        assertEquals(expected, actual);
+        for (IndexId indexId : indices.keySet()) {
+            assertEquals(indices.get(indexId), newRepoData.getSnapshots(indexId));
+        }
+    }
+
+    public void testRemoveSnapshot() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        List<SnapshotId> snapshotIds = new ArrayList<>(repositoryData.getSnapshotIds());
+        assertThat(snapshotIds.size(), greaterThan(0));
+        SnapshotId removedSnapshotId = snapshotIds.remove(randomIntBetween(0, snapshotIds.size() - 1));
+        RepositoryData newRepositoryData = repositoryData.removeSnapshot(removedSnapshotId, ShardGenerations.EMPTY);
+        // make sure the repository data's indices no longer contain the removed snapshot
+        for (final IndexId indexId : newRepositoryData.getIndices().values()) {
+            assertFalse(newRepositoryData.getSnapshots(indexId).contains(removedSnapshotId));
+        }
+    }
+
+    public void testResolveIndexId() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        Map<String, IndexId> indices = repositoryData.getIndices();
+        Set<String> indexNames = indices.keySet();
+        assertThat(indexNames.size(), greaterThan(0));
+        String indexName = indexNames.iterator().next();
+        IndexId indexId = indices.get(indexName);
+        assertEquals(indexId, repositoryData.resolveIndexId(indexName));
+    }
+
+    public void testGetSnapshotState() {
+        final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
+        final SnapshotState state = randomFrom(SnapshotState.values());
+        final RepositoryData repositoryData = RepositoryData.EMPTY.addSnapshot(snapshotId, state, ShardGenerations.EMPTY);
+        assertEquals(state, repositoryData.getSnapshotState(snapshotId));
+        assertNull(repositoryData.getSnapshotState(new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())));
+    }
+
+    public void testIndexThatReferencesAnUnknownSnapshot() throws IOException {
+        final XContent xContent = randomFrom(XContentType.values()).xContent();
+        final RepositoryData repositoryData = generateRandomRepoData();
+
+        XContentBuilder builder = XContentBuilder.builder(xContent);
+        repositoryData.snapshotsToXContent(builder, true);
+        RepositoryData parsedRepositoryData;
+        try (XContentParser xParser = createParser(builder)) {
+            parsedRepositoryData = RepositoryData.snapshotsFromXContent(xParser, repositoryData.getGenId());
+        }
+        assertEquals(repositoryData, parsedRepositoryData);
+
+        Map<String, SnapshotId> snapshotIds = new HashMap<>();
+        Map<String, SnapshotState> snapshotStates = new HashMap<>();
+        for (SnapshotId snapshotId : parsedRepositoryData.getSnapshotIds()) {
+            snapshotIds.put(snapshotId.getUUID(), snapshotId);
+            snapshotStates.put(snapshotId.getUUID(), parsedRepositoryData.getSnapshotState(snapshotId));
+        }
+
+        final IndexId corruptedIndexId = randomFrom(parsedRepositoryData.getIndices().values());
+
+        Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
+        final ShardGenerations.Builder shardGenBuilder = ShardGenerations.builder();
+        for (Map.Entry<String, IndexId> snapshottedIndex : parsedRepositoryData.getIndices().entrySet()) {
+            IndexId indexId = snapshottedIndex.getValue();
+            Set<SnapshotId> snapshotsIds = new LinkedHashSet<>(parsedRepositoryData.getSnapshots(indexId));
+            if (corruptedIndexId.equals(indexId)) {
+                snapshotsIds.add(new SnapshotId("_uuid", "_does_not_exist"));
+            }
+            indexSnapshots.put(indexId, snapshotsIds);
+            final int shardCount = randomIntBetween(1, 10);
+            for (int i = 0; i < shardCount; ++i) {
+                shardGenBuilder.put(indexId, i, UUIDs.randomBase64UUID(random()));
+            }
+        }
+        assertNotNull(corruptedIndexId);
+
+        RepositoryData corruptedRepositoryData = new RepositoryData(parsedRepositoryData.getGenId(), snapshotIds, snapshotStates,
+                                                                    indexSnapshots, shardGenBuilder.build());
+
+        final XContentBuilder corruptedBuilder = XContentBuilder.builder(xContent);
+        corruptedRepositoryData.snapshotsToXContent(corruptedBuilder, true);
+
+        try (XContentParser xParser = createParser(corruptedBuilder)) {
+            ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
+                RepositoryData.snapshotsFromXContent(xParser, corruptedRepositoryData.getGenId()));
+            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index " + corruptedIndexId + " references an unknown " +
+                                               "snapshot uuid [_does_not_exist]"));
+        }
+    }
+
+    public void testIndexThatReferenceANullSnapshot() throws IOException {
+        final XContentBuilder builder = XContentBuilder.builder(randomFrom(XContentType.JSON).xContent());
+        builder.startObject();
+        {
+            builder.startArray("snapshots");
+            builder.value(new SnapshotId("_name", "_uuid"));
+            builder.endArray();
+
+            builder.startObject("indices");
+            {
+                builder.startObject("docs");
+                {
+                    builder.field("id", "_id");
+                    builder.startArray("snapshots");
+                    {
+                        builder.startObject();
+                        if (randomBoolean()) {
+                            builder.field("name", "_name");
+                        }
+                        builder.endObject();
+                    }
+                    builder.endArray();
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+
+        try (XContentParser xParser = createParser(builder)) {
+            ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
+                RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong()));
+            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, " +
+                                               "index [docs/_id] references an unknown snapshot uuid [null]"));
+        }
+    }
+
+    public static RepositoryData generateRandomRepoData() {
+        final int numIndices = randomIntBetween(1, 30);
+        final List<IndexId> indices = new ArrayList<>(numIndices);
+        for (int i = 0; i < numIndices; i++) {
+            indices.add(new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()));
+        }
+        final int numSnapshots = randomIntBetween(1, 30);
+        RepositoryData repositoryData = RepositoryData.EMPTY;
+        for (int i = 0; i < numSnapshots; i++) {
+            final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
+            final List<IndexId> someIndices = indices.subList(0, randomIntBetween(1, numIndices));
+            final ShardGenerations.Builder builder = ShardGenerations.builder();
+            for (IndexId someIndex : someIndices) {
+                final int shardCount = randomIntBetween(1, 10);
+                for (int j = 0; j < shardCount; ++j) {
+                    builder.put(someIndex, 0, UUIDs.randomBase64UUID(random()));
+                }
+            }
+            repositoryData = repositoryData.addSnapshot(snapshotId, randomFrom(SnapshotState.values()), builder.build());
+        }
+        return repositoryData;
+    }
+
+    private static Map<IndexId, Set<SnapshotId>> randomIndices(final Map<String, SnapshotId> snapshotIdsMap) {
+        final List<SnapshotId> snapshotIds = new ArrayList<>(snapshotIdsMap.values());
+        final int totalSnapshots = snapshotIds.size();
+        final int numIndices = randomIntBetween(1, 30);
+        final Map<IndexId, Set<SnapshotId>> indices = new HashMap<>(numIndices);
+        for (int i = 0; i < numIndices; i++) {
+            final IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
+            final Set<SnapshotId> indexSnapshots = new LinkedHashSet<>();
+            final int numIndicesForSnapshot = randomIntBetween(1, numIndices);
+            for (int j = 0; j < numIndicesForSnapshot; j++) {
+                indexSnapshots.add(snapshotIds.get(randomIntBetween(0, totalSnapshots - 1)));
+            }
+            indices.put(indexId, indexSnapshots);
+        }
+        return indices;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -79,7 +79,7 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
             }
         }
         ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = builder.build();
-        return new Entry(snapshot, includeGlobalState, partial, state, indices, startTime, repositoryStateId, shards);
+        return new Entry(snapshot, includeGlobalState, partial, state, indices, startTime, repositoryStateId, shards, randomBoolean());
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Based on https://github.com/elastic/elasticsearch/pull/46250 , also contains  elastic/elasticsearch@be397b7 and elastic/elasticsearch@4849c3e

All tests are passing, but what is missing is the logic to trigger the cleanup from the master node introduced in  https://github.com/elastic/elasticsearch/pull/43900. My plan was to put this into a separate pr and only the parts which we need, not the whole endpoint.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
