### PR TITLE
Improve error messages on repository creation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ Breaking Changes
 Changes
 =======
 
+- Added detailed information to possible errors on ``repository`` creation to
+  give better insights on the root cause of the error.
+
 - Added scalar function :ref:`pg_get_function_result <pg_get_function_result>`.
 
 - Added full support for quoted subscript expressions like ``"myObj['x']"``.

--- a/plugins/es-repository-s3/build.gradle
+++ b/plugins/es-repository-s3/build.gradle
@@ -15,10 +15,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.6.0'
     implementation 'javax.xml.bind:jaxb-api:2.2.2'
 
+    testImplementation project(path: ':libs:dex', configuration: 'testOutput')
     testImplementation project(path: ':server', configuration: 'testOutput')
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.apache.lucene:lucene-test-framework:${versions.lucene}"
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+    testImplementation("org.postgresql:postgresql:${versions.jdbc}")
     testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
     testImplementation "junit:junit:${versions.junit}"
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import org.elasticsearch.plugins.Plugin;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.SQLErrorMatcher.isSQLError;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static org.hamcrest.Matchers.startsWith;
+
+public class S3RepositoryIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(S3RepositoryPlugin.class);
+        return plugins;
+    }
+
+    @Test
+    public void test_unable_to_create_s3_repository() throws Throwable {
+        assertThrows(() -> execute(
+            "create repository test123 type s3 with (bucket='bucket', endpoint='https://s3.region.amazonaws.com', " +
+            "protocol='https', access_key='access',secret_key='secret', base_path='test123')"),
+                     isSQLError(
+                         startsWith("[test123] Unable to verify the repository, [test123] is not accessible on master " +
+                              "node: SdkClientException 'Unable to execute HTTP request: bucket.s3.region.amazonaws.com"),
+                         INTERNAL_ERROR,
+                         INTERNAL_SERVER_ERROR,
+                         5000)
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -106,6 +106,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -790,8 +791,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
                 return seed;
             }
-        } catch (IOException exp) {
-            throw new RepositoryVerificationException(metadata.name(), "path " + basePath() + " is not accessible on master node", exp);
+        } catch (Exception e) {
+            throw new RepositoryVerificationException(metadata.name(),
+                        String.format(Locale.ENGLISH,
+                                      "Unable to verify the repository, [%s] is not accessible on master node: %s '%s'",
+                                      metadata.name(),
+                                      e.getCause().getClass().getSimpleName(),
+                                      e.getCause().getMessage()));
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes  the error message for failed repository creation, adding additional information of the underlying failure to make it
easier to understand the root cause from the client side. Error codes for the client remain the same.

Before: 
```
cr> create repository test123 type s3 with (bucket='bucket', endpoint='https://s3.region.amazonaws.com', protocol='https', access_key='access
    ',secret_key='secret' ,base_path='test123');
RepositoryException[[] [test123] path [test123] is not accessible on master node]
```

Now:

```
cr> create repository test123 type s3 with (bucket='bucket', endpoint='https://s3.region.amazonaws.com', protocol='https', access_key='access
    ',secret_key='secret' ,base_path='test123');
RepositoryException[[] [test123] Unable verify repository, [test123] is not accessible on master node: Unable to execute HTTP request: bucket.s3.region.amazonaws.com]
```
Or:

```
cr> create repository r1 type azure with (container = 'invalid', account = 'devstoreaccount1', key = 'ZGV2c3RvcmVhY2NvdW50MQ==', endpoint_suff
    ix = 'ignored;DefaultEndpointsProtocol=http;BlobEndpoint');
RepositoryException[[] [r1] Unable verify repository, [r1] is not accessible on master node: Invalid connection string.]
```




## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
