### PR TITLE
Fix ADD COLUMN on tables with INDEX OFF primary key columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,4 +54,6 @@ None
 Fixes
 =====
 
-None
+- Fixed an issue that prevented ``ALTER TABLE .. ADD COLUMN`` statements from
+  working on tables containing a ``PRIMARY KEY`` column with a ``INDEX OFF``
+  definition.

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -215,7 +215,7 @@ public class AnalyzedColumnDefinition<T> {
         this.indexMethod = indexMethod;
     }
 
-    void indexConstraint(Reference.IndexType indexType) {
+    public void indexConstraint(Reference.IndexType indexType) {
         this.indexType = indexType;
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -62,6 +62,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
                       "     pk object as (a int, b object as (c int))," +
                       "     primary key (pk['a'], pk['b']['c'])" +
                       ")")
+            .addTable("create table tbl_index_off (num bigint index off, primary key (num))")
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }
@@ -418,5 +419,12 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         assertThat(mapToSortedString(mapping),
             is("_meta={primary_keys=[id]}, properties={id={type=long}, " +
                "string_no_docvalues={doc_values=false, position=18, type=keyword}}"));
+    }
+
+    @Test
+    public void test_primary_key_contains_index_definitions_on_alter_table_new_column() throws Exception {
+        BoundAddColumn addColumn = analyze("alter table tbl_index_off add column browser text");
+        Map<String, Object> mapping = (Map<String, Object>) addColumn.mapping().get("properties");
+        assertThat(mapping, Matchers.hasEntry(is("num"), is(Map.of("index", false, "type", "long"))));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The alter table logic is currently not fully diff-based, so we add the
existing primary keys into the `mapping` request.

This mapping must mirror the existing primary key definitions, otherwise
it leads to a mapping merge error.

The index constraint information wasn't set correctly.

Fixes https://github.com/crate/crate/issues/10215


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)