### PR TITLE
Make sure null returned by `not` predicate is typed as boolean

### DIFF
--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -73,7 +73,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
             Object value = ((Input<?>) arg).value();
             if (value == null) {
                 // WHERE NOT NULL -> WHERE NULL
-                return Literal.NULL;
+                return Literal.of(DataTypes.BOOLEAN, null);
             }
             if (value instanceof Boolean) {
                 return Literal.of(!((Boolean) value));

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -50,7 +50,7 @@ public final class Filter extends ForwardingLogicalPlan {
             return source;
         }
         assert query.valueType().equals(DataTypes.BOOLEAN)
-            : "query must have a boolean result type, got: " + query.valueType();
+            : "query must have a boolean result type, got query `" + query + "` with result type: " + query.valueType();
         if (isMatchAll(query)) {
             return source;
         }

--- a/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.predicate;
 
 import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class NotPredicateTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeSymbolNull() throws Exception {
-        assertNormalize("not null", isLiteral(null));
+        assertNormalize("not null", isLiteral(null, DataTypes.BOOLEAN));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Not an issue if assertions are disabled, but if enabled and a query like
`HAVING NOT NULL` is used it resulted in an assertion error in the
filter operator


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)