### PR TITLE
Add doc-value aggregator for min aggregation

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/MutableDouble.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableDouble.java
@@ -26,6 +26,10 @@ public final class MutableDouble {
     private double value;
     private boolean hasValue = false;
 
+    public MutableDouble(double value) {
+        this.value = value;
+    }
+
     public boolean hasValue() {
         return hasValue;
     }

--- a/libs/shared/src/main/java/io/crate/common/MutableLong.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableLong.java
@@ -27,6 +27,10 @@ public final class MutableLong {
     private long value;
     private boolean hasValue = false;
 
+    public MutableLong(long value) {
+        this.value = value;
+    }
+
     public boolean hasValue() {
         return hasValue;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -87,7 +87,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableLong initialState() {
-            return new MutableLong();
+            return new MutableLong(Long.MIN_VALUE);
         }
 
         @Override
@@ -129,7 +129,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableDouble initialState() {
-            return new MutableDouble();
+            return new MutableDouble(Double.MIN_VALUE);
         }
 
         @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See also: https://github.com/crate/crate-benchmarks/pull/212 

    Q: select min(duration) from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       67.925 ±   46.711 |     51.515 |     64.499 |     67.515 |   1100.817 |
    |   V2    |       24.338 ±   19.621 |     19.274 |     21.725 |     23.292 |    443.536 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  94.48%                           -  99.22%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 94.48%
    The test has statistical significance

    Q: select min("adRevenue") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       70.576 ±   14.037 |     58.433 |     69.340 |     71.356 |    361.102 |
    |   V2    |       32.801 ±    7.910 |     21.266 |     34.532 |     36.867 |    129.560 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  73.08%                           -  67.02%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 73.08%
    The test has statistical significance


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)