### PR TITLE
Add missing functionality required to run crate-node tool

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     compileNotTransitive project(':libs:pgwire')
     compileNotTransitive project(':libs:dex')
     compileNotTransitive project(':libs:shared')
+    compileNotTransitive project(':libs:cli')
     compileNotTransitive project(':libs:guice')
     compileNotTransitive project(':libs:es-x-content')
     compileNotTransitive project(':libs:es-plugin-classloader')

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -12,6 +12,7 @@ aws=1.11.789
 elasticsearchhadoop=2.4.0
 slf4j_log4j12=1.7.10
 jaxb_api=2.2.2
+jopt_simple=5.0.2
 
 
 jackson=2.11.0

--- a/libs/cli/build.gradle
+++ b/libs/cli/build.gradle
@@ -1,0 +1,6 @@
+apply from: "$rootDir/gradle/javaModule.gradle"
+archivesBaseName = 'crate-cli'
+
+dependencies {
+    compile "net.sf.jopt-simple:jopt-simple:${versions.jopt_simple}"
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+/**
+ * An action to execute within a cli.
+ */
+public abstract class Command implements Closeable {
+
+    /** A description of the command, used in the help output. */
+    protected final String description;
+
+    private final Runnable beforeMain;
+
+    /** The option parser for this command. */
+    protected final OptionParser parser = new OptionParser();
+
+    private final OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "show help").forHelp();
+    private final OptionSpec<Void> silentOption = parser.acceptsAll(Arrays.asList("s", "silent"), "show minimal output");
+    private final OptionSpec<Void> verboseOption =
+        parser.acceptsAll(Arrays.asList("v", "verbose"), "show verbose output").availableUnless(silentOption);
+
+    /**
+     * Construct the command with the specified command description and runnable to execute before main is invoked.
+     *
+     * @param description the command description
+     * @param beforeMain the before-main runnable
+     */
+    public Command(final String description, final Runnable beforeMain) {
+        this.description = description;
+        this.beforeMain = beforeMain;
+    }
+
+    private Thread shutdownHookThread;
+
+    /** Parses options for this command from args and executes it. */
+    public final int main(String[] args, Terminal terminal) throws Exception {
+        if (addShutdownHook()) {
+
+            shutdownHookThread = new Thread(() -> {
+                try {
+                    this.close();
+                } catch (final IOException e) {
+                    try (
+                        StringWriter sw = new StringWriter();
+                        PrintWriter pw = new PrintWriter(sw)) {
+                        e.printStackTrace(pw);
+                        terminal.println(sw.toString());
+                    } catch (final IOException impossible) {
+                        // StringWriter#close declares a checked IOException from the Closeable interface but the Javadocs for StringWriter
+                        // say that an exception here is impossible
+                        throw new AssertionError(impossible);
+                    }
+                }
+            });
+            Runtime.getRuntime().addShutdownHook(shutdownHookThread);
+        }
+
+        beforeMain.run();
+
+        try {
+            mainWithoutErrorHandling(args, terminal);
+        } catch (OptionException e) {
+            printHelp(terminal);
+            terminal.println(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage());
+            return ExitCodes.USAGE;
+        } catch (UserException e) {
+            if (e.exitCode == ExitCodes.USAGE) {
+                printHelp(terminal);
+            }
+            terminal.println(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage());
+            return e.exitCode;
+        }
+        return ExitCodes.OK;
+    }
+
+    /**
+     * Executes the command, but all errors are thrown.
+     */
+    void mainWithoutErrorHandling(String[] args, Terminal terminal) throws Exception {
+        final OptionSet options = parser.parse(args);
+
+        if (options.has(helpOption)) {
+            printHelp(terminal);
+            return;
+        }
+
+        if (options.has(silentOption)) {
+            terminal.setVerbosity(Terminal.Verbosity.SILENT);
+        } else if (options.has(verboseOption)) {
+            terminal.setVerbosity(Terminal.Verbosity.VERBOSE);
+        } else {
+            terminal.setVerbosity(Terminal.Verbosity.NORMAL);
+        }
+
+        execute(terminal, options);
+    }
+
+    /** Prints a help message for the command to the terminal. */
+    private void printHelp(Terminal terminal) throws IOException {
+        terminal.println(description);
+        terminal.println("");
+        printAdditionalHelp(terminal);
+        parser.printHelpOn(terminal.getWriter());
+    }
+
+    /**
+     * Prints additional help information, specific to the command
+     */
+    protected void printAdditionalHelp(Terminal terminal) {
+    }
+
+    @SuppressForbidden(reason = "Allowed to exit explicitly from #main()")
+    protected static void exit(int status) {
+        System.exit(status);
+    }
+
+    /**
+     * Executes this command.
+     *
+     * Any runtime user errors (like an input file that does not exist), should throw a {@link UserException}. */
+    protected abstract void execute(Terminal terminal, OptionSet options) throws Exception;
+
+    /**
+     * Return whether or not to install the shutdown hook to cleanup resources on exit. This method should only be overridden in test
+     * classes.
+     *
+     * @return whether or not to install the shutdown hook
+     */
+    protected boolean addShutdownHook() {
+        return true;
+    }
+
+    /** Gets the shutdown hook thread if it exists **/
+    Thread getShutdownHookThread() {
+        return shutdownHookThread;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/ExitCodes.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/ExitCodes.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+/**
+ * POSIX exit codes.
+ */
+public class ExitCodes {
+    public static final int OK = 0;
+    public static final int USAGE = 64;          /* command line usage error */
+    public static final int CONFIG = 78;         /* configuration error */
+
+    private ExitCodes() {
+        /* no instance, just constants */
+    }
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/MultiCommand.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/MultiCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+import joptsimple.NonOptionArgumentSpec;
+import joptsimple.OptionSet;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A cli tool which is made up of multiple subcommands.
+ */
+public class MultiCommand extends Command {
+
+    protected final Map<String, Command> subcommands = new LinkedHashMap<>();
+
+    private final NonOptionArgumentSpec<String> arguments = parser.nonOptions("command");
+
+    /**
+     * Construct the multi-command with the specified command description and runnable to execute before main is invoked.
+     *
+     * @param description the multi-command description
+     * @param beforeMain the before-main runnable
+     */
+    public MultiCommand(final String description, final Runnable beforeMain) {
+        super(description, beforeMain);
+        parser.posixlyCorrect(true);
+    }
+
+    @Override
+    protected void printAdditionalHelp(Terminal terminal) {
+        if (subcommands.isEmpty()) {
+            throw new IllegalStateException("No subcommands configured");
+        }
+        terminal.println("Commands");
+        terminal.println("--------");
+        for (Map.Entry<String, Command> subcommand : subcommands.entrySet()) {
+            terminal.println(subcommand.getKey() + " - " + subcommand.getValue().description);
+        }
+        terminal.println("");
+    }
+
+    @Override
+    protected void execute(Terminal terminal, OptionSet options) throws Exception {
+        if (subcommands.isEmpty()) {
+            throw new IllegalStateException("No subcommands configured");
+        }
+        String[] args = arguments.values(options).toArray(new String[0]);
+        if (args.length == 0) {
+            throw new UserException(ExitCodes.USAGE, "Missing command");
+        }
+        Command subcommand = subcommands.get(args[0]);
+        if (subcommand == null) {
+            throw new UserException(ExitCodes.USAGE, "Unknown command [" + args[0] + "]");
+        }
+        subcommand.mainWithoutErrorHandling(Arrays.copyOfRange(args, 1, args.length), terminal);
+    }
+
+    @Override
+    public void close() throws IOException {
+        close(subcommands.values());
+    }
+
+    /**
+     * Closes all given {@link Closeable}s. Some of the {@linkplain Closeable}s may be null; they are
+     * ignored. After everything is closed, the method either throws the first exception it hit
+     * while closing with other exceptions added as suppressed, or completes normally if there were
+     * no exceptions.
+     *
+     * @param objects objects to close
+     */
+    public static void close(final Iterable<? extends Closeable> objects) throws IOException {
+        close(null, objects);
+    }
+
+    /**
+     * Closes all given {@link Closeable}s. If a non-null exception is passed in, or closing a
+     * stream causes an exception, throws the exception with other {@link RuntimeException} or
+     * {@link IOException} exceptions added as suppressed.
+     *
+     * @param ex existing Exception to add exceptions occurring during close to
+     * @param objects objects to close
+     */
+    public static void close(final Exception ex, final Iterable<? extends Closeable> objects) throws IOException {
+        Exception firstException = ex;
+        for (final Closeable object : objects) {
+            try {
+                if (object != null) {
+                    object.close();
+                }
+            } catch (final IOException | RuntimeException e) {
+                if (firstException == null) {
+                    firstException = e;
+                } else {
+                    firstException.addSuppressed(e);
+                }
+            }
+        }
+
+        if (firstException != null) {
+            if (firstException instanceof IOException) {
+                throw (IOException) firstException;
+            } else {
+                // since we only assigned an IOException or a RuntimeException to ex above, in this case ex must be a RuntimeException
+                throw (RuntimeException) firstException;
+            }
+        }
+    }
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/SuppressForbidden.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/SuppressForbidden.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to suppress forbidden-apis errors inside a whole class, a method, or a field.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+public @interface SuppressForbidden {
+    String reason();
+}
+

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+import java.io.BufferedReader;
+import java.io.Console;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+
+/**
+ * A Terminal wraps access to reading input and writing output for a cli.
+ *
+ * The available methods are similar to those of {@link Console}, with the ability
+ * to read either normal text or a password, and the ability to print a line
+ * of text. Printing is also gated by the {@link Verbosity} of the terminal,
+ * which allows {@link #println(Verbosity,String)} calls which act like a logger,
+ * only actually printing if the verbosity level of the terminal is above
+ * the verbosity of the message.
+*/
+public abstract class Terminal {
+
+    /** The default terminal implementation, which will be a console if available, or stdout/stderr if not. */
+    public static final Terminal DEFAULT = ConsoleTerminal.isSupported() ? new ConsoleTerminal() : new SystemTerminal();
+
+    /** Defines the available verbosity levels of messages to be printed. */
+    public enum Verbosity {
+        SILENT, /* always printed */
+        NORMAL, /* printed when no options are given to cli */
+        VERBOSE /* printed only when cli is passed verbose option */
+    }
+
+    /** The current verbosity for the terminal, defaulting to {@link Verbosity#NORMAL}. */
+    private Verbosity verbosity = Verbosity.NORMAL;
+
+    /** The newline used when calling println. */
+    private final String lineSeparator;
+
+    protected Terminal(String lineSeparator) {
+        this.lineSeparator = lineSeparator;
+    }
+
+    /** Sets the verbosity of the terminal. */
+    public void setVerbosity(Verbosity verbosity) {
+        this.verbosity = verbosity;
+    }
+
+    /** Reads clear text from the terminal input. See {@link Console#readLine()}. */
+    public abstract String readText(String prompt);
+
+    /** Returns a Writer which can be used to write to the terminal directly. */
+    public abstract PrintWriter getWriter();
+
+    /** Prints a line to the terminal at {@link Verbosity#NORMAL} verbosity level. */
+    public final void println(String msg) {
+        println(Verbosity.NORMAL, msg);
+    }
+
+    /** Prints a line to the terminal at {@code verbosity} level. */
+    public final void println(Verbosity verbosity, String msg) {
+        print(verbosity, msg + lineSeparator);
+    }
+
+    /** Prints message to the terminal at {@code verbosity} level, without a newline. */
+    public final void print(Verbosity verbosity, String msg) {
+        if (isPrintable(verbosity)) {
+            getWriter().print(msg);
+            getWriter().flush();
+        }
+    }
+
+    /** Checks if is enough {@code verbosity} level to be printed */
+    public final boolean isPrintable(Verbosity verbosity) {
+        return this.verbosity.ordinal() >= verbosity.ordinal();
+    }
+
+    private static class ConsoleTerminal extends Terminal {
+
+        private static final Console CONSOLE = System.console();
+
+        ConsoleTerminal() {
+            super(System.lineSeparator());
+        }
+
+        static boolean isSupported() {
+            return CONSOLE != null;
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return CONSOLE.writer();
+        }
+
+        @Override
+        public String readText(String prompt) {
+            return CONSOLE.readLine("%s", prompt);
+        }
+    }
+
+    private static class SystemTerminal extends Terminal {
+
+        private static final PrintWriter WRITER = newWriter();
+
+        SystemTerminal() {
+            super(System.lineSeparator());
+        }
+
+        @SuppressForbidden(reason = "Writer for System.out")
+        private static PrintWriter newWriter() {
+            return new PrintWriter(System.out);
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return WRITER;
+        }
+
+        @Override
+        public String readText(String text) {
+            getWriter().print(text);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
+            try {
+                final String line = reader.readLine();
+                if (line == null) {
+                    throw new IllegalStateException("unable to read from standard input; is standard input open and a tty attached?");
+                }
+                return line;
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+    }
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/UserException.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/UserException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+/**
+ * An exception representing a user fixable problem in {@link Command} usage.
+ */
+public class UserException extends Exception {
+
+    /** The exist status the cli should use when catching this user error. */
+    public final int exitCode;
+
+    /** Constructs a UserException with an exit status and message to show the user. */
+    public UserException(int exitCode, String msg) {
+        super(msg);
+        this.exitCode = exitCode;
+    }
+
+    /**
+     * Constructs a new user exception with specified exit status, message, and underlying cause.
+     *
+     * @param exitCode the exit code
+     * @param msg      the message
+     * @param cause    the underlying cause
+     */
+    public UserException(final int exitCode, final String msg, final Throwable cause) {
+        super(msg, cause);
+        this.exitCode = exitCode;
+    }
+
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile project(':libs:es-x-content')
     compile project(':libs:pgwire')
     compile project(':libs:shared')
+    compile project(':libs:cli')
     compile project(':libs:sql-parser')
     compile project(':libs:guice')
 
@@ -44,10 +45,6 @@ dependencies {
 
     compile "org.apache.logging.log4j:log4j-api:${versions.log4j2}"
     compile "org.apache.logging.log4j:log4j-core:${versions.log4j2}"
-
-    compile("org.elasticsearch:elasticsearch-cli:${versions.elasticsearch}") {
-        exclude group: 'org.elasticsearch', module: 'elasticsearch-core'
-    }
 
     compile "net.java.dev.jna:jna:${versions.jna}"
 

--- a/server/src/test/java/org/elasticsearch/cli/MockTerminal.java
+++ b/server/src/test/java/org/elasticsearch/cli/MockTerminal.java
@@ -60,7 +60,6 @@ public class MockTerminal extends Terminal {
         return textInput.get(textIndex++);
     }
 
-    @Override
     public char[] readSecret(String prompt) {
         if (secretIndex >= secretInput.size()) {
             throw new IllegalStateException("No secret input configured for prompt [" + prompt + "]");

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include 'libs:shared',
+        'libs:cli',
         'libs:dex',
         'libs:pgwire',
         'libs:es-x-content',


### PR DESCRIPTION
We were missing class org.elasticsearch.core.internal.io.IOUtils
which we need only for the purpose of closing Closeables at the
end of the command. I have create the class and added the least
ammount of code to make it work.

Fixes https://github.com/crate/crate/issues/10166
