### PR TITLE
Resolve unnest and _values signature return type correctly.

### DIFF
--- a/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -64,7 +64,6 @@ public class ValuesFunction {
         private ValuesTableFunctionImplementation(Signature signature,
                                                   Signature boundSignature) {
             this.signature = signature;
-            this.boundSignature = boundSignature;
             var argTypes = boundSignature.getArgumentDataTypes();
             ArrayList<DataType<?>> fieldTypes = new ArrayList<>(argTypes.size());
             for (int i = 0; i < argTypes.size(); i++) {
@@ -74,6 +73,12 @@ public class ValuesFunction {
                 fieldTypes.add(((ArrayType<?>) dataType).innerType());
             }
             returnType = new RowType(fieldTypes);
+            this.boundSignature = Signature.builder()
+                .name(boundSignature.getName())
+                .kind(boundSignature.getKind())
+                .argumentTypes(boundSignature.getArgumentTypes())
+                .returnType(returnType.getTypeSignature())
+                .build();
         }
 
         @Override

--- a/server/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
@@ -22,7 +22,15 @@
 
 package io.crate.expression.tablefunctions;
 
+import io.crate.expression.symbol.Function;
+import io.crate.metadata.tablefunctions.TableFunctionImplementation;
+import io.crate.types.DataTypes;
 import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
 
 public class UnnestFunctionTest extends AbstractTableFunctionsTest {
 
@@ -80,5 +88,17 @@ public class UnnestFunctionTest extends AbstractTableFunctionsTest {
             "4| NULL\n" +
             "5| NULL\n"
         );
+    }
+
+    @Test
+    public void test_unnest_bound_signature_return_type_resolves_correct_row_type_parameters() {
+        var function = (Function) sqlExpressions.asSymbol("unnest([1], ['a'], [{}])");
+        var functionImplementation = (TableFunctionImplementation<?>) functions.getQualified(
+            function,
+            txnCtx.sessionSettings().searchPath()
+        );
+        assertThat(
+            functionImplementation.boundSignature().getReturnType().createType().getTypeParameters(),
+            is(List.of(DataTypes.INTEGER, DataTypes.STRING, DataTypes.UNTYPED_OBJECT)));
     }
 }

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -28,7 +28,10 @@ import io.crate.types.DataTypes;
 import io.crate.types.RowType;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 
 public class ValuesFunctionTest extends AbstractTableFunctionsTest {
@@ -109,5 +112,17 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
         expectedException.expectMessage("Unknown function: _values(200)," +
                                         " no overload found for matching argument types: (integer).");
         assertExecute("_values(200)", "");
+    }
+
+    @Test
+    public void test_bound_signature_return_type_resolves_correct_row_type_parameters() {
+        var function = (Function) sqlExpressions.asSymbol("_values([1], ['a'], [{}])");
+        var functionImplementation = (TableFunctionImplementation<?>) functions.getQualified(
+            function,
+            txnCtx.sessionSettings().searchPath()
+        );
+        assertThat(
+            functionImplementation.boundSignature().getReturnType().createType().getTypeParameters(),
+            is(List.of(DataTypes.INTEGER, DataTypes.STRING, DataTypes.UNTYPED_OBJECT)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The inner type of the `unnest` and `_values` function resolved
correctly and accounts the inner types of the record type, while
the return type of the bound signature return always the empty
record type. It happens due to the type signature binding limitation
of functions that have an argument represented by the array type
that has a variable of any type and variable arity.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
