### PR TITLE
Docs: Add a snippet to show how to escape s3 access keys

### DIFF
--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -176,6 +176,14 @@ Using the ``s3://`` schema automatically sets the `shared`_ to true.
    as '/', '+' or '='. These characters must be `URL encoded`_. For a detailed
    explanation read the official `AWS documentation`_.
 
+   To escape a secret key, you can use a snippet like this:
+
+   .. code-block:: console
+
+      sh$ python -c "from getpass import getpass; from urllib.parse import quote_plus; print(quote_plus(getpass('secret_key: ')))"
+
+   This will prompt for the secret key and print the encoded variant.
+
    Additionally, versions prior to 0.51.x use HTTP for connections to S3. Since
    0.51.x these connections are using the HTTPS protocol. Please make sure you
    update your firewall rules to allow outgoing connections on port ``443``.


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)