### PR TITLE
Add new extensions for Lucene86 points codec

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -173,7 +173,10 @@ public class FsDirectoryService extends DirectoryService {
                 // We want to open the terms index and KD-tree index off-heap to save memory, but this only performs
                 // well if using mmap.
                 case "tip":
+                // dim files only apply up to lucene 8.x indices. It can be removed once we are in lucene 10
                 case "dim":
+                case "kdd":
+                case "kdi":
                 // Compound files are tricky because they store all the information for the segment. Benchmarks
                 // suggested that not mapping them hurts performance.
                 case "cfs":

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryServiceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.junit.Test;
+
+public class FsDirectoryServiceTest extends ESTestCase {
+
+    @Test
+    public void testPreload() throws IOException {
+        Settings build = Settings.builder()
+            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.HYBRIDFS.name().toLowerCase(Locale.ROOT))
+            .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), "dvd", "bar")
+            .build();
+        try (Directory directory = newDirectory(build)) {
+            assertTrue(FsDirectoryService.isHybridFs(directory));
+            try (FsDirectoryService.HybridDirectory hybridDirectory = (FsDirectoryService.HybridDirectory) directory) {
+                assertTrue(hybridDirectory.useDelegate("foo.dvd"));
+                assertTrue(hybridDirectory.useDelegate("foo.nvd"));
+                assertTrue(hybridDirectory.useDelegate("foo.tim"));
+                assertTrue(hybridDirectory.useDelegate("foo.tip"));
+                assertTrue(hybridDirectory.useDelegate("foo.cfs"));
+                assertTrue(hybridDirectory.useDelegate("foo.dim"));
+                assertTrue(hybridDirectory.useDelegate("foo.kdd"));
+                assertTrue(hybridDirectory.useDelegate("foo.kdi"));
+                assertFalse(hybridDirectory.useDelegate("foo.bar"));
+            }
+        }
+    }
+
+     private Directory newDirectory(Settings settings) throws IOException {
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("foo", settings);
+        Path tempDir = createTempDir().resolve(idxSettings.getUUID()).resolve("0");
+        Files.createDirectories(tempDir);
+        ShardPath path = new ShardPath(false, tempDir, tempDir, new ShardId(idxSettings.getIndex(), 0));
+        return new FsDirectoryService(idxSettings, path).newDirectory();
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Port of https://github.com/elastic/elasticsearch/pull/58226
We miss https://github.com/elastic/elasticsearch/commit/62620f286635d17054b696f3e16d713e181d229f
so the ported test looks a bit different.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)