### PR TITLE
Always go through planner in Session#execute

### DIFF
--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -360,6 +360,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier executor = mock(DependencyCarrier.class);
         when(executor.threadPool()).thenReturn(mock(ThreadPool.class));
+        when(executor.clusterService()).thenReturn(clusterService);
         Session session = new Session(
             sqlExecutor.analyzer,
             sqlExecutor.planner,
@@ -387,6 +388,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier executor = mock(DependencyCarrier.class);
         when(executor.threadPool()).thenReturn(mock(ThreadPool.class));
+        when(executor.clusterService()).thenReturn(clusterService);
         Session session = new Session(
             sqlExecutor.analyzer,
             sqlExecutor.planner,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The change in 4952ae49317d8089ed5fa3b2580e24d4dd07f45a broke the asyncpg
tests again (getting stuck again), because the `activeExecution` future
handling was skipped.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)