### PR TITLE
Quote only base part of subscript expressions with `quote_ident`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,10 @@ None
 Fixes
 =====
 
+- Fixed an issue with the :ref:`quote_ident <scalar-quote-ident>` scalar
+  function that caused it to quote subscript expressions like ``"col['x']"``
+  instead of ``"col"['x']``.
+
 - Fixed an issue that prevented the use of subscript expressions as conflict
   target in ``ON CONFLICT`` clauses of ``INSERT`` statements.
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import java.util.List;
+
 public class IdentifiersTest {
 
     @Test
@@ -73,5 +75,37 @@ public class IdentifiersTest {
         assertThat(Identifiers.quoteIfNeeded("_col"), is("_col"));
         assertThat(Identifiers.quoteIfNeeded("col_1"), is("col_1"));
         assertThat(Identifiers.quoteIfNeeded("col['a']"), is("\"col['a']\""));
+    }
+
+    @Test
+    public void test_maybe_quote_expression_behaves_like_quote_if_needed_for_non_subscripts() throws Exception {
+        for (String candidate : List.of(
+            (""),
+            ("\""),
+            ("fhjgadhjgfhs"),
+            ("fhjgadhjgfhsÖ"),
+            ("ABC"),
+            ("abc\""),
+            ("select"),
+            ("1column"),
+            ("column name"),
+            ("col1a"),
+            ("_col"),
+            ("col_1")
+        )) {
+            assertThat(Identifiers.maybeQuoteExpression(candidate), is(Identifiers.quoteIfNeeded(candidate)));
+        }
+    }
+
+    @Test
+    public void test_quote_expression_quotes_only_base_part_of_subscript_expression() throws Exception {
+        assertThat(Identifiers.maybeQuoteExpression("col['a']"), is("col['a']"));
+        assertThat(Identifiers.maybeQuoteExpression("Col['a']"), is("\"Col\"['a']"));
+        assertThat(Identifiers.maybeQuoteExpression("col with space['a']"), is("\"col with space\"['a']"));
+    }
+
+    @Test
+    public void test_quote_expression_quotes_keywords() throws Exception {
+        assertThat(Identifiers.maybeQuoteExpression("select"), is("\"select\"")); // keyword
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -43,7 +43,7 @@ public final class QuoteIdentFunction {
                     signature,
                     boundSignature,
                     DataTypes.STRING,
-                    Identifiers::quoteIfNeeded
+                    Identifiers::maybeQuoteExpression
                 )
         );
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Would fix the issue mentioned in https://github.com/crate/crate/issues/10163#issuecomment-657599815

Not sure if this should count as a fix for 4.2.x or if we should have it in 4.3
as a change.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)