### PR TITLE
Fix time measurement in SysSnapshotsTest

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -71,6 +71,7 @@ public class SysSnapshotsTest extends SQLTransportIntegrationTest {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put("path.repo", TEMP_FOLDER.getRoot().getAbsolutePath())
+            .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // We have tests that verify an exact wait time
             .build();
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING` should be set to 0 when used for exact time measurements.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
