### PR TITLE
Expose text and _text in pg_type table

### DIFF
--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -171,6 +171,7 @@ table available in CrateDB::
     |   21 | int2                         |     1005 |       0 |      2 | b       | N           |
     |   23 | int4                         |     1007 |       0 |      4 | b       | N           |
     |   24 | regproc                      |     1008 |       0 |      4 | b       | N           |
+    |   25 | text                         |     1009 |       0 |     -1 | b       | S           |
     |   26 | oid                          |     1028 |       0 |      4 | b       | N           |
     |   30 | oidvector                    |     1013 |      26 |     -1 | b       | A           |
     |  114 | json                         |      199 |       0 |     -1 | b       | U           |
@@ -183,6 +184,7 @@ table available in CrateDB::
     | 1005 | _int2                        |        0 |      21 |     -1 | b       | A           |
     | 1007 | _int4                        |        0 |      23 |     -1 | b       | A           |
     | 1008 | _regproc                     |        0 |      24 |     -1 | b       | A           |
+    | 1009 | _text                        |        0 |      25 |     -1 | b       | A           |
     | 1015 | _varchar                     |        0 |    1043 |     -1 | b       | A           |
     | 1016 | _int8                        |        0 |      20 |     -1 | b       | A           |
     | 1017 | _point                       |        0 |     600 |     -1 | b       | A           |
@@ -202,7 +204,7 @@ table available in CrateDB::
     | 2277 | anyarray                     |        0 |    2276 |     -1 | p       | P           |
     | 2287 | _record                      |        0 |    2249 |     -1 | p       | A           |
     +------+------------------------------+----------+---------+--------+---------+-------------+
-    SELECT 37 rows in set (... sec)
+    SELECT 39 rows in set (... sec)
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -46,6 +46,7 @@ public class PGArray extends PGType<List<Object>> {
     static final PGArray TIMESTAMP_ARRAY = new PGArray(1115, TimestampType.INSTANCE);
     static final PGArray TIMETZ_ARRAY = new PGArray(1270, TimeTZType.INSTANCE);
     static final PGArray VARCHAR_ARRAY = new PGArray(1015, VarCharType.INSTANCE);
+    static final PGArray TEXT_ARRAY = new PGArray(1009, VarCharType.TextType.INSTANCE);
     static final PGArray JSON_ARRAY = new PGArray(199, JsonType.INSTANCE);
     static final PGArray POINT_ARRAY = new PGArray(1017, PointType.INSTANCE);
     static final PGArray INTERVAL_ARRAY = new PGArray(1187, IntervalType.INSTANCE);

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -84,8 +84,6 @@ public class PGTypes {
 
     private static final IntObjectMap<DataType<?>> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();
     private static final Set<PGType> TYPES;
-    private static final int TEXT_OID = 25;
-    private static final int TEXT_ARRAY_OID = 1009;
 
     static {
         for (Map.Entry<DataType<?>, PGType> e : CRATE_TO_PG_TYPES.entrySet()) {
@@ -96,8 +94,8 @@ public class PGTypes {
             }
         }
         PG_TYPES_TO_CRATE_TYPE.put(0, DataTypes.UNDEFINED);
-        PG_TYPES_TO_CRATE_TYPE.put(TEXT_OID, DataTypes.STRING);
-        PG_TYPES_TO_CRATE_TYPE.put(TEXT_ARRAY_OID, new ArrayType<>(DataTypes.STRING));
+        PG_TYPES_TO_CRATE_TYPE.put(VarCharType.TextType.OID, DataTypes.STRING);
+        PG_TYPES_TO_CRATE_TYPE.put(PGArray.TEXT_ARRAY.oid(), new ArrayType<>(DataTypes.STRING));
         TYPES = new HashSet<>(CRATE_TO_PG_TYPES.values()); // some pgTypes are used multiple times, de-dup them
         // the following polymorphic types are added manually,
         // because there are no corresponding data types in CrateDB
@@ -107,6 +105,11 @@ public class PGTypes {
         // we merely need this type information in 'pg_types' static table for postgres compatibility
         TYPES.add(VarCharType.NameType.INSTANCE);
         TYPES.add(OidType.INSTANCE);
+
+        // We map DataTypes.STRING to varchar (for no good reason, other than history)
+        // But want to expose text additionally as well
+        TYPES.add(VarCharType.TextType.INSTANCE);
+        TYPES.add(PGArray.TEXT_ARRAY);
     }
 
     public static Iterable<PGType> pgTypes() {

--- a/server/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -101,4 +101,10 @@ class VarCharType extends PGType<Object> {
 
         static final VarCharType INSTANCE = new VarCharType(OID, ARRAY_OID, TYPE_LEN, "name");
     }
+
+    static class TextType {
+        static final int OID = 25;
+        static final int TEXT_ARRAY_OID = 1009;
+        static final VarCharType INSTANCE = new VarCharType(OID, TEXT_ARRAY_OID, -1, "text");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The missing `text` is part of the reason
https://github.com/crate/crate/issues/10154 is not working


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)