### PR TITLE
Keep gradle test kit artefacts under buildSrc/build.

### DIFF
--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
@@ -88,9 +88,15 @@ public class JdkDownloadPluginFunctionalTest {
                                  Consumer<BuildResult> assertions,
                                  String vendor,
                                  String version) {
+        var testKitDirPath = Paths.get(
+            System.getProperty("user.dir"),
+            "build",
+            System.getProperty("user.name")
+        );
         GradleRunner runner = GradleRunner.create()
             .withDebug(true)
             .withProjectDir(getTestKitProjectDir("jdk-download"))
+            .withTestKitDir(testKitDirPath.toFile())
             .withArguments(
                 task,
                 "-Dtests.jdk_vendor=" + vendor,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

That should prevent from using `/tmp` as a cache for the `buildSrc` related gradle tasks.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
