### PR TITLE
Fix stuck query on pg-wire-fetch

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -377,6 +377,7 @@ public class Session implements AutoCloseable {
         } else if (analyzedStmt instanceof AnalyzedCommit) {
             currentTransactionState = TransactionState.IDLE;
             resultReceiver.allFinished(false);
+            return resultReceiver.completionFuture();
         } else if (analyzedStmt instanceof AnalyzedDeallocate) {
             String stmtToDeallocate = ((AnalyzedDeallocate) analyzedStmt).preparedStmtName();
             if (stmtToDeallocate != null) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The change in https://github.com/crate/crate/commit/4952ae49317d8089ed5fa3b2580e24d4dd07f45a
broke the asyncpg tests and led to stuck queries.

This is an alternative to https://github.com/crate/crate/pull/10165


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)