### PR TITLE
Make sure credentials for s3 repo plugin are masked

### DIFF
--- a/blackbox/test_s3.py
+++ b/blackbox/test_s3.py
@@ -118,6 +118,13 @@ class S3SnapshotIntegrationTest(unittest.TestCase):
                     CREATE REPOSITORY r1 TYPE S3
                     WITH (access_key = 'minio', secret_key = 'miniostorage', bucket='backups', endpoint = '127.0.0.1:9000', protocol = 'http')
                 """)
+
+                # Make sure access_key and secret_key are masked in sys.repositories
+                c.execute('''SELECT settings['access_key'], settings['secret_key'] from sys.repositories where name = 'r1' ''')
+                settings = c.fetchone()
+                self.assertEqual(settings[0], '[xxxxx]')
+                self.assertEqual(settings[1], '[xxxxx]')
+
                 c.execute('CREATE SNAPSHOT r1.s1 ALL WITH (wait_for_completion = true)')
                 c.execute('DROP TABLE t1')
                 c.execute('RESTORE SNAPSHOT r1.s1 ALL WITH (wait_for_completion = true)')

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -268,6 +268,10 @@ Performance improvements
 Fixes
 =====
 
+- Fixed an issue where ``access_key`` and ``secret_key`` settings for
+  :ref:`s3 repositories <ref-create-repository-types-s3>` were exposed as
+  unmasked settings.
+
 - Fixed an issue that would prevent the :ref:`pg_stats <pg_stats>` table from
   querying if the ``most_common_vals`` or ``histogram_bounds`` columns contain
   values of the ``OBJECT`` or ``ARRAY`` types.

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.util.json.Jackson;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
@@ -35,6 +36,9 @@ import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.ACCESS_KEY_SETTING;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 
 /**
  * A plugin to add a repository type that writes to and from the AWS S3.
@@ -60,6 +64,11 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     public S3RepositoryPlugin() {
         this.service = new S3Service();
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(ACCESS_KEY_SETTING, SECRET_KEY_SETTING);
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adding the credentials `access_key` and `secret_key` back to the plugin settings will register them as masked settings in `ClusterSettings`. Therefore they will not be shown in `sys.repositories`.

```
cr> select * from sys.repositories;
+------+------------------------------------------------------------------------------------------------------------------------------+------+
| name | settings                                                                                                                     | type |
+------+------------------------------------------------------------------------------------------------------------------------------+------+
| r1  | {"access_key": "[xxxxx]", "bucket": "backups", "endpoint": "192.168.1.33:9000", "protocol": "http", "secret_key": "[xxxxx]"} | s3   |
+------+------------------------------------------------------------------------------------------------------------------------------+------+
```

I tried to find a better solution, as this change allows to define `access_key` and `secret_key` as part of `crate.yml`, which we wanted to prevent.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
