### PR TITLE
Add an empty pg_role table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -48,7 +48,7 @@ None
 Changes
 =======
 
-None
+- Added the `pg_catalog.pg_roles table <postgres_pg_catalog>`
 
 
 Fixes

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -92,6 +92,7 @@ number of replicas.
     | pg_catalog         | pg_namespace            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_proc                 | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_range                | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_roles                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_settings             | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
@@ -114,7 +115,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 47 rows in set (... sec)
+    SELECT 48 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -145,6 +145,7 @@ following tables:
  - `pg_description`_
  - `pg_range`_
  - `pg_enum`_
+ - `pg_roles`_
 
 
 .. _postgres_pg_type:
@@ -410,25 +411,26 @@ either because of the table is empty or by a not matching where clause.
 
 .. _Arrays: https://www.postgresql.org/docs/current/static/arrays.html
 .. _Enterprise Edition: https://crate.io/enterprise-edition/
-.. _Simple Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
 .. _Extended Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 .. _Github: https://github.com/crate/crate
 .. _High Level Architecture: https://crate.io/overview/high-level-architecture
+.. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
+.. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
+.. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html
+.. _pg_roles: https://www.postgresql.org/docs/10/view-pg-roles.html
+.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html
+.. _pgsql_pg_attribute: https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html
+.. _pgsql_pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
+.. _pgsql_pg_constraint: https://www.postgresql.org/docs/10/static/catalog-pg-constraint.html
+.. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
+.. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
+.. _pgsql_pg_namespace: https://www.postgresql.org/docs/10/static/catalog-pg-namespace.html
+.. _pgsql_pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
+.. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html
+.. _pgsql_pg_type: https://www.postgresql.org/docs/10/static/catalog-pg-type.html
 .. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/current/static/functions-textsearch.html
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/head/connect.html#connection-failover
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
+.. _Simple Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
 .. _Value Expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html
-.. _pgsql_pg_type: https://www.postgresql.org/docs/10/static/catalog-pg-type.html
-.. _pgsql_pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
-.. _pgsql_pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
-.. _pgsql_pg_namespace: https://www.postgresql.org/docs/10/static/catalog-pg-namespace.html
-.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html
-.. _pgsql_pg_attribute: https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html
-.. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
-.. _pgsql_pg_constraint: https://www.postgresql.org/docs/10/static/catalog-pg-constraint.html
-.. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
-.. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html
-.. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
-.. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html
-.. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -67,7 +67,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgSettingsTable.IDENT.name(), PgSettingsTable.create()),
             Map.entry(PgProcTable.IDENT.name(), PgProcTable.create()),
             Map.entry(PgRangeTable.IDENT.name(), PgRangeTable.create()),
-            Map.entry(PgEnumTable.IDENT.name(), PgEnumTable.create())
+            Map.entry(PgEnumTable.IDENT.name(), PgEnumTable.create()),
+            Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -118,6 +118,11 @@ public class PgCatalogTableDefinitions {
             PgEnumTable.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgRolesTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgRolesTable.create().expressions(),
+            false
+        ));
         Iterable<NamedSessionSetting> sessionSettings =
             () -> sessionSettingRegistry.settings().entrySet().stream()
                 .map(s -> new NamedSessionSetting(s.getKey(), s.getValue()))

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
+import static io.crate.types.DataTypes.BOOLEAN;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.TIMESTAMPZ;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+public final class PgRolesTable {
+
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_roles");
+
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("oid", INTEGER, ignored -> null)
+            .add("rolname", STRING, ignored -> null)
+            .add("rolsuper", BOOLEAN, ignored -> null)
+            .add("rolinherit", BOOLEAN, ignored -> null)
+            .add("rolcreaterole", BOOLEAN, ignored -> null)
+            .add("rolcreatedb", BOOLEAN, ignored -> null)
+            .add("rolcanlogin", BOOLEAN, ignored -> null)
+            .add("rolreplication", BOOLEAN, ignored -> null)
+            .add("rolconnlimit", INTEGER, ignored -> null)
+            .add("rolpassword", STRING, ignored -> null)
+            .add("rolvaliduntil", TIMESTAMPZ, ignored -> null)
+            .add("rolbypassrls", BOOLEAN, ignored -> null)
+            .add("rolconfig", STRING_ARRAY, ignored -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -59,7 +59,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(41L, response.rowCount());
+        assertEquals(42L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -84,6 +84,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_namespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_proc| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_range| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_roles| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_settings| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
@@ -183,13 +184,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(41L, response.rowCount());
+        assertEquals(42L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(42L, response.rowCount());
+        assertEquals(43L, response.rowCount());
     }
 
     @Test
@@ -517,7 +518,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(794, response.rowCount());
+        assertEquals(807, response.rowCount());
     }
 
     @Test
@@ -761,7 +762,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(44L, response.rows()[0][0]);
+        assertEquals(45L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -91,7 +91,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(41L, response.rowCount());
+        assertEquals(42L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We currently don't have roles that map nicely to PostgreSQL roles, so
the table is empty for now.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)