### PR TITLE
Extend `pg_catalog.pg_proc` with `<data type>recv` functions.  

### DIFF
--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -67,14 +67,17 @@ public class Regproc {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        // Such as we cannot lookup the function name by oid and fallback
+        // to using the oid as name, we cannot use the name to check the
+        // equality of the Regproc objects. Therefore, we use the oid only
+        // to check the equality and calculate the hash code.
         Regproc regproc = (Regproc) o;
-        return oid == regproc.oid &&
-               Objects.equals(name, regproc.name);
+        return oid == regproc.oid;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(oid, name);
+        return Objects.hash(oid);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -186,4 +186,14 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
             "WHERE typname = 'bool'");
         assertThat(printedTable(response.rows()), is("bool| boolrecv| 994071801| boolrecv\n"));
     }
+
+    @Test
+    public void test_join_pg_proc_with_pg_type_on_typreceive_for_bool() {
+        execute(
+            "SELECT pg_type.typname, pg_type.typreceive, pg_proc.oid " +
+            "FROM pg_type " +
+            "JOIN pg_proc ON pg_proc.oid = pg_type.typreceive " +
+            "WHERE pg_type.typname = 'bool'");
+        assertThat(printedTable(response.rows()), is("bool| boolrecv| 994071801\n"));
+    }
 }

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -26,7 +26,6 @@ import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -100,6 +99,6 @@ public class RegprocTypeTest extends CrateUnitTest {
         DataTypes.toStream(REGPROC, out);
 
         var in = out.bytes().streamInput();
-        assertThat(DataTypes.fromStream(in), CoreMatchers.is(REGPROC));
+        assertThat(DataTypes.fromStream(in), is(REGPROC));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We have the `Added the 'pg_catalog.pg_proc <postgres_pg_catalog>'_ table` change log entry already.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
