### PR TITLE
Don't flush when sending row description

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -416,7 +416,7 @@ public class Messages {
         }
 
         buffer.setInt(1, length);
-        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
+        ChannelFuture channelFuture = channel.write(buffer);
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace("sentRowDescription"));
         }

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -247,6 +247,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             channel.releaseInbound();
 
             // we should get back a RowDescription message
+            channel.flushOutbound();
             ByteBuf response = channel.readOutbound();
             try {
                 assertThat(response.readByte(), is((byte) 'T'));
@@ -297,6 +298,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             channel.releaseInbound();
 
             // we should get back a ParameterDescription message
+            channel.flushOutbound();
             ByteBuf response = channel.readOutbound();
             try {
                 assertThat(response.readByte(), is((byte) 't'));


### PR DESCRIPTION
Tested asyncpg and npgsql to see if they've a problem with this change. Both worked.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)