### PR TITLE
Use Signature instead of FunctionIdent/Info 

### DIFF
--- a/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
-import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class PluginLoaderTest extends ESIntegTestCase {
@@ -52,29 +51,6 @@ public class PluginLoaderTest extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(PluginLoaderPlugin.class, Netty4Plugin.class);
-    }
-
-    @Test
-    public void testLoadPlugin() throws Exception {
-        String node = startNodeWithPlugins("/io/crate/plugin/simple_plugin");
-
-        PluginsService pluginsService = internalCluster().getInstance(PluginsService.class, node);
-        PluginLoaderPlugin corePlugin = getCratePlugin(pluginsService);
-
-        PluginLoader pluginLoader = corePlugin.pluginLoader;
-        assertThat(pluginLoader.plugins.size(), is(1));
-        assertThat(pluginLoader.plugins.get(0).getClass().getCanonicalName(), is("io.crate.plugin.ExamplePlugin"));
-    }
-
-    @Test
-    public void testPluginWithCrateSettings() throws Exception {
-        String node = startNodeWithPlugins("/io/crate/plugin/plugin_with_crate_settings");
-
-        PluginsService pluginsService = internalCluster().getInstance(PluginsService.class, node);
-        PluginLoaderPlugin corePlugin = getCratePlugin(pluginsService);
-        Settings settings = corePlugin.settings;
-
-        assertThat(settings.get("setting.for.crate"), is("foo"));
     }
 
     @Test

--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -96,7 +96,8 @@ public class RowsBatchIteratorBenchmark {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            List.of(DataTypes.INTEGER)
+            List.of(DataTypes.INTEGER),
+            DataTypes.INTEGER
         );
     }
 

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -64,13 +64,14 @@ public class AggregateCollectorBenchmark {
     @Setup
     public void setup() {
         InputCollectExpression inExpr0 = new InputCollectExpression(0);
-        SumAggregation<?> sumAggregation = ((SumAggregation<?>) getFunctions().getQualified(
+        SumAggregation<?> sumAggregation = (SumAggregation<?>) getFunctions().getQualified(
             Signature.aggregate(
                 SumAggregation.NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
             ),
-            List.of(DataTypes.INTEGER))
+            List.of(DataTypes.INTEGER),
+            DataTypes.INTEGER
         );
         var memoryManager = new OnHeapMemoryManager(bytes -> {});
         collector = new AggregateCollector(

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -98,13 +97,14 @@ public class GroupingLongCollectorBenchmark {
         IndexWriter iw = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
         Functions functions = new ModulesBuilder().add(new AggregationImplModule())
             .createInjector().getInstance(Functions.class);
-        SumAggregation<?> sumAgg = ((SumAggregation<?>) getFunctions().getQualified(
+        SumAggregation<?> sumAgg = (SumAggregation<?>) getFunctions().getQualified(
             Signature.aggregate(
                 SumAggregation.NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
             ),
-            List.of(DataTypes.INTEGER))
+            List.of(DataTypes.INTEGER),
+            DataTypes.INTEGER
         );
         var memoryManager = new OnHeapMemoryManager(bytes -> {});
         groupBySumCollector = createGroupBySumCollector(sumAgg, memoryManager);

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -36,7 +36,6 @@ import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -98,7 +97,8 @@ public class GroupingStringCollectorBenchmark {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            List.of(DataTypes.STRING)
+            List.of(DataTypes.STRING),
+            DataTypes.STRING
         );
 
         return GroupingCollector.singleKey(

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -34,7 +34,6 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OffHeapMemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
@@ -91,7 +90,8 @@ public class HyperLogLogDistinctAggregationBenchmark {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
             ),
-            List.of(DataTypes.STRING)
+            List.of(DataTypes.STRING),
+            DataTypes.STRING
         );
         onHeapMemoryManager = new OnHeapMemoryManager(bytes -> {});
         offHeapMemoryManager = new OffHeapMemoryManager();

--- a/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -26,8 +26,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.BooleanType;
@@ -68,42 +66,31 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature()),
-                (signature, argTypes) -> {
-                    var info = new FunctionInfo(
-                        new FunctionIdent(NAME, argTypes),
-                        DataTypes.LONG,
-                        FunctionInfo.Type.AGGREGATE
-                    );
-                    return new HyperLogLogDistinctAggregation(signature, info, supportedType);
-                }
+                (signature, boundSignature) ->
+                    new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );
             mod.register(
                 Signature.aggregate(
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()),
-                (signature, argTypes) -> {
-                    var info = new FunctionInfo(
-                        new FunctionIdent(NAME, argTypes),
-                        DataTypes.LONG,
-                        FunctionInfo.Type.AGGREGATE
-                    );
-                    return new HyperLogLogDistinctAggregation(signature, info, supportedType);
-                }
+                    DataTypes.LONG.getTypeSignature()
+                ),
+                (signature, boundSignature) ->
+                    new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );
         }
     }
 
     private final Signature signature;
-    private final FunctionInfo info;
+    private final Signature boundSignature;
     private final DataType<?> dataType;
 
     private HyperLogLogDistinctAggregation(Signature signature,
-                                           FunctionInfo info,
+                                           Signature boundSignature,
                                            DataType<?> dataType) {
         this.signature = signature;
-        this.info = info;
+        this.boundSignature = boundSignature;
         this.dataType = dataType;
     }
 
@@ -160,13 +147,13 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     public static class HllState implements Comparable<HllState>, Writeable {

--- a/enterprise/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/enterprise/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -24,8 +24,6 @@ import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.DataTypes;
@@ -65,23 +63,23 @@ public class OffsetValueFunctions implements WindowFunction {
     private static final String LEAD_NAME = "lead";
 
     private final OffsetDirection offsetDirection;
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private OffsetValueFunctions(FunctionInfo info, Signature signature, OffsetDirection offsetDirection) {
-        this.info = info;
+    private OffsetValueFunctions(Signature signature, Signature boundSignature, OffsetDirection offsetDirection) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.offsetDirection = offsetDirection;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override
@@ -130,13 +128,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LEAD_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.FORWARD
                 )
         );
@@ -147,13 +142,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 DataTypes.INTEGER.getTypeSignature(),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LEAD_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.FORWARD
                 )
         );
@@ -165,13 +157,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LEAD_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.FORWARD
                 )
         );
@@ -182,13 +171,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LAG_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.BACKWARD
                 )
         );
@@ -199,13 +185,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 DataTypes.INTEGER.getTypeSignature(),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LAG_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.BACKWARD
                 )
         );
@@ -217,13 +200,10 @@ public class OffsetValueFunctions implements WindowFunction {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new OffsetValueFunctions(
-                    new FunctionInfo(
-                        new FunctionIdent(LAG_NAME, args),
-                        args.get(0),
-                        FunctionInfo.Type.WINDOW),
                     signature,
+                    boundSignature,
                     OffsetDirection.BACKWARD
                 )
         );

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -21,8 +21,6 @@ package io.crate.operation.language;
 import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetaData;
 import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -59,11 +57,7 @@ public class JavaScriptLanguage implements UDFLanguage {
 
     public Scalar createFunctionImplementation(UserDefinedFunctionMetaData meta,
                                                Signature signature) throws ScriptException {
-        FunctionInfo info = new FunctionInfo(
-            new FunctionIdent(meta.schema(), meta.name(), meta.argumentTypes()),
-            meta.returnType()
-        );
-        return new JavaScriptUserDefinedFunction(info, signature, meta.definition());
+        return new JavaScriptUserDefinedFunction(signature, meta.definition());
     }
 
     @Nullable

--- a/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
+++ b/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
@@ -18,13 +18,10 @@
 
 package io.crate.scalar.systeminformation;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -32,7 +29,6 @@ import io.crate.scalar.UsersScalarFunctionModule;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 
 public class UserFunction extends Scalar<String, Object> {
 
@@ -45,39 +41,33 @@ public class UserFunction extends Scalar<String, Object> {
                 CURRENT_USER_FUNCTION_NAME,
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, dataTypes) ->
-                new UserFunction(signature)
+            UserFunction::new
         );
         module.register(
             Signature.scalar(
                 SESSION_USER_FUNCTION_NAME,
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, dataTypes) ->
-                new UserFunction(signature)
+            UserFunction::new
         );
     }
 
     private final Signature signature;
-    private final FunctionInfo functionInfo;
+    private final Signature boundSignature;
 
