### PR TITLE
Unnest issue

### DIFF
--- a/server/src/main/java/io/crate/types/RowType.java
+++ b/server/src/main/java/io/crate/types/RowType.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public final class RowType extends DataType<Row> implements Streamer<Row> {
 
@@ -183,5 +184,10 @@ public final class RowType extends DataType<Row> implements Streamer<Row> {
     @Override
     public List<DataType<?>> getTypeParameters() {
         return fieldTypes;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ENGLISH, "%s{%s}", getName(), fieldTypes);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -45,6 +45,17 @@ public class TableFunctionITest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testSelectUnnestNoFrom() {
+        execute("select unnest([1, 2, 3, 4], ['uno', 'dos', 'tres', 'quatro'])");
+
+        assertThat(response.rowCount(), is(4L));
+        assertThat(printedTable(response.rows()), is("(1,uno)\n" +
+                                                     "(2,dos)\n" +
+                                                     "(3,tres)\n" +
+                                                     "(4,quatro)\n"));
+    }
+
+    @Test
     public void testSelectFromUnnestWithOrderByAndLimit() {
         execute("select * from unnest([1, 2], ['Trillian', 'Marvin']) order by col1 desc limit 1");
         assertThat(response.rowCount(), is(1L));


### PR DESCRIPTION
`UnnestFunction` is registered with a signature which return type is RowType.EMPTY, so when using the function in a select clause the return type is an empty record. 

