### PR TITLE
Make sure there is an entry in pg_proc for each pg_type typreceive

### DIFF
--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -22,18 +22,16 @@
 
 package io.crate.metadata.pgcatalog;
 
-import io.crate.metadata.RelationName;
-import io.crate.metadata.SystemTable;
-import io.crate.protocols.postgres.types.PGType;
-import io.crate.protocols.postgres.types.PGTypes;
-import io.crate.types.Regproc;
-
 import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.REGPROC;
 import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.STRING;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.protocols.postgres.types.PGType;
 
 public class PgTypeTable {
 
@@ -64,31 +62,10 @@ public class PgTypeTable {
             .add("typtypmod", INTEGER, c -> -1)
             .add("typnamespace", INTEGER, c -> TYPE_NAMESPACE_OID)
             .add("typarray", INTEGER, PGType::typArray)
-            .add("typinput", REGPROC, t -> {
-                if (t.typArray() == 0) {
-                    return Regproc.of("array_in");
-                } else {
-                    return regprocForMetaFunction(t, "_in");
-                }
-            })
-            .add("typoutput", REGPROC, t -> {
-                if (t.typArray() == 0) {
-                    return Regproc.of("array_out");
-                } else {
-                    return regprocForMetaFunction(t, "_out");
-                }
-            })
-            .add("typreceive", REGPROC, t -> regprocForMetaFunction(t, "recv"))
+            .add("typinput", REGPROC, PGType::typInput)
+            .add("typoutput", REGPROC, PGType::typOutput)
+            .add("typreceive", REGPROC, PGType::typReceive)
             .add("typnotnull", BOOLEAN, c -> false)
             .build();
-    }
-
-    private static Regproc regprocForMetaFunction(PGType<?> type,
-                                                  String suffix) {
-        if (PGTypes.fromOID(type.oid()) != null) {
-            return Regproc.of(type.typName() + suffix);
-        } else {
-            return Regproc.of(0, "0");
-        }
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/types/AnyType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/AnyType.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres.types;
 
+import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
 
 import javax.annotation.Nonnull;
@@ -59,6 +60,11 @@ public class AnyType extends PGType<Integer> {
         buffer.writeInt(TYPE_LEN);
         buffer.writeInt(value);
         return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    public Regproc typReceive() {
+        return Regproc.of(0, "-");
     }
 
     @Override

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres.types;
 
+import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -110,6 +111,30 @@ public abstract class PGType<T> {
 
     public String typName() {
         return typName;
+    }
+
+    public Regproc typInput() {
+        if (typArray() == 0) {
+            return Regproc.of("array_in");
+        } else {
+            return Regproc.of(typName() + "_in");
+        }
+    }
+
+    public Regproc typOutput() {
+        if (typArray() == 0) {
+            return Regproc.of("array_out");
+        } else {
+            return Regproc.of(typName() + "_out");
+        }
+    }
+
+    public Regproc typReceive() {
+        if (typArray() == 0) {
+            return Regproc.of("array_recv");
+        } else {
+            return Regproc.of(typName() + "recv");
+        }
     }
 
     public int typElem() {

--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -36,17 +36,17 @@ public class Regproc {
         return new Regproc(OidHash.functionOid(name), name);
     }
 
-    public static Regproc of(int oid, @Nonnull String name) {
+    public static Regproc of(int functionOid, @Nonnull String name) {
         // To match PostgreSQL behavior 1:1 this would need to lookup the
         // function name by oid and fallback to using the oid as name if there is
         // no match.
         // It looks like for compatibility with clients it is good enough
         // to not mirror this behavior.
-        return new Regproc(oid, name);
+        return new Regproc(functionOid, name);
     }
 
-    private Regproc(int oid, String name) {
-        this.oid = oid;
+    private Regproc(int functionOid, String name) {
+        this.oid = functionOid;
         this.name = name;
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -887,6 +887,24 @@ public class PostgresITest extends SQLTransportIntegrationTest {
         }
     }
 
+    @Test
+    public void test_each_non_array_pg_type_entry_can_be_joined_with_pg_proc() throws Exception {
+        try (Connection conn = DriverManager.getConnection(url(RW))) {
+            PreparedStatement stmt = conn.prepareStatement(
+                "SELECT pg_type.oid, pg_type.typname, pg_proc.proname " +
+                "FROM pg_catalog.pg_type LEFT OUTER JOIN pg_catalog.pg_proc ON pg_proc.oid = pg_type.typreceive " +
+                "WHERE pg_type.typarray <> 0");
+            ResultSet result = stmt.executeQuery();
+            while (result.next()) {
+                assertThat(
+                    "There must be an entry for `" + result.getInt(1) + "/" + result.getString(2) + "` in pg_proc",
+                    result.getString(3),
+                    Matchers.notNullValue(String.class)
+                );
+            }
+        }
+    }
+
     private void assertSelectNameFromSysClusterWorks(Connection conn) throws SQLException {
         PreparedStatement stmt;// verify that queries can be made after an error occurred
         stmt = conn.prepareStatement("select name from sys.cluster");

--- a/server/src/test/java/io/crate/protocols/postgres/types/AnyTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/AnyTypeTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres.types;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -46,5 +47,32 @@ public class AnyTypeTest extends BasePGTypeTest<Integer> {
     public void test_read_value_text() {
         byte[] bytesToRead = String.valueOf(Integer.MAX_VALUE).getBytes(StandardCharsets.UTF_8);
         assertBytesReadText(bytesToRead, Integer.MAX_VALUE, bytesToRead.length);
+    }
+
+    @Test
+    public void test_typreceive_is_0_for_anytype() throws Exception {
+        /** PostgreSQL types that have a 0 oid as "typreceive" value
+         * select typname  from pg_type where typreceive = 0;
+         *     typname
+         *------------------
+         * aclitem
+         * gtsvector
+         * any
+         * trigger
+         * event_trigger
+         * language_handler
+         * internal
+         * opaque
+         * anyelement
+         * anynonarray
+         * anyenum
+         * fdw_handler
+         * index_am_handler
+         * tsm_handler
+         * table_am_handler
+         * anyrange
+         **/
+        assertThat(AnyType.INSTANCE.typReceive().oid(), Matchers.is(0));
+        assertThat(AnyType.INSTANCE.typReceive().name(), Matchers.is("-"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Each `pg_type` entry must be able to join with an entry in `pg_proc` for
clients like npgsql.

(Except arrays, they've a generic `array_recv` value)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)