### PR TITLE
Fix between handling in expression analyzer

### DIFF
--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -234,8 +234,14 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBetweenIsRewrittenToLteAndGte() throws Exception {
-        Symbol symbol = expressions.asSymbol("10 between 1 and 10");
-        assertThat(symbol, isSQL("true"));
+        Symbol symbol = executor.asSymbol("2 between t1.x and 20");
+        assertThat(symbol, isSQL("(doc.t1.x <= 2)"));
+    }
+
+    @Test
+    public void test_between_rewrite_if_first_arg_is_a_reference() throws Exception {
+        Symbol symbol = executor.asSymbol("t1.x between 10 and 20");
+        assertThat(symbol, isSQL("((doc.t1.x >= 10) AND (doc.t1.x <= 20))"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


https://github.com/crate/crate/commit/28de18fcc33f14c44121d49daedcdcc11caf536f broke the operator-swap logic
(left alignment of references)

The sqllogic tests failed because of that.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)