### PR TITLE
Allow users to kill their own statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -48,6 +48,9 @@ None
 Changes
 =======
 
+- Changed the privileges for ``KILL``, all users are now allowed to kill their
+  own statements.
+
 - Added the `pg_catalog.pg_roles table <postgres_pg_catalog>`
 
 

--- a/docs/sql/statements/kill.rst
+++ b/docs/sql/statements/kill.rst
@@ -23,8 +23,15 @@ Synopsis
 Description
 ===========
 
-The ``KILL ALL`` statement kills all active jobs within the CrateDB cluster.
-The statement ``KILL job_id`` kills the job with a specified ``job_id``.
+The ``KILL ALL`` statement kills all active jobs within the CrateDB cluster
+which are owned by the current user.
+
+The statement ``KILL job_id`` kills the job with a specified ``job_id`` if the
+job was started by the current user.
+
+An exception to this is the ``CRATE`` super-user, which can also kill
+statements of other users.
+
 
 Be aware that CrateDB doesn't have transactions. If an operation which modifies
 data is killed, it won't rollback. For example if a update operation is killed

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -469,7 +469,8 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitKillAnalyzedStatement(AnalyzedKill analysis, User user) {
-            throwRequiresSuperUserPermission(user.name());
+            // All users can kill their own statements.
+            // If the user doesn't have privileges to kill a certain job-id the row-count will be lower or 0
             return null;
         }
 

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -196,10 +196,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testKillNotAllowedAsNormalUser() throws Exception {
-        expectedException.expect(UnauthorizedException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement. " +
-                                        "Superuser permissions are required");
+    public void test_kill_is_allowed_for_any_user() throws Exception {
+        // Only kills their own statements
         analyze("kill all");
     }
 

--- a/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine;
 
+import io.crate.auth.user.User;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -93,6 +94,7 @@ class InterceptingRowConsumer implements RowConsumer {
         } else {
             KillJobsRequest killRequest = new KillJobsRequest(
                 List.of(jobId),
+                User.CRATE_USER.name(),
                 "An error was encountered: " + failure
             );
             transportKillJobsNodeAction.broadcast(

--- a/server/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/server/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -198,7 +198,12 @@ public final class JobLauncher {
         List<Tuple<ExecutionPhase, RowConsumer>> handlerPhaseAndReceiver = createHandlerPhaseAndReceivers(
             handlerPhases, handlerConsumers, initializationTracker);
 
-        RootTask.Builder builder = tasksService.newBuilder(jobId, localNodeId, operationByServer.keySet());
+        RootTask.Builder builder = tasksService.newBuilder(
+            jobId,
+            txnCtx.sessionSettings().userName(),
+            localNodeId,
+            operationByServer.keySet()
+        );
         SharedShardContexts sharedShardContexts = maybeInstrumentProfiler(builder);
         List<CompletableFuture<StreamBucket>> directResponseFutures = jobSetup.prepareOnHandler(
             txnCtx.sessionSettings(),

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -173,7 +173,12 @@ public class RemoteCollector {
     }
 
     private RootTask.Builder createPageDownstreamContext() {
-        RootTask.Builder builder = tasksService.newBuilder(jobId, localNode, Collections.emptySet());
+        RootTask.Builder builder = tasksService.newBuilder(
+            jobId,
+            sessionSettings.userName(),
+            localNode,
+            Collections.emptySet()
+        );
 
         PassThroughPagingIterator<Integer, Row> pagingIterator;
         if (scrollRequired) {
@@ -201,7 +206,11 @@ public class RemoteCollector {
     }
 
     private void killRemoteContext() {
-        KillJobsRequest killRequest = new KillJobsRequest(List.of(jobId), null);
+        KillJobsRequest killRequest = new KillJobsRequest(
+            List.of(jobId),
+            sessionSettings.userName(),
+            null
+        );
         transportKillJobsNodeAction.broadcast(killRequest, new ActionListener<>() {
 
                 @Override

--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.distribution;
 
+import io.crate.auth.user.User;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.JobKilledException;
@@ -186,6 +187,7 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
              */
             KillJobsRequest killRequest = new KillJobsRequest(
                 List.of(request.jobId()),
+                User.CRATE_USER.name(),
                 "Received data for job=" + request.jobId() + " but there is no job context present. " +
                 "This can happen due to bad network latency or if individual nodes are unresponsive due to high load"
             );

--- a/server/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -23,6 +23,7 @@ package io.crate.execution.jobs;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.cursors.IntCursor;
+
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.exceptions.JobKilledException;
@@ -62,6 +63,7 @@ public class RootTask implements CompletionListenable<Void> {
     private final CompletableFuture<Void> finishedFuture = new CompletableFuture<>();
     private final AtomicBoolean killTasksOngoing = new AtomicBoolean(false);
     private final Collection<String> participatedNodes;
+    private final String user;
 
     @Nullable
     private final ProfilingContext profiler;
@@ -80,6 +82,7 @@ public class RootTask implements CompletionListenable<Void> {
         private final String coordinatorNode;
         private final JobsLogs jobsLogs;
         private final List<Task> tasks = new ArrayList<>();
+        private final String user;
         private final Collection<String> participatingNodes;
 
         @Nullable
@@ -87,11 +90,13 @@ public class RootTask implements CompletionListenable<Void> {
 
         Builder(Logger logger,
                 UUID jobId,
+                String user,
                 String coordinatorNode,
                 Collection<String> participatingNodes,
                 JobsLogs jobsLogs) {
             this.logger = logger;
             this.jobId = jobId;
+            this.user = user;
             this.coordinatorNode = coordinatorNode;
             this.participatingNodes = participatingNodes;
             this.jobsLogs = jobsLogs;
@@ -116,19 +121,28 @@ public class RootTask implements CompletionListenable<Void> {
 
         RootTask build() throws Exception {
             return new RootTask(
-                logger, jobId, coordinatorNode, participatingNodes, jobsLogs, tasks, profilingContext);
+                logger,
+                jobId,
+                user,
+                coordinatorNode,
+                participatingNodes,
+                jobsLogs,
+                tasks,
+                profilingContext
+            );
         }
     }
 
-
     private RootTask(Logger logger,
                      UUID jobId,
+                     String user,
                      String coordinatorNodeId,
                      Collection<String> participatingNodes,
                      JobsLogs jobsLogs,
                      List<Task> orderedTasks,
                      @Nullable ProfilingContext profilingContext) throws Exception {
         this.logger = logger;
+        this.user = user;
         this.coordinatorNodeId = coordinatorNodeId;
         this.participatedNodes = participatingNodes;
         this.jobId = jobId;
@@ -296,6 +310,10 @@ public class RootTask implements CompletionListenable<Void> {
     @Override
     public CompletableFuture<Void> completionFuture() {
         return finishedFuture;
+    }
+
+    public String userName() {
+        return user;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/kill/TransportKillAllNodeAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/kill/TransportKillAllNodeAction.java
@@ -41,6 +41,6 @@ public class TransportKillAllNodeAction extends TransportKillNodeAction<KillAllR
 
     @Override
     protected CompletableFuture<Integer> doKill(KillAllRequest request) {
-        return tasksService.killAll();
+        return tasksService.killAll(request.userName());
     }
 }

--- a/server/src/main/java/io/crate/execution/jobs/kill/TransportKillJobsNodeAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/kill/TransportKillJobsNodeAction.java
@@ -43,7 +43,7 @@ public class TransportKillJobsNodeAction extends TransportKillNodeAction<KillJob
 
     @Override
     protected CompletableFuture<Integer> doKill(KillJobsRequest request) {
-        return tasksService.killJobs(request.toKill(), request.reason());
+        return tasksService.killJobs(request.toKill(), request.userName(), request.reason());
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.jobs.transport;
 
+import io.crate.auth.user.User;
 import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
@@ -118,7 +119,11 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
                 deadNode.getId());
         }
         List<String> excludedNodeIds = Collections.singletonList(deadNode.getId());
-        KillJobsRequest killRequest = new KillJobsRequest(affectedJobs, "Participating node=" + deadNode.getName() + " disconnected.");
+        KillJobsRequest killRequest = new KillJobsRequest(
+            affectedJobs,
+            User.CRATE_USER.name(),
+            "Participating node=" + deadNode.getName() + " disconnected."
+        );
         killJobsNodeAction.broadcast(killRequest, new ActionListener<>() {
             @Override
             public void onResponse(Long numKilled) {
@@ -151,7 +156,11 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
         if (jobsStartedByDeadNode.isEmpty()) {
             return;
         }
-        tasksService.killJobs(jobsStartedByDeadNode, "Participating node=" + deadNode.getName() + " disconnected.");
+        tasksService.killJobs(
+            jobsStartedByDeadNode,
+            User.CRATE_USER.name(),
+            "Participating node=" + deadNode.getName() + " disconnected."
+        );
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Killed {} jobs started by disconnected node={}", jobsStartedByDeadNode.size(), deadNode.getId());
         }

--- a/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -83,7 +83,11 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
     @Override
     public CompletableFuture<JobResponse> nodeOperation(final JobRequest request) {
         RootTask.Builder contextBuilder = tasksService.newBuilder(
-            request.jobId(), request.coordinatorNodeId(), Collections.emptySet());
+            request.jobId(),
+            request.sessionSettings().userName(),
+            request.coordinatorNodeId(),
+            Collections.emptySet()
+        );
 
         SharedShardContexts sharedShardContexts = maybeInstrumentProfiler(request.enableProfiling(), contextBuilder);
 

--- a/server/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -71,6 +71,7 @@ public class KillPlan implements Plan {
                 plannerContext.functions(),
                 params,
                 subQueryResults),
+            plannerContext.transactionContext().sessionSettings().userName(),
             dependencies.transportActionProvider().transportKillAllNodeAction(),
             dependencies.transportActionProvider().transportKillJobsNodeAction(),
             consumer
@@ -104,16 +105,17 @@ public class KillPlan implements Plan {
 
     @VisibleForTesting
     void execute(@Nullable UUID jobId,
+                 String userName,
                  TransportKillAllNodeAction killAllNodeAction,
                  TransportKillJobsNodeAction killJobsNodeAction,
                  RowConsumer consumer) {
         if (jobId != null) {
             killJobsNodeAction.broadcast(
-                new KillJobsRequest(List.of(jobId), "KILL invoked by user"),
+                new KillJobsRequest(List.of(jobId), userName, "KILL invoked by user: " + userName),
                 new OneRowActionListener<>(consumer, Row1::new));
         } else {
             killAllNodeAction.broadcast(
-                new KillAllRequest(),
+                new KillAllRequest(userName),
                 new OneRowActionListener<>(consumer, Row1::new));
         }
     }

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -69,7 +69,7 @@ public class RootTaskTest extends CrateUnitTest {
     @Test
     public void testAddTheSameContextTwiceThrowsAnError() throws Exception {
         RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
         builder.addTask(new AbstractTaskTest.TestingTask());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Task for 0 already added");
@@ -80,7 +80,7 @@ public class RootTaskTest extends CrateUnitTest {
     @Test
     public void testKillPropagatesToSubContexts() throws Exception {
         RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
 
 
         AbstractTaskTest.TestingTask ctx1 = new AbstractTaskTest.TestingTask(1);
@@ -101,7 +101,7 @@ public class RootTaskTest extends CrateUnitTest {
     public void testErrorMessageIsIncludedInStatsTableOnFailure() throws Exception {
         JobsLogs jobsLogs = mock(JobsLogs.class);
         RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), jobsLogs);
+            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), jobsLogs);
 
         Task task = new AbstractTask(0) {
             @Override
@@ -131,7 +131,7 @@ public class RootTaskTest extends CrateUnitTest {
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
 
         RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
 
         CollectTask collectChildTask = new CollectTask(
             collectPhase,
@@ -180,7 +180,7 @@ public class RootTaskTest extends CrateUnitTest {
     @Test
     public void testEnablingProfilingGathersExecutionTimes() throws Throwable {
         RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
         ProfilingContext profilingContext = new ProfilingContext(Collections::emptyList);
         builder.profilingContext(profilingContext);
 

--- a/server/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
@@ -38,7 +38,7 @@ public class KillJobsRequestTest extends CrateUnitTest {
     @Test
     public void testStreaming() throws Exception {
         ImmutableList<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
-        KillJobsRequest r = new KillJobsRequest(toKill, "just because");
+        KillJobsRequest r = new KillJobsRequest(toKill, "dummy-user", "just because");
 
         BytesStreamOutput out = new BytesStreamOutput();
         r.writeTo(out);
@@ -48,5 +48,6 @@ public class KillJobsRequestTest extends CrateUnitTest {
 
         assertThat(r.toKill(), equalTo(r2.toKill()));
         assertThat(r.reason(), is(r2.reason()));
+        assertThat(r.userName(), is(r2.userName()));
     }
 }

--- a/server/src/test/java/io/crate/execution/jobs/kill/TransportKillAllNodeActionTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/TransportKillAllNodeActionTest.java
@@ -48,8 +48,8 @@ public class TransportKillAllNodeActionTest extends CrateDummyClusterServiceUnit
                 Settings.EMPTY, Version.CURRENT, THREAD_POOL, clusterService.getClusterSettings())
         );
 
-        transportKillAllNodeAction.nodeOperation(new KillAllRequest()).get(5, TimeUnit.SECONDS);
-        verify(tasksService, times(1)).killAll();
+        transportKillAllNodeAction.nodeOperation(new KillAllRequest("dummy-user")).get(5, TimeUnit.SECONDS);
+        verify(tasksService, times(1)).killAll("dummy-user");
     }
 
 }

--- a/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
@@ -52,7 +52,7 @@ public class TransportKillJobsNodeActionTest extends CrateDummyClusterServiceUni
 
         List<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
 
-        transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill, null)).get(5, TimeUnit.SECONDS);
-        verify(tasksService, times(1)).killJobs(toKill, null);
+        transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill, "dummy-user", null)).get(5, TimeUnit.SECONDS);
+        verify(tasksService, times(1)).killJobs(toKill, "dummy-user", null);
     }
 }

--- a/server/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
@@ -80,13 +80,13 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServic
         DiscoveryNode coordinator = newNode("coordinator");
         DiscoveryNode dataNode = newNode("dataNode");
 
-        RootTask.Builder builder = tasksService.newBuilder(UUID.randomUUID(), coordinator.getId(), Arrays.asList(coordinator.getId(), dataNode.getId()));
+        RootTask.Builder builder = tasksService.newBuilder(UUID.randomUUID(), "dummy-user", coordinator.getId(), Arrays.asList(coordinator.getId(), dataNode.getId()));
         builder.addTask(new DummyTask());
         tasksService.createTask(builder);
 
         // add a second job that is coordinated by the other node to make sure the the broadcast logic is run
         // even though there are jobs coordinated by the disconnected node
-        builder = tasksService.newBuilder(UUID.randomUUID(), dataNode.getId(), Collections.emptySet());
+        builder = tasksService.newBuilder(UUID.randomUUID(), "dummy-user", dataNode.getId(), Collections.emptySet());
         builder.addTask(new DummyTask());
         tasksService.createTask(builder);
 

--- a/server/src/test/java/io/crate/planner/node/management/KillPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/management/KillPlanTest.java
@@ -65,6 +65,7 @@ public class KillPlanTest extends CrateDummyClusterServiceUnitTest {
         KillPlan killPlan = new KillPlan(null);
         killPlan.execute(
             null,
+            "dummy-user",
             killAllNodeAction,
             mock(TransportKillJobsNodeAction.class),
             new TestingRowConsumer());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/10207


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)