### PR TITLE
Increase stats.service.interval from 1h to 24h

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,10 @@ Changes
 Fixes
 =====
 
+- Increased the default interval for `stats.service.interval
+  <stats.service.interval>` from one hour to 24 hours because invoking it every
+  hour caused significant extra load on a cluster.
+
 - Updated the bundled JDK to 14.0.2-12
 
 - Fixed an issue that caused ``SHOW CREATE TABLE`` to print columns of type

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -162,7 +162,7 @@ Collecting stats
 .. _stats.service.interval:
 
 **stats.service.interval**
-  | *Default:*    ``1h``
+  | *Default:*    ``24h``
   | *Runtime:*   ``yes``
 
   Defines the refresh interval to refresh tables statistics used to produce

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -54,7 +54,7 @@ public class TableStatsService implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger(TableStatsService.class);
 
     public static final CrateSetting<TimeValue> STATS_SERVICE_REFRESH_INTERVAL_SETTING = CrateSetting.of(Setting.timeSetting(
-        "stats.service.interval", TimeValue.timeValueHours(1), Setting.Property.NodeScope, Setting.Property.Dynamic),
+        "stats.service.interval", TimeValue.timeValueHours(24), Setting.Property.NodeScope, Setting.Property.Dynamic),
         DataTypes.STRING);
 
     static final String STMT = "ANALYZE";


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We've seen increased loads on cluster being upgraded from 4.0 to 4.1
after the upgrade. The reason for the increased load is the `ANALYZE`
statement that is periodically invoked every 1h by default.

This increases the refresh interval to 24h.
Stats are currently used sparringly, and even if used, the differences
in the execution plans are minor compared to the effect that a frequent
`ANALYZE` has on the cluster.

See https://github.com/crate/crate/issues/10240

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)