### PR TITLE
Fix simple query channel delay handling

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -752,12 +752,10 @@ public class PostgresWireProtocol {
                 );
                 execute = session.execute("", 0, resultSetReceiver);
             }
-            if (execute == null) {
-                return session.sync();
-            } else {
+            if (execute != null) {
                 channel.delayWritesUntil(execute);
-                return execute.thenCompose(ignored -> session.sync());
             }
+            return session.sync();
         } catch (Throwable t) {
             Messages.sendErrorResponse(channel, t);
             result.completeExceptionally(t);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Chaining the `session.sync()` future to the `execute` future caused a
`OperationalError` with the psycopg2 client in our sqllogic test suite.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)