### PR TITLE
Send transaction-state based on BEGIN/COMMIT in ready-for-query messages

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -84,6 +84,13 @@ Breaking Changes
   issue for most clients as the ``HTTP`` endpoint uses ``JSON`` for
   serialization and PostgreSQL clients usually use a typed ``getLong``.
 
+- In the PostgreSQL Wire Protocol, ``ReadyForQuery`` messages now contain the
+  ``IN TRANSACTION`` or ``FAILED TRANSACTION`` indicator based on previous
+  ``BEGIN`` and ``COMMIT`` SQL statements. Before this change, the status
+  always defaulted to ``IDLE``. This change may have the side-effect that an
+  explicit ``rollback`` call in a client library will result in an unsupported
+  ``ROLLBACK`` statement.
+
 Deprecations
 ============
 

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -130,11 +130,11 @@ public class Messages {
      * block; or 'E' if in a failed transaction block (queries will be
      * rejected until block is ended).
      */
-    static void sendReadyForQuery(Channel channel) {
+    static void sendReadyForQuery(Channel channel, TransactionState transactionState) {
         ByteBuf buffer = channel.alloc().buffer(6);
         buffer.writeByte('Z');
         buffer.writeInt(5);
-        buffer.writeByte('I');
+        buffer.writeByte(transactionState.code());
         ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace("sentReadyForQuery"));

--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -39,6 +39,7 @@ class ResultSetReceiver extends BaseResultReceiver {
     private final Channel channel;
     private final Function<Throwable, Exception> wrapError;
     private final List<PGType<?>> columnTypes;
+    private final TransactionState transactionState;
 
     @Nullable
     private final FormatCodes.FormatCode[] formatCodes;
@@ -47,11 +48,13 @@ class ResultSetReceiver extends BaseResultReceiver {
 
     ResultSetReceiver(String query,
                       Channel channel,
+                      TransactionState transactionState,
                       Function<Throwable, Exception> wrapError,
                       List<PGType<?>> columnTypes,
                       @Nullable FormatCodes.FormatCode[] formatCodes) {
         this.query = query;
         this.channel = channel;
+        this.transactionState = transactionState;
         this.wrapError = wrapError;
         this.columnTypes = columnTypes;
         this.formatCodes = formatCodes;
@@ -69,7 +72,7 @@ class ResultSetReceiver extends BaseResultReceiver {
     @Override
     public void batchFinished() {
         Messages.sendPortalSuspended(channel);
-        Messages.sendReadyForQuery(channel);
+        Messages.sendReadyForQuery(channel, transactionState);
     }
 
     @Override

--- a/server/src/main/java/io/crate/protocols/postgres/TransactionState.java
+++ b/server/src/main/java/io/crate/protocols/postgres/TransactionState.java
@@ -22,36 +22,19 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.data.Row1;
-import io.crate.protocols.postgres.types.PGTypes;
-import io.crate.types.DataTypes;
-import io.netty.channel.Channel;
-import org.junit.Test;
-import org.mockito.Answers;
 
-import java.util.Collections;
+public enum TransactionState {
+    IDLE('I'),
+    IN_TRANSACTION('T'),
+    FAILED_TRANSACTION('E');
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+    private final char code;
 
-public class ResultSetReceiverTest {
+    private TransactionState(char code) {
+        this.code = code;
+    }
 
-    @Test
-    public void testChannelIsPeriodicallyFlushedToAvoidConsumingTooMuchMemory() {
-        Channel channel = mock(Channel.class, Answers.RETURNS_DEEP_STUBS);
-        ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
-            "select * from t",
-            channel,
-            TransactionState.IDLE,
-            RuntimeException::new,
-            Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
-            null
-        );
-        Row1 row1 = new Row1(1);
-        for (int i = 0; i < 1500; i++) {
-            resultSetReceiver.setNextRow(row1);
-        }
-        verify(channel, times(1)).flush();
+    public int code() {
+        return (int) code;
     }
 }

--- a/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -22,24 +22,23 @@
 
 package io.crate.analyze;
 
+import static io.crate.testing.SymbolMatchers.isLiteral;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
 import io.crate.expression.symbol.Literal;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.SetTransactionStatement;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static io.crate.testing.SymbolMatchers.isLiteral;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -263,8 +263,6 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 statement.executeUpdate("refresh table t");
             }
 
-            // Because our ReadyForQuery messages always sends transaction-status IDLE, rollback and commit don't do anything
-            conn.rollback();
             conn.commit();
 
             try (Statement statement = conn.createStatement()) {

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -494,6 +494,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         DescribeResult describeResult = mock(DescribeResult.class);
         when(describeResult.getFields()).thenReturn(null);
         when(session.describe(anyChar(), anyString())).thenReturn(describeResult);
+        when(session.transactionState()).thenReturn(TransactionState.IDLE);
 
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Solves https://github.com/crate/crate/issues/10154

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)