-    public UserFunction(Signature signature) {
+    public UserFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.functionInfo = new FunctionInfo(
-            new FunctionIdent(signature.getName(), ImmutableList.of()),
-            DataTypes.STRING,
-            FunctionInfo.Type.SCALAR,
-            Collections.emptySet());
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return functionInfo;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -58,6 +58,7 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testFormatFunctionsWithoutBrackets() {
         setupFunctionsFor(TEST_USER);
+        sqlExpressions.context().allowEagerNormalize(false);
         Symbol f = sqlExpressions.asSymbol("current_user");
         assertThat(f.toString(), is("CURRENT_USER"));
 

--- a/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -129,7 +129,7 @@ public final class GeneratedColumnExpander {
 
         @Override
         public Symbol visitFunction(Function function, Context context) {
-            if (Operators.COMPARISON_OPERATORS.contains(function.info().ident().name())) {
+            if (Operators.COMPARISON_OPERATORS.contains(function.name())) {
                 Reference reference = null;
                 Symbol otherSide = null;
                 for (int i = 0; i < function.arguments().size(); i++) {
@@ -179,26 +179,13 @@ public final class GeneratedColumnExpander {
 
                 Function generatedFunction = (Function) generatedReference.generatedExpression();
 
-                String operatorName;
-                String generatedFunctionName;
-                java.util.function.Function<Scalar.Feature, Boolean> hasFeatures;
-                var signature = function.signature();
-                var generatedFunctionSignature = generatedFunction.signature();
-                if (signature != null && generatedFunctionSignature != null) {
-                    operatorName = signature.getName().name();
-                    generatedFunctionName = generatedFunctionSignature.getName().name();
-                    hasFeatures = generatedFunctionSignature::hasFeature;
-                } else {
-                    operatorName = function.info().ident().name();
-                    generatedFunctionName = generatedFunction.info().ident().name();
-                    hasFeatures = f ->  generatedFunction.info().hasFeature(f);
-                }
+                String operatorName = function.name();
                 if (!operatorName.equals(EqOperator.NAME)) {
-                    if (!hasFeatures.apply(Scalar.Feature.COMPARISON_REPLACEMENT)) {
+                    if (!generatedFunction.hasFeature(Scalar.Feature.COMPARISON_REPLACEMENT)) {
                         return null;
                     }
                     // rewrite operator
-                    if (ROUNDING_FUNCTIONS.contains(generatedFunctionName)) {
+                    if (ROUNDING_FUNCTIONS.contains(generatedFunction.name())) {
                         String replacedOperatorName = ROUNDING_FUNCTION_MAPPING.get(operatorName);
                         if (replacedOperatorName != null) {
                             operatorName = replacedOperatorName;

--- a/server/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
+++ b/server/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
@@ -67,14 +67,14 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
 
     @Override
     public Symbol visitFunction(Function symbol, Void context) {
-        String functionName = symbol.info().ident().name();
+        String functionName = symbol.name();
 
         if (functionName.equals(NotPredicate.NAME)) {
             Symbol argument = symbol.arguments().get(0);
             if (argument instanceof Reference) {
                 return argument.accept(this, context);
             } else if (argument instanceof Function) {
-                if (!Operators.LOGICAL_OPERATORS.contains(((Function) argument).info().ident().name())) {
+                if (!Operators.LOGICAL_OPERATORS.contains(((Function) argument).name())) {
                     return argument.accept(this, context);
                 }
             }

--- a/server/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
+++ b/server/src/main/java/io/crate/analyze/ScalarsAndRefsToTrue.java
@@ -96,7 +96,7 @@ public final class ScalarsAndRefsToTrue extends SymbolVisitor<Void, Symbol> {
         if (allLiterals && !Operators.LOGICAL_OPERATORS.contains(functionName)) {
             return isNull ? Literal.NULL : Literal.BOOLEAN_TRUE;
         }
-        return new Function(symbol.info(), symbol.signature(), newArgs);
+        return new Function(symbol.signature(), newArgs, symbol.valueType());
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -221,7 +221,7 @@ public class ExpressionAnalyzer {
         var symbol = expression.accept(innerAnalyzer, expressionAnalysisContext);
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             functions,
-            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.info().isDeterministic()
+            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.isDeterministic()
         );
         return normalizer.normalize(symbol, coordinatorTxnCtx);
     }

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -44,7 +44,9 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.AllOperator;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.EqOperator;
+import io.crate.expression.operator.GteOperator;
 import io.crate.expression.operator.LikeOperators;
+import io.crate.expression.operator.LteOperator;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.OrOperator;
 import io.crate.expression.operator.RegexpMatchCaseInsensitiveOperator;
@@ -69,9 +71,8 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.interval.IntervalParser;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -136,7 +137,6 @@ import org.joda.time.Period;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -741,8 +741,7 @@ public class ExpressionAnalyzer {
 
             Comparison comparison = new Comparison(functions, coordinatorTxnCtx, node.getType(), left, right);
             comparison.normalize(context);
-            FunctionIdent ident = comparison.toFunctionIdent();
-            return allocateFunction(ident.name(), comparison.arguments(), context);
+            return allocateFunction(comparison.operatorName, comparison.arguments(), context);
         }
 
         @Override
@@ -993,16 +992,16 @@ public class ExpressionAnalyzer {
             Symbol max = node.getMax().accept(this, context);
 
             Comparison gte = new Comparison(functions, coordinatorTxnCtx, ComparisonExpression.Type.GREATER_THAN_OR_EQUAL, value, min);
-            FunctionIdent gteIdent = gte.normalize(context).toFunctionIdent();
+            gte.normalize(context);
             Symbol gteFunc = allocateFunction(
-                gteIdent.name(),
+                GteOperator.NAME,
                 gte.arguments(),
                 context);
 
             Comparison lte = new Comparison(functions, coordinatorTxnCtx, ComparisonExpression.Type.LESS_THAN_OR_EQUAL, value, max);
-            FunctionIdent lteIdent = lte.normalize(context).toFunctionIdent();
+            lte.normalize(context);
             Symbol lteFunc = allocateFunction(
-                lteIdent.name(),
+                LteOperator.NAME,
                 lte.arguments(),
                 context);
 
@@ -1133,29 +1132,29 @@ public class ExpressionAnalyzer {
             arguments,
             coordinatorTxnCtx.sessionContext().searchPath());
 
-        FunctionInfo functionInfo = funcImpl.info();
         Signature signature = funcImpl.signature();
-        List<Symbol> castArguments = cast(arguments, functionInfo.ident().argumentTypes());
+        Signature boundSignature = funcImpl.boundSignature();
+        List<Symbol> castArguments = cast(arguments, boundSignature.getArgumentDataTypes());
         Function newFunction;
         if (windowDefinition == null) {
-            if (functionInfo.type() == FunctionInfo.Type.AGGREGATE) {
+            if (signature.getKind() == FunctionType.AGGREGATE) {
                 context.indicateAggregates();
             } else if (filter != null) {
                 throw new UnsupportedOperationException(
                     "Only aggregate functions allow a FILTER clause");
             }
-            newFunction = new Function(functionInfo, signature, castArguments, filter);
+            newFunction = new Function(signature, castArguments, boundSignature.getReturnType().createType(), filter);
         } else {
-            if (functionInfo.type() != FunctionInfo.Type.WINDOW && functionInfo.type() != FunctionInfo.Type.AGGREGATE) {
+            if (signature.getKind() != FunctionType.WINDOW && signature.getKind() != FunctionType.AGGREGATE) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
                     "OVER clause was specified, but %s is neither a window nor an aggregate function.",
                     functionName));
             }
             newFunction = new WindowFunction(
-                functionInfo,
                 signature,
                 castArguments,
+                boundSignature.getReturnType().createType(),
                 filter,
                 windowDefinition);
         }
@@ -1198,7 +1197,6 @@ public class ExpressionAnalyzer {
         private Symbol left;
         private Symbol right;
         private String operatorName;
-        private FunctionIdent functionIdent;
 
         private Comparison(Functions functions,
                            CoordinatorTxnCtx coordinatorTxnCtx,
@@ -1269,17 +1267,7 @@ public class ExpressionAnalyzer {
                 functions,
                 coordinatorTxnCtx);
             right = null;
-            functionIdent = NotPredicate.INFO.ident();
             operatorName = NotPredicate.NAME;
-        }
-
-        FunctionIdent toFunctionIdent() {
-            if (functionIdent == null) {
-                return new FunctionIdent(
-                    operatorName,
-                    Arrays.asList(left.valueType(), right.valueType()));
-            }
-            return functionIdent;
         }
 
         List<Symbol> arguments() {

--- a/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -113,7 +113,9 @@ public class QuerySplitter {
 
         @Override
         public Void visitFunction(Function function, Context ctx) {
-            if (!function.info().equals(AndOperator.INFO)) {
+            var signature = function.signature();
+            assert signature != null : "Expecting functions signature not to be null";
+            if (!signature.equals(AndOperator.SIGNATURE)) {
                 Set<RelationName> qualifiedNames = RelationNameCollector.collect(function);
                 Symbol prevQuery = ctx.parts.put(qualifiedNames, function);
                 if (prevQuery != null) {

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -53,9 +53,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.expression.tablefunctions.TableFunctionFactory;
 import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -94,6 +92,7 @@ import io.crate.sql.tree.ValuesList;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.RowType;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
@@ -650,8 +649,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
         Function function = (Function) symbol;
         FunctionImplementation functionImplementation = functions.getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
+            function,
+            statementContext.sessionContext().searchPath()
         );
         assert functionImplementation != null : "Function implementation not found using full qualified lookup";
         TableFunctionImplementation<?> tableFunction = TableFunctionFactory.from(functionImplementation);
@@ -745,19 +744,20 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 s -> normalizer.normalize(s.cast(targetType), context.transactionContext())
             );
             arrays.add(new Function(
-                new FunctionInfo(new FunctionIdent(ArrayFunction.NAME, Symbols.typeView(columnValues)), arrayType),
                 ArrayFunction.SIGNATURE,
-                columnValues
+                columnValues,
+                arrayType
             ));
         }
         FunctionImplementation implementation = functions.getQualified(
             ValuesFunction.SIGNATURE,
-            Symbols.typeView(arrays)
+            Symbols.typeView(arrays),
+            RowType.EMPTY
         );
         Function function = new Function(
-            implementation.info(),
             implementation.signature(),
-            arrays
+            arrays,
+            RowType.EMPTY
         );
 
         TableFunctionImplementation<?> tableFunc = TableFunctionFactory.from(implementation);

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -171,7 +171,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             functions,
-            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.info().isDeterministic()
+            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.isDeterministic()
         );
 
         return new QueriedSelectRelation(
@@ -353,7 +353,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             functions,
-            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.info().isDeterministic()
+            f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.isDeterministic()
         );
 
         QueriedSelectRelation relation = new QueriedSelectRelation(
@@ -732,7 +732,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             functions,
-            f -> f.info().isDeterministic()
+            f -> f.isDeterministic()
         );
 
         ArrayList<Symbol> arrays = new ArrayList<>(columns.size());

--- a/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -59,7 +59,7 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
         RowType rowType = functionImplementation.returnType();
         this.outputs = new ArrayList<>(rowType.numElements());
         int idx = 0;
-        FunctionName functionName = function.info().ident().fqnName();
+        FunctionName functionName = function.fqnName();
         this.relationName = new RelationName(null, functionName.name());
         for (int i = 0; i < rowType.numElements(); i++) {
             DataType<?> type = rowType.getFieldType(i);

--- a/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -41,7 +41,7 @@ public class GroupBySymbolValidator {
 
         @Override
         public Void visitFunction(Function function, String errorMsgTemplate) {
-            switch (function.info().type()) {
+            switch (function.type()) {
                 case SCALAR:
                     for (Symbol argument : function.arguments()) {
                         argument.accept(this, errorMsgTemplate);
@@ -53,7 +53,7 @@ public class GroupBySymbolValidator {
                     throw new IllegalArgumentException("Table functions are not allowed in GROUP BY");
                 default:
                     throw new UnsupportedOperationException(
-                        String.format(Locale.ENGLISH, "FunctionInfo.Type %s not handled", function.info().type()));
+                        String.format(Locale.ENGLISH, "FunctionInfo.Type %s not handled", function.type()));
             }
             return null;
         }

--- a/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
@@ -82,7 +82,7 @@ public class HavingSymbolValidator {
 
         @Override
         public Void visitFunction(Function function, HavingContext context) {
-            FunctionType type = function.info().type();
+            FunctionType type = function.type();
             if (type == FunctionType.TABLE) {
                 throw new IllegalArgumentException("Table functions are not allowed in HAVING");
             } else if (type == FunctionType.AGGREGATE) {

--- a/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
@@ -27,7 +27,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 
 import javax.annotation.Nullable;
@@ -82,10 +82,10 @@ public class HavingSymbolValidator {
 
         @Override
         public Void visitFunction(Function function, HavingContext context) {
-            FunctionInfo.Type type = function.info().type();
-            if (type == FunctionInfo.Type.TABLE) {
+            FunctionType type = function.info().type();
+            if (type == FunctionType.TABLE) {
                 throw new IllegalArgumentException("Table functions are not allowed in HAVING");
-            } else if (type == FunctionInfo.Type.AGGREGATE) {
+            } else if (type == FunctionType.AGGREGATE) {
                 context.insideAggregation = true;
             } else {
                 // allow function if it is part of the grouping symbols
@@ -97,7 +97,7 @@ public class HavingSymbolValidator {
             for (Symbol argument : function.arguments()) {
                 argument.accept(this, context);
             }
-            if (type == FunctionInfo.Type.AGGREGATE) {
+            if (type == FunctionType.AGGREGATE) {
                 context.insideAggregation = false;
             }
             return null;

--- a/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -43,14 +43,14 @@ public class SelectSymbolValidator {
 
         @Override
         public Void visitFunction(Function symbol, Void context) {
-            switch (symbol.info().type()) {
+            switch (symbol.type()) {
                 case SCALAR:
                 case AGGREGATE:
                 case TABLE:
                     break;
                 default:
                     throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                        "FunctionInfo.Type %s not handled", symbol.info().type()));
+                        "FunctionInfo.Type %s not handled", symbol.type()));
             }
             for (Symbol arg : symbol.arguments()) {
                 arg.accept(this, context);

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -24,6 +24,7 @@ package io.crate.analyze.where;
 import com.google.common.collect.Sets;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.EqOperator;
+import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.Operators;
 import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Function;
@@ -36,12 +37,9 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -62,12 +60,9 @@ import java.util.Set;
 public class EqualityExtractor {
 
     private static final Function NULL_MARKER = new Function(
-        new FunctionInfo(
-            new FunctionIdent("null_marker", List.of()),
-            DataTypes.UNDEFINED
-        ),
         Signature.scalar("null_marker", DataTypes.UNDEFINED.getTypeSignature()),
-        List.of()
+        List.of(),
+        DataTypes.UNDEFINED
     );
     private static final EqProxy NULL_MARKER_PROXY = new EqProxy(NULL_MARKER);
 
@@ -182,18 +177,11 @@ public class EqualityExtractor {
             Symbol left = origin.arguments().get(0);
             DataType<?> leftType = origin.info().ident().argumentTypes().get(0);
             DataType<?> rightType = ((ArrayType<?>) origin.info().ident().argumentTypes().get(1)).innerType();
-            FunctionInfo eqInfo = new FunctionInfo(
-                new FunctionIdent(
-                    EqOperator.NAME,
-                    List.of(leftType, rightType)
-                ),
-                DataTypes.BOOLEAN
-            );
             Literal<?> arrayLiteral = (Literal<?>) origin.arguments().get(1);
 
             proxies = new HashMap<>();
             for (Literal<?> arrayElem : Literal.explodeCollection(arrayLiteral)) {
-                Function f = new Function(eqInfo, EqOperator.SIGNATURE, Arrays.asList(left, arrayElem));
+                Function f = new Function(EqOperator.SIGNATURE, Arrays.asList(left, arrayElem), Operator.RETURN_TYPE);
                 EqProxy existingProxy = existingProxies.get(f);
                 if (existingProxy == null) {
                     existingProxy = new ChildEqProxy(f, this);
@@ -450,7 +438,7 @@ public class EqualityExtractor {
                 if (!context.proxyBelow && function.valueType().equals(DataTypes.BOOLEAN)) {
                     return Literal.BOOLEAN_TRUE;
                 }
-                return new Function(function.info(), function.signature(), newArgs);
+                return new Function(function.signature(), newArgs, function.valueType());
             }
             context.seenUnknown = true;
             return Literal.BOOLEAN_TRUE;

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -175,8 +175,8 @@ public class EqualityExtractor {
 
         private void initProxies(Map<Function, EqProxy> existingProxies) {
             Symbol left = origin.arguments().get(0);
-            DataType<?> leftType = origin.info().ident().argumentTypes().get(0);
-            DataType<?> rightType = ((ArrayType<?>) origin.info().ident().argumentTypes().get(1)).innerType();
+            var signature = origin.signature();
+            assert signature != null : "Expecting non-null signature while analyzing";
             Literal<?> arrayLiteral = (Literal<?>) origin.arguments().get(1);
 
             proxies = new HashMap<>();
@@ -335,7 +335,7 @@ public class EqualityExtractor {
             }
 
             public EqProxy add(Function compared) {
-                if (compared.info().ident().name().equals(AnyOperators.Type.EQ.opName())) {
+                if (compared.name().equals(AnyOperators.Type.EQ.opName())) {
                     AnyEqProxy anyEqProxy = new AnyEqProxy(compared, proxies);
                     for (EqProxy proxiedProxy : anyEqProxy) {
                         if (!proxies.containsKey(proxiedProxy.origin())) {
@@ -400,7 +400,7 @@ public class EqualityExtractor {
 
         public Symbol visitFunction(Function function, Context context) {
 
-            String functionName = function.info().ident().name();
+            String functionName = function.name();
             List<Symbol> arguments = function.arguments();
             Symbol firstArg = arguments.get(0);
 

--- a/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -96,7 +96,7 @@ public final class WhereClauseValidator {
         @Override
         public Symbol visitFunction(Function function, Context context) {
             context.functions.push(function);
-            if (function.info().type().equals(FunctionType.TABLE)) {
+            if (function.type().equals(FunctionType.TABLE)) {
                 throw new UnsupportedOperationException("Table functions are not allowed in WHERE");
             }
             continueTraversal(function, context);
@@ -117,7 +117,7 @@ public final class WhereClauseValidator {
 
         private static boolean insideNotPredicate(Context context) {
             for (Function function : context.functions) {
-                if (function.info().ident().name().equals(NotPredicate.NAME)) {
+                if (function.name().equals(NotPredicate.NAME)) {
                     return true;
                 }
             }
@@ -132,9 +132,9 @@ public final class WhereClauseValidator {
             var lastFunction = context.functions.get(numFunctions - 1);
             var parentFunction = context.functions.get(numFunctions - 2);
 
-            if (CAST_FUNCTION_NAMES.contains(lastFunction.info().ident().name())
-                && parentFunction.info().ident().name().startsWith(Operator.PREFIX)
-                && requiredFunctionNames.contains(parentFunction.info().ident().name())) {
+            if (CAST_FUNCTION_NAMES.contains(lastFunction.name())
+                && parentFunction.name().startsWith(Operator.PREFIX)
+                && requiredFunctionNames.contains(parentFunction.name())) {
                 var rightArg = parentFunction.arguments().get(1);
                 return rightArg.symbolType().isValueSymbol();
             }
@@ -159,7 +159,7 @@ public final class WhereClauseValidator {
             }
             Function function = context.functions.lastElement();
             if ((!insideCastComparedWithLiteral(context, requiredFunctionNames)
-                && !requiredFunctionNames.contains(function.info().ident().name().toLowerCase(Locale.ENGLISH)))
+                && !requiredFunctionNames.contains(function.name().toLowerCase(Locale.ENGLISH)))
                 || insideNotPredicate(context)) {
                 throw error.get();
             }

--- a/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.WindowFunction;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.sql.tree.ComparisonExpression;
@@ -96,7 +96,7 @@ public final class WhereClauseValidator {
         @Override
         public Symbol visitFunction(Function function, Context context) {
             context.functions.push(function);
-            if (function.info().type().equals(FunctionInfo.Type.TABLE)) {
+            if (function.info().type().equals(FunctionType.TABLE)) {
                 throw new UnsupportedOperationException("Table functions are not allowed in WHERE");
             }
             continueTraversal(function, context);

--- a/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -29,8 +29,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
@@ -79,14 +77,9 @@ public class WriterProjection extends Projection {
 
 
     public static final Symbol DIRECTORY_TO_FILENAME = new Function(
-        new FunctionInfo(
-            new FunctionIdent(
-                FormatFunction.NAME,
-                List.of(StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE)
-            ),
-            StringType.INSTANCE),
         FormatFunction.SIGNATURE,
-        List.of(Literal.of("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF)
+        List.of(Literal.of("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF),
+        DataTypes.STRING
     );
 
     private final Symbol uri;

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -38,8 +38,6 @@ import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.types.DataType;
@@ -170,7 +168,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
             return replacement;
         }
         ArrayList<Symbol> replacedFunctionArgs = getProcessedArgs(symbol.arguments(), sourceSymbols);
-        return new Function(symbol.info(), symbol.signature(), replacedFunctionArgs);
+        return new Function(symbol.signature(), replacedFunctionArgs, symbol.valueType());
     }
 
     @Nullable
@@ -205,9 +203,9 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
             filterWithReplacedArgs = null;
         }
         return new WindowFunction(
-            windowFunction.info(),
             windowFunction.signature(),
             replacedFunctionArgs,
+            windowFunction.valueType(),
             filterWithReplacedArgs,
             windowFunction.windowDefinition()
         );
@@ -310,12 +308,9 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         List<DataType<?>> argumentTypes = Symbols.typeView(arguments);
 
         return new Function(
-            new FunctionInfo(
-                new FunctionIdent(SubscriptObjectFunction.NAME, argumentTypes),
-                returnType
-            ),
             SubscriptObjectFunction.SIGNATURE,
-            arguments
+            arguments,
+            returnType
         );
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -101,7 +101,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
             if (!symbolType.isValueSymbol()) {
                 DataType<?> valueType = input.valueType();
                 if ((symbolType == SymbolType.FUNCTION || symbolType == SymbolType.WINDOW_FUNCTION)
-                    && !((Function) input).info().isDeterministic()) {
+                    && !((Function) input).isDeterministic()) {
                     nonDeterministicFunctions.put(input, new InputColumn(i, valueType));
                 } else {
                     this.inputs.put(input, new InputColumn(i, valueType));
@@ -173,7 +173,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
 
     @Nullable
     private static Symbol getFunctionReplacementOrNull(Function symbol, SourceSymbols sourceSymbols) {
-        if (symbol.info().isDeterministic()) {
+        if (symbol.isDeterministic()) {
             return sourceSymbols.inputs.get(symbol);
         } else {
             return sourceSymbols.nonDeterministicFunctions.get(symbol);

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -86,7 +86,7 @@ public class ProjectionBuilder {
                                                    SearchPath searchPath) {
         ArrayList<Aggregation> aggregations = new ArrayList<>(functions.size());
         for (Function function : functions) {
-            assert function.info().type() == FunctionType.AGGREGATE :
+            assert function.type() == FunctionType.AGGREGATE :
                     "function type must be " + FunctionType.AGGREGATE;
             List<Symbol> aggregationInputs;
             Symbol filterInput;

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -123,7 +123,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
 
     @Override
     public Void visitFunction(Function function, Context context) {
-        FunctionType type = function.info().type();
+        FunctionType type = function.type();
         switch (type) {
             case SCALAR:
                 return super.visitFunction(function, context);

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -28,7 +28,7 @@ import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -123,7 +123,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
 
     @Override
     public Void visitFunction(Function function, Context context) {
-        FunctionInfo.Type type = function.info().type();
+        FunctionType type = function.info().type();
         switch (type) {
             case SCALAR:
                 return super.visitFunction(function, context);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -86,7 +86,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
      */
     public abstract TFinal terminatePartial(RamAccounting ramAccounting, TPartial state);
 
-    public abstract DataType partialType();
+    public abstract DataType<?> partialType();
 
     /**
      * Executing aggregations as window functions might require different runtime implementations in order to still be

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -28,8 +28,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -62,7 +60,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         DataTypes.register(AverageStateType.ID, in -> AverageStateType.INSTANCE);
     }
 
-    private static final List<DataType> SUPPORTED_TYPES = Lists2.concat(
+    private static final List<DataType<?>> SUPPORTED_TYPES = Lists2.concat(
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     /**
@@ -76,15 +74,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                         functionName,
                         supportedType.getTypeSignature(),
                         DataTypes.DOUBLE.getTypeSignature()),
-                    (signature, args) ->
-                        new AverageAggregation(
-                            new FunctionInfo(
-                                new FunctionIdent(functionName, args),
-                                DataTypes.DOUBLE,
-                                FunctionInfo.Type.AGGREGATE
-                            ),
-                            signature
-                        )
+                    AverageAggregation::new
                 );
             }
         }
@@ -180,12 +170,12 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         }
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    AverageAggregation(FunctionInfo info, Signature signature) {
-        this.info = info;
+    AverageAggregation(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -251,18 +241,18 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     @Override
-    public DataType partialType() {
+    public DataType<?> partialType() {
         return AverageStateType.INSTANCE;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -28,8 +28,6 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -53,7 +51,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         DataTypes.register(GeometricMeanStateType.ID, in -> GeometricMeanStateType.INSTANCE);
     }
 
-    private static final List<DataType> SUPPORTED_TYPES = Lists2.concat(
+    private static final List<DataType<?>> SUPPORTED_TYPES = Lists2.concat(
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(AggregationImplModule mod) {
@@ -62,16 +60,9 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                 Signature.aggregate(
                     NAME,
                     supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()),
-                (signature, args) ->
-                    new GeometricMeanAggregation(
-                        new FunctionInfo(
-                            new FunctionIdent(NAME, args),
-                            DataTypes.DOUBLE,
-                            FunctionInfo.Type.AGGREGATE
-                        ),
-                        signature
-                    )
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                GeometricMeanAggregation::new
             );
         }
     }
@@ -187,12 +178,12 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         }
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public GeometricMeanAggregation(FunctionInfo info, Signature signature) {
-        this.info = info;
+    public GeometricMeanAggregation(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Nullable
@@ -260,12 +251,12 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -28,8 +28,6 @@ import io.crate.breaker.StringSizeEstimator;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -50,11 +48,6 @@ import java.util.List;
 public final class StringAgg extends AggregationFunction<StringAgg.StringAggState, String> {
 
     private static final String NAME = "string_agg";
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, List.of(DataTypes.STRING, DataTypes.STRING)),
-        DataTypes.STRING,
-        FunctionInfo.Type.AGGREGATE
-    );
     public static final Signature SIGNATURE =
         Signature.aggregate(
             NAME,
@@ -73,7 +66,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     public static void register(AggregationImplModule mod) {
         mod.register(
             SIGNATURE,
-            (signature, args) -> new StringAgg(signature)
+            StringAgg::new
         );
     }
 
@@ -144,9 +137,11 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public StringAgg(Signature signature) {
+    public StringAgg(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -239,17 +234,17 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     }
 
     @Override
-    public DataType partialType() {
+    public DataType<?> partialType() {
         return StringAggStateType.INSTANCE;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -28,8 +28,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.statistics.Variance;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -51,7 +49,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         DataTypes.register(VarianceStateType.ID, in -> VarianceStateType.INSTANCE);
     }
 
-    private static final List<DataType> SUPPORTED_TYPES = Lists2.concat(
+    private static final List<DataType<?>> SUPPORTED_TYPES = Lists2.concat(
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(AggregationImplModule mod) {
@@ -60,16 +58,9 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                 Signature.aggregate(
                     NAME,
                     supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()),
-                (signature, args) ->
-                    new VarianceAggregation(
-                        new FunctionInfo(
-                            new FunctionIdent(NAME, args),
-                            DataTypes.DOUBLE,
-                            FunctionInfo.Type.AGGREGATE
-                        ),
-                        signature
-                    )
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                VarianceAggregation::new
             );
         }
     }
@@ -125,12 +116,12 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         }
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public VarianceAggregation(FunctionInfo info, Signature signature) {
-        this.info = info;
+    public VarianceAggregation(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Nullable
@@ -199,12 +190,12 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -36,6 +36,7 @@ import io.crate.execution.engine.collect.ValueAndInputRow;
 import io.crate.expression.InputCondition;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -79,7 +80,8 @@ public class TableFunctionCollectSource implements CollectSource {
                         return new InputCollectExpression(i);
                     }
                 }
-                throw new IllegalStateException("Column `" + ref + "` not found in " + functionImplementation.info().ident());
+                throw new IllegalStateException("Column `" + ref + "` not found in "
+                                                + functionImplementation.signature().getName().toString(Style.QUALIFIED));
             });
         for (Symbol symbol : phase.toCollect()) {
             topLevelInputs.add(ctx.add(symbol));

--- a/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -32,7 +32,6 @@ import io.crate.expression.ExpressionsInput;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import org.elasticsearch.Version;
@@ -77,13 +76,13 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     }
 
     @Override
-    public FunctionInfo info() {
-        return aggregationFunction.info();
+    public Signature signature() {
+        return aggregationFunction.signature();
     }
 
     @Override
-    public Signature signature() {
-        return aggregationFunction.signature();
+    public Signature boundSignature() {
+        return aggregationFunction.boundSignature();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
@@ -34,7 +34,6 @@ import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
 
-import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 
@@ -50,18 +49,20 @@ class ArithmeticOperatorsFactory {
     private static final BinaryOperator<Long> SUB_LONG_FUNCTION = (arg0, arg1) -> arg0 - arg1;
     private static final BinaryOperator<Float> SUB_FLOAT_FUNCTION = (arg0, arg1) -> arg0 - arg1;
 
-    static BiFunction getAddFunction(DataType fstArgDataType, DataType sndArgDataType) {
+    static BiFunction getAddFunction(DataType<?> fstArgDataType, DataType<?> sndArgDataType) {
         switch (fstArgDataType.id()) {
             case LongType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {
+                    var signature = IntervalTimestampArithmeticScalar.signatureFor(
+                        fstArgDataType,
+                        ArithmeticFunctions.Names.ADD
+                    );
                     return new IntervalTimestampArithmeticScalar(
                         "+",
-                        ArithmeticFunctions.Names.ADD,
-                        List.of(fstArgDataType, sndArgDataType),
-                        fstArgDataType,
-                        IntervalTimestampArithmeticScalar.signatureFor(fstArgDataType, ArithmeticFunctions.Names.ADD)
+                        signature,
+                        signature
                     );
                 }
                 return ADD_LONG_FUNCTION;
@@ -79,18 +80,20 @@ class ArithmeticOperatorsFactory {
         }
     }
 
-    static BiFunction getSubtractFunction(DataType fstArgDataType, DataType sndArgDataType) {
+    static BiFunction getSubtractFunction(DataType<?> fstArgDataType, DataType<?> sndArgDataType) {
         switch (fstArgDataType.id()) {
             case LongType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {
+                    var signature = IntervalTimestampArithmeticScalar.signatureFor(
+                        fstArgDataType,
+                        ArithmeticFunctions.Names.SUBTRACT
+                    );
                     return new IntervalTimestampArithmeticScalar(
                         "-",
-                        ArithmeticFunctions.Names.SUBTRACT,
-                        List.of(fstArgDataType, sndArgDataType),
-                        fstArgDataType,
-                        IntervalTimestampArithmeticScalar.signatureFor(fstArgDataType, ArithmeticFunctions.Names.SUBTRACT)
+                        signature,
+                        signature
                     );
                 }
                 return SUB_LONG_FUNCTION;

--- a/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
@@ -25,8 +25,6 @@ package io.crate.execution.engine.window;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -38,23 +36,20 @@ public class RowNumberWindowFunction implements WindowFunction {
 
     public static void register(WindowFunctionModule module) {
         module.register(
-            Signature.window(NAME, DataTypes.INTEGER.getTypeSignature()),
-            (signature, args) -> new RowNumberWindowFunction(
-                new FunctionInfo(
-                    new FunctionIdent(NAME, args),
-                    DataTypes.INTEGER,
-                    FunctionInfo.Type.WINDOW),
-                signature
-            )
+            Signature.window(
+                NAME,
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            RowNumberWindowFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private RowNumberWindowFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private RowNumberWindowFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -66,12 +61,12 @@ public class RowNumberWindowFunction implements WindowFunction {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/AbstractFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/AbstractFunctionModule.java
@@ -22,11 +22,10 @@
 
 package io.crate.expression;
 
-import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.TypeLiteral;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
@@ -42,7 +41,7 @@ public abstract class AbstractFunctionModule<T extends FunctionImplementation> e
     private HashMap<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
     private MapBinder<FunctionName, List<FunctionProvider>> implementationsBinder;
 
-    public void register(Signature signature, BiFunction<Signature, List<DataType<?>>, FunctionImplementation> factory) {
+    public void register(Signature signature, BiFunction<Signature, Signature, FunctionImplementation> factory) {
         List<FunctionProvider> functions = functionImplementations.computeIfAbsent(
             signature.getName(),
             k -> new ArrayList<>());

--- a/server/src/main/java/io/crate/expression/FunctionExpression.java
+++ b/server/src/main/java/io/crate/expression/FunctionExpression.java
@@ -48,7 +48,7 @@ public final class FunctionExpression<ReturnType, InputType> implements Input<Re
     @Override
     public String toString() {
         return "FuncExpr{" +
-               scalar.info().ident().name() +
+               scalar.signature().getName() +
                ", args=" + Arrays.toString(arguments) + '}';
     }
 }

--- a/server/src/main/java/io/crate/expression/eval/NullEliminator.java
+++ b/server/src/main/java/io/crate/expression/eval/NullEliminator.java
@@ -83,7 +83,7 @@ public final class NullEliminator {
 
         @Override
         public Symbol visitFunction(Function func, Context context) {
-            String functionName = func.info().ident().name();
+            String functionName = func.name();
 
             // only operate inside logical operators
             if (Operators.LOGICAL_OPERATORS.contains(functionName)) {

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -24,8 +24,6 @@ package io.crate.expression.operator;
 
 import io.crate.common.collections.Tuple;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -36,7 +34,6 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Locale;
 
 public final class CIDROperator {
@@ -44,10 +41,6 @@ public final class CIDROperator {
     public static final String CONTAINED_WITHIN = Operator.PREFIX + "<<";
 
     private static final int IPV4_ADDRESS_LEN = 4;
-
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(CONTAINED_WITHIN, Arrays.asList(DataTypes.IP, DataTypes.STRING)),
-        DataTypes.BOOLEAN);
 
     public static void register(OperatorModule module) {
         module.register(
@@ -57,7 +50,7 @@ public final class CIDROperator {
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
             ),
-            (signature, dataTypes) -> new ContainedWithinOperator(signature)
+            ContainedWithinOperator::new
         );
     }
 
@@ -105,9 +98,11 @@ public final class CIDROperator {
     public static class ContainedWithinOperator extends Scalar<Boolean, Object> {
 
         private final Signature signature;
+        private final Signature boundSignature;
 
-        public ContainedWithinOperator(Signature signature) {
+        public ContainedWithinOperator(Signature signature, Signature boundSignature) {
             this.signature = signature;
+            this.boundSignature = boundSignature;
         }
 
         @Override
@@ -125,13 +120,13 @@ public final class CIDROperator {
         }
 
         @Override
-        public FunctionInfo info() {
-            return INFO;
+        public Signature signature() {
+            return signature;
         }
 
         @Override
-        public Signature signature() {
-            return signature;
+        public Signature boundSignature() {
+            return boundSignature;
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -24,7 +24,6 @@ package io.crate.expression.operator;
 
 import io.crate.common.collections.MapComparator;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
@@ -34,24 +33,24 @@ import java.util.function.IntPredicate;
 
 public final class CmpOperator extends Operator<Object> {
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final IntPredicate isMatch;
 
-    public CmpOperator(FunctionInfo info, Signature signature, IntPredicate cmpResultIsMatch) {
-        this.info = info;
+    public CmpOperator(Signature signature, Signature boundSignature, IntPredicate cmpResultIsMatch) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.isMatch = cmpResultIsMatch;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -22,8 +22,6 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
@@ -44,23 +42,16 @@ public final class EqOperator extends Operator<Object> {
     public static void register(OperatorModule module) {
         module.register(
             SIGNATURE,
-            (signature, dataTypes) ->
-                new EqOperator(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, dataTypes),
-                        Operator.RETURN_TYPE
-                    ),
-                    signature
-                )
+            EqOperator::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public EqOperator(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private EqOperator(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -78,12 +69,12 @@ public final class EqOperator extends Operator<Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -25,8 +25,6 @@ package io.crate.expression.operator;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.expression.operator.Operator.generateInfo;
-
 public final class GtOperator {
 
     public static final String NAME = "op_>";
@@ -40,9 +38,9 @@ public final class GtOperator {
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
                 ),
-                (signature, args) -> new CmpOperator(
-                    generateInfo(NAME, args.get(0)),
+                (signature, boundSignature) -> new CmpOperator(
                     signature,
+                    boundSignature,
                     cmpResult -> cmpResult > 0
                 )
             );

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -25,8 +25,6 @@ package io.crate.expression.operator;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.expression.operator.Operator.generateInfo;
-
 public final class GteOperator {
 
     public static final String NAME = "op_>=";
@@ -40,9 +38,9 @@ public final class GteOperator {
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
                 ),
-                (signature, args) -> new CmpOperator(
-                    generateInfo(NAME, args.get(0)),
+                (signature, boundSignature) -> new CmpOperator(
                     signature,
+                    boundSignature,
                     cmpResult -> cmpResult >= 0
                 )
             );

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -24,8 +24,6 @@ package io.crate.expression.operator;
 
 import io.crate.expression.operator.any.AnyLikeOperator;
 import io.crate.expression.operator.any.AnyOperator;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -70,7 +68,8 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
             ),
-            (signature, dataTypes) -> LikeOperator.of(signature, LikeOperators::matches, CASE_SENSITIVE)
+            (signature, boundSignature) ->
+                new LikeOperator(signature, boundSignature, LikeOperators::matches, CASE_SENSITIVE)
         );
         module.register(
             Signature.scalar(
@@ -79,7 +78,8 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
             ),
-            (signature, dataTypes) -> LikeOperator.of(signature, LikeOperators::matches, CASE_INSENSITIVE)
+            (signature, boundSignature) ->
+                new LikeOperator(signature, boundSignature, LikeOperators::matches, CASE_INSENSITIVE)
         );
         module.register(
             Signature.scalar(
@@ -88,12 +88,13 @@ public class LikeOperators {
                 parseTypeSignature("array(E)"),
                 Operator.RETURN_TYPE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, dataTypes) -> new AnyLikeOperator(
-                new FunctionInfo(new FunctionIdent(signature.getName().name(), dataTypes), DataTypes.BOOLEAN),
-                signature,
-                LikeOperators::matches,
-                CASE_SENSITIVE
-            )
+            (signature, boundSignature) ->
+                new AnyLikeOperator(
+                    signature,
+                    boundSignature,
+                    LikeOperators::matches,
+                    CASE_SENSITIVE
+                )
         );
         module.register(
             Signature.scalar(
@@ -102,12 +103,13 @@ public class LikeOperators {
                 parseTypeSignature("array(E)"),
                 Operator.RETURN_TYPE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, dataTypes) -> new AnyLikeOperator(
-                new FunctionInfo(new FunctionIdent(signature.getName().name(), dataTypes), DataTypes.BOOLEAN),
-                signature,
-                TriPredicate.negate(LikeOperators::matches),
-                CASE_SENSITIVE
-            )
+            (signature, boundSignature) ->
+                new AnyLikeOperator(
+                    signature,
+                    boundSignature,
+                    TriPredicate.negate(LikeOperators::matches),
+                    CASE_SENSITIVE
+                )
         );
         module.register(
             Signature.scalar(
@@ -116,12 +118,13 @@ public class LikeOperators {
                 parseTypeSignature("array(E)"),
                 Operator.RETURN_TYPE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, dataTypes) -> new AnyLikeOperator(
-                new FunctionInfo(new FunctionIdent(signature.getName().name(), dataTypes), DataTypes.BOOLEAN),
-                signature,
-                LikeOperators::matches,
-                CASE_INSENSITIVE
-            )
+            (signature, boundSignature) ->
+                new AnyLikeOperator(
+                    signature,
+                    boundSignature,
+                    LikeOperators::matches,
+                    CASE_INSENSITIVE
+                )
         );
         module.register(
             Signature.scalar(
@@ -130,12 +133,13 @@ public class LikeOperators {
                 parseTypeSignature("array(E)"),
                 Operator.RETURN_TYPE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, dataTypes) -> new AnyLikeOperator(
-                new FunctionInfo(new FunctionIdent(signature.getName().name(), dataTypes), DataTypes.BOOLEAN),
-                signature,
-                TriPredicate.negate(LikeOperators::matches),
-                CASE_INSENSITIVE
-            )
+            (signature, boundSignature) ->
+                new AnyLikeOperator(
+                    signature,
+                    boundSignature,
+                    TriPredicate.negate(LikeOperators::matches),
+                    CASE_INSENSITIVE
+                )
         );
     }
 

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -25,8 +25,6 @@ package io.crate.expression.operator;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.expression.operator.Operator.generateInfo;
-
 public final class LtOperator {
 
     public static final String NAME = "op_<";
@@ -40,11 +38,8 @@ public final class LtOperator {
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
                 ),
-                (signature, args) -> new CmpOperator(
-                    generateInfo(NAME, args.get(0)),
-                    signature,
-                    cmpResult -> cmpResult < 0
-                )
+                (signature, boundSignature) ->
+                    new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -25,8 +25,6 @@ package io.crate.expression.operator;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import static io.crate.expression.operator.Operator.generateInfo;
-
 public final class LteOperator {
 
     public static final String NAME = "op_<=";
@@ -40,9 +38,9 @@ public final class LteOperator {
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
                 ),
-                (signature, args) -> new CmpOperator(
-                    generateInfo(NAME, args.get(0)),
+                (signature, boundSignature) -> new CmpOperator(
                     signature,
+                    boundSignature,
                     cmpResult -> cmpResult <= 0
                 )
             );

--- a/server/src/main/java/io/crate/expression/operator/Operator.java
+++ b/server/src/main/java/io/crate/expression/operator/Operator.java
@@ -26,15 +26,10 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.BooleanType;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import java.util.List;
 
 public abstract class Operator<I> extends Scalar<Boolean, I> {
 
@@ -51,9 +46,5 @@ public abstract class Operator<I> extends Scalar<Boolean, I> {
             }
         }
         return super.normalizeSymbol(function, txnCtx);
-    }
-
-    static FunctionInfo generateInfo(String name, DataType<?> type) {
-        return new FunctionInfo(new FunctionIdent(name, List.of(type, type)), RETURN_TYPE);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -26,7 +26,6 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -34,7 +33,6 @@ import io.crate.types.DataTypes;
 public class OrOperator extends Operator<Boolean> {
 
     public static final String NAME = "op_or";
-    public static final FunctionInfo INFO = generateInfo(NAME, DataTypes.BOOLEAN);
 
     public static final Signature SIGNATURE = Signature.scalar(
         NAME,
@@ -47,14 +45,16 @@ public class OrOperator extends Operator<Boolean> {
     public static void register(OperatorModule module) {
         module.register(
             SIGNATURE,
-            (signature, dataTypes) -> new OrOperator(signature)
+            OrOperator::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public OrOperator(Signature signature) {
+    public OrOperator(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -63,8 +63,8 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -22,7 +22,6 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -34,7 +33,6 @@ import java.util.regex.Pattern;
 public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
 
     public static final String NAME = "op_~*";
-    public static final FunctionInfo INFO = generateInfo(NAME, DataTypes.STRING);
 
     public static void register(OperatorModule module) {
         var supportedArgumentTypes = List.of(DataTypes.STRING, DataTypes.UNDEFINED);
@@ -47,16 +45,18 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
                         right.getTypeSignature(),
                         Operator.RETURN_TYPE.getTypeSignature()
                     ).withForbiddenCoercion(),
-                    (signature, dataTypes) -> new RegexpMatchCaseInsensitiveOperator(signature)
+                    RegexpMatchCaseInsensitiveOperator::new
                 );
             }
         }
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public RegexpMatchCaseInsensitiveOperator(Signature signature) {
+    public RegexpMatchCaseInsensitiveOperator(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -76,12 +76,12 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -22,7 +22,6 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -38,7 +37,6 @@ import static io.crate.expression.scalar.regex.RegexMatcher.isPcrePattern;
 public class RegexpMatchOperator extends Operator<String> {
 
     public static final String NAME = "op_~";
-    public static final FunctionInfo INFO = generateInfo(NAME, DataTypes.STRING);
 
     public static void register(OperatorModule module) {
         var supportedArgumentTypes = List.of(DataTypes.STRING, DataTypes.UNDEFINED);
@@ -51,16 +49,18 @@ public class RegexpMatchOperator extends Operator<String> {
                         right.getTypeSignature(),
                         Operator.RETURN_TYPE.getTypeSignature()
                     ).withForbiddenCoercion(),
-                    (signature, dataTypes) -> new RegexpMatchOperator(signature)
+                    RegexpMatchOperator::new
                 );
             }
         }
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public RegexpMatchOperator(Signature signature) {
+    public RegexpMatchOperator(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -85,12 +85,12 @@ public class RegexpMatchOperator extends Operator<String> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -24,7 +24,6 @@ package io.crate.expression.operator.any;
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.TriPredicate;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -35,33 +34,33 @@ import static io.crate.expression.operator.any.AnyOperators.collectionValueToIte
 
 public class AnyLikeOperator extends Operator<Object> {
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final TriPredicate<String, String, Integer> matcher;
     private final int patternMatchingFlags;
 
-    public AnyLikeOperator(FunctionInfo info,
-                           Signature signature,
+    public AnyLikeOperator(Signature signature,
+                           Signature boundSignature,
                            TriPredicate<String, String, Integer> matcher,
                            int patternMatchingFlags) {
-        this.info = info;
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.matcher = matcher;
         this.patternMatchingFlags = patternMatchingFlags;
-        DataType<?> innerType = ((ArrayType<?>) info.ident().argumentTypes().get(1)).innerType();
+        DataType<?> innerType = ((ArrayType<?>) boundSignature.getArgumentDataTypes().get(1)).innerType();
         if (innerType.id() == ObjectType.ID) {
             throw new IllegalArgumentException("ANY on object arrays is not supported");
         }
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     private Boolean doEvaluate(Object left, Iterable<?> rightIterable) {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -23,7 +23,6 @@ package io.crate.expression.operator.any;
 
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -36,29 +35,29 @@ public final class AnyOperator extends Operator<Object> {
 
     public static final String OPERATOR_PREFIX = "any_";
 
-    private final FunctionInfo functionInfo;
     private final Signature signature;
+    private final Signature boundSignature;
     private final IntPredicate cmpIsMatch;
     private final DataType leftType;
 
     /**
      * @param cmpIsMatch predicate to test if a comparison (-1, 0, 1) should be considered a match
      */
-    AnyOperator(FunctionInfo functionInfo, Signature signature, IntPredicate cmpIsMatch) {
-        this.functionInfo = functionInfo;
+    AnyOperator(Signature signature, Signature boundSignature, IntPredicate cmpIsMatch) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.cmpIsMatch = cmpIsMatch;
-        this.leftType = functionInfo.ident().argumentTypes().get(0);
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return functionInfo;
+        this.leftType = boundSignature.getArgumentDataTypes().get(0);
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperators.java
@@ -27,11 +27,8 @@ import io.crate.common.collections.Lists2;
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.OperatorModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ComparisonExpression;
-import io.crate.types.DataTypes;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,10 +93,10 @@ public final class AnyOperators {
                     parseTypeSignature("array(E)"),
                     Operator.RETURN_TYPE.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E")),
-                (signature, dataTypes) ->
+                (signature, boundSignature) ->
                     new AnyOperator(
-                        new FunctionInfo(new FunctionIdent(signature.getName().name(), dataTypes), DataTypes.BOOLEAN),
                         signature,
+                        boundSignature,
                         type.cmp
                     )
             );

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -25,15 +25,10 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import java.util.List;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -50,29 +45,26 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     public static void register(PredicateModule module) {
         module.register(
             SIGNATURE,
-            (signature, argTypes) -> new IsNullPredicate<>(signature, generateInfo(argTypes)));
-    }
-
-    public static FunctionInfo generateInfo(List<DataType<?>> types) {
-        return new FunctionInfo(new FunctionIdent(NAME, types), DataTypes.BOOLEAN);
+            IsNullPredicate::new
+        );
     }
 
     private final Signature signature;
-    private final FunctionInfo info;
+    private final Signature boundSignature;
 
-    private IsNullPredicate(Signature signature, FunctionInfo info) {
+    private IsNullPredicate(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.info = info;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -21,9 +21,7 @@
 
 package io.crate.expression.predicate;
 
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -32,7 +30,6 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.index.query.MultiMatchQueryType;
 
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -67,7 +64,7 @@ public class MatchPredicate implements FunctionImplementation {
     public static void register(PredicateModule module) {
         module.register(
             SIGNATURE,
-            (signature, dataTypes) -> new MatchPredicate(signature)
+            MatchPredicate::new
         );
     }
 
@@ -82,30 +79,22 @@ public class MatchPredicate implements FunctionImplementation {
 
     private static final Set<String> SUPPORTED_GEO_MATCH_TYPES = Set.of("intersects", "disjoint", "within");
 
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(
-            NAME,
-            List.of(
-                DataTypes.UNTYPED_OBJECT,
-                DataTypes.STRING,
-                DataTypes.STRING,
-                DataTypes.UNTYPED_OBJECT)),
-        DataTypes.BOOLEAN);
-
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private MatchPredicate(Signature signature) {
+    private MatchPredicate(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     private static String defaultMatchType(DataType<?> dataType) {

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -25,18 +25,14 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
-
 public class NotPredicate extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "op_not";
-    public static final FunctionInfo INFO = FunctionInfo.of(NAME, List.of(DataTypes.BOOLEAN), DataTypes.BOOLEAN);
     public static final Signature SIGNATURE = Signature.scalar(
         NAME,
         DataTypes.BOOLEAN.getTypeSignature(),
@@ -45,23 +41,26 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
     public static void register(PredicateModule module) {
         module.register(
             SIGNATURE,
-            (signature, argTypes) -> new NotPredicate(signature));
+            NotPredicate::new
+        );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private NotPredicate(Signature signature) {
+    private NotPredicate(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -23,8 +23,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -48,32 +46,27 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, argumentTypes) -> {
-                ensureInnerTypeIsNotUndefined(argumentTypes, NAME);
-                return new ArrayLowerFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.INTEGER),
-                    signature
-                );
-            }
+            ArrayLowerFunction::new
         );
     }
 
-    private final FunctionInfo functionInfo;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private ArrayLowerFunction(FunctionInfo functionInfo, Signature signature) {
-        this.functionInfo = functionInfo;
+    public ArrayLowerFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return functionInfo;
+        this.boundSignature = boundSignature;
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), NAME);
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -23,8 +23,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -50,33 +48,28 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E")),
-                (signature, argumentTypes) -> {
-                    ensureInnerTypeIsNotUndefined(argumentTypes, name);
-                    return new ArrayUpperFunction(
-                        new FunctionInfo(new FunctionIdent(name, argumentTypes), DataTypes.INTEGER),
-                        signature
-                    );
-                }
+                ArrayUpperFunction::new
             );
         }
     }
 
-    private final FunctionInfo functionInfo;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private ArrayUpperFunction(FunctionInfo functionInfo, Signature signature) {
-        this.functionInfo = functionInfo;
+    private ArrayUpperFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return functionInfo;
+        this.boundSignature = boundSignature;
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -22,8 +22,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -45,20 +43,16 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
                 parseTypeSignature("array(E)"),
                 DataTypes.DOUBLE.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, argumentTypes) ->
-                new CollectionAverageFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.DOUBLE),
-                    signature
-                )
+            CollectionAverageFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private CollectionAverageFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private CollectionAverageFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -81,12 +75,12 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -22,8 +22,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -45,20 +43,16 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
                 parseTypeSignature("array(E)"),
                 DataTypes.LONG.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, argumentTypes) ->
-                new CollectionCountFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.LONG),
-                    signature
-                )
+            CollectionCountFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private CollectionCountFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private CollectionCountFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -71,12 +65,12 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.scalar;
 
 import io.crate.Constants;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -33,14 +31,9 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
-import java.util.Collections;
-
 final class CurrentDatabaseFunction extends Scalar<String, Void> {
 
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, "current_database");
-
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(FQN, Collections.emptyList()), DataTypes.STRING);
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -48,24 +41,26 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
                 FQN,
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) -> new CurrentDatabaseFunction(signature)
+            CurrentDatabaseFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public CurrentDatabaseFunction(Signature signature) {
+    public CurrentDatabaseFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
@@ -23,18 +23,11 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
 import java.util.function.DoubleUnaryOperator;
-
-import static java.util.Collections.singletonList;
 
 /**
  * Scalar implementation that wraps another function: f(double) -> double
@@ -44,29 +37,24 @@ import static java.util.Collections.singletonList;
  */
 public final class DoubleScalar extends Scalar<Double, Number> {
 
-    private final FunctionInfo info;
-    @Nullable
     private final Signature signature;
+    private final Signature boundSignature;
     private final DoubleUnaryOperator func;
 
-    public DoubleScalar(String name, DataType inputType, DoubleUnaryOperator func) {
-        this(name, null, inputType, func);
-    }
-
-    public DoubleScalar(String name, Signature signature, DataType inputType, DoubleUnaryOperator func) {
-        this.info = new FunctionInfo(new FunctionIdent(name, singletonList(inputType)), DataTypes.DOUBLE);
+    public DoubleScalar(Signature signature, Signature boundSignature, DoubleUnaryOperator func) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.func = func;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SafeVarargs

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -22,8 +22,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -50,23 +48,15 @@ public class FormatFunction extends Scalar<String, Object> {
 
 
     public static void register(ScalarFunctionModule module) {
-        module.register(
-            SIGNATURE,
-            (signature, argumentTypes) ->
-                new FormatFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
-                    signature
-                )
-
-        );
+        module.register(SIGNATURE, FormatFunction::new);
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private FormatFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    public FormatFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @SafeVarargs
@@ -86,12 +76,12 @@ public class FormatFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -23,14 +23,10 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-
-import java.util.Collections;
 
 /**
  * This scalar function removes the 3-valued logic from the tree of operators below it.
@@ -47,9 +43,6 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "ignore3vl";
 
-    private static final FunctionInfo FUNCTION_INFO = new FunctionInfo(
-        new FunctionIdent(NAME, Collections.singletonList(DataTypes.BOOLEAN)), DataTypes.BOOLEAN);
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
@@ -57,14 +50,16 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
             ),
-            (signature, argumentTypes) -> new Ignore3vlFunction(signature)
+            Ignore3vlFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public Ignore3vlFunction(Signature signature) {
+    public Ignore3vlFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -78,12 +73,12 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return FUNCTION_INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -23,14 +23,10 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-
-import java.util.List;
 
 public final class PiFunction extends Scalar<Double, Object> {
 
@@ -42,16 +38,16 @@ public final class PiFunction extends Scalar<Double, Object> {
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            (signature, args) -> new PiFunction(signature)
+            PiFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public PiFunction(Signature signature) {
+    public PiFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        info = new FunctionInfo(new FunctionIdent(NAME, List.of()), DataTypes.DOUBLE);
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -61,12 +57,12 @@ public final class PiFunction extends Scalar<Double, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -22,8 +22,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -48,11 +46,7 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
-                new StringToArrayFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY),
-                    signature
-                )
+            StringToArrayFunction::new
         );
         module.register(
             Signature.scalar(
@@ -62,30 +56,26 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
-                new StringToArrayFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING_ARRAY),
-                    signature
-                )
+            StringToArrayFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private StringToArrayFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    public StringToArrayFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunctions.java
@@ -25,12 +25,8 @@ import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
 
@@ -45,12 +41,9 @@ public final class SubscriptFunctions {
         List<Symbol> arguments = Lists2.mapTail(base, path, Literal::of);
         DataType<?> returnType = ((ObjectType) base.valueType()).resolveInnerType(path);
         return new Function(
-            new FunctionInfo(
-                new FunctionIdent(SubscriptObjectFunction.NAME, Symbols.typeView(arguments)),
-                returnType
-            ),
             SubscriptObjectFunction.SIGNATURE,
-            arguments
+            arguments,
+            returnType
         );
     }
 
@@ -68,12 +61,9 @@ public final class SubscriptFunctions {
                 List<Symbol> arguments = Lists2.mapTail(baseSymbol, path, Literal::of);
                 DataType<?> returnType = ((ObjectType) baseType).resolveInnerType(path);
                 return new Function(
-                    new FunctionInfo(
-                        new FunctionIdent(SubscriptObjectFunction.NAME, Symbols.typeView(arguments)),
-                        returnType
-                    ),
                     SubscriptObjectFunction.SIGNATURE,
-                    arguments
+                    arguments,
+                    returnType
                 );
             }
 
@@ -85,12 +75,9 @@ public final class SubscriptFunctions {
                     return null;
                 }
                 Function recordSubscript = new Function(
-                    new FunctionInfo(
-                        new FunctionIdent(SubscriptRecordFunction.NAME, List.of(baseType, DataTypes.STRING)),
-                        rowType.getFieldType(idx)
-                    ),
                     SubscriptRecordFunction.SIGNATURE,
-                    List.of(baseSymbol, Literal.of(child))
+                    List.of(baseSymbol, Literal.of(child)),
+                    rowType.getFieldType(idx)
                 );
                 if (path.size() > 1) {
                     return tryCreateSubscript(recordSubscript, path.subList(1, path.size()));

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -26,8 +26,6 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -58,31 +56,26 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
     public static void register(ScalarFunctionModule module) {
         module.register(
             SIGNATURE,
-            (signature, dataTypes) -> new SubscriptObjectFunction(
-                signature,
-                new FunctionInfo(
-                    new FunctionIdent(NAME, dataTypes),
-                    DataTypes.UNDEFINED
-                )
-            ));
+            SubscriptObjectFunction::new
+        );
     }
 
     private final Signature signature;
-    private final FunctionInfo info;
+    private final Signature boundSignature;
 
-    private SubscriptObjectFunction(Signature signature, FunctionInfo info) {
+    private SubscriptObjectFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.info = info;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override
@@ -108,9 +101,9 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
             return returnType.equals(DataTypes.UNDEFINED)
                 ? func
                 : new Function(
-                    new FunctionInfo(func.info().ident(), returnType),
                     func.signature(),
-                    func.arguments()
+                    func.arguments(),
+                    returnType
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
@@ -23,15 +23,11 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.RowType;
-
-import java.util.List;
 
 public final class SubscriptRecordFunction extends Scalar<Object, Object> {
 
@@ -40,39 +36,34 @@ public final class SubscriptRecordFunction extends Scalar<Object, Object> {
         NAME,
         RowType.EMPTY.getTypeSignature(),
         DataTypes.STRING.getTypeSignature(),
-        DataTypes.UNDEFINED.getTypeSignature());
+        DataTypes.UNDEFINED.getTypeSignature()
+    );
 
     public static void register(ScalarFunctionModule module) {
         module.register(
             SIGNATURE,
-            (signature, dataTypes) ->
-                new SubscriptRecordFunction(
-                    signature,
-                    (RowType) dataTypes.get(0))
+            SubscriptRecordFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
     private final RowType rowType;
-    private final FunctionInfo info;
 
-    public SubscriptRecordFunction(Signature signature, RowType rowType) {
+    public SubscriptRecordFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.rowType = rowType;
-        this.info = new FunctionInfo(
-            new FunctionIdent(NAME, List.of(rowType, DataTypes.STRING)),
-            DataTypes.UNDEFINED
-        );
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
+        this.rowType = (RowType) boundSignature.getArgumentDataTypes().get(0);
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -23,8 +23,6 @@ package io.crate.expression.scalar;
 
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -44,11 +42,7 @@ public class SubstrFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
-                new SubstrFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
-                    signature
-                )
+            SubstrFunction::new
         );
         module.register(
             Signature.scalar(
@@ -58,30 +52,26 @@ public class SubstrFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
-                new SubstrFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, argumentTypes), DataTypes.STRING),
-                    signature
-                )
+            SubstrFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private SubstrFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private SubstrFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -37,12 +37,11 @@ public final class AbsFunction {
             var typeSignature = type.getTypeSignature();
             module.register(
                 scalar(NAME, typeSignature, typeSignature),
-                (signature, args) -> {
-                    DataType<?> argType = args.get(0);
+                (signature, boundSignature) -> {
+                    DataType<?> argType = boundSignature.getArgumentDataTypes().get(0);
                     return new UnaryScalar<>(
-                        NAME,
                         signature,
-                        argType,
+                        boundSignature,
                         argType,
                         x -> argType.value(Math.abs(((Number) x).doubleValue()))
                     );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -23,7 +23,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -46,56 +46,56 @@ public class ArithmeticFunctions {
 
     private enum Operations {
         ADD(
-            FunctionInfo.DETERMINISTIC_AND_COMPARISON_REPLACEMENT,
+            Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT,
             Math::addExact,
             Double::sum,
             Math::addExact,
             Float::sum
         ),
         SUBTRACT(
-            FunctionInfo.DETERMINISTIC_ONLY,
+            Scalar.DETERMINISTIC_ONLY,
             Math::subtractExact,
                 (arg0, arg1) -> arg0 - arg1,
             Math::subtractExact,
                 (arg0, arg1) -> arg0 - arg1
         ),
         MULTIPLY(
-            FunctionInfo.DETERMINISTIC_ONLY,
+            Scalar.DETERMINISTIC_ONLY,
             Math::multiplyExact,
                 (arg0, arg1) -> arg0 * arg1,
             Math::multiplyExact,
                 (arg0, arg1) -> arg0 * arg1
         ),
         DIVIDE(
-            FunctionInfo.DETERMINISTIC_ONLY,
+            Scalar.DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1
         ),
         MODULUS(
-            FunctionInfo.DETERMINISTIC_ONLY,
+            Scalar.DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1
         ),
         MOD(
-            FunctionInfo.DETERMINISTIC_ONLY,
+            Scalar.DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1
         );
 
-        private final Set<FunctionInfo.Feature> features;
+        private final Set<Scalar.Feature> features;
 
         private final BinaryOperator<Integer> integerFunction;
         private final BinaryOperator<Double> doubleFunction;
         private final BinaryOperator<Long> longFunction;
         private final BinaryOperator<Float> floatFunction;
 
-        Operations(Set<FunctionInfo.Feature> features,
+        Operations(Set<Scalar.Feature> features,
                    BinaryOperator<Integer> integerFunction,
                    BinaryOperator<Double> doubleFunction,
                    BinaryOperator<Long> longFunction,
@@ -121,9 +121,9 @@ public class ArithmeticFunctions {
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
-                ),
-                (signature, args) ->
-                    new BinaryScalar<>(op.integerFunction, op.toString(), signature, DataTypes.INTEGER, op.features)
+                ).withFeatures(op.features),
+                (signature, boundSignature) ->
+                    new BinaryScalar<>(op.integerFunction, signature, boundSignature, DataTypes.INTEGER)
             );
             for (var type : List.of(DataTypes.LONG, DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
                 module.register(
@@ -132,9 +132,9 @@ public class ArithmeticFunctions {
                         type.getTypeSignature(),
                         type.getTypeSignature(),
                         type.getTypeSignature()
-                    ),
-                    (signature, args) ->
-                        new BinaryScalar<>(op.longFunction, op.toString(), signature, type, op.features)
+                    ).withFeatures(op.features),
+                    (signature, boundSignature) ->
+                        new BinaryScalar<>(op.longFunction, signature, boundSignature, type)
                 );
             }
             module.register(
@@ -143,9 +143,9 @@ public class ArithmeticFunctions {
                     DataTypes.FLOAT.getTypeSignature(),
                     DataTypes.FLOAT.getTypeSignature(),
                     DataTypes.FLOAT.getTypeSignature()
-                ),
-                (signature, args) ->
-                    new BinaryScalar<>(op.floatFunction, op.toString(), signature, DataTypes.FLOAT, op.features)
+                ).withFeatures(op.features),
+                (signature, boundSignature) ->
+                    new BinaryScalar<>(op.floatFunction, signature, boundSignature, DataTypes.FLOAT)
             );
             module.register(
                 Signature.scalar(
@@ -153,9 +153,9 @@ public class ArithmeticFunctions {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
-                ),
-                (signature, args) ->
-                    new BinaryScalar<>(op.doubleFunction, op.toString(), signature, DataTypes.DOUBLE, op.features)
+                ).withFeatures(op.features),
+                (signature, boundSignature) ->
+                    new BinaryScalar<>(op.doubleFunction, signature, boundSignature, DataTypes.DOUBLE)
             );
         }
 
@@ -165,9 +165,9 @@ public class ArithmeticFunctions {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
-            (signature, dataTypes) ->
-                new BinaryScalar<>(Math::pow, Names.POWER, signature, DataTypes.DOUBLE, FunctionInfo.DETERMINISTIC_ONLY)
+            ).withFeatures(Scalar.DETERMINISTIC_ONLY),
+            (signature, boundSignature) ->
+                new BinaryScalar<>(Math::pow, signature, boundSignature, DataTypes.DOUBLE)
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -24,16 +24,12 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -44,7 +40,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
     public static final Signature SIGNATURE =
         Signature.builder()
             .name(NAME)
-            .kind(FunctionInfo.Type.SCALAR)
+            .kind(FunctionType.SCALAR)
             .typeVariableConstraints(typeVariable("E"))
             .argumentTypes(parseTypeSignature("E"))
             .returnType(parseTypeSignature("array(E)"))
@@ -55,31 +51,26 @@ public class ArrayFunction extends Scalar<Object, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             SIGNATURE,
-            (signature, args) -> new ArrayFunction(createInfo(args), signature)
+            ArrayFunction::new
         );
     }
 
-    public static FunctionInfo createInfo(List<DataType<?>> argumentTypes) {
-        DataType<?> innerType = argumentTypes.get(0);
-        return new FunctionInfo(new FunctionIdent(NAME, argumentTypes), new ArrayType<>(innerType));
-    }
-
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private ArrayFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private ArrayFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SafeVarargs

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -23,49 +23,40 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Set;
 import java.util.function.BinaryOperator;
 
 public final class BinaryScalar<T> extends Scalar<T, T> {
 
     private final BinaryOperator<T> func;
-    private final FunctionInfo info;
-    @Nullable
     private final Signature signature;
+    private final Signature boundSignature;
     private final DataType<T> type;
 
-    public BinaryScalar(BinaryOperator<T> func, String name, DataType<T> type, Set<FunctionInfo.Feature> feature) {
-        this(func, name, null, type, feature);
-    }
-
     public BinaryScalar(BinaryOperator<T> func,
-                        String name,
-                        @Nullable Signature signature,
-                        DataType<T> type,
-                        Set<FunctionInfo.Feature> feature) {
+                        Signature signature,
+                        Signature boundSignature,
+                        DataType<T> type) {
+        assert boundSignature.getArgumentDataTypes().stream().allMatch(t -> t.id() == type.id()) :
+            "All bound argument types of the signature must match the type argument";
         this.func = func;
-        this.info = new FunctionInfo(new FunctionIdent(name, Arrays.asList(type, type)), type, FunctionInfo.Type.SCALAR, feature);
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.type = type;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -38,21 +38,18 @@ public final class CeilFunction {
     public static void register(ScalarFunctionModule module) {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
+            DataType<?> returnType = DataTypes.getIntegralReturnType(type);
+            assert returnType != null : "Could not get integral type of " + type;
             for (var name : List.of(CEIL, CEILING)) {
                 module.register(
-                    scalar(name, typeSignature, typeSignature),
-                    (signature, argumentTypes) -> {
-                        DataType<?> argType = argumentTypes.get(0);
-                        DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
-                        assert returnType != null : "Could not get integral type of " + argType;
-                        return new UnaryScalar<>(
-                            name,
+                    scalar(name, typeSignature, returnType.getTypeSignature()),
+                    (signature, boundSignature) ->
+                        new UnaryScalar<>(
                             signature,
-                            argType,
-                            returnType,
+                            boundSignature,
+                            type,
                             x -> returnType.value(Math.ceil(((Number) x).doubleValue()))
-                        );
-                    }
+                        )
                 );
             }
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -35,20 +35,17 @@ public final class FloorFunction {
     public static void register(ScalarFunctionModule module) {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
+            DataType<?> returnType = DataTypes.getIntegralReturnType(type);
+            assert returnType != null : "Could not get integral type of " + type;
             module.register(
-                scalar(NAME, typeSignature, typeSignature),
-                (signature, argumentTypes) -> {
-                    DataType<?> argType = argumentTypes.get(0);
-                    DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
-                    assert returnType != null : "Could not get integral type of " + argType;
-                    return new UnaryScalar<>(
-                        NAME,
+                scalar(NAME, typeSignature, returnType.getTypeSignature()),
+                (signature, boundSignature) ->
+                    new UnaryScalar<>(
                         signature,
-                        argType,
-                        returnType,
+                        boundSignature,
+                        type,
                         x -> returnType.value(Math.floor(((Number) x).doubleValue()))
-                    );
-                }
+                    )
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
@@ -24,15 +24,12 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.joda.time.Period;
 
-import java.util.List;
 import java.util.function.BiFunction;
 
 public class IntervalArithmeticScalar extends Scalar<Period, Object> {
@@ -45,8 +42,8 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
             ),
-            (signature, args) ->
-                new IntervalArithmeticScalar("+", ArithmeticFunctions.Names.ADD, signature)
+            (signature, boundSignature) ->
+                new IntervalArithmeticScalar("+", signature, boundSignature)
         );
         module.register(
             Signature.scalar(
@@ -55,22 +52,18 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
             ),
-            (signature, args) ->
-                new IntervalArithmeticScalar("-", ArithmeticFunctions.Names.SUBTRACT, signature)
+            (signature, boundSignature) ->
+                new IntervalArithmeticScalar("-", signature, boundSignature)
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final BiFunction<Period, Period, Period> operation;
 
-    IntervalArithmeticScalar(String operator, String name, Signature signature) {
-        info = new FunctionInfo(
-            new FunctionIdent(
-                name,
-                List.of(DataTypes.INTERVAL, DataTypes.INTERVAL)),
-            DataTypes.INTERVAL);
+    IntervalArithmeticScalar(String operator, Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
 
         switch (operator) {
             case "+":
@@ -87,13 +80,13 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return this.info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -23,8 +23,6 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -43,22 +41,22 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         LnFunction.registerLnFunctions(module);
     }
 
-    protected final FunctionInfo info;
     protected final Signature signature;
+    protected final Signature boundSignature;
 
-    LogFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    LogFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     /**
@@ -86,17 +84,12 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
                     parseTypeSignature("double precision")),
-                (signature, args) -> new LogBaseFunction(
-                    new FunctionInfo(
-                        new FunctionIdent(NAME, args), DataTypes.DOUBLE
-                    ),
-                    signature
-                )
+                LogBaseFunction::new
             );
         }
 
-        LogBaseFunction(FunctionInfo info, Signature signature) {
-            super(info, signature);
+        LogBaseFunction(Signature signature, Signature boundSignature) {
+            super(signature, boundSignature);
         }
 
         @Override
@@ -129,15 +122,12 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
                 ),
-                (signature, args) -> new Log10Function(
-                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE),
-                    signature
-                )
+                Log10Function::new
             );
         }
 
-        Log10Function(FunctionInfo info, Signature signature) {
-            super(info, signature);
+        Log10Function(Signature signature, Signature boundSignature) {
+            super(signature, boundSignature);
         }
 
         @Override
@@ -166,17 +156,14 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
                 ),
-                (signature, args) -> new LnFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.DOUBLE),
-                    signature
-                )
+                LnFunction::new
             );
         }
 
         public static final String NAME = "ln";
 
-        LnFunction(FunctionInfo info, Signature signature) {
-            super(info, signature);
+        LnFunction(Signature signature, Signature boundSignature) {
+            super(signature, boundSignature);
         }
 
         @Override
@@ -184,5 +171,4 @@ public abstract class LogFunction extends Scalar<Number, Number> {
             return validateResult(Math.log(value), "ln(x)");
         }
     }
-
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -24,14 +24,11 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +53,7 @@ public class MapFunction extends Scalar<Object, Object> {
     public static final Signature SIGNATURE =
         Signature.builder()
             .name(new FunctionName(null, NAME))
-            .kind(FunctionInfo.Type.SCALAR)
+            .kind(FunctionType.SCALAR)
             .typeVariableConstraints(List.of(typeVariableOfAnyType("V")))
             .argumentTypes(parseTypeSignature("text"), parseTypeSignature("V"))
             // This is not 100% correct because each variadic `V` is type independent, resulting in a return type
@@ -70,30 +67,26 @@ public class MapFunction extends Scalar<Object, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             SIGNATURE,
-            (signature, args) -> new MapFunction(createInfo(args), signature)
+            MapFunction::new
         );
     }
 
-    public static FunctionInfo createInfo(List<DataType<?>> dataTypes) {
-        return new FunctionInfo(new FunctionIdent(NAME, dataTypes), DataTypes.UNTYPED_OBJECT);
-    }
-
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private MapFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private MapFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SafeVarargs

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -25,7 +25,7 @@ package io.crate.expression.scalar.arithmetic;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -41,10 +41,8 @@ public final class NegateFunctions {
                 parseTypeSignature("double precision")
             )
                 .withForbiddenCoercion(),
-            (signature, argumentTypes) -> {
-                DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Double, Double>(NAME, signature, dataType, dataType, x -> x * -1);
-            }
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, x -> x * -1)
         );
         module.register(
             Signature.scalar(
@@ -53,10 +51,8 @@ public final class NegateFunctions {
                 parseTypeSignature("float")
             )
                 .withForbiddenCoercion(),
-            (signature, argumentTypes) -> {
-                DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Float, Float>(NAME, signature, dataType, dataType, x -> x * -1);
-            }
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.FLOAT, x -> x * -1)
         );
         module.register(
             Signature.scalar(
@@ -65,10 +61,8 @@ public final class NegateFunctions {
                 parseTypeSignature("integer")
             )
                 .withForbiddenCoercion(),
-            (signature, argumentTypes) -> {
-                DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Integer, Integer>(NAME, signature, dataType, dataType, x -> x * -1);
-            }
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.INTEGER, x -> x * -1)
         );
         module.register(
             Signature.scalar(
@@ -77,10 +71,8 @@ public final class NegateFunctions {
                 parseTypeSignature("bigint")
             )
                 .withForbiddenCoercion(),
-            (signature, argumentTypes) -> {
-                DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Long, Long>(NAME, signature, dataType, dataType, x -> x * -1);
-            }
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.LONG, x -> x * -1)
         );
         module.register(
             Signature.scalar(
@@ -89,10 +81,8 @@ public final class NegateFunctions {
                 parseTypeSignature("smallint")
             )
                 .withForbiddenCoercion(),
-            (signature, argumentTypes) -> {
-                DataType<?> dataType = argumentTypes.get(0);
-                return new UnaryScalar<Short, Short>(NAME, signature, dataType, dataType, x -> (short) (x * -1));
-            }
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.SHORT, x -> (short) (x * -1))
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -37,8 +37,8 @@ public class RadiansDegreesFunctions {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<>("radians", signature, args.get(0), args.get(0), Math::toRadians));
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toRadians));
 
         module.register(
             scalar(
@@ -46,7 +46,7 @@ public class RadiansDegreesFunctions {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<>("degrees", signature, args.get(0), args.get(0), Math::toDegrees));
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toDegrees));
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -26,14 +26,11 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.Collections;
 import java.util.Random;
 
 import static io.crate.metadata.functions.Signature.scalar;
@@ -42,22 +39,23 @@ public class RandomFunction extends Scalar<Double, Void> {
 
     public static final String NAME = "random";
 
-    protected static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, Collections.emptyList()), DataTypes.DOUBLE,
-        FunctionInfo.Type.SCALAR, FunctionInfo.NO_FEATURES);
-
     public static void register(ScalarFunctionModule module) {
         module.register(
-            scalar(NAME, DataTypes.DOUBLE.getTypeSignature()),
-            (signature, args) -> new RandomFunction(signature)
+            scalar(
+                NAME,
+                DataTypes.DOUBLE.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            RandomFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
     private final Random random = new Random();
 
-    public RandomFunction(Signature signature) {
+    public RandomFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -70,13 +68,13 @@ public class RandomFunction extends Scalar<Double, Void> {
 
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -35,26 +35,23 @@ public final class RoundFunction {
     public static void register(ScalarFunctionModule module) {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
+            DataType<?> returnType = DataTypes.getIntegralReturnType(type);
+            assert returnType != null : "Could not get integral type of " + type;
             module.register(
-                scalar(NAME, typeSignature, typeSignature),
-                (signature, argumentTypes) -> {
-                    DataType<?> argType = argumentTypes.get(0);
-                    DataType<?> returnType = DataTypes.getIntegralReturnType(argType);
-                    assert returnType != null : "Could not get integral type of " + argType;
+                scalar(NAME, typeSignature, returnType.getTypeSignature()),
+                (signature, boundSignature) -> {
                     if (returnType.equals(DataTypes.INTEGER)) {
                         return new UnaryScalar<>(
-                            NAME,
                             signature,
-                            argType,
-                            returnType,
+                            boundSignature,
+                            type,
                             x -> Math.round(((Number) x).floatValue())
                         );
                     } else {
                         return new UnaryScalar<>(
-                            NAME,
                             signature,
-                            argType,
-                            returnType,
+                            boundSignature,
+                            type,
                             x -> Math.round(((Number) x).doubleValue())
                         );
                     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -35,9 +35,9 @@ public final class SquareRootFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             module.register(
-                scalar(NAME, typeSignature, typeSignature),
-                (signature, argumentTypes) ->
-                    new DoubleScalar(NAME, signature, argumentTypes.get(0), SquareRootFunction::sqrt)
+                scalar(NAME, typeSignature, DataTypes.DOUBLE.getTypeSignature()),
+                (signature, boundSignature) ->
+                    new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -24,15 +24,13 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
-import io.crate.types.DataType;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 
 import java.util.function.DoubleUnaryOperator;
 
 import static io.crate.metadata.functions.Signature.scalar;
-import static io.crate.types.DataTypes.NUMERIC_PRIMITIVE_TYPES;
 
 public final class TrigonometricFunctions {
 
@@ -45,24 +43,21 @@ public final class TrigonometricFunctions {
         register(module, "cot", x -> 1 / Math.tan(x));
         register(module, "atan", x -> Math.atan(checkRange(x)));
 
-        for (DataType<?> inputType : NUMERIC_PRIMITIVE_TYPES) {
-            module.register(
-                scalar(
-                    "atan2",
-                    inputType.getTypeSignature(),
-                    inputType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
-                (signature, argumentTypes) ->
-                    new BinaryScalar<>(
-                        Math::atan2,
-                        "atan2",
-                        signature,
-                        DoubleType.INSTANCE,
-                        FunctionInfo.DETERMINISTIC_ONLY
-                    )
-            );
-        }
+        module.register(
+            scalar(
+                "atan2",
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ).withFeatures(Scalar.DETERMINISTIC_ONLY),
+            (signature, boundSignature) ->
+                new BinaryScalar<>(
+                    Math::atan2,
+                    signature,
+                    boundSignature,
+                    DoubleType.INSTANCE
+                )
+        );
     }
 
     private static void register(ScalarFunctionModule module, String name, DoubleUnaryOperator func) {
@@ -72,8 +67,8 @@ public final class TrigonometricFunctions {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
-                new DoubleScalar(name, signature, argumentTypes.get(0), func)
+            (signature, boundSignature) ->
+                new DoubleScalar(signature, boundSignature, func)
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -27,7 +27,6 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -49,20 +48,18 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
                     parseTypeSignature("V"),
                     parseTypeSignature("V"))
                 .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
-            (signature, args) -> new ExplicitCastFunction(
-                FunctionInfo.of(NAME, args, args.get(1)),
-                signature)
+            ExplicitCastFunction::new
         );
     }
 
     private final DataType<?> returnType;
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private ExplicitCastFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private ExplicitCastFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.returnType = info.returnType();
+        this.boundSignature = boundSignature;
+        this.returnType = boundSignature.getReturnType().createType();
     }
 
     @Override
@@ -75,13 +72,13 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -27,7 +27,6 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -48,19 +47,16 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.UNDEFINED.getTypeSignature()
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new ImplicitCastFunction(
-                    FunctionInfo.of(NAME, args, args.get(1)),
-                    signature)
+            ImplicitCastFunction::new
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private ImplicitCastFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private ImplicitCastFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -75,13 +71,13 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -26,7 +26,6 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -48,21 +47,18 @@ public class TryCastFunction extends Scalar<Object, Object> {
                     parseTypeSignature("V"),
                     parseTypeSignature("V"))
                 .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
-            (signature, args) -> new TryCastFunction(
-                FunctionInfo.of(NAME, args, args.get(1)),
-                signature
-            )
+            TryCastFunction::new
         );
     }
 
     private final DataType<?> returnType;
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private TryCastFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private TryCastFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.returnType = info.returnType();
+        this.boundSignature = boundSignature;
+        this.returnType = boundSignature.getReturnType().createType();
     }
 
     @Override
@@ -75,13 +71,13 @@ public class TryCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -24,7 +24,6 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -43,28 +42,28 @@ public class CoalesceFunction extends Scalar<Object, Object> {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new CoalesceFunction(FunctionInfo.of(NAME, args, args.get(0)), signature)
+            CoalesceFunction::new
         );
     }
 
     public static final String NAME = "coalesce";
-    private final FunctionInfo info;
+
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private CoalesceFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private CoalesceFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
@@ -23,7 +23,6 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -32,22 +31,22 @@ import java.util.Comparator;
 
 abstract class ConditionalCompareFunction extends Scalar<Object, Object> implements Comparator<Object> {
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    ConditionalCompareFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    ConditionalCompareFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
@@ -23,28 +23,15 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.DataTypes.tryFindNotNullType;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class GreatestFunction extends ConditionalCompareFunction {
 
     private static final String NAME = "greatest";
-
-    private GreatestFunction(FunctionInfo info, Signature signature) {
-        super(info, signature);
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Override
-    public int compare(Object o1, Object o2) {
-        DataType dataType = info().returnType();
-        return dataType.compare(o2, o1);
-    }
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -55,8 +42,18 @@ public class GreatestFunction extends ConditionalCompareFunction {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new GreatestFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
+            GreatestFunction::new
         );
+    }
+
+    public GreatestFunction(Signature signature, Signature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public int compare(Object o1, Object o2) {
+        DataType dataType = info().returnType();
+        return dataType.compare(o2, o1);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -24,7 +24,6 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -61,8 +60,7 @@ public class IfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new IfFunction(FunctionInfo.of(NAME, args, args.get(1)), signature)
+            IfFunction::new
         );
         // if (condition, result, default)
         module.register(
@@ -73,29 +71,28 @@ public class IfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new IfFunction(FunctionInfo.of(NAME, args, args.get(1)), signature)
+            IfFunction::new
         );
     }
 
     public static final String NAME = "if";
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private IfFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private IfFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
@@ -23,28 +23,15 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.DataTypes.tryFindNotNullType;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class LeastFunction extends ConditionalCompareFunction {
 
     private static final String NAME = "least";
-
-    private LeastFunction(FunctionInfo info, Signature signature) {
-        super(info, signature);
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Override
-    public int compare(Object o1, Object o2) {
-        DataType dataType = info().returnType();
-        return dataType.compare(o1, o2);
-    }
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -55,8 +42,18 @@ public class LeastFunction extends ConditionalCompareFunction {
                     parseTypeSignature("E"))
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new LeastFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
+            LeastFunction::new
         );
+    }
+
+    public LeastFunction(Signature signature, Signature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public int compare(Object o1, Object o2) {
+        DataType dataType = info().returnType();
+        return dataType.compare(o1, o2);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -24,13 +24,11 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.DataTypes.tryFindNotNullType;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class NullIfFunction extends Scalar<Object, Object> {
@@ -43,28 +41,27 @@ public class NullIfFunction extends Scalar<Object, Object> {
                 parseTypeSignature("E"),
                 parseTypeSignature("E")
             ).withTypeVariableConstraints(typeVariable("E")),
-            (signature, args) ->
-                new NullIfFunction(FunctionInfo.of(NAME, args, tryFindNotNullType(args)), signature)
+            NullIfFunction::new
         );
     }
 
     public static final String NAME = "nullif";
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private NullIfFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private NullIfFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -28,7 +28,6 @@ import io.crate.types.DataTypes;
 import io.crate.types.GeoPointType;
 
 import java.util.List;
-import java.util.function.Function;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
@@ -37,18 +36,27 @@ public final class CoordinateFunction {
     private static final List<DataType<?>> SUPPORTED_INPUT_TYPES =
         List.of(DataTypes.GEO_POINT, DataTypes.STRING, DataTypes.DOUBLE_ARRAY);
 
-    private static void register(ScalarFunctionModule module, String name, Function<Object, Double> func) {
-        for (DataType<?> inputType : SUPPORTED_INPUT_TYPES) {
+    public static void register(ScalarFunctionModule module) {
+        for (var inputType : SUPPORTED_INPUT_TYPES) {
             module.register(
-                scalar(name, inputType.getTypeSignature(), DataTypes.DOUBLE.getTypeSignature()),
-                (signature, args) -> new UnaryScalar<>(name, signature, inputType, DataTypes.DOUBLE, func)
+                scalar(
+                    "latitude",
+                    inputType.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                (signature, boundSignature) ->
+                    new UnaryScalar<>(signature, boundSignature, inputType, CoordinateFunction::getLatitude)
+            );
+            module.register(
+                scalar(
+                    "longitude",
+                    inputType.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ),
+                (signature, boundSignature) ->
+                    new UnaryScalar<>(signature, boundSignature, inputType, CoordinateFunction::getLongitude)
             );
         }
-    }
-
-    public static void register(ScalarFunctionModule module) {
-        register(module, "latitude", CoordinateFunction::getLatitude);
-        register(module, "longitude", CoordinateFunction::getLongitude);
     }
 
 

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -39,19 +39,18 @@ public final class GeoHashFunction {
         List.of(DataTypes.GEO_POINT, DataTypes.STRING, DataTypes.DOUBLE_ARRAY);
 
     public static void register(ScalarFunctionModule module) {
-        for (DataType<?> inputType : SUPPORTED_INPUT_TYPES) {
+        for (var inputType : SUPPORTED_INPUT_TYPES) {
             module.register(
                 scalar(
                     "geohash",
                     inputType.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
                 ),
-                (signature, args) ->
+                (signature, boundSignature) ->
                     new UnaryScalar<>(
-                        "geohash",
                         signature,
+                        boundSignature,
                         inputType,
-                        DataTypes.STRING,
                         GeoHashFunction::getGeoHash
                     )
             );

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -28,27 +28,17 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.locationtech.spatial4j.shape.Shape;
 
-import java.util.List;
-
 import static io.crate.metadata.functions.Signature.scalar;
 
 public class IntersectsFunction extends Scalar<Boolean, Object> {
 
     public static final String NAME = "intersects";
-
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, List.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE)),
-        DataTypes.BOOLEAN
-    );
-
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -58,14 +48,16 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
             ),
-            (signature, args) -> new IntersectsFunction(signature)
+            IntersectsFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public IntersectsFunction(Signature signature) {
+    public IntersectsFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -85,13 +77,13 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -27,8 +27,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -53,11 +51,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
             ),
-            (signature, args) ->
-                new WithinFunction(
-                    new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.BOOLEAN),
-                    signature
-                )
+            WithinFunction::new
         );
         // Needed to avoid casts on references of `geo_point` and thus to avoid generic function filter on lucene.
         // Coercion must be forbidden, as string representation could be a `geo_shape` and thus must match
@@ -70,21 +64,17 @@ public class WithinFunction extends Scalar<Boolean, Object> {
                     type.getTypeSignature(),
                     DataTypes.BOOLEAN.getTypeSignature()
                 ).withForbiddenCoercion(),
-                (signature, args) ->
-                    new WithinFunction(
-                        new FunctionInfo(new FunctionIdent(NAME, args), DataTypes.BOOLEAN),
-                        signature
-                    )
+                WithinFunction::new
             );
         }
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    private WithinFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private WithinFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -130,13 +120,13 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.scalar.postgres;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -50,10 +48,10 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new CurrentSettingFunction(
-                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0)),
                     signature,
+                    boundSignature,
                     sessionSettingRegistry
                 )
         );
@@ -65,34 +63,34 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new CurrentSettingFunction(
-                    new FunctionInfo(new FunctionIdent(FQN, argumentTypes), argumentTypes.get(0)),
                     signature,
+                    boundSignature,
                     sessionSettingRegistry
                 )
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final Provider<SessionSettingRegistry> sessionSettingRegistry;
 
-    CurrentSettingFunction(FunctionInfo info, Signature signature, Provider<SessionSettingRegistry> sessionSettingRegistry) {
-        this.info = info;
+    CurrentSettingFunction(Signature signature, Signature boundSignature, Provider<SessionSettingRegistry> sessionSettingRegistry) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.sessionSettingRegistry = sessionSettingRegistry;
 
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -27,16 +27,12 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
-
-import java.util.Collections;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
@@ -45,24 +41,22 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     public static final String NAME = "pg_backend_pid";
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
-
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(FQN, Collections.emptyList()),
-        DataTypes.INTEGER,
-        FunctionInfo.Type.SCALAR,
-        FunctionInfo.NO_FEATURES);
-
     public static void register(ScalarFunctionModule module) {
         module.register(
-            scalar(FQN, DataTypes.INTEGER.getTypeSignature()),
-            (signature, args) -> new PgBackendPidFunction(signature)
+            scalar(
+                FQN,
+                DataTypes.INTEGER.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            PgBackendPidFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public PgBackendPidFunction(Signature signature) {
+    public PgBackendPidFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -72,13 +66,13 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -24,7 +24,6 @@ package io.crate.expression.scalar.postgres;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
@@ -42,11 +41,11 @@ public class PgGetUserByIdFunction {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new UnaryScalar<>(
-                    new FunctionIdent(name, args),
                     signature,
-                    DataTypes.STRING,
+                    boundSignature,
+                    DataTypes.INTEGER,
                     id -> CRATE_USER.name()
                 )
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -36,8 +36,8 @@ public final class AsciiFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<>("ascii", signature, args.get(0), DataTypes.INTEGER, AsciiFunction::ascii)
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, AsciiFunction::ascii)
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -24,24 +24,12 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
-
 public final class ChrFunction extends Scalar<String, Object> {
-
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(
-            "chr",
-            List.of(DataTypes.INTEGER)
-        ),
-        DataTypes.STRING
-    );
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -50,14 +38,16 @@ public final class ChrFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) -> new ChrFunction(signature)
+            ChrFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public ChrFunction(Signature signature) {
+    public ChrFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -78,12 +68,12 @@ public final class ChrFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -26,7 +26,6 @@ import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -46,13 +45,12 @@ public class EncodeDecodeFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new BinaryScalar<>(
-                    new Encode(),
-                    "encode",
-                    signature,
-                    DataTypes.STRING,
-                    FunctionInfo.DETERMINISTIC_ONLY
+                        new Encode(),
+                        signature,
+                        boundSignature,
+                        DataTypes.STRING
                 )
         );
         module.register(
@@ -62,13 +60,12 @@ public class EncodeDecodeFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new BinaryScalar<>(
-                    new Decode(),
-                    "decode",
-                    signature,
-                    DataTypes.STRING,
-                    FunctionInfo.DETERMINISTIC_ONLY
+                        new Decode(),
+                        signature,
+                        boundSignature,
+                        DataTypes.STRING
                 )
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -49,8 +49,8 @@ public final class HashFunctions {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<>(name, signature, DataTypes.STRING, DataTypes.STRING, func)
+            (signature, boundSignature) ->
+                new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -36,11 +36,10 @@ public final class InitCapFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new UnaryScalar<>(
-                    "initcap",
                     signature,
-                    DataTypes.STRING,
+                    boundSignature,
                     DataTypes.STRING,
                     InitCapFunction::toCapital
                 )

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -46,7 +46,7 @@ public final class LengthFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
             ),
-            (signature, args) -> new UnaryScalar<>(name, signature, DataTypes.STRING, DataTypes.INTEGER, func)
+            (signature, boundSignature) -> new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -38,11 +38,10 @@ public final class QuoteIdentFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
+            (signature, boundSignature) ->
                 new UnaryScalar<>(
-                    "quote_ident",
                     signature,
-                    DataTypes.STRING,
+                    boundSignature,
                     DataTypes.STRING,
                     Identifiers::quoteIfNeeded
                 )

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -24,13 +24,9 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.TripleScalar;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.Strings;
-
-import java.util.List;
 
 
 public final class ReplaceFunction {
@@ -46,13 +42,13 @@ public final class ReplaceFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) -> new TripleScalar<>(
-                new FunctionInfo(
-                    new FunctionIdent(NAME, List.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING)),
-                    DataTypes.STRING
-                ),
-                signature,
-                Strings::replace)
+            (signature, boundSignature) ->
+                new TripleScalar<>(
+                    signature,
+                    boundSignature,
+                    DataTypes.STRING,
+                    Strings::replace
+                )
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -38,11 +38,10 @@ public final class StringCaseFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<String, String>(
-                    "upper",
+            (signature, boundSignature) ->
+                new UnaryScalar<>(
                     signature,
-                    DataTypes.STRING,
+                    boundSignature,
                     DataTypes.STRING,
                     val -> val.toUpperCase(Locale.ENGLISH)
                 )
@@ -53,11 +52,10 @@ public final class StringCaseFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
-                new UnaryScalar<String, String>(
-                    "lower",
+            (signature, boundSignature) ->
+                new UnaryScalar<>(
                     signature,
-                    DataTypes.STRING,
+                    boundSignature,
                     DataTypes.STRING,
                     val -> val.toLowerCase(Locale.ENGLISH)
                 )

--- a/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -24,14 +24,11 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
 
@@ -45,8 +42,8 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
-                new StringLeftRightFunction("left", signature, StringLeftRightFunction::left)
+            (signature, boundSignature) ->
+                new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::left)
         );
         module.register(
             Signature.scalar(
@@ -55,33 +52,31 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) ->
-                new StringLeftRightFunction("right", signature, StringLeftRightFunction::right)
+            (signature, boundSignature) ->
+                new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::right)
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final BiFunction<String, Integer, String> func;
 
-    private StringLeftRightFunction(String funcName,
-                                    Signature signature,
+    private StringLeftRightFunction(Signature signature,
+                                    Signature boundSignature,
                                     BiFunction<String, Integer, String> func) {
-        info = new FunctionInfo(new FunctionIdent(funcName,
-                                                  List.of(DataTypes.STRING, DataTypes.INTEGER)),
-                                DataTypes.STRING);
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.func = func;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -25,8 +25,6 @@ package io.crate.expression.scalar.string;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.ThreeParametersFunction;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -50,10 +48,10 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new StringPaddingFunction(
-                    new FunctionInfo(new FunctionIdent(LNAME, argumentTypes), DataTypes.STRING),
                     signature,
+                    boundSignature,
                     StringPaddingFunction::lpad
                 )
         );
@@ -66,10 +64,10 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new StringPaddingFunction(
-                    new FunctionInfo(new FunctionIdent(LNAME, argumentTypes), DataTypes.STRING),
                     signature,
+                    boundSignature,
                     StringPaddingFunction::lpad
                 )
         );
@@ -81,10 +79,10 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new StringPaddingFunction(
-                    new FunctionInfo(new FunctionIdent(RNAME, argumentTypes), DataTypes.STRING),
                     signature,
+                    boundSignature,
                     StringPaddingFunction::rpad
                 )
         );
@@ -97,35 +95,35 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) ->
+            (signature, boundSignature) ->
                 new StringPaddingFunction(
-                    new FunctionInfo(new FunctionIdent(RNAME, argumentTypes), DataTypes.STRING),
                     signature,
+                    boundSignature,
                     StringPaddingFunction::rpad
                 )
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final ThreeParametersFunction<char[], Integer, char[], String> func;
 
-    private StringPaddingFunction(FunctionInfo info,
-                                  Signature signature,
+    private StringPaddingFunction(Signature signature,
+                                  Signature boundSignature,
                                   ThreeParametersFunction<char[], Integer, char[], String> func) {
-        this.info = info;
         this.signature = signature;
+        this.boundSignature = boundSignature;
         this.func = func;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -24,24 +24,12 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
-
 public final class StringRepeatFunction extends Scalar<String, Object> {
-
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(
-            "repeat",
-            List.of(DataTypes.STRING, DataTypes.INTEGER)
-        ),
-        DataTypes.STRING
-    );
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -51,14 +39,16 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, argumentTypes) -> new StringRepeatFunction(signature)
+            StringRepeatFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public StringRepeatFunction(Signature signature) {
+    public StringRepeatFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -78,12 +68,12 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -22,14 +22,11 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -38,7 +35,6 @@ import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 
 
 public class CurrentSchemaFunction extends Scalar<String, Object> {
@@ -47,36 +43,32 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
 
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(FQN, ImmutableList.of()),
-        DataTypes.STRING,
-        FunctionInfo.Type.SCALAR,
-        Collections.emptySet());
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 FQN,
                 DataTypes.STRING.getTypeSignature()
-            ),
-            (signature, args) -> new CurrentSchemaFunction(signature)
+            ).withFeatures(NO_FEATURES),
+            CurrentSchemaFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public CurrentSchemaFunction(Signature signature) {
+    public CurrentSchemaFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -22,11 +22,8 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -35,7 +32,6 @@ import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
@@ -43,37 +39,33 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
     public static final String NAME = "current_schemas";
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(FQN, ImmutableList.of(DataTypes.BOOLEAN)),
-        DataTypes.STRING_ARRAY,
-        FunctionInfo.Type.SCALAR,
-        Collections.emptySet());
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 FQN,
                 DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ),
-            (signature, args) -> new CurrentSchemasFunction(signature)
+                DataTypes.STRING_ARRAY.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            CurrentSchemasFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public CurrentSchemasFunction(Signature signature) {
+    public CurrentSchemasFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return INFO;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SafeVarargs

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -24,18 +24,13 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.protocols.postgres.types.PGTypes;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import java.util.List;
 
 public final class FormatTypeFunction extends Scalar<String, Object> {
 
@@ -54,22 +49,22 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public FormatTypeFunction(Signature signature, List<DataType<?>> argumentTypes) {
-        this.info = new FunctionInfo(new FunctionIdent(FQN, argumentTypes), DataTypes.STRING);
+    public FormatTypeFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return this.info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
     public Signature signature() {
         return this.signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -24,17 +24,12 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import java.util.List;
 
 public final class ObjDescriptionFunction extends Scalar<String, Object> {
 
@@ -53,15 +48,12 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
         );
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public ObjDescriptionFunction(Signature signature, List<DataType<?>> argumentTypes) {
-        info = new FunctionInfo(
-            new FunctionIdent(FQN, argumentTypes),
-            DataTypes.STRING
-        );
+    public ObjDescriptionFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @SafeVarargs
@@ -72,12 +64,12 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -24,16 +24,12 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
-
-import java.util.Arrays;
 
 public class PgGetExpr extends Scalar<String, Object> {
 
@@ -48,14 +44,16 @@ public class PgGetExpr extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),
-            (signature, args) -> new PgGetExpr(signature)
+            PgGetExpr::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public PgGetExpr(Signature signature) {
+    public PgGetExpr(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -64,14 +62,12 @@ public class PgGetExpr extends Scalar<String, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return new FunctionInfo(
-            new FunctionIdent(FQN, Arrays.asList(DataTypes.STRING, DataTypes.INTEGER)),
-            DataTypes.STRING);
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -48,34 +46,29 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature()
             )
                 .withTypeVariableConstraints(typeVariable("E")),
-            (signature, argumentTypes) ->
-                new PgTypeofFunction(
-                    new FunctionInfo(new FunctionIdent(FQNAME, argumentTypes),
-                                     DataTypes.STRING),
-                    signature
-                )
+            PgTypeofFunction::new
         );
 
     }
 
-    private final FunctionInfo info;
     private final Signature signature;
+    private final Signature boundSignature;
     private final String type;
 
-    private PgTypeofFunction(FunctionInfo info, Signature signature) {
-        this.info = info;
+    private PgTypeofFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        type = this.info.ident().argumentTypes().get(0).getName();
-    }
-
-    @Override
-    public FunctionInfo info() {
-        return info;
+        this.boundSignature = boundSignature;
+        type = boundSignature.getArgumentDataTypes().get(0).getName();
     }
 
     @Override
     public Signature signature() {
         return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @SafeVarargs

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -35,7 +33,6 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 
-import java.util.Collections;
 import java.util.Locale;
 
 public class VersionFunction extends Scalar<String, Void> {
@@ -44,17 +41,13 @@ public class VersionFunction extends Scalar<String, Void> {
 
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
-    protected static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(FQN, Collections.emptyList()), DataTypes.STRING,
-        FunctionInfo.Type.SCALAR, FunctionInfo.NO_FEATURES);
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 FQN,
                 DataTypes.STRING.getTypeSignature()
-            ),
-            (signature, args) -> new VersionFunction(signature)
+            ).withFeatures(Scalar.NO_FEATURES),
+            VersionFunction::new
         );
 
     }
@@ -90,9 +83,11 @@ public class VersionFunction extends Scalar<String, Void> {
     private static final String VERSION = formatVersion();
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public VersionFunction(Signature signature) {
+    public VersionFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -101,12 +96,12 @@ public class VersionFunction extends Scalar<String, Void> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -24,16 +24,12 @@ package io.crate.expression.scalar.timestamp;
 import com.google.common.math.LongMath;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 import java.math.RoundingMode;
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 
 public class CurrentTimestampFunction extends Scalar<Long, Integer> {
@@ -41,27 +37,23 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
     public static final String NAME = "current_timestamp";
     public static final int DEFAULT_PRECISION = 3;
 
-    public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, List.of(DataTypes.INTEGER)),
-        DataTypes.TIMESTAMPZ,
-        FunctionInfo.Type.SCALAR,
-        Collections.emptySet());
-
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ),
-            (signature, args) -> new CurrentTimestampFunction(signature)
+            ).withFeatures(NO_FEATURES),
+            CurrentTimestampFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public CurrentTimestampFunction(Signature signature) {
+    public CurrentTimestampFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -100,12 +92,12 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -24,23 +24,14 @@ package io.crate.expression.scalar.timestamp;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
-import java.util.List;
-
 public final class NowFunction extends Scalar<Long, Object> {
 
     public static final String NAME = "now";
-    private static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(null, NAME, List.of()),
-        DataTypes.TIMESTAMPZ,
-        FunctionInfo.Type.SCALAR
-    );
 
     public static void register(ScalarFunctionModule module) {
         module.register(
@@ -48,14 +39,16 @@ public final class NowFunction extends Scalar<Long, Object> {
                 NAME,
                 DataTypes.TIMESTAMPZ.getTypeSignature()
             ),
-            (signature, args) -> new NowFunction(signature)
+            NowFunction::new
         );
     }
 
     private final Signature signature;
+    private final Signature boundSignature;
 
-    public NowFunction(Signature signature) {
+    public NowFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -65,12 +58,12 @@ public final class NowFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public FunctionInfo info() {
-        return INFO;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -34,7 +34,7 @@ import java.util.List;
 public enum AggregateMode {
     ITER_PARTIAL {
         @Override
-        public DataType returnType(AggregationFunction<?, ?> function) {
+        public DataType<?> returnType(AggregationFunction<?, ?> function) {
             return function.partialType();
         }
 
@@ -48,8 +48,8 @@ public enum AggregateMode {
 
     private static final List<AggregateMode> VALUES = List.of(values());
 
-    public DataType returnType(AggregationFunction<?, ?> function) {
-        return function.info().returnType();
+    public DataType<?> returnType(AggregationFunction<?, ?> function) {
+        return function.boundSignature().getReturnType().createType();
     }
 
     public <TP, TF> TF finishCollect(RamAccounting ramAccounting, AggregationFunction<TP, TF> function, TP state) {

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -46,7 +46,9 @@ import io.crate.expression.symbol.format.MatchPrinter;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -120,6 +122,56 @@ public class Function extends Symbol implements Cloneable {
      */
     public FunctionInfo info() {
         return info;
+    }
+
+    /**
+     * Wrapper method for BWC when symbols are retrieved from older nodes without a signature.
+     */
+    public String name() {
+        if (signature != null) {
+            return signature.getName().name();
+        }
+        return info.ident().name();
+    }
+
+    /**
+     * Wrapper method for BWC when symbols are retrieved from older nodes without a signature.
+     */
+    public boolean hasFeature(Scalar.Feature feature) {
+        if (signature != null) {
+            return signature.hasFeature(feature);
+        }
+        return info.hasFeature(feature);
+    }
+
+    /**
+     * Wrapper method for BWC when symbols are retrieved from older nodes without a signature.
+     */
+    public boolean isDeterministic() {
+        if (signature != null) {
+            return signature.isDeterministic();
+        }
+        return info.isDeterministic();
+    }
+
+    /**
+     * Wrapper method for BWC when symbols are retrieved from older nodes without a signature.
+     */
+    public FunctionName fqnName() {
+        if (signature != null) {
+            return signature.getName();
+        }
+        return info.ident().fqnName();
+    }
+
+    /**
+     * Wrapper method for BWC when symbols are retrieved from older nodes without a signature.
+     */
+    public FunctionType type() {
+        if (signature != null) {
+            return signature.getKind();
+        }
+        return info.type();
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -80,7 +80,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         changed |= filter != newFilter;
 
         if (changed) {
-            return new Function(func.info(), func.signature(), newArgs, newFilter);
+            var signature = func.signature();
+            assert signature != null : "Expecting signature not to be null";
+            return new Function(signature, newArgs, func.valueType(), newFilter);
         }
         return func;
     }
@@ -101,7 +103,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (arg1 == newArg1 && arg2 == newArg2 && filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), func.signature(), List.of(newArg1, newArg2), newFilter);
+        var signature = func.signature();
+        assert signature != null : "Expecting signature not to be null";
+        return new Function(signature, List.of(newArg1, newArg2), func.valueType(), newFilter);
     }
 
     private Function zeroArg(Function func, C context) {
@@ -116,7 +120,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), func.signature(), List.of(), newFilter);
+        var signature = func.signature();
+        assert signature != null : "Expecting signature not to be null";
+        return new Function(signature, List.of(), func.valueType(), newFilter);
     }
 
     private Function oneArg(Function func, C context) {
@@ -130,7 +136,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (arg == newArg && filter == newFilter) {
             return func;
         }
-        return new Function(func.info(), func.signature(), List.of(newArg), newFilter);
+        var signature = func.signature();
+        assert signature != null : "Expecting signature not to be null";
+        return new Function(signature, List.of(newArg), func.valueType(), newFilter);
     }
 
     @Nullable
@@ -150,9 +158,9 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
     public Symbol visitWindowFunction(WindowFunction windowFunction, C context) {
         Function processedFunction = processAndMaybeCopy(windowFunction, context);
         return new WindowFunction(
-            processedFunction.info(),
             processedFunction.signature(),
             processedFunction.arguments(),
+            processedFunction.valueType(),
             processNullable(windowFunction.filter(), context),
             windowFunction.windowDefinition().map(s -> s.accept(this, context))
         );

--- a/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
+++ b/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.symbol;
 
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 
 import java.util.List;
@@ -56,7 +56,7 @@ public final class GroupAndAggregateSemantics {
     public static void validate(List<Symbol> outputSymbols,
                                 List<Symbol> groupBy) throws IllegalArgumentException {
         boolean containsAggregations = SymbolVisitors.any(
-            x -> x instanceof Function && ((Function) x).info().type() == FunctionInfo.Type.AGGREGATE,
+            x -> x instanceof Function && ((Function) x).info().type() == FunctionType.AGGREGATE,
             outputSymbols
         );
         if (!containsAggregations && groupBy.isEmpty()) {

--- a/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
+++ b/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
@@ -56,7 +56,7 @@ public final class GroupAndAggregateSemantics {
     public static void validate(List<Symbol> outputSymbols,
                                 List<Symbol> groupBy) throws IllegalArgumentException {
         boolean containsAggregations = SymbolVisitors.any(
-            x -> x instanceof Function && ((Function) x).info().type() == FunctionType.AGGREGATE,
+            x -> x instanceof Function && ((Function) x).type() == FunctionType.AGGREGATE,
             outputSymbols
         );
         if (!containsAggregations && groupBy.isEmpty()) {
@@ -87,7 +87,7 @@ public final class GroupAndAggregateSemantics {
 
         @Override
         public Symbol visitFunction(Function function, List<Symbol> groupBy) {
-            switch (function.info().type()) {
+            switch (function.type()) {
                 case SCALAR: {
                     /* valid:
                      *  SELECT 4 * x FROM tbl GROUP BY x
@@ -123,7 +123,7 @@ public final class GroupAndAggregateSemantics {
                     return null;
 
                 default:
-                    throw new IllegalStateException("Unexpected function type: " + function.info().type());
+                    throw new IllegalStateException("Unexpected function type: " + function.type());
             }
         }
 

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -179,7 +179,7 @@ public class Symbols {
 
     public static Symbol unwrapReferenceFromCast(Symbol symbol) {
         if (symbol instanceof Function
-            && CAST_FUNCTION_NAMES.contains(((Function) symbol).info().ident().name())) {
+            && CAST_FUNCTION_NAMES.contains(((Function) symbol).name())) {
             return ((Function) symbol).arguments().get(0);
         }
         return symbol;

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -28,6 +28,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -52,6 +53,10 @@ public class Symbols {
 
     public static List<DataType<?>> typeView(List<? extends Symbol> symbols) {
         return LazyMapList.of(symbols, Symbol::valueType);
+    }
+
+    public static List<TypeSignature> typeSignatureView(List<? extends Symbol> symbols) {
+        return LazyMapList.of(symbols, s -> s.valueType().getTypeSignature());
     }
 
     public static Streamer<?>[] streamerArray(Collection<? extends Symbol> symbols) {

--- a/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
+++ b/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
@@ -28,8 +28,8 @@ import io.crate.analyze.WindowDefinition;
 import io.crate.analyze.WindowFrameDefinition;
 import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.format.Style;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -38,8 +38,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-import static io.crate.metadata.FunctionInfo.Type.AGGREGATE;
-import static io.crate.metadata.FunctionInfo.Type.WINDOW;
+import static io.crate.metadata.FunctionType.AGGREGATE;
+import static io.crate.metadata.FunctionType.WINDOW;
 
 public class WindowFunction extends Function {
 
@@ -50,20 +50,13 @@ public class WindowFunction extends Function {
         windowDefinition = new WindowDefinition(in);
     }
 
-    public WindowFunction(FunctionInfo info,
+    public WindowFunction(Signature signature,
                           List<Symbol> arguments,
+                          DataType<?> returnType,
                           @Nullable Symbol filter,
                           WindowDefinition windowDefinition) {
-        this(info, null, arguments, filter, windowDefinition);
-    }
-
-    public WindowFunction(FunctionInfo info,
-                          Signature signature,
-                          List<Symbol> arguments,
-                          @Nullable Symbol filter,
-                          WindowDefinition windowDefinition) {
-        super(info, signature, arguments, filter);
-        assert info.type() == WINDOW || info.type() == AGGREGATE :
+        super(signature, arguments, returnType, filter);
+        assert signature.getKind() == WINDOW || signature.getKind() == AGGREGATE :
             "only window and aggregate functions are allowed to be modelled over a window";
         this.windowDefinition = windowDefinition;
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.tablefunctions;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -43,34 +41,28 @@ public class EmptyRowTableFunction {
     public static void register(TableFunctionModule module) {
         module.register(
             Signature.table(NAME, RowType.EMPTY.getTypeSignature()),
-            (signature, argTypes) -> new EmptyRowTableFunctionImplementation(
-                signature,
-                new FunctionInfo(
-                    new FunctionIdent(NAME, argTypes),
-                    RowType.EMPTY,
-                    FunctionInfo.Type.TABLE)
-            )
+            EmptyRowTableFunctionImplementation::new
         );
     }
 
     static class EmptyRowTableFunctionImplementation extends TableFunctionImplementation<Object> {
 
-        private final FunctionInfo info;
         private final Signature signature;
+        private final Signature boundSignature;
 
-        private EmptyRowTableFunctionImplementation(Signature signature, FunctionInfo info) {
-            this.info = info;
+        private EmptyRowTableFunctionImplementation(Signature signature, Signature boundSignature) {
             this.signature = signature;
-        }
-
-        @Override
-        public FunctionInfo info() {
-            return info;
+            this.boundSignature = boundSignature;
         }
 
         @Override
         public Signature signature() {
             return signature;
+        }
+
+        @Override
+        public Signature boundSignature() {
+            return boundSignature;
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -25,8 +25,6 @@ package io.crate.expression.tablefunctions;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -54,24 +52,19 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
 
         module.register(
             Signature.table(
-                FUNCTION_NAME, RETURN_TYPE.getTypeSignature()),
-            (signature, argTypes) -> new PgGetKeywordsFunction(
-                signature,
-                new FunctionInfo(
-                    new FunctionIdent(FUNCTION_NAME, argTypes),
-                    RETURN_TYPE,
-                    FunctionInfo.Type.TABLE
-                )
-            )
+                FUNCTION_NAME,
+                RETURN_TYPE.getTypeSignature()
+            ),
+            PgGetKeywordsFunction::new
         );
     }
 
     private final Signature signature;
-    private final FunctionInfo info;
+    private final Signature boundSignature;
 
-    public PgGetKeywordsFunction(Signature signature, FunctionInfo info) {
+    public PgGetKeywordsFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
-        this.info = info;
+        this.boundSignature = boundSignature;
     }
 
     @Override
@@ -98,13 +91,13 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
     }
 
     @Override
-    public FunctionInfo info() {
-        return info;
+    public Signature signature() {
+        return signature;
     }
 
     @Override
-    public Signature signature() {
-        return signature;
+    public Signature boundSignature() {
+        return boundSignature;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -24,8 +24,6 @@ package io.crate.expression.tablefunctions;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -59,13 +57,15 @@ public class ValuesFunction {
 
     private static class ValuesTableFunctionImplementation extends TableFunctionImplementation<List<Object>> {
 
-        private final FunctionInfo info;
         private final RowType returnType;
         private final Signature signature;
+        private final Signature boundSignature;
 
         private ValuesTableFunctionImplementation(Signature signature,
-                                                  List<DataType<?>> argTypes) {
+                                                  Signature boundSignature) {
             this.signature = signature;
+            this.boundSignature = boundSignature;
+            var argTypes = boundSignature.getArgumentDataTypes();
             ArrayList<DataType<?>> fieldTypes = new ArrayList<>(argTypes.size());
             for (int i = 0; i < argTypes.size(); i++) {
                 DataType<?> dataType = argTypes.get(i);
@@ -74,23 +74,16 @@ public class ValuesFunction {
                 fieldTypes.add(((ArrayType<?>) dataType).innerType());
             }
             returnType = new RowType(fieldTypes);
-            this.info = new FunctionInfo(
-                new FunctionIdent(NAME, argTypes),
-                returnType.numElements() == 1
-                    ? returnType.getFieldType(0)
-                    : returnType,
-                FunctionInfo.Type.TABLE
-            );
-        }
-
-        @Override
-        public FunctionInfo info() {
-            return info;
         }
 
         @Override
         public Signature signature() {
             return signature;
+        }
+
+        @Override
+        public Signature boundSignature() {
+            return boundSignature;
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -27,8 +27,8 @@ import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.metadata.FunctionProvider;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -222,7 +222,7 @@ public class UserDefinedFunctionService {
         var functionName = new FunctionName(udf.schema(), udf.name());
         var signature = Signature.builder()
             .name(functionName)
-            .kind(FunctionInfo.Type.SCALAR)
+            .kind(FunctionType.SCALAR)
             .argumentTypes(
                 Lists2.map(
                     udf.argumentTypes(),

--- a/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
+++ b/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
@@ -58,7 +58,7 @@ abstract class AbstractAnyQuery implements FunctionToQuery {
 
         if (DataTypes.isArray(left.valueType())) {
             throw new UnsupportedFeatureException(
-                "Cannot use " + function.info().ident().name() + " when the left side is an array");
+                "Cannot use " + function.name() + " when the left side is an array");
         }
         if (left.symbolType().isValueSymbol()) {
             // 1 = any (array_col) - simple eq

--- a/server/src/main/java/io/crate/lucene/ArrayLengthQuery.java
+++ b/server/src/main/java/io/crate/lucene/ArrayLengthQuery.java
@@ -91,7 +91,7 @@ public final class ArrayLengthQuery implements InnerFunctionToQuery {
     @Nullable
     @Override
     public Query apply(Function parent, Function arrayLength, LuceneQueryBuilder.Context context) {
-        String parentName = parent.info().ident().name();
+        String parentName = parent.name();
         if (!Operators.COMPARISON_OPERATORS.contains(parentName)) {
             return null;
         }

--- a/server/src/main/java/io/crate/lucene/DistanceQuery.java
+++ b/server/src/main/java/io/crate/lucene/DistanceQuery.java
@@ -52,7 +52,7 @@ class DistanceQuery implements InnerFunctionToQuery {
      */
     @Override
     public Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) {
-        assert inner.info().ident().name().equals(DistanceFunction.NAME) :
+        assert inner.name().equals(DistanceFunction.NAME) :
             "function must be " + DistanceFunction.NAME;
 
         RefAndLiteral distanceRefLiteral = RefAndLiteral.of(inner);

--- a/server/src/main/java/io/crate/lucene/FunctionLiteralPair.java
+++ b/server/src/main/java/io/crate/lucene/FunctionLiteralPair.java
@@ -37,7 +37,7 @@ class FunctionLiteralPair {
         Symbol left = outerFunction.arguments().get(0);
         Symbol right = outerFunction.arguments().get(1);
 
-        functionName = outerFunction.info().ident().name();
+        functionName = outerFunction.name();
 
         if (left instanceof Function) {
             function = (Function) left;

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -87,7 +87,7 @@ class GenericFunctionQuery extends Query {
         return new Weight(this) {
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                if (SymbolVisitors.any(s -> s instanceof Function && !((Function) s).info().isDeterministic(), function)) {
+                if (SymbolVisitors.any(s -> s instanceof Function && !((Function) s).isDeterministic(), function)) {
                     return false;
                 }
                 var fields = new ArrayList<String>();

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -398,9 +398,9 @@ public class LuceneQueryBuilder {
                     Reference ref = (Reference) left;
                     if (ref.column().equals(DocSysColumns.UID)) {
                         return new Function(
-                            function.info(),
                             function.signature(),
-                            List.of(DocSysColumns.forTable(ref.ident().tableIdent(), DocSysColumns.ID), right)
+                            List.of(DocSysColumns.forTable(ref.ident().tableIdent(), DocSysColumns.ID), right),
+                            function.valueType()
                         );
                     } else {
                         String unsupportedMessage = context.unsupportedMessage(ref.column().name());

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -327,7 +327,7 @@ public class LuceneQueryBuilder {
             }
             function = rewriteAndValidateFields(function, context);
 
-            FunctionToQuery toQuery = functions.get(function.info().ident().name());
+            FunctionToQuery toQuery = functions.get(function.name());
             if (toQuery == null) {
                 return genericFunctionFilter(function, context);
             }
@@ -352,7 +352,7 @@ public class LuceneQueryBuilder {
         private Query queryFromInnerFunction(Function function, Context context) {
             for (Symbol symbol : function.arguments()) {
                 if (symbol.symbolType() == SymbolType.FUNCTION) {
-                    String functionName = ((Function) symbol).info().ident().name();
+                    String functionName = ((Function) symbol).name();
                     InnerFunctionToQuery functionToQuery = innerFunctions.get(functionName);
                     if (functionToQuery != null) {
                         try {

--- a/server/src/main/java/io/crate/lucene/NotQuery.java
+++ b/server/src/main/java/io/crate/lucene/NotQuery.java
@@ -31,6 +31,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.metadata.Reference;
+import io.crate.types.DataTypes;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
@@ -149,9 +150,10 @@ final class NotQuery implements FunctionToQuery {
         }
         if (ctx.hasStrictThreeValuedLogicFunction) {
             Function isNullFunction = new Function(
-                IsNullPredicate.generateInfo(Collections.singletonList(arg.valueType())),
                 IsNullPredicate.SIGNATURE,
-                Collections.singletonList(arg));
+                Collections.singletonList(arg),
+                DataTypes.BOOLEAN
+            );
             builder.add(
                 Queries.not(LuceneQueryBuilder.genericFunctionFilter(isNullFunction, context)),
                 BooleanClause.Occur.MUST

--- a/server/src/main/java/io/crate/lucene/NotQuery.java
+++ b/server/src/main/java/io/crate/lucene/NotQuery.java
@@ -94,7 +94,7 @@ final class NotQuery implements FunctionToQuery {
 
         @Override
         public Void visitFunction(Function function, SymbolToNotNullContext context) {
-            String functionName = function.info().ident().name();
+            String functionName = function.name();
             if (Ignore3vlFunction.NAME.equals(functionName)) {
                 return null;
             }
@@ -124,7 +124,7 @@ final class NotQuery implements FunctionToQuery {
         Symbol arg = input.arguments().get(0);
 
         // Optimize `NOT (<ref> IS NULL)`
-        if (arg instanceof Function && ((Function) arg).info().ident().name().equals(IsNullPredicate.NAME)) {
+        if (arg instanceof Function && ((Function) arg).name().equals(IsNullPredicate.NAME)) {
             Function innerFunction = (Function) arg;
             if (innerFunction.arguments().size() == 1 && innerFunction.arguments().get(0) instanceof Reference) {
                 return ExistsQueryBuilder.newFilter(

--- a/server/src/main/java/io/crate/lucene/SubscriptQuery.java
+++ b/server/src/main/java/io/crate/lucene/SubscriptQuery.java
@@ -67,7 +67,7 @@ class SubscriptQuery implements InnerFunctionToQuery {
     @Nullable
     @Override
     public Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) throws IOException {
-        assert inner.info().ident().name().equals(SubscriptFunction.NAME) :
+        assert inner.name().equals(SubscriptFunction.NAME) :
             "function must be " + SubscriptFunction.NAME;
 
         RefAndLiteral innerPair = RefAndLiteral.of(inner);
@@ -78,7 +78,7 @@ class SubscriptQuery implements InnerFunctionToQuery {
 
         if (DataTypes.isArray(innerPair.reference().valueType())) {
             PreFilterQueryBuilder preFilterQueryBuilder =
-                PRE_FILTER_QUERY_BUILDER_BY_OP.get(parent.info().ident().name());
+                PRE_FILTER_QUERY_BUILDER_BY_OP.get(parent.name());
             if (preFilterQueryBuilder == null) {
                 return null;
             }

--- a/server/src/main/java/io/crate/metadata/FunctionIdent.java
+++ b/server/src/main/java/io/crate/metadata/FunctionIdent.java
@@ -24,17 +24,20 @@ package io.crate.metadata;
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated Use {@link Signature} instead. Exists only for BWC and will be removed with the next major version
+ */
 public final class FunctionIdent implements Comparable<FunctionIdent>, Writeable {
 
     private final FunctionName fqnName;
@@ -43,14 +46,6 @@ public final class FunctionIdent implements Comparable<FunctionIdent>, Writeable
     public FunctionIdent(FunctionName functionName, List<DataType<?>> argumentTypes) {
         this.fqnName = functionName;
         this.argumentTypes = argumentTypes;
-    }
-
-    public FunctionIdent(@Nullable String schema, String name, List<DataType<?>> argumentTypes) {
-        this(new FunctionName(schema, name), argumentTypes);
-    }
-
-    public FunctionIdent(String name, List<DataType<?>> argumentTypes) {
-        this(null, name, argumentTypes);
     }
 
     public List<DataType<?>> argumentTypes() {

--- a/server/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/server/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -33,15 +33,29 @@ import javax.annotation.Nullable;
 public interface FunctionImplementation {
 
     /**
+     * @deprecated Use {@link #signature()} instead. Will be removed with next major version.
+     *
      * Provides meta information about this function implementation.
      */
-    FunctionInfo info();
+    default FunctionInfo info() {
+        return FunctionInfo.of(boundSignature());
+    }
 
     /**
      * Return the declared signature for this implementation.
-     * This should be favoured over {@link #info()}.
+     * All function implementations are registered under their declared signature, thus function symbols must
+     * carry the declared signature in order to look up each implementation for execution.
      */
     Signature signature();
+
+    /**
+     * Return the bound signature for this implementation.
+     * This signature has all actual argument types bound, possible type variables of the declared signature are
+     * replaced.
+     *
+     * Bound argument and return types are required by function symbols.
+     */
+    Signature boundSignature();
 
     /**
      * Normalize a symbol into a simplified form.

--- a/server/src/main/java/io/crate/metadata/FunctionProvider.java
+++ b/server/src/main/java/io/crate/metadata/FunctionProvider.java
@@ -23,18 +23,16 @@
 package io.crate.metadata;
 
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
 
-import java.util.List;
 import java.util.function.BiFunction;
 
 public class FunctionProvider {
 
     private final Signature signature;
-    private final BiFunction<Signature, List<DataType<?>>, FunctionImplementation> factory;
+    private final BiFunction<Signature, Signature, FunctionImplementation> factory;
 
     public FunctionProvider(Signature signature,
-                            BiFunction<Signature, List<DataType<?>>, FunctionImplementation> factory) {
+                            BiFunction<Signature, Signature, FunctionImplementation> factory) {
         this.signature = signature;
         this.factory = factory;
     }
@@ -43,7 +41,7 @@ public class FunctionProvider {
         return signature;
     }
 
-    public BiFunction<Signature, List<DataType<?>>, FunctionImplementation> getFactory() {
+    public BiFunction<Signature, Signature, FunctionImplementation> getFactory() {
         return factory;
     }
 

--- a/server/src/main/java/io/crate/metadata/FunctionType.java
+++ b/server/src/main/java/io/crate/metadata/FunctionType.java
@@ -20,31 +20,11 @@
  * agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.metadata;
 
-import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.scalar.UnaryScalar;
-import io.crate.types.DataTypes;
-
-import static io.crate.metadata.functions.Signature.scalar;
-
-public class ExpFunction {
-
-    public static final String NAME = "exp";
-
-    public static void register(ScalarFunctionModule module) {
-        for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
-            var typeSignature = type.getTypeSignature();
-            module.register(
-                scalar(NAME, typeSignature, typeSignature),
-                (declaredSignature, boundSignature) ->
-                    new UnaryScalar<>(
-                        declaredSignature,
-                        boundSignature,
-                        type,
-                        x -> type.value(Math.exp(((Number) x).doubleValue()))
-                    )
-            );
-        }
-    }
+public enum FunctionType {
+    SCALAR,
+    AGGREGATE,
+    TABLE,
+    WINDOW
 }

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -27,7 +27,9 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Base class for Scalar functions in crate.
@@ -37,7 +39,7 @@ import java.util.List;
  * </p>
  *
  * <p>
- *     Usually functions are registered as deterministic (See {@link io.crate.metadata.FunctionInfo.Feature}.
+ *     Usually functions are registered as deterministic (See {@link Feature}.
  *     If this is the case the function must be a pure function. Meaning that given the same input it must always produce
  *     the same output.
  *
@@ -58,6 +60,11 @@ import java.util.List;
  * @param <ReturnType> the class of the returned value
  */
 public abstract class Scalar<ReturnType, InputType> implements FunctionImplementation {
+
+    public static final Set<Feature> NO_FEATURES = Set.of();
+    public static final Set<Feature> DETERMINISTIC_ONLY = EnumSet.of(Feature.DETERMINISTIC);
+    public static final Set<Feature> DETERMINISTIC_AND_COMPARISON_REPLACEMENT = EnumSet.of(
+        Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT);
 
     /**
      * Evaluate the function using the provided arguments
@@ -117,5 +124,79 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
         }
         //noinspection unchecked
         return Literal.ofUnchecked(function.info().returnType(), scalar.evaluate(txnCtx, inputs));
+    }
+
+    public enum Feature {
+        DETERMINISTIC,
+        /**
+         * If this feature is set, for this function it is possible to replace the containing
+         * comparison while preserving the truth value for all used operators
+         * with or without an operator mapping.
+         * <p>
+         * It describes the following:
+         * <p>
+         * say we have a comparison-query like this:
+         * <p>
+         * col > 10.5
+         * <p>
+         * then a function f, for which comparisons are replaceable, can be applied so
+         * that:
+         * <p>
+         * f(col) > f(10.5)
+         * <p>
+         * for all col for which col > 10.5 is true. Maybe > needs to be mapped to another
+         * operator, but this may not depend on the actual values used here.
+         * <p>
+         * Fun facts:
+         * <p>
+         * * This property holds for the = comparison operator for all functions f.
+         * * This property is transitive so if f and g are replaceable,
+         * then f(g(x)) also is
+         * * it is possible to replace:
+         * <p>
+         * col > 10.5
+         * <p>
+         * with:
+         * <p>
+         * f(col) > f(10.5)
+         * <p>
+         * for every operator (possibly mapped) and the query is still equivalent.
+         * <p>
+         * Example 1:
+         * <p>
+         * if f is defined as f(v) = v + 1
+         * then col + 1 > 11.5 must be true for all col > 10.5.
+         * This is indeed true.
+         * <p>
+         * So f is replaceable for >.
+         * <p>
+         * Fun fact: for f all comparison operators =, >, <, >=,<= are replaceable
+         * <p>
+         * Example 2 (a rounding function):
+         * <p>
+         * if f is defined as f(v) = ceil(v)
+         * then ceil(col) > 11 for all col > 10.5.
+         * But there is 10.8 for which f is 11 and
+         * 11 > 11 is false.
+         * <p>
+         * Here a simple mapping of the operator will do the trick:
+         * <p>
+         * > -> >=
+         * < -> <=
+         * <p>
+         * So for f comparisons are replaceable using the mapping above.
+         * <p>
+         * Example 3:
+         * <p>
+         * if f is defined as f(v) = v % 5
+         * then col % 5 > 0.5 for all col > 10.5
+         * but there is 20 for which
+         * f is 0 and
+         * 0 > 0.5 is false.
+         * <p>
+         * So for f comparisons cannot be replaced.
+         */
+        COMPARISON_REPLACEMENT,
+        LAZY_ATTRIBUTES
     }
 }

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -123,7 +123,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             idx++;
         }
         //noinspection unchecked
-        return Literal.ofUnchecked(function.info().returnType(), scalar.evaluate(txnCtx, inputs));
+        return Literal.ofUnchecked(function.valueType(), scalar.evaluate(txnCtx, inputs));
     }
 
     public enum Feature {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -38,8 +38,8 @@ import io.crate.types.TypeSignature;
 import java.util.ArrayList;
 import java.util.Set;
 
-import static io.crate.metadata.FunctionInfo.Type.AGGREGATE;
-import static io.crate.metadata.FunctionInfo.Type.WINDOW;
+import static io.crate.metadata.FunctionType.AGGREGATE;
+import static io.crate.metadata.FunctionType.WINDOW;
 import static io.crate.metadata.pgcatalog.PgProcTable.Entry.pgTypeIdFrom;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.FLOAT;

--- a/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
+++ b/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
@@ -77,7 +77,7 @@ public class OrderByWithAggregationValidator {
             if (context.isDistinct) {
                 throw new UnsupportedOperationException(Symbols.format(INVALID_FIELD_IN_DISTINCT_TEMPLATE, symbol));
             }
-            if (symbol.info().type() == FunctionType.SCALAR) {
+            if (symbol.type() == FunctionType.SCALAR) {
                 for (Symbol arg : symbol.arguments()) {
                     arg.accept(this, context);
                 }

--- a/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
+++ b/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
@@ -27,7 +27,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 
 import java.util.Collection;
@@ -77,7 +77,7 @@ public class OrderByWithAggregationValidator {
             if (context.isDistinct) {
                 throw new UnsupportedOperationException(Symbols.format(INVALID_FIELD_IN_DISTINCT_TEMPLATE, symbol));
             }
-            if (symbol.info().type() == FunctionInfo.Type.SCALAR) {
+            if (symbol.info().type() == FunctionType.SCALAR) {
                 for (Symbol arg : symbol.arguments()) {
                     arg.accept(this, context);
                 }

--- a/server/src/main/java/io/crate/planner/operators/EnsureNoMatchPredicate.java
+++ b/server/src/main/java/io/crate/planner/operators/EnsureNoMatchPredicate.java
@@ -46,7 +46,7 @@ public final class EnsureNoMatchPredicate extends SymbolVisitor<String, Void> {
 
     @Override
     public Void visitFunction(Function symbol, String errorMsg) {
-        if (symbol.info().ident().name().equals(MatchPredicate.NAME)) {
+        if (symbol.name().equals(MatchPredicate.NAME)) {
             throw new UnsupportedFeatureException(errorMsg);
         }
         for (Symbol argument : symbol.arguments()) {

--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -75,7 +75,7 @@ public class EquiJoinDetector {
 
         @Override
         public Void visitFunction(Function function, Context context) {
-            String functionName = function.info().ident().name();
+            String functionName = function.name();
             switch (functionName) {
                 case AndOperator.NAME:
                     for (Symbol arg : function.arguments()) {

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -212,7 +212,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         @Override
         public Void visitFunction(Function symbol, OutputValidatorContext context) {
             context.insideAggregation =
-                context.insideAggregation || symbol.info().type().equals(FunctionType.AGGREGATE);
+                context.insideAggregation || symbol.type().equals(FunctionType.AGGREGATE);
             for (Symbol argument : symbol.arguments()) {
                 argument.accept(this, context);
             }

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
@@ -84,14 +84,33 @@ public class HashAggregate extends ForwardingLogicalPlan {
         }
         if (ExecutionPhases.executesOnHandler(plannerContext.handlerNode(), executionPlan.resultDescription().nodeIds())) {
             if (source.preferShardProjections()) {
-                executionPlan.addProjection(projectionBuilder.aggregationProjection(
-                    sourceOutputs, boundAggregates, AggregateMode.ITER_PARTIAL, RowGranularity.SHARD));
-                executionPlan.addProjection(projectionBuilder.aggregationProjection(
-                    boundAggregates, boundAggregates, AggregateMode.PARTIAL_FINAL, RowGranularity.CLUSTER));
+                executionPlan.addProjection(
+                    projectionBuilder.aggregationProjection(
+                        sourceOutputs,
+                        boundAggregates,
+                        AggregateMode.ITER_PARTIAL,
+                        RowGranularity.SHARD,
+                        plannerContext.transactionContext().sessionContext().searchPath()
+                    )
+                );
+                executionPlan.addProjection(
+                    projectionBuilder.aggregationProjection(
+                        boundAggregates,
+                        boundAggregates,
+                        AggregateMode.PARTIAL_FINAL,
+                        RowGranularity.CLUSTER,
+                        plannerContext.transactionContext().sessionContext().searchPath()
+                    )
+                );
                 return executionPlan;
             }
             AggregationProjection fullAggregation = projectionBuilder.aggregationProjection(
-                sourceOutputs, boundAggregates, AggregateMode.ITER_FINAL, RowGranularity.CLUSTER);
+                sourceOutputs,
+                boundAggregates,
+                AggregateMode.ITER_FINAL,
+                RowGranularity.CLUSTER,
+                plannerContext.transactionContext().sessionContext().searchPath()
+            );
             executionPlan.addProjection(fullAggregation);
             return executionPlan;
         }
@@ -99,7 +118,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
             sourceOutputs,
             boundAggregates,
             AggregateMode.ITER_PARTIAL,
-            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE
+            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE,
+            plannerContext.transactionContext().sessionContext().searchPath()
         );
         executionPlan.addProjection(toPartial);
 
@@ -107,7 +127,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
             boundAggregates,
             boundAggregates,
             AggregateMode.PARTIAL_FINAL,
-            RowGranularity.CLUSTER
+            RowGranularity.CLUSTER,
+            plannerContext.transactionContext().sessionContext().searchPath()
         );
         return new Merge(
             executionPlan,
@@ -191,7 +212,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         @Override
         public Void visitFunction(Function symbol, OutputValidatorContext context) {
             context.insideAggregation =
-                context.insideAggregation || symbol.info().type().equals(FunctionInfo.Type.AGGREGATE);
+                context.insideAggregation || symbol.info().type().equals(FunctionType.AGGREGATE);
             for (Symbol argument : symbol.arguments()) {
                 argument.accept(this, context);
             }

--- a/server/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
@@ -83,7 +83,7 @@ public final class HashJoinConditionSymbolsExtractor {
 
         @Override
         public Void visitFunction(Function function, Context context) {
-            String functionName = function.info().ident().name();
+            String functionName = function.name();
             switch (functionName) {
                 case AndOperator.NAME:
                     return super.visitFunction(function, context);

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -69,7 +69,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              Functions functions) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
-        if (relation.function().info().ident().name().equals(ValuesFunction.NAME)) {
+        if (relation.function().name().equals(ValuesFunction.NAME)) {
             return new InsertFromValues(tableFunction.relation(), plan.columnIndexWriterProjection());
         } else {
             return null;

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -164,7 +164,7 @@ public final class TableFunction implements LogicalPlan {
     public void print(PrintContext printContext) {
         printContext
             .text("TableFunction[")
-            .text(relation.function().info().ident().name())
+            .text(relation.function().name())
             .text(" | [")
             .text(Lists2.joinOn(", ", toCollect, Symbol::toString))
             .text("] | ")

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -52,7 +52,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                 .with(collect -> collect.relation().tableInfo() instanceof DocTableInfo))
             .with(aggregate ->
                 aggregate.aggregates().size() == 1
-                && aggregate.aggregates().get(0).info().equals(CountAggregation.COUNT_STAR_FUNCTION));
+                && aggregate.aggregates().get(0).signature().equals(CountAggregation.COUNT_STAR_SIGNATURE));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -26,7 +26,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
@@ -135,6 +135,6 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     }
 
     private static boolean isAggregate(Symbol s) {
-        return s instanceof Function && ((Function) s).info().type() == FunctionInfo.Type.AGGREGATE;
+        return s instanceof Function && ((Function) s).info().type() == FunctionType.AGGREGATE;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -135,6 +135,6 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     }
 
     private static boolean isAggregate(Symbol s) {
-        return s instanceof Function && ((Function) s).info().type() == FunctionType.AGGREGATE;
+        return s instanceof Function && ((Function) s).type() == FunctionType.AGGREGATE;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -105,6 +105,6 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     }
 
     private static boolean isTableFunction(Symbol s) {
-        return s instanceof Function && ((Function) s).info().type() == FunctionType.TABLE;
+        return s instanceof Function && ((Function) s).type() == FunctionType.TABLE;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -26,7 +26,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
@@ -105,6 +105,6 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     }
 
     private static boolean isTableFunction(Symbol s) {
-        return s instanceof Function && ((Function) s).info().type() == FunctionInfo.Type.TABLE;
+        return s instanceof Function && ((Function) s).info().type() == FunctionType.TABLE;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -52,13 +52,13 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
         this.functionResolver = functionResolver;
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> COMPARISON_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
                 .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
-                    .with(f -> f.info().ident().name().equals(ArrayUpperFunction.ARRAY_LENGTH)
-                               || f.info().ident().name().equals(ArrayUpperFunction.ARRAY_UPPER))
+                    .with(f -> f.name().equals(ArrayUpperFunction.ARRAY_LENGTH)
+                               || f.name().equals(ArrayUpperFunction.ARRAY_UPPER))
                     .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
                 )
             );
@@ -79,7 +79,7 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
         DataType<?> targetType = function.valueType();
 
         return functionResolver.apply(
-            operator.info().ident().name(),
+            operator.name(),
             List.of(function, literal.cast(targetType))
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
@@ -61,10 +61,10 @@ public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Funct
         this.functionResolver = functionResolver;
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> MATCHING_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> MATCHING_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );
     }
@@ -84,7 +84,7 @@ public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Funct
         DataType<?> targetType = reference.valueType();
 
         return functionResolver.apply(
-            operator.info().ident().name(),
+            operator.name(),
             List.of(reference, literal.cast(targetType))
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
@@ -52,10 +52,10 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
         this.functionResolver = functionResolver;
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.info().ident().name()))
+            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );
     }
@@ -75,7 +75,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
         DataType<?> targetType = new ArrayType<>(reference.valueType());
 
         return functionResolver.apply(
-            operator.info().ident().name(),
+            operator.name(),
             List.of(reference, literal.cast(targetType))
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -52,10 +52,10 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
         this.functionResolver = functionResolver;
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.info().ident().name()))
+            .with(f -> AnyOperators.OPERATOR_NAMES.contains(f.name()))
             .with(f -> f.arguments().get(0).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(1)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );
     }
@@ -78,7 +78,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
         }
         targetType = ((ArrayType<?>) targetType).innerType();
 
-        var operatorName = operator.info().ident().name();
+        var operatorName = operator.name();
         if (List.of(AnyOperators.Type.EQ.opName(), AnyOperators.Type.NEQ.opName()).contains(operatorName) == false
             && literal.valueType().id() == ArrayType.ID) {
             // this is not supported and will fail later on with more verbose error than a cast error
@@ -86,7 +86,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
         }
 
         return functionResolver.apply(
-            operator.info().ident().name(),
+            operator.name(),
             List.of(literal.cast(targetType), reference)
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -52,12 +52,12 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
         this.functionResolver = functionResolver;
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> COMPARISON_OPERATORS.contains(f.info().ident().name()))
+            .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.info().ident().name()))
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
                 .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
-                    .with(f -> f.info().ident().name().equals(SubscriptFunction.NAME))
+                    .with(f -> f.name().equals(SubscriptFunction.NAME))
                     .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
                 )
             );
@@ -78,7 +78,7 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
         DataType<?> targetType = subscript.valueType();
 
         return functionResolver.apply(
-            operator.info().ident().name(),
+            operator.name(),
             List.of(subscript, literal.cast(targetType))
         );
     }

--- a/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
+++ b/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
@@ -94,7 +94,7 @@ public class SelectivityFunctions {
 
         @Override
         public Double visitFunction(Function function, Void context) {
-            switch (function.info().ident().name()) {
+            switch (function.name()) {
                 case AndOperator.NAME: {
                     double selectivity = 1.0;
                     for (Symbol argument : function.arguments()) {

--- a/server/src/main/java/io/crate/types/ParameterTypeSignature.java
+++ b/server/src/main/java/io/crate/types/ParameterTypeSignature.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-final class ParameterTypeSignature extends TypeSignature {
+public final class ParameterTypeSignature extends TypeSignature {
 
     private final String parameterName;
 

--- a/server/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/server/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -71,9 +71,9 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         Reference load_1 = dummyLoadInfo;
         Literal<Double> d01 = Literal.of(0.08);
         Function load_eq_01 = new Function(
-            functionInfo(EqOperator.SIGNATURE, DataTypes.DOUBLE),
             EqOperator.SIGNATURE,
-            List.of(load_1, d01)
+            List.of(load_1, d01),
+            EqOperator.RETURN_TYPE
         );
 
         Symbol name_ref = new Reference(
@@ -87,36 +87,39 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         Symbol y_literal = Literal.of("y");
 
         Function name_eq_x = new Function(
-            functionInfo(EqOperator.SIGNATURE, DataTypes.STRING),
             EqOperator.SIGNATURE,
-            List.of(name_ref, x_literal)
+            List.of(name_ref, x_literal),
+            EqOperator.RETURN_TYPE
         );
 
         Function nameNeqX = new Function(
-            functionInfo(NotPredicate.SIGNATURE, DataTypes.BOOLEAN),
             NotPredicate.SIGNATURE,
-            Collections.singletonList(name_eq_x));
+            Collections.singletonList(name_eq_x),
+            NotPredicate.SIGNATURE.getReturnType().createType()
+        );
 
         Function name_eq_y = new Function(
-            functionInfo(EqOperator.SIGNATURE, DataTypes.STRING),
             EqOperator.SIGNATURE,
-            List.of(name_ref, y_literal));
+            List.of(name_ref, y_literal),
+            EqOperator.RETURN_TYPE
+        );
 
         Function nameNeqY = new Function(
-            functionInfo(NotPredicate.SIGNATURE, DataTypes.BOOLEAN),
             NotPredicate.SIGNATURE,
-            Collections.singletonList(name_eq_y));
+            Collections.singletonList(name_eq_y),
+            NotPredicate.SIGNATURE.getReturnType().createType()
+        );
 
         Function op_and = new Function(
-            functionInfo(AndOperator.SIGNATURE, DataTypes.BOOLEAN),
             AndOperator.SIGNATURE,
-            List.of(nameNeqX, nameNeqY)
+            List.of(nameNeqX, nameNeqY),
+            AndOperator.RETURN_TYPE
         );
 
         return new Function(
-            functionInfo(OrOperator.SIGNATURE, DataTypes.BOOLEAN),
             OrOperator.SIGNATURE,
-            List.of(load_eq_01, op_and)
+            List.of(load_eq_01, op_and),
+            OrOperator.RETURN_TYPE
         );
     }
 
@@ -139,9 +142,5 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         Function op_or = prepareFunctionTree();
         Symbol query = visitor.normalize(op_or, coordinatorTxnCtx);
         assertThat(query, instanceOf(Function.class));
-    }
-
-    private FunctionInfo functionInfo(Signature signature, DataType dataType) {
-        return functions.getQualified(signature, List.of(dataType, dataType)).info();
     }
 }

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -406,7 +406,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                                             "group by name having 1=0 or sum(bytes) in (42, 43, 44) and name not like 'Slartibart%'");
         Function andFunction = (Function) relation.having();
         assertThat(andFunction, is(notNullValue()));
-        assertThat(andFunction.info().ident().name(), is("op_and"));
+        assertThat(andFunction.signature().getName().name(), is("op_and"));
         assertThat(andFunction.arguments().size(), is(2));
 
         assertThat(andFunction.arguments().get(0), isFunction("any_="));

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -120,10 +120,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze("select * from sys.nodes where id is not null");
         Function query = (Function) relation.where();
 
-        assertThat(query.info().ident().name(), is(NotPredicate.NAME));
+        assertThat(query.name(), is(NotPredicate.NAME));
         assertThat(query.arguments().get(0), instanceOf(Function.class));
         Function isNull = (Function) query.arguments().get(0);
-        assertThat(isNull.info().ident().name(), is(IsNullPredicate.NAME));
+        assertThat(isNull.name(), is(IsNullPredicate.NAME));
     }
 
     @Test
@@ -180,8 +180,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.groupBy().isEmpty(), is(true));
         assertThat(relation.outputs().size(), is(1));
         Function col1 = (Function) relation.outputs().get(0);
-        assertThat(col1.info().type(), is(FunctionType.AGGREGATE));
-        assertThat(col1.info().ident().name(), is(AverageAggregation.NAME));
+        assertThat(col1.signature().getKind(), is(FunctionType.AGGREGATE));
+        assertThat(col1.name(), is(AverageAggregation.NAME));
     }
 
     private List<String> outputNames(AnalyzedRelation relation) {
@@ -231,11 +231,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.groupBy().isEmpty(), is(true));
 
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
-        assertThat(whereClause.info().type() == FunctionType.AGGREGATE, is(false));
+        assertThat(whereClause.name(), is(OrOperator.NAME));
+        assertThat(whereClause.signature().getKind() == FunctionType.AGGREGATE, is(false));
 
         Function left = (Function) whereClause.arguments().get(0);
-        assertThat(left.info().ident().name(), is(EqOperator.NAME));
+        assertThat(left.name(), is(EqOperator.NAME));
 
         assertThat(left.arguments().get(0), isReference("load['1']"));
 
@@ -243,7 +243,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(left.arguments().get(1).valueType(), is(DataTypes.DOUBLE));
 
         Function right = (Function) whereClause.arguments().get(1);
-        assertThat(right.info().ident().name(), is(LteOperator.NAME));
+        assertThat(right.name(), is(LteOperator.NAME));
         assertThat(right.arguments().get(0), isReference("load['5']"));
         assertThat(right.arguments().get(1), IsInstanceOf.instanceOf(Literal.class));
         assertThat(left.arguments().get(1).valueType(), is(DataTypes.DOUBLE));
@@ -256,18 +256,18 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "where load['1'] = ? or load['5'] <= ? or load['15'] >= ? or load['1'] = ? " +
             "or load['1'] = ? or name = ?");
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
-        assertThat(whereClause.info().type() == FunctionType.AGGREGATE, is(false));
+        assertThat(whereClause.name(), is(OrOperator.NAME));
+        assertThat(whereClause.signature().getKind() == FunctionType.AGGREGATE, is(false));
 
         Function function = (Function) whereClause.arguments().get(0);
-        assertThat(function.info().ident().name(), is(OrOperator.NAME));
+        assertThat(function.name(), is(OrOperator.NAME));
         function = (Function) function.arguments().get(1);
-        assertThat(function.info().ident().name(), is(EqOperator.NAME));
+        assertThat(function.name(), is(EqOperator.NAME));
         assertThat(function.arguments().get(1), IsInstanceOf.instanceOf(ParameterSymbol.class));
         assertThat(function.arguments().get(1).valueType(), is(DataTypes.DOUBLE));
 
         function = (Function) whereClause.arguments().get(1);
-        assertThat(function.info().ident().name(), is(EqOperator.NAME));
+        assertThat(function.name(), is(EqOperator.NAME));
         assertThat(function.arguments().get(1), IsInstanceOf.instanceOf(ParameterSymbol.class));
         assertThat(function.arguments().get(1).valueType(), is(DataTypes.STRING));
     }
@@ -374,11 +374,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             QueriedSelectRelation relation = analyze(statement);
 
             Function notFunction = (Function) relation.where();
-            assertThat(notFunction.info().ident().name(), is(NotPredicate.NAME));
+            assertThat(notFunction.name(), is(NotPredicate.NAME));
             assertThat(notFunction.arguments().size(), is(1));
 
             Function eqFunction = (Function) notFunction.arguments().get(0);
-            assertThat(eqFunction.info().ident().name(), is(EqOperator.NAME));
+            assertThat(eqFunction.name(), is(EqOperator.NAME));
             assertThat(eqFunction.arguments().size(), is(2));
 
             List<Symbol> eqArguments = eqFunction.arguments();
@@ -392,11 +392,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze(statement);
 
         Function notFunction = (Function) relation.where();
-        assertThat(notFunction.info().ident().name(), is(NotPredicate.NAME));
+        assertThat(notFunction.name(), is(NotPredicate.NAME));
         assertThat(notFunction.arguments().size(), is(1));
 
         Function eqFunction = (Function) notFunction.arguments().get(0);
-        assertThat(eqFunction.info().ident().name(), is(RegexpMatchOperator.NAME));
+        assertThat(eqFunction.name(), is(RegexpMatchOperator.NAME));
         assertThat(eqFunction.arguments().size(), is(2));
 
         List<Symbol> eqArguments = eqFunction.arguments();
@@ -433,7 +433,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testWhereInSelect() throws Exception {
         QueriedSelectRelation relation = analyze("select load from sys.nodes where load['1'] in (1.0, 2.0, 4.0, 8.0, 16.0)");
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
+        assertThat(whereClause.name(), is(AnyOperators.Type.EQ.opName()));
     }
 
     @Test
@@ -477,7 +477,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(symbol, isFunction("collect_set"));
 
         Function collectSet = (Function) symbol;
-        assertThat(collectSet.info().type(), equalTo(FunctionType.AGGREGATE));
+        assertThat(collectSet.signature().getKind(), equalTo(FunctionType.AGGREGATE));
 
         assertThat(collectSet.arguments().size(), is(1));
         assertThat(collectSet.arguments().get(0), isReference("load['1']"));
@@ -546,9 +546,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         assertNotNull(relation.where());
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(LikeOperators.OP_LIKE));
+        assertThat(whereClause.name(), is(LikeOperators.OP_LIKE));
         ImmutableList<DataType> argumentTypes = ImmutableList.of(DataTypes.STRING, DataTypes.STRING);
-        assertEquals(argumentTypes, whereClause.info().ident().argumentTypes());
+        assertEquals(argumentTypes, Symbols.typeView(whereClause.arguments()));
 
         assertThat(whereClause.arguments().get(0), isReference("name"));
         assertThat(whereClause.arguments().get(1), isLiteral("foo"));
@@ -560,9 +560,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         assertNotNull(relation.where());
         Function whereClause = (Function) relation.where();
-        assertThat(whereClause.info().ident().name(), is(LikeOperators.OP_ILIKE));
+        assertThat(whereClause.name(), is(LikeOperators.OP_ILIKE));
         ImmutableList<DataType> argumentTypes = ImmutableList.of(DataTypes.STRING, DataTypes.STRING);
-        assertEquals(argumentTypes, whereClause.info().ident().argumentTypes());
+        assertEquals(argumentTypes, Symbols.typeView(whereClause.arguments()));
 
         assertThat(whereClause.arguments().get(0), isReference("name"));
         assertThat(whereClause.arguments().get(1), isLiteral("foo%"));
@@ -591,7 +591,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // check if the implicit cast of the pattern worked
         ImmutableList<DataType> argumentTypes = ImmutableList.of(DataTypes.STRING, DataTypes.STRING);
         Function whereClause = (Function) relation.where();
-        assertEquals(argumentTypes, whereClause.info().ident().argumentTypes());
+        assertEquals(argumentTypes, Symbols.typeView(whereClause.arguments()));
         assertThat(whereClause.arguments().get(1), IsInstanceOf.instanceOf(Literal.class));
         Literal stringLiteral = (Literal) whereClause.arguments().get(1);
         assertThat(stringLiteral.value(), is("1"));
@@ -614,7 +614,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze("select * from sys.nodes where name is null");
         Function isNullFunction = (Function) relation.where();
 
-        assertThat(isNullFunction.info().ident().name(), is(IsNullPredicate.NAME));
+        assertThat(isNullFunction.name(), is(IsNullPredicate.NAME));
         assertThat(isNullFunction.arguments().size(), is(1));
         assertThat(isNullFunction.arguments().get(0), isReference("name"));
         assertNotNull(relation.where());
@@ -635,7 +635,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testNotPredicate() {
         QueriedSelectRelation relation = analyze("select * from users where name not like 'foo%'");
-        assertThat(((Function) relation.where()).info().ident().name(), is(NotPredicate.NAME));
+        assertThat(((Function) relation.where()).name(), is(NotPredicate.NAME));
     }
 
     @Test
@@ -821,21 +821,21 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testArrayCompareAny() throws Exception {
         QueriedSelectRelation relation = analyze("select * from users where 0 = ANY (counters)");
 
-        FunctionInfo anyInfo = ((Function) relation.where()).info();
-        assertThat(anyInfo.ident().name(), is("any_="));
+        var func = (Function) relation.where();
+        assertThat(func.name(), is("any_="));
 
         relation = analyze("select * from users where 0 = ANY (counters)");
 
-        anyInfo = ((Function) relation.where()).info();
-        assertThat(anyInfo.ident().name(), is("any_="));
+        func = (Function) relation.where();
+        assertThat(func.name(), is("any_="));
     }
 
     @Test
     public void testArrayCompareAnyNeq() throws Exception {
         QueriedSelectRelation relation = analyze("select * from users where 4.3 != ANY (counters)");
 
-        FunctionInfo anyInfo = ((Function) relation.where()).info();
-        assertThat(anyInfo.ident().name(), is("any_<>"));
+        var func = (Function) relation.where();
+        assertThat(func.name(), is("any_<>"));
     }
 
     @Test
@@ -860,7 +860,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze(
             "select * from users where 5 = ANY (friends['id'])");
         Function anyFunction = (Function) relation.where();
-        assertThat(anyFunction.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
+        assertThat(anyFunction.name(), is(AnyOperators.Type.EQ.opName()));
         assertThat(anyFunction.arguments().get(1), isReference("friends['id']", new ArrayType<>(DataTypes.LONG)));
         assertThat(anyFunction.arguments().get(0), isLiteral(5L));
     }
@@ -933,7 +933,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testArithmeticPlus() throws Exception {
         AnalyzedRelation relation = analyze("select load['1'] + load['5'] from sys.nodes");
-        assertThat(((Function) relation.outputs().get(0)).info().ident().name(), is(ArithmeticFunctions.Names.ADD));
+        assertThat(((Function) relation.outputs().get(0)).name(), is(ArithmeticFunctions.Names.ADD));
     }
 
     @Test
@@ -955,7 +955,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAnyLike() throws Exception {
         QueriedSelectRelation relation = analyze("select * from users where 'awesome' LIKE ANY (tags)");
         Function query = (Function) relation.where();
-        assertThat(query.info().ident().name(), is("any_like"));
+        assertThat(query.name(), is("any_like"));
         assertThat(query.arguments().size(), is(2));
         assertThat(query.arguments().get(0), instanceOf(Literal.class));
         assertThat(query.arguments().get(0), isLiteral("awesome", DataTypes.STRING));
@@ -978,7 +978,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAnyNotLike() throws Exception {
         QueriedSelectRelation relation = analyze("select * from users where 'awesome' NOT LIKE ANY (tags)");
         Function query = (Function) relation.where();
-        assertThat(query.info().ident().name(), is("any_not_like"));
+        assertThat(query.name(), is("any_not_like"));
 
         assertThat(query.arguments().size(), is(2));
         assertThat(query.arguments().get(0), instanceOf(Literal.class));
@@ -1224,7 +1224,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         Function havingFunction = (Function) relation.having();
 
         // assert that the in was converted to or
-        assertThat(havingFunction.info().ident().name(), is(AnyOperators.Type.EQ.opName()));
+        assertThat(havingFunction.name(), is(AnyOperators.Type.EQ.opName()));
     }
 
     @Test
@@ -1303,7 +1303,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testRegexpMatch() throws Exception {
         QueriedSelectRelation relation = analyze("select * from users where name ~ '.*foo(bar)?'");
-        assertThat(((Function) relation.where()).info().ident().name(), is("op_~"));
+        assertThat(((Function) relation.where()).name(), is("op_~"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -55,6 +55,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.sql.parser.ParsingException;
@@ -179,7 +180,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.groupBy().isEmpty(), is(true));
         assertThat(relation.outputs().size(), is(1));
         Function col1 = (Function) relation.outputs().get(0);
-        assertThat(col1.info().type(), is(FunctionInfo.Type.AGGREGATE));
+        assertThat(col1.info().type(), is(FunctionType.AGGREGATE));
         assertThat(col1.info().ident().name(), is(AverageAggregation.NAME));
     }
 
@@ -231,7 +232,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         Function whereClause = (Function) relation.where();
         assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
-        assertThat(whereClause.info().type() == FunctionInfo.Type.AGGREGATE, is(false));
+        assertThat(whereClause.info().type() == FunctionType.AGGREGATE, is(false));
 
         Function left = (Function) whereClause.arguments().get(0);
         assertThat(left.info().ident().name(), is(EqOperator.NAME));
@@ -256,7 +257,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "or load['1'] = ? or name = ?");
         Function whereClause = (Function) relation.where();
         assertThat(whereClause.info().ident().name(), is(OrOperator.NAME));
-        assertThat(whereClause.info().type() == FunctionInfo.Type.AGGREGATE, is(false));
+        assertThat(whereClause.info().type() == FunctionType.AGGREGATE, is(false));
 
         Function function = (Function) whereClause.arguments().get(0);
         assertThat(function.info().ident().name(), is(OrOperator.NAME));
@@ -476,7 +477,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(symbol, isFunction("collect_set"));
 
         Function collectSet = (Function) symbol;
-        assertThat(collectSet.info().type(), equalTo(FunctionInfo.Type.AGGREGATE));
+        assertThat(collectSet.info().type(), equalTo(FunctionType.AGGREGATE));
 
         assertThat(collectSet.arguments().size(), is(1));
         assertThat(collectSet.arguments().get(0), isReference("load['1']"));

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -228,7 +228,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testSwapFunctionLeftSide() throws Exception {
         Function cmp = (Function) expressions.normalize(executor.asSymbol("8 + 5 > t1.x"));
         // the comparison was swapped so the field is on the left side
-        assertThat(cmp.info().ident().name(), is("op_<"));
+        assertThat(cmp.name(), is("op_<"));
         assertThat(cmp.arguments().get(0), isReference("x"));
     }
 

--- a/server/src/test/java/io/crate/execution/dsl/projection/FilterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/FilterProjectionTest.java
@@ -24,8 +24,6 @@ package io.crate.execution.dsl.projection;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -41,15 +39,12 @@ public class FilterProjectionTest extends CrateUnitTest {
     @Test
     public void testStreaming() throws Exception {
         var eqFunction =  new Function(
-            new FunctionInfo(
-                new FunctionIdent(EqOperator.NAME, List.of(DataTypes.INTEGER, DataTypes.INTEGER)),
-                DataTypes.BOOLEAN
-            ),
             EqOperator.SIGNATURE,
             List.of(
                 new InputColumn(0, DataTypes.INTEGER),
                 new InputColumn(1, DataTypes.INTEGER)
-            )
+            ),
+            EqOperator.RETURN_TYPE
         );
 
         FilterProjection p = new FilterProjection(

--- a/server/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
@@ -64,9 +64,8 @@ public class GroupProjectionTest extends CrateUnitTest {
         List<Symbol> keys = Collections.singletonList(new InputColumn(0, DataTypes.STRING));
         List<Aggregation> aggregations = Collections.singletonList(
             new Aggregation(
-                CountAggregation.COUNT_STAR_FUNCTION,
                 CountAggregation.COUNT_STAR_SIGNATURE,
-                CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+                CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
                 Collections.emptyList()
             )
         );

--- a/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -65,9 +65,19 @@ public class WindowAggProjectionSerialisationTest {
             new WindowDefinition(singletonList(Literal.of(2L)), null, null);
 
         WindowFunction firstWindowFunction = new WindowFunction(
-            sumFunctionImpl.info(), singletonList(Literal.of(1L)), null, partitionByOneWindowDef);
+            sumFunctionImpl.signature(),
+            singletonList(Literal.of(1L)),
+            sumFunctionImpl.boundSignature().getReturnType().createType(),
+            null,
+            partitionByOneWindowDef
+        );
         WindowFunction secondWindowFunction = new WindowFunction(
-            sumFunctionImpl.info(), singletonList(Literal.of(2L)), null, partitionByTwoWindowDef);
+            sumFunctionImpl.signature(),
+            singletonList(Literal.of(2L)),
+            sumFunctionImpl.boundSignature().getReturnType().createType(),
+            null,
+            partitionByTwoWindowDef
+        );
 
         ArrayList<WindowFunctionContext> windowFunctionContexts = new ArrayList<>(2);
         windowFunctionContexts.add(new WindowFunctionContext(
@@ -106,8 +116,9 @@ public class WindowAggProjectionSerialisationTest {
             new WindowDefinition(singletonList(Literal.of(1L)), null, null);
 
         WindowFunction windowFunction = new WindowFunction(
-            sumFunctionImpl.info(),
+            sumFunctionImpl.signature(),
             singletonList(Literal.of(2L)),
+            sumFunctionImpl.boundSignature().getReturnType().createType(),
             null,
             partitionByOneWindowDef);
 
@@ -145,7 +156,8 @@ public class WindowAggProjectionSerialisationTest {
                 SumAggregation.NAME,
                 DataTypes.FLOAT.getTypeSignature(),
                 DataTypes.FLOAT.getTypeSignature()),
-            List.of(DataTypes.FLOAT)
+            List.of(DataTypes.FLOAT),
+            DataTypes.FLOAT
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -50,8 +49,9 @@ public class ArrayAggTest extends AggregationTest {
     public void test_array_agg_return_type_is_array_of_argument_type() {
         DataType<?> returnType = functions.getQualified(
             ArrayAgg.SIGNATURE,
-            List.of(DataTypes.LONG)
-        ).info().returnType();
-        assertThat(returnType, Matchers.is(new ArrayType<>(DataTypes.LONG)));
+            List.of(DataTypes.LONG),
+            DataTypes.BIGINT_ARRAY
+        ).boundSignature().getReturnType().createType();
+        assertThat(returnType, Matchers.is(DataTypes.BIGINT_ARRAY));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -21,28 +21,15 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
-import java.util.List;
-
 public class MaximumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
+    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
         return executeAggregation("max", dataType, data);
-    }
-
-    @Test
-    public void testReturnType() throws Exception {
-        FunctionImplementation max = functions.getQualified(
-            Signature.aggregate("max", DataTypes.INTEGER.getTypeSignature(), DataTypes.INTEGER.getTypeSignature()),
-            List.of(DataTypes.INTEGER)
-        );
-        assertEquals(DataTypes.INTEGER, max.info().returnType());
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -21,28 +21,15 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
-import java.util.List;
-
 public class MinimumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
+    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
         return executeAggregation("min", dataType, data);
-    }
-
-    @Test
-    public void testReturnType() throws Exception {
-        FunctionImplementation min = functions.getQualified(
-            Signature.aggregate("min", DataTypes.INTEGER.getTypeSignature(), DataTypes.INTEGER.getTypeSignature()),
-            List.of(DataTypes.INTEGER)
-        );
-        assertEquals(DataTypes.INTEGER, min.info().returnType());
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -63,7 +63,8 @@ public class PercentileAggregationTest extends AggregationTest {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE)
+            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE),
+            DataTypes.DOUBLE
         );
         arraysPercentile = (PercentileAggregation) functions.getQualified(
             Signature.aggregate(
@@ -72,7 +73,8 @@ public class PercentileAggregationTest extends AggregationTest {
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
             ),
-            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY)
+            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY),
+            DataTypes.DOUBLE_ARRAY
         );
     }
 
@@ -207,7 +209,8 @@ public class PercentileAggregationTest extends AggregationTest {
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
             ),
-            List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY)
+            List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
+            DataTypes.DOUBLE_ARRAY
         );
 
         RamAccounting ramAccounting = RamAccounting.NO_ACCOUNTING;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -67,7 +67,7 @@ public class StringAggTest extends AggregationTest {
 
     @Test
     public void testMergeOf2States() throws Exception {
-        var stringAgg = new StringAgg(StringAgg.SIGNATURE);
+        var stringAgg = new StringAgg(StringAgg.SIGNATURE, StringAgg.SIGNATURE);
         var state1 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("a"), Literal.of(","));
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("b"), Literal.of(";"));

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -178,7 +178,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
         List<Symbol> toCollect = Collections.singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(
-            new Function(op.info(), op.signature(), arguments)
+            new Function(op.signature(), arguments, EqOperator.RETURN_TYPE)
         );
         RoutedCollectPhase collectNode = getCollectNode(toCollect, whereClause);
 

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -92,7 +92,8 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         inExpr = new InputCollectExpression(0);
         CountAggregation aggregation = (CountAggregation) getFunctions().getQualified(
             CountAggregation.COUNT_STAR_SIGNATURE,
-            Collections.emptyList()
+            Collections.emptyList(),
+            CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType()
         );
         aggregationContexts = List.of(new AggregationContext(aggregation, () -> true, List.of()));
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -155,7 +155,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         List<Symbol> arguments = Arrays.asList(tableNameRef, Literal.of("shards"));
         FunctionImplementation eqImpl
             = functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
-        Function whereClause = new Function(eqImpl.info(), eqImpl.signature(),  arguments);
+        Function whereClause = new Function(eqImpl.signature(),  arguments, EqOperator.RETURN_TYPE);
 
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC, new WhereClause(whereClause));
         Bucket result = collect(collectNode);

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -32,8 +32,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateUnitTest;
@@ -59,19 +58,14 @@ public class MapRowUsingInputsTest extends CrateUnitTest {
         InputFactory inputFactory = new InputFactory(getFunctions());
         InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         var addFunction = new Function(
-            new FunctionInfo(
-                new FunctionIdent(ArithmeticFunctions.Names.ADD, List.of(DataTypes.LONG, DataTypes.LONG)),
-                DataTypes.LONG,
-                FunctionInfo.Type.SCALAR,
-                FunctionInfo.DETERMINISTIC_AND_COMPARISON_REPLACEMENT
-            ),
             Signature.scalar(
                 ArithmeticFunctions.Names.ADD,
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
-            ),
-            List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L))
+            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+            List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L)),
+            DataTypes.LONG
         );
         inputs = Collections.singletonList(ctx.add(addFunction));
         expressions = ctx.expressions();

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -130,7 +130,7 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
         List<Symbol> arguments = Arrays.asList(Literal.of(2), new InputColumn(1, DataTypes.INTEGER));
         EqOperator op =
             (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
-        Function function = new Function(op.info(), op.signature(), arguments);
+        Function function = new Function(op.signature(), arguments, EqOperator.RETURN_TYPE);
         FilterProjection filterProjection = new FilterProjection(function,
             Arrays.asList(new InputColumn(0), new InputColumn(1)));
 

--- a/server/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -140,11 +140,11 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
         argsCtx.add(windowFunctionSymbol.arguments());
 
         FunctionImplementation impl = functions.getQualified(
-            windowFunctionSymbol.signature(),
-            Symbols.typeView(windowFunctionSymbol.arguments())
+            windowFunctionSymbol,
+            txnCtx.sessionSettings().searchPath()
         );
-
         assert impl instanceof WindowFunction || impl instanceof AggregationFunction: "Got " + impl + " but expected a window function";
+
         WindowFunction windowFunctionImpl;
         if (impl instanceof AggregationFunction) {
             windowFunctionImpl = new AggregateToWindowFunctionAdapter(

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -32,8 +32,6 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.sort.OrderingByPosition;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.FrameBound;
 import io.crate.sql.tree.WindowFrame;
@@ -55,8 +53,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static io.crate.execution.engine.window.WindowFunctionBatchIterator.sortAndComputeWindowFunctions;
 import static io.crate.common.collections.Tuple.tuple;
+import static io.crate.execution.engine.window.WindowFunctionBatchIterator.sortAndComputeWindowFunctions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -392,15 +390,13 @@ public class WindowBatchIteratorTest {
             }
 
             @Override
-            public FunctionInfo info() {
-                return new FunctionInfo(
-                    new FunctionIdent("first_cell_value", Collections.emptyList()),
-                    DataTypes.INTEGER);
+            public Signature signature() {
+                return Signature.window("first_cell_value", DataTypes.INTEGER.getTypeSignature());
             }
 
             @Override
-            public Signature signature() {
-                return Signature.window("first_cell_value", DataTypes.INTEGER.getTypeSignature());
+            public Signature boundSignature() {
+                return signature();
             }
         };
     }
@@ -413,15 +409,13 @@ public class WindowBatchIteratorTest {
             }
 
             @Override
-            public FunctionInfo info() {
-                return new FunctionInfo(
-                    new FunctionIdent("a_frame_bounded_window_function", Collections.emptyList()),
-                    DataTypes.INTEGER);
+            public Signature signature() {
+                return Signature.window("a_frame_bounded_window_function", DataTypes.INTEGER.getTypeSignature());
             }
 
             @Override
-            public Signature signature() {
-                return Signature.window("a_frame_bounded_window_function", DataTypes.INTEGER.getTypeSignature());
+            public Signature boundSignature() {
+                return signature();
             }
         };
     }
@@ -434,15 +428,13 @@ public class WindowBatchIteratorTest {
             }
 
             @Override
-            public FunctionInfo info() {
-                return new FunctionInfo(
-                    new FunctionIdent("row_number", Collections.emptyList()),
-                    DataTypes.INTEGER);
+            public Signature signature() {
+                return Signature.window("row_number", DataTypes.INTEGER.getTypeSignature());
             }
 
             @Override
-            public Signature signature() {
-                return Signature.window("row_number", DataTypes.INTEGER.getTypeSignature());
+            public Signature boundSignature() {
+                return signature();
             }
         };
     }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
@@ -28,7 +28,6 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.sort.OrderingByPosition;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateUnitTest;
 import org.hamcrest.Matchers;
@@ -73,12 +72,12 @@ public class WindowFunctionBatchIteratorTest extends CrateUnitTest {
                 }
 
                 @Override
-                public FunctionInfo info() {
+                public Signature signature() {
                     return null;
                 }
 
                 @Override
-                public Signature signature() {
+                public Signature boundSignature() {
                     return null;
                 }
             }),

--- a/server/src/test/java/io/crate/expression/AbstractFunctionModuleTest.java
+++ b/server/src/test/java/io/crate/expression/AbstractFunctionModuleTest.java
@@ -23,7 +23,6 @@
 package io.crate.expression;
 
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -46,12 +45,12 @@ public class AbstractFunctionModuleTest extends CrateUnitTest {
         }
 
         @Override
-        public FunctionInfo info() {
-            return null;
+        public Signature signature() {
+            return signature;
         }
 
         @Override
-        public Signature signature() {
+        public Signature boundSignature() {
             return signature;
         }
     }

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -188,7 +188,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         java.lang.reflect.Field f = FunctionExpression.class.getDeclaredField("scalar");
         f.setAccessible(true);
         FunctionImplementation impl = (FunctionImplementation) f.get(expression);
-        assertThat(impl.info(), is(function.info()));
+        assertThat(impl.signature(), is(function.signature()));
 
         FunctionImplementation uncompiled = expressions.functions().getQualified(
             function,

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -37,10 +37,9 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -65,19 +64,14 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
     private InputFactory factory;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private Function add = new Function(
-        new FunctionInfo(
-            new FunctionIdent(ArithmeticFunctions.Names.ADD, List.of(DataTypes.INTEGER, DataTypes.INTEGER)),
-            DataTypes.INTEGER,
-            FunctionInfo.Type.SCALAR,
-            FunctionInfo.DETERMINISTIC_AND_COMPARISON_REPLACEMENT
-        ),
         Signature.scalar(
             ArithmeticFunctions.Names.ADD,
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
-        ),
-        List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10))
+        ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+        List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
+        DataTypes.INTEGER
     );
 
     @Before
@@ -95,8 +89,8 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         Function avgX = (Function) expressions.asSymbol("avg(x)");
 
         List<Symbol> aggregations = Arrays.asList(
-            new Aggregation(countX.info(), countX.signature(), countX.info().returnType(), Arrays.asList(new InputColumn(0))),
-            new Aggregation(avgX.info(), avgX.signature(), countX.info().returnType(), Arrays.asList(new InputColumn(0)))
+            new Aggregation( countX.signature(), countX.signature().getReturnType().createType(), List.of(new InputColumn(0))),
+            new Aggregation(avgX.signature(), avgX.signature().getReturnType().createType(), List.of(new InputColumn(0)))
         );
 
         InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);
@@ -149,7 +143,6 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
 
         // values: [ count(in(0)) ]
         List<Aggregation> values = List.of(new Aggregation(
-            countX.info(),
             countX.signature(),
             countX.valueType(),
             List.of(new InputColumn(0))
@@ -198,8 +191,8 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         assertThat(impl.info(), is(function.info()));
 
         FunctionImplementation uncompiled = expressions.functions().getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
+            function,
+            txnCtx.sessionSettings().searchPath()
         );
         assertThat(uncompiled, not(sameInstance(impl)));
     }

--- a/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Lists2;
@@ -33,7 +34,6 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
@@ -140,10 +140,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             return;
         }
         Function function = (Function) functionSymbol;
-        FunctionImplementation impl = functions.getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
-        );
+        FunctionImplementation impl = functions.getQualified(function, txnCtx.sessionSettings().searchPath());
         assertThat("Function implementation not found using full qualified lookup", impl, Matchers.notNullValue());
 
         Symbol normalized = sqlExpressions.normalize(function);
@@ -193,10 +190,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
             }
             return literal;
         });
-        Scalar scalar = (Scalar) functions.getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
-        );
+        Scalar scalar = (Scalar) functions.getQualified(function, txnCtx.sessionSettings().searchPath());
         assertThat("Function implementation not found using full qualified lookup", scalar, Matchers.notNullValue());
 
         AssertMax1ValueCallInput[] arguments = new AssertMax1ValueCallInput[function.arguments().size()];
@@ -244,10 +238,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServi
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         assertThat("function expression was normalized, compile would not be hit", functionSymbol, not(instanceOf(Literal.class)));
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
-        );
+        Scalar scalar = (Scalar) functions.getQualified(function, txnCtx.sessionSettings().searchPath());
         assertThat("Function implementation not found using full qualified lookup", scalar, Matchers.notNullValue());
 
         Scalar compiled = scalar.compile(function.arguments());

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -26,6 +26,7 @@ import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
+import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,7 +58,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void normalizeReference() {
-        Function function = new Function(random.info(), random.signature(), Collections.emptyList());
+        Function function = new Function(random.signature(), Collections.emptyList(), DataTypes.DOUBLE);
         Function normalized = (Function) random.normalizeSymbol(function, txnCtx);
         assertThat(normalized, sameInstance(function));
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
@@ -89,10 +89,10 @@ public class TruncFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluateLong() throws Exception {
         Literal<Long> value = Literal.of(DataTypes.LONG, 246L);
-        assertEvaluate("trunc(age)", 246, value);
-        assertEvaluate("trunc(age, -2)", 200.0, value);
-        assertEvaluate("trunc(age, -1)", 240.0, value);
-        assertEvaluate("trunc(age, 0)", 246.0, value);
-        assertEvaluate("trunc(age, 1)",  246.0, value);
+        assertEvaluate("trunc(x)", 246L, value);
+        assertEvaluate("trunc(x, -2)", 200.0, value);
+        assertEvaluate("trunc(x, -1)", 240.0, value);
+        assertEvaluate("trunc(x, 0)", 246.0, value);
+        assertEvaluate("trunc(x, 1)",  246.0, value);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -243,7 +243,8 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         ).withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
         var functionImpl = functions.getQualified(
             signature,
-            List.of(DataTypes.UNTYPED_OBJECT, returnType)
+            List.of(DataTypes.UNTYPED_OBJECT, returnType),
+            returnType
         );
 
         assertThat(functionImpl.info().returnType(), is(returnType));

--- a/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
@@ -38,9 +38,9 @@ public class AggregationTest extends CrateUnitTest {
     @Test
     public void test_serialization_with_filter() throws Exception {
         Aggregation actual = new Aggregation(
-            CountAggregation.COUNT_STAR_FUNCTION,
             CountAggregation.COUNT_STAR_SIGNATURE,
-            CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+            CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
+            CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
             List.of(),
             Literal.BOOLEAN_FALSE
         );
@@ -57,9 +57,8 @@ public class AggregationTest extends CrateUnitTest {
     @Test
     public void test_serialization_with_filter_before_version_4_1_0() throws Exception {
         Aggregation actual = new Aggregation(
-            CountAggregation.COUNT_STAR_FUNCTION,
             CountAggregation.COUNT_STAR_SIGNATURE,
-            CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+            CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
             List.of()
         );
         BytesStreamOutput output = new BytesStreamOutput();

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.expression.symbol;
 
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingHelpers;
@@ -45,31 +44,21 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class FunctionTest extends CrateUnitTest {
 
-    private FunctionIdent functionIdent = new FunctionIdent(
-        randomAsciiLettersOfLength(10),
-        List.of(DataTypes.BOOLEAN)
-    );
-
     private DataType<?> returnType = TestingHelpers.randomPrimitiveType();
 
     private Signature signature = Signature.scalar(
-        functionIdent.fqnName(),
+        randomAsciiLettersOfLength(10),
         DataTypes.BOOLEAN.getTypeSignature(),
         returnType.getTypeSignature()
-    );
+    ).withFeatures(randomFeatures());
 
 
     @Test
     public void test_serialization_without_filter() throws Exception {
         Function fn = new Function(
-            new FunctionInfo(
-                functionIdent,
-                returnType,
-                FunctionInfo.Type.SCALAR,
-                randomFeatures()
-            ),
             signature,
-            List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN))
+            List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN)),
+            returnType
         );
 
         BytesStreamOutput output = new BytesStreamOutput();
@@ -84,14 +73,9 @@ public class FunctionTest extends CrateUnitTest {
     @Test
     public void test_serialization_with_filter() throws Exception {
         Function fn = new Function(
-            new FunctionInfo(
-                functionIdent,
-                returnType,
-                FunctionInfo.Type.SCALAR,
-                randomFeatures()
-            ),
             signature,
             List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN)),
+            returnType,
             Literal.of(true)
         );
 
@@ -108,14 +92,9 @@ public class FunctionTest extends CrateUnitTest {
     @Test
     public void test_serialization_before_version_4_1_0() throws Exception {
         Function fn = new Function(
-            new FunctionInfo(
-                functionIdent,
-                returnType,
-                FunctionInfo.Type.SCALAR,
-                randomFeatures()
-            ),
             signature,
-            List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN))
+            List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN)),
+            returnType
         );
 
         var output = new BytesStreamOutput();
@@ -130,9 +109,9 @@ public class FunctionTest extends CrateUnitTest {
         assertThat(fn, is(fn2));
     }
 
-    private static Set<FunctionInfo.Feature> randomFeatures() {
-        Set<FunctionInfo.Feature> features = EnumSet.noneOf(FunctionInfo.Feature.class);
-        for (FunctionInfo.Feature feature : FunctionInfo.Feature.values()) {
+    private static Set<Scalar.Feature> randomFeatures() {
+        Set<Scalar.Feature> features = EnumSet.noneOf(Scalar.Feature.class);
+        for (Scalar.Feature feature : Scalar.Feature.values()) {
             if (randomBoolean()) {
                 features.add(feature);
             }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
@@ -25,8 +25,6 @@ package io.crate.expression.symbol.format;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -42,17 +40,15 @@ public class SymbolFormatterTest extends CrateUnitTest {
     @Test
     public void testFormat() throws Exception {
         Function f = new Function(
-            new FunctionInfo(
-                new FunctionIdent("foo", List.of(DataTypes.STRING, DataTypes.UNDEFINED)),
-                DataTypes.DOUBLE
-            ),
             Signature.scalar(
                 "foo",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.UNDEFINED.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            List.of(Literal.of("bar"), Literal.of(3.4)));
+            List.of(Literal.of("bar"), Literal.of(3.4)),
+            DataTypes.DOUBLE
+        );
         assertThat(Symbols.format("This Symbol is formatted %s", f), is("This Symbol is formatted foo('bar', 3.4)"));
     }
 

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -31,8 +31,6 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -133,18 +131,16 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFormatAggregation() throws Exception {
-        FunctionInfo functionInfo = new FunctionInfo(
-            new FunctionIdent("agg", Collections.singletonList(DataTypes.INTEGER)),
-            DataTypes.LONG,
-            FunctionInfo.Type.AGGREGATE
-        );
         Signature signature = Signature.aggregate(
             "agg",
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.LONG.getTypeSignature()
         );
         Aggregation a = new Aggregation(
-            functionInfo, signature, DataTypes.LONG, Collections.singletonList(Literal.of(-127)));
+            signature,
+            DataTypes.LONG,
+            Collections.singletonList(Literal.of(-127))
+        );
 
         assertPrint(a, "agg(-127)");
     }

--- a/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -23,12 +23,10 @@
 package io.crate.expression.tablefunctions;
 
 import io.crate.analyze.relations.DocTableRelation;
-import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
@@ -36,7 +34,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SqlExpressions;
-import io.crate.types.TypeSignature;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -49,7 +46,7 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
 
     protected SqlExpressions sqlExpressions;
     protected Functions functions;
-    private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    protected TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void prepareFunctions() throws Exception {
@@ -62,8 +59,8 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
 
         var function = (Function) functionSymbol;
         TableFunctionImplementation<?> functionImplementation = (TableFunctionImplementation<?>) functions.getQualified(
-            function.signature(),
-            Symbols.typeView(function.arguments())
+            function,
+            txnCtx.sessionSettings().searchPath()
         );
         return functionImplementation.evaluate(
             txnCtx,

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -94,8 +94,9 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
         Function function = (Function) sqlExpressions.asSymbol("_values([['a', 'b']])");
 
         var funcImplementation = (TableFunctionImplementation<?>) functions.getQualified(
-            function.signature(),
-            function.info().ident().argumentTypes());
+            function,
+            txnCtx.sessionSettings().searchPath()
+        );
 
         assertThat(funcImplementation.returnType(), instanceOf(RowType.class));
         assertThat(funcImplementation.returnType().fieldTypes(), contains(DataTypes.STRING_ARRAY));

--- a/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -23,10 +23,8 @@
 package io.crate.expression.udf;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -45,11 +43,7 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
         @Override
         public Scalar createFunctionImplementation(UserDefinedFunctionMetaData metaData,
                                                    Signature signature) throws ScriptException {
-            FunctionInfo info = new FunctionInfo(
-                new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()),
-                metaData.returnType()
-            );
-            return new DummyFunction(info, signature);
+            return new DummyFunction(signature);
         }
 
         @Nullable
@@ -68,21 +62,19 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
         public static final Integer RESULT = -42;
 
-        private final FunctionInfo info;
         private final Signature signature;
 
-        DummyFunction(FunctionInfo info, Signature signature) {
-            this.info = info;
+        DummyFunction(Signature signature) {
             this.signature = signature;
         }
 
         @Override
-        public FunctionInfo info() {
-            return info;
+        public Signature signature() {
+            return signature;
         }
 
         @Override
-        public Signature signature() {
+        public Signature boundSignature() {
             return signature;
         }
 

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -33,8 +33,6 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetaData;
 import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -61,24 +59,22 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
 
     public static class DummyFunction<InputType> extends Scalar<String, InputType>  {
 
-        private final FunctionInfo info;
         private final Signature signature;
         private final UserDefinedFunctionMetaData metaData;
 
         private DummyFunction(UserDefinedFunctionMetaData metaData,
                               Signature signature) {
-            this.info = new FunctionInfo(new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()), DataTypes.STRING);
             this.signature = signature;
             this.metaData = metaData;
         }
 
         @Override
-        public FunctionInfo info() {
-            return info;
+        public Signature signature() {
+            return signature;
         }
 
         @Override
-        public Signature signature() {
+        public Signature boundSignature() {
             return signature;
         }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -29,11 +29,9 @@ import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetaData;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
@@ -67,20 +65,19 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
                 if (error != null) {
                     throw new ScriptException("this is not Burlesque");
                 }
-                return new Scalar() {
-                    private final FunctionInfo info = new FunctionInfo(new FunctionIdent(metaData.schema(), metaData.name(), metaData.argumentTypes()), metaData.returnType());
+                return new Scalar<>() {
                     @Override
                     public Object evaluate(TransactionContext txnCtx, Input[] args) {
                         return null;
                     }
 
                     @Override
-                    public FunctionInfo info() {
-                        return info;
+                    public Signature signature() {
+                        return signature;
                     }
 
                     @Override
-                    public Signature signature() {
+                    public Signature boundSignature() {
                         return signature;
                     }
                 };

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.crate.metadata.FunctionInfo.Type.SCALAR;
+import static io.crate.metadata.FunctionType.SCALAR;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
 import static io.crate.types.TypeSignature.parseTypeSignature;

--- a/server/src/test/java/io/crate/metadata/functions/SignatureTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.functions;
 
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -46,7 +46,7 @@ public class SignatureTest {
 
         var signature = Signature.builder()
             .name("foo")
-            .kind(FunctionInfo.Type.SCALAR)
+            .kind(FunctionType.SCALAR)
             .argumentTypes(
                 parseTypeSignature("E"),
                 DataTypes.INTEGER.getTypeSignature(),

--- a/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -34,12 +34,9 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.SearchPath;
 import io.crate.test.integration.CrateUnitTest;
@@ -127,7 +124,7 @@ public abstract class AggregationTest extends CrateUnitTest {
         AggregationFunction function =
             (AggregationFunction) functions.get(null, functionName, arguments, SearchPath.pathWithPGCatalogAndDoc());
         return function.normalizeSymbol(
-            new Function(function.info(), function.signature(), arguments),
+            new Function(function.signature(), arguments, function.partialType()),
             new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
     }
 }

--- a/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -64,7 +64,7 @@ public abstract class AggregationTest extends CrateUnitTest {
         memoryManager = new OnHeapMemoryManager(RAM_ACCOUNTING::addBytes);
         evaluatingNormalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             functions,
-            f -> f.info().isDeterministic()
+            Function::isDeterministic
         );
     }
 

--- a/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
@@ -28,15 +28,12 @@ import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.table.TableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.types.DataTypes;
 import org.elasticsearch.common.Randomness;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -66,15 +63,9 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
         RoutingBuilder routingBuilder = new RoutingBuilder(clusterService.state(), routingProvider);
         WhereClause whereClause = new WhereClause(
             new Function(
-                new FunctionInfo(
-                    new FunctionIdent(
-                        EqOperator.NAME,
-                        List.of(DataTypes.INTEGER, DataTypes.INTEGER)
-                    ),
-                    DataTypes.BOOLEAN
-                ),
                 EqOperator.SIGNATURE,
-                List.of(tableInfo.getReference(new ColumnIdent("id")), Literal.of(2))
+                List.of(tableInfo.getReference(new ColumnIdent("id")), Literal.of(2)),
+                EqOperator.RETURN_TYPE
             ));
 
         routingBuilder.allocateRouting(tableInfo, WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, null);

--- a/server/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/server/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -54,9 +54,8 @@ public class MergeNodeTest extends CrateUnitTest {
         List<Symbol> keys = Collections.singletonList(new InputColumn(0, DataTypes.STRING));
         List<Aggregation> aggregations = Collections.singletonList(
             new Aggregation(
-                CountAggregation.COUNT_STAR_FUNCTION,
                 CountAggregation.COUNT_STAR_SIGNATURE,
-                CountAggregation.COUNT_STAR_FUNCTION.returnType(),
+                CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
                 Collections.emptyList()
             )
         );

--- a/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -23,6 +23,7 @@
 package io.crate.planner.node.ddl;
 
 import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.collections.MapBuilder;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.expression.scalar.arithmetic.ArrayFunction;
@@ -36,7 +37,6 @@ import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
-import io.crate.common.collections.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
@@ -161,9 +161,9 @@ public class UpdateSettingsPlanTest extends CrateUnitTest {
     @Test
     public void test_array_is_implicitly_converted_to_comma_separated_string() {
         var idsArray = new io.crate.expression.symbol.Function(
-            ArrayFunction.createInfo(List.of(DataTypes.STRING, DataTypes.STRING)),
             ArrayFunction.SIGNATURE,
-            List.of(Literal.of("id1"), Literal.of("id2"))
+            List.of(Literal.of("id1"), Literal.of("id2")),
+            DataTypes.STRING_ARRAY
         );
         Assignment<Symbol> assignment = new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), idsArray);
         Settings settings = buildSettingsFrom(List.of(assignment), symbolEvaluator(Row.EMPTY));

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -31,8 +31,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.test.integration.CrateUnitTest;
@@ -84,15 +82,12 @@ public class JoinPhaseTest extends CrateUnitTest {
             DistributionInfo.DEFAULT_BROADCAST,
             null);
         joinCondition = new Function(
-            new FunctionInfo(
-                new FunctionIdent(EqOperator.NAME, List.of(DataTypes.STRING, DataTypes.STRING)),
-                DataTypes.BOOLEAN
-            ),
             EqOperator.SIGNATURE,
             List.of(
                 new InputColumn(0, DataTypes.STRING),
                 new InputColumn(1, DataTypes.STRING)
-            )
+            ),
+            EqOperator.RETURN_TYPE
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -28,9 +28,6 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
@@ -39,7 +36,6 @@ import io.crate.metadata.table.Operation;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -71,17 +67,14 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
             collect,
             List.of(
                 new Function(
-                    new FunctionInfo(
-                        new FunctionIdent("add", Symbols.typeView(List.of(x, x))),
-                        DataTypes.INTEGER
-                    ),
                     Signature.scalar(
                         "add",
                         DataTypes.INTEGER.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature()
                     ),
-                    List.of(x, x)
+                    List.of(x, x),
+                    DataTypes.INTEGER
                 )
             )
         );

--- a/server/src/test/java/io/crate/testing/SleepScalarFunction.java
+++ b/server/src/test/java/io/crate/testing/SleepScalarFunction.java
@@ -22,38 +22,30 @@
 package io.crate.testing;
 
 import io.crate.data.Input;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-
-import java.util.Collections;
 
 
 public class SleepScalarFunction extends Scalar<Boolean, Long> {
 
     public static final String NAME = "sleep";
 
-    private final static FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, Collections.singletonList(DataTypes.LONG)),
-        DataTypes.BOOLEAN,
-        FunctionInfo.Type.SCALAR, FunctionInfo.NO_FEATURES);
-
-    private final static Signature SIGNATURE = Signature.scalar(
+    public final static Signature SIGNATURE = Signature.scalar(
         NAME,
         DataTypes.LONG.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeatures(NO_FEATURES);
 
-    @Override
-    public FunctionInfo info() {
-        return INFO;
-    }
 
     @Override
     public Signature signature() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public Signature boundSignature() {
         return SIGNATURE;
     }
 

--- a/server/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/server/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -183,6 +183,6 @@ public class SymbolMatchers {
 
     public static Matcher<Symbol> isAggregation(String name) {
         return both(Matchers.<Symbol>instanceOf(Aggregation.class))
-            .and(withFeature(s -> ((Aggregation) s).functionIdent().name(), "name", equalTo(name)));
+            .and(withFeature(s -> ((Aggregation) s).signature().getName().name(), "name", equalTo(name)));
     }
 }

--- a/server/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/server/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -163,7 +163,7 @@ public class SymbolMatchers {
 
     public static Matcher<Symbol> isFunction(String name) {
         return both(Matchers.<Symbol>instanceOf(Function.class))
-            .and(withFeature(s -> ((Function) s).info().ident().name(), "name", equalTo(name)));
+            .and(withFeature(s -> ((Function) s).name(), "name", equalTo(name)));
     }
 
     public static Matcher<Symbol> isFunction(final String name, @Nullable final List<DataType> argumentTypes) {

--- a/server/src/test/java/io/crate/testing/plugin/CrateTestingPlugin.java
+++ b/server/src/test/java/io/crate/testing/plugin/CrateTestingPlugin.java
@@ -21,14 +21,9 @@
 
 package io.crate.testing.plugin;
 
-import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
+import io.crate.expression.AbstractFunctionModule;
 import io.crate.testing.SleepScalarFunction;
-import io.crate.types.DataTypes;
-import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.Collection;
@@ -38,15 +33,13 @@ public class CrateTestingPlugin extends Plugin {
 
     @Override
     public Collection<Module> createGuiceModules() {
-        return Collections.singletonList(new AbstractModule() {
+        return Collections.singletonList(new AbstractFunctionModule<>() {
             @Override
-            protected void configure() {
-                MapBinder<FunctionIdent, FunctionImplementation> functionBinder =
-                    MapBinder.newMapBinder(binder(), FunctionIdent.class, FunctionImplementation.class);
-                functionBinder.addBinding(new FunctionIdent(
-                    SleepScalarFunction.NAME,
-                    ImmutableList.of(DataTypes.LONG))
-                ).toInstance(new SleepScalarFunction());
+            public void configureFunctions() {
+                register(
+                    SleepScalarFunction.SIGNATURE,
+                    (signature, boundSignature) -> new SleepScalarFunction()
+                );
             }
         });
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Replace all usages of `FunctionIdent` and `FunctionInfo` with `Signature` and mark them as deprecated.
Remaining usages are only for BWC inside mixed version clusters. Implementation and usages should be removed with the next major version (5.0).

Also some function signatures return types are fixed. The signature return type is now used the first time and thus highlighted the errors. These fixes could be committed dedicated but without real usage, they wouldn't be tested.

Relates #9901.