### PR TITLE
Add oid type to pg_type table

### DIFF
--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -171,7 +171,8 @@ table available in CrateDB::
     |   21 | int2                         |     1005 |       0 |      2 | b       | N           |
     |   23 | int4                         |     1007 |       0 |      4 | b       | N           |
     |   24 | regproc                      |     1008 |       0 |      4 | b       | N           |
-    |   30 | oidvector                    |     1013 |       0 |     -1 | b       | A           |
+    |   26 | oid                          |     1028 |       0 |      4 | b       | N           |
+    |   30 | oidvector                    |     1013 |      26 |     -1 | b       | A           |
     |  114 | json                         |      199 |       0 |     -1 | b       | U           |
     |  199 | _json                        |        0 |     114 |     -1 | b       | A           |
     |  600 | point                        |     1017 |       0 |     16 | b       | G           |
@@ -201,7 +202,7 @@ table available in CrateDB::
     | 2277 | anyarray                     |        0 |    2276 |     -1 | p       | P           |
     | 2287 | _record                      |        0 |    2249 |     -1 | p       | A           |
     +------+------------------------------+----------+---------+--------+---------+-------------+
-    SELECT 36 rows in set (... sec)
+    SELECT 37 rows in set (... sec)
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/OidType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/OidType.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+
+public class OidType extends PGType<Integer> {
+
+    public static final OidType INSTANCE = new OidType();
+
+    static final int OID = 26;
+
+    private static final int TYPE_LEN = 4;
+    private static final int TYPE_MOD = -1;
+
+    OidType() {
+        super(OID, TYPE_LEN, TYPE_MOD, "oid");
+    }
+
+    @Override
+    public int typArray() {
+        return PGArray.OID_ARRAY.oid();
+    }
+
+    @Override
+    public String typeCategory() {
+        return TypeCategory.NUMERIC.code();
+    }
+
+    @Override
+    public String type() {
+        return Type.BASE.code();
+    }
+
+    @Override
+    public int writeAsBinary(ByteBuf buffer, Integer value) {
+        buffer.writeInt(TYPE_LEN);
+        buffer.writeInt(value);
+        return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    public Integer readBinaryValue(ByteBuf buffer, int valueLength) {
+        assert valueLength == TYPE_LEN
+            : "length should be " + TYPE_LEN + " because oid is int32. Actual length: " + valueLength;
+        return buffer.readInt();
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(Integer value) {
+        return Integer.toString(value).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    Integer decodeUTF8Text(byte[] bytes) {
+        return Integer.parseInt(new String(bytes, StandardCharsets.UTF_8));
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -37,6 +37,7 @@ public class PGArray extends PGType<List<Object>> {
     static final PGArray CHAR_ARRAY = new PGArray(1002, CharType.INSTANCE);
     static final PGArray INT2_ARRAY = new PGArray(1005, SmallIntType.INSTANCE);
     static final PGArray INT4_ARRAY = new PGArray(1007, IntegerType.INSTANCE);
+    static final PGArray OID_ARRAY = new PGArray(1028, OidType.INSTANCE);
     static final PGArray INT8_ARRAY = new PGArray(1016, BigIntType.INSTANCE);
     static final PGArray FLOAT4_ARRAY = new PGArray(1021, RealType.INSTANCE);
     static final PGArray FLOAT8_ARRAY = new PGArray(1022, DoubleType.INSTANCE);

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -106,6 +106,7 @@ public class PGTypes {
         // the below is added manually as currently we do not want to expose this type to crateDB
         // we merely need this type information in 'pg_types' static table for postgres compatibility
         TYPES.add(VarCharType.NameType.INSTANCE);
+        TYPES.add(OidType.INSTANCE);
     }
 
     public static Iterable<PGType> pgTypes() {

--- a/server/src/main/java/io/crate/protocols/postgres/types/PgOidVectorType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PgOidVectorType.java
@@ -46,6 +46,11 @@ public class PgOidVectorType extends PGType<List<Integer>> {
     }
 
     @Override
+    public int typElem() {
+        return OidType.OID;
+    }
+
+    @Override
     public String typeCategory() {
         return TypeCategory.ARRAY.code();
     }

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -35,12 +35,17 @@ import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+
+import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static io.crate.types.DataTypes.GEO_POINT;
 import static io.crate.types.DataTypes.GEO_SHAPE;
@@ -135,6 +140,22 @@ public class PGTypesTest extends CrateUnitTest {
         )) {
             PGType pgType = PGTypes.get(entry.type);
             assertEntryOfPgType(entry, pgType);
+        }
+    }
+
+    @Test
+    public void test_pgtypes_has_en_entry_for_each_typelem() throws Exception {
+        Map<Integer, PGType<?>> typeByOid = StreamSupport.stream(PGTypes.pgTypes().spliterator(), false)
+            .collect(Collectors.toMap(x -> x.oid(), x -> x));
+        for (PGType<?> type : PGTypes.pgTypes()) {
+            if (type.typElem() == 0) {
+                continue;
+            }
+            assertThat(
+                "The element type with oid " + type.typElem() + " must exist for " + type.typName(),
+                typeByOid.get(type.typElem()),
+                Matchers.notNullValue()
+            );
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

After the introduction of the oidvector, the npgsql driver failed with:

    Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key 'oid' was not present in the dictionary.
       at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
       at Npgsql.TypeHandlers.InternalTypesHandlers.OIDVectorHandlerFactory.Create(PostgresType pgType, NpgsqlConnection conn)
       at Npgsql.TypeMapping.ConnectorTypeMapper.BindType(NpgsqlTypeMapping mapping, NpgsqlConnector connector, Boolean externalCall)
       at Npgsql.TypeMapping.ConnectorTypeMapper.BindTypes()
       at Npgsql.TypeMapping.ConnectorTypeMapper.Bind(NpgsqlDatabaseInfo databaseInfo)
       at Npgsql.NpgsqlConnector.LoadDatabaseInfo(NpgsqlTimeout timeout, Boolean async)
       at Npgsql.NpgsqlConnector.Open(NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)
       at Npgsql.ConnectorPool.AllocateLong(NpgsqlConnection conn, NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)
       at Npgsql.NpgsqlConnection.<>c__DisplayClass32_0.<<Open>g__OpenLong|0>d.MoveNext()

This adds an Oid type entry to the `pg_type` table to fix the issue.
(It doesn't add a oid cratedb type, looks like it is not necessary - we
can still follow up on that later)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)