### PR TITLE
Add an oidvector type for use in pg_proc

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -127,6 +127,9 @@ SQL Standard and PostgreSQL compatibility improvements
   which is to be used as return type for time related functions such as the
   future `current_time`.
 
+- Added the :ref:`oidvector_type` data type which is used in some
+  :ref:`postgres_pg_catalog` tables.
+
 - Added the :ref:`oid_regproc` alias data type that is used to reference
   functions in the :ref:`postgres_pg_catalog` tables.
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1196,6 +1196,18 @@ For more information, see PostgreSQL :ref:`postgres_pg_oid`.
 Casting a column of the ``regproc`` alias data type to ``text`` or
 ``integer`` results in a function name or its ``oid``, respectively.
 
+
+.. _oidvector_type:
+
+oidvector
+---------
+
+This is a system type used to represent one or more OID values.
+
+It looks similar to an array of integers, but doesn't support any of the scalar
+functions or expressions that can be used on regular arrays.
+
+
 .. _type_conversion:
 
 Type conversion

--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -293,6 +293,9 @@ IDs of all currently available data types:
    * - 20
      - :ref:`time with time zone <time-data-type>`
      - [``bigint``, ``integer``] e.g. [70652987666, 0]
+   * - 21
+     - :ref:`oidvector <oidvector_type>`
+     - An array of numbers
    * - 100
      - :ref:`array <data-type-array>`
      - [``integer``, ``integer``] e.g. [100, 9] for a ``array(integer)``

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -171,6 +171,7 @@ table available in CrateDB::
     |   21 | int2                         |     1005 |       0 |      2 | b       | N           |
     |   23 | int4                         |     1007 |       0 |      4 | b       | N           |
     |   24 | regproc                      |     1008 |       0 |      4 | b       | N           |
+    |   30 | oidvector                    |     1013 |       0 |     -1 | b       | A           |
     |  114 | json                         |      199 |       0 |     -1 | b       | U           |
     |  199 | _json                        |        0 |     114 |     -1 | b       | A           |
     |  600 | point                        |     1017 |       0 |     16 | b       | G           |
@@ -200,7 +201,7 @@ table available in CrateDB::
     | 2277 | anyarray                     |        0 |    2276 |     -1 | p       | P           |
     | 2287 | _record                      |        0 |    2249 |     -1 | p       | A           |
     +------+------------------------------+----------+---------+--------+---------+-------------+
-    SELECT 35 rows in set (... sec)
+    SELECT 36 rows in set (... sec)
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
+++ b/server/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
@@ -24,10 +24,12 @@ package io.crate.breaker;
 import io.crate.common.collections.Lists2;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.FixedWidthType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IpType;
 import io.crate.types.ObjectType;
+import io.crate.types.OidVectorType;
 import io.crate.types.RegprocType;
 import io.crate.types.RowType;
 import io.crate.types.StringType;
@@ -58,6 +60,9 @@ public class SizeEstimatorFactory {
             case ArrayType.ID:
                 var innerEstimator = create(((ArrayType<?>) type).innerType());
                 return (SizeEstimator<T>) ArraySizeEstimator.create(innerEstimator);
+
+            case OidVectorType.ID:
+                return (SizeEstimator<T>) ArraySizeEstimator.create(create(DataTypes.INTEGER));
 
             case RowType.ID:
                 return (SizeEstimator<T>) new RecordSizeEstimator(Lists2.map(((RowType) type).fieldTypes(), SizeEstimatorFactory::create));

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -85,7 +85,7 @@ public class PgProcTable {
             .add("pronargs", SHORT, x -> (short) x.signature.getArgumentTypes().size())
             .add("pronargdefaults", SHORT, x -> null)
             .add("prorettype", INTEGER, x -> x.returnTypeId)
-            .add("proargtypes", INTEGER_ARRAY, x ->
+            .add("proargtypes", DataTypes.OIDVECTOR, x ->
                 Lists2.map(x.signature.getArgumentTypes(), Entry::pgTypeIdFrom))
             .add("proallargtypes", INTEGER_ARRAY, x -> null)
             .add("proargmodes", STRING_ARRAY, x -> {

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -79,6 +79,7 @@ public class PGTypes {
         .put(new ArrayType<>(DataTypes.INTERVAL), PGArray.INTERVAL_ARRAY)
         .put(new ArrayType<>(RowType.EMPTY), PGArray.EMPTY_RECORD_ARRAY)
         .put(new ArrayType<>(DataTypes.REGPROC), PGArray.REGPROC_ARRAY)
+        .put(DataTypes.OIDVECTOR, PgOidVectorType.INSTANCE)
         .build();
 
     private static final IntObjectMap<DataType<?>> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();

--- a/server/src/main/java/io/crate/protocols/postgres/types/PgOidVectorType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PgOidVectorType.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.collections.Lists2;
+import io.netty.buffer.ByteBuf;
+
+public class PgOidVectorType extends PGType<List<Integer>> {
+
+    public static final PgOidVectorType INSTANCE = new PgOidVectorType();
+    private static final int OID = 30;
+
+    PgOidVectorType() {
+        super(OID, -1, -1, "oidvector");
+    }
+
+    @Override
+    public int typArray() {
+        return 1013;
+    }
+
+    @Override
+    public String typeCategory() {
+        return TypeCategory.ARRAY.code();
+    }
+
+    @Override
+    public String type() {
+        return Type.BASE.code();
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public int writeAsBinary(ByteBuf buffer, List<Integer> value) {
+        return PGArray.INT4_ARRAY.writeAsBinary(buffer, (List) value);
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public List<Integer> readBinaryValue(ByteBuf buffer, int valueLength) {
+        return (List<Integer>) (List) PGArray.INT4_ARRAY.readBinaryValue(buffer, valueLength);
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(List<Integer> value) {
+        return Lists2.joinOn(" ", value, x -> Integer.toString(x)).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    List<Integer> decodeUTF8Text(byte[] bytes) {
+        String string = new String(bytes, StandardCharsets.UTF_8);
+        return listFromOidVectorString(string);
+    }
+
+    @VisibleForTesting
+    public static List<Integer> listFromOidVectorString(String value) {
+        var tokenizer = new StringTokenizer(value, " ");
+        ArrayList<Integer> oids = new ArrayList<>();
+        while (tokenizer.hasMoreTokens()) {
+            oids.add(Integer.parseInt(tokenizer.nextToken()));
+        }
+        return oids;
+    }
+}

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -135,7 +135,7 @@ public class ArrayType<T> extends DataType<List<T>> {
         }
         ArrayList<T> result;
         if (value instanceof Collection) {
-            Collection values = (Collection) value;
+            Collection<?> values = (Collection<?>) value;
             result = new ArrayList<>(values.size());
             for (Object o : values) {
                 result.add(innerType.apply(o));

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -86,6 +86,8 @@ public final class DataTypes {
     public static final ArrayType<Long> BIGINT_ARRAY = new ArrayType<>(LONG);
     public static final ArrayType<Boolean> BOOLEAN_ARRAY = new ArrayType<>(BOOLEAN);
 
+    public static final OidVectorType OIDVECTOR = new OidVectorType();
+
     public static final IntervalType INTERVAL = IntervalType.INSTANCE;
 
     public static final ObjectType UNTYPED_OBJECT = ObjectType.UNTYPED;
@@ -121,7 +123,9 @@ public final class DataTypes {
 
 
     public static final Set<DataType<?>> STORAGE_UNSUPPORTED = Set.of(
-        INTERVAL, TIMETZ
+        INTERVAL,
+        TIMETZ,
+        OIDVECTOR
     );
 
     public static final List<DataType<?>> NUMERIC_PRIMITIVE_TYPES = List.of(
@@ -164,7 +168,8 @@ public final class DataTypes {
             entry(ArrayType.ID, ArrayType::new),
             entry(IntervalType.ID, in -> INTERVAL),
             entry(RowType.ID, RowType::new),
-            entry(RegprocType.ID, in -> REGPROC)
+            entry(RegprocType.ID, in -> REGPROC),
+            entry(OidVectorType.ID, in -> OIDVECTOR)
         )
     );
 
@@ -347,6 +352,7 @@ public final class DataTypes {
         entry(GEO_POINT.getName(), GEO_POINT),
         entry(GEO_SHAPE.getName(), GEO_SHAPE),
         entry(REGPROC.getName(), REGPROC),
+        entry(OIDVECTOR.getName(), OIDVECTOR),
         entry("int2", SHORT),
         entry("int", INTEGER),
         entry("int4", INTEGER),

--- a/server/src/main/java/io/crate/types/OidVectorType.java
+++ b/server/src/main/java/io/crate/types/OidVectorType.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import java.util.List;
+
+import io.crate.Streamer;
+
+public class OidVectorType extends DataType<List<Integer>> {
+
+    public static final String NAME = "oidvector";
+    public static final int ID = 21;
+
+    @Override
+    public int compare(List<Integer> o1, List<Integer> o2) {
+        return DataTypes.INTEGER_ARRAY.compare(o1, o2);
+    }
+
+    @Override
+    public int id() {
+        return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.ARRAY;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Streamer<List<Integer>> streamer() {
+        return DataTypes.INTEGER_ARRAY.streamer();
+    }
+
+    @Override
+    public List<Integer> value(Object value) throws IllegalArgumentException, ClassCastException {
+        return (List<Integer>) value;
+    }
+}

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1375,4 +1375,10 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "of type \"" + DataTypes.STRING.getName() + "\" of the unbound length limit.");
         analyze("CREATE TABLE tbl (name varchar(2) INDEX using fulltext WITH (analyzer='german'))");
     }
+
+    @Test
+    public void test_oidvector_cannot_be_used_in_create_table() throws Exception {
+        expectedException.expectMessage("Cannot use the type `oidvector` for column: x");
+        analyze("CREATE TABLE tbl (x oidvector)");
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -878,6 +878,15 @@ public class PostgresITest extends SQLTransportIntegrationTest {
        assertThat(response.rowCount(), is (0L));
     }
 
+    @Test
+    public void test_getProcedureColumns() throws Exception {
+        try (Connection conn = DriverManager.getConnection(url(RW))) {
+            var results = conn.getMetaData().getProcedureColumns("", "", "", "");
+            assertThat(results.next(), is(true));
+            assertThat(results.getString(3), is("_pg_expandarray"));
+        }
+    }
+
     private void assertSelectNameFromSysClusterWorks(Connection conn) throws SQLException {
         PreparedStatement stmt;// verify that queries can be made after an error occurred
         stmt = conn.prepareStatement("select name from sys.cluster");

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -116,10 +116,10 @@ public class PGTypesTest extends CrateUnitTest {
     }
 
     private static class Entry {
-        final DataType type;
+        final DataType<?> type;
         final Object value;
 
-        public Entry(DataType type, Object value) {
+        public Entry(DataType<?> type, Object value) {
             this.type = type;
             this.value = value;
         }
@@ -160,6 +160,24 @@ public class PGTypesTest extends CrateUnitTest {
     @Test
     public void testReadWriteVarCharType() {
         assertEntryOfPgType(new Entry(DataTypes.STRING, "test"), VarCharType.INSTANCE);
+    }
+
+    @Test
+    public void test_binary_oidvector_streaming_roundtrip() throws Exception {
+        Entry entry = new Entry(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
+        assertThat(
+            writeAndReadBinary(entry, PGTypes.get(entry.type)),
+            is(entry.value)
+        );
+    }
+
+    @Test
+    public void test_text_oidvector_streaming_roundtrip() throws Exception {
+        Entry entry = new Entry(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
+        assertThat(
+            writeAndReadAsText(entry, PGTypes.get(entry.type)),
+            is(entry.value)
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -39,6 +39,7 @@ import io.crate.metadata.SearchPath;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.protocols.postgres.types.PGTypes;
+import io.crate.protocols.postgres.types.PgOidVectorType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -89,6 +90,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
+import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -452,6 +454,13 @@ public class SQLTransportExecutor {
                     elements.add(Byte.parseByte((String) o));
                 }
                 return elements;
+            }
+            case "oidvector": {
+                String textval = resultSet.getString(columnIndex);
+                if (textval == null) {
+                    return null;
+                }
+                return PgOidVectorType.listFromOidVectorString(textval);
             }
             case "char":
                 String strValue = resultSet.getString(columnIndex);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/10131


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)