### PR TITLE
Add recursive deletes for BlobContainers and fix Snapshot Deletion

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -10,6 +10,7 @@ tqdm==4.24.0
 sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
+minio>=5.0.0
 
 # packages for local dev
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -268,5 +268,9 @@ Performance improvements
 Fixes
 =====
 
+- Fixed an issue where :ref:`drop snapshot <ref-drop-snapshot>` on an
+  :ref:`azure repository <ref-create-repository-types-azure>` would not delete
+  all the related data.
+
 - Fixed an issue that could lead to a ``Field is not streamable`` error message
   when using window functions.

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -120,6 +120,15 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void delete() throws IOException {
+        try {
+            blobStore.deleteBlobDirectory(keyPath);
+        } catch (URISyntaxException | StorageException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
     public Map<String, BlobMetadata> listBlobsByPrefix(@Nullable String prefix) throws IOException {
         logger.trace("listBlobsByPrefix({})", prefix);
 

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -99,6 +99,10 @@ public class AzureBlobStore implements BlobStore {
         service.deleteBlob(container, blob);
     }
 
+    public void deleteBlobDirectory(String keyPath) throws URISyntaxException, StorageException, IOException {
+        service.deleteBlobDirectory(container, keyPath);
+    }
+
     public Map<String, BlobContainer> children(BlobPath path) throws URISyntaxException, StorageException {
         return Collections.unmodifiableMap(service.children(clientName, container, path).stream().collect(
             Collectors.toMap(Function.identity(), name -> new AzureBlobContainer(path.add(name), this))));

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -79,6 +79,11 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void delete() throws IOException {
+        store.execute(fileContext -> fileContext.delete(path, true));
+    }
+
+    @Override
     public InputStream readBlob(String blobName) throws IOException {
         // FSDataInputStream does buffering internally
         // FSDataInputStream can open connections on read() or skip() so we wrap in

--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -96,6 +96,11 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository is read only");
     }
 
+    @Override
+    public void delete() {
+        throw new UnsupportedOperationException("URL repository is read only");
+    }
+
     /**
      * This operation is not supported by URLBlobContainer
      */

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -115,6 +115,12 @@ public interface BlobContainer {
     void deleteBlob(String blobName) throws IOException;
 
     /**
+     * Deletes this container and all its contents from the repository.
+     * @throws IOException on failure
+     */
+    void delete() throws IOException;
+
+    /**
      * Deletes the blobs with given names. Unlike {@link #deleteBlob(String)} this method will not throw an exception
      * when one or multiple of the given blobs don't exist and simply ignore this case.
      *

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -124,6 +124,11 @@ public class FsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void delete() throws IOException {
+        IOUtils.rm(path);
+    }
+
+    @Override
     public boolean blobExists(String blobName) {
         return Files.exists(path.resolve(blobName));
     }

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
@@ -555,11 +556,11 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         assertThat(response.rows()[0][1], is(1));
     }
 
-    private static void assertAllRepoSnapshotFilesAreDeleted(File location) {
+    private static void assertAllRepoSnapshotFilesAreDeleted(File location) throws IOException {
         //Make sure the file location does not consist of any .dat file
-        for (var file : location.listFiles()) {
-            assertThat(file.getName().endsWith(".dat"), is(false));
-        }
+        Files.walk(location.toPath())
+            .filter(Files::isRegularFile)
+            .forEach(x -> assertThat(x.getFileName().endsWith(".dat"), is(false)));
     }
 
     private RepositoryData getRepositoryData() throws Exception {


### PR DESCRIPTION
This improves the snapshot deletion process making sure all files are removed when a snapshot is deleted. The problem was discovered while porting over https://github.com/elastic/elasticsearch/pull/43281.

It is based on the following steps:

- Add recursive deletes based on https://github.com/elastic/elasticsearch/pull/43281 implementing `blobContainer.delete()` to simplify the deletion process.
- Adding assertions for the Snapshot tests to make sure all files are removed.
- Adapt the relevant parts of the `BlobStoreRepository` according to the state of https://github.com/elastic/elasticsearch/pull/46250/.



## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
