### PR TITLE
Exclude build-hash if releaseZip task is used

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -100,7 +100,7 @@ task getVersion(dependsOn: 'classes') {
 
         ext.buildDate = new Date().format('yyyyMMddHHmm')
         ext.buildShortHash = "git rev-parse --short HEAD".execute().text.trim()
-        if (gradle.taskGraph.hasTask(':app:release')) {
+        if (gradle.taskGraph.hasTask(':app:release') || gradle.taskGraph.hasTask(':app:releaseZip')) {
             assert gitTag == version, "Version mismatch gitTag: " + gitTag + " does not match crate version: " + version
         } else {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`:app:release` and `:app:releaseZip` should both result in the same
naming pattern (`crate-${version}.{extension}`)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)