### PR TITLE
Allow all users to execute discard and set transaction

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ Changes
 Fixes
 =====
 
+- Allow all users to execute ``DISCARD`` and ``SET TRANSACTION`` statement.
+  These are session local statements and shouldn't require special privileges.
+
 - Increased the default interval for `stats.service.interval
   <stats.service.interval>` from one hour to 24 hours because invoking it every
   hour caused significant extra load on a cluster.

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -39,6 +39,7 @@ import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateUser;
 import io.crate.analyze.AnalyzedDeallocate;
 import io.crate.analyze.AnalyzedDeleteStatement;
+import io.crate.analyze.AnalyzedDiscard;
 import io.crate.analyze.AnalyzedDropFunction;
 import io.crate.analyze.AnalyzedDropRepository;
 import io.crate.analyze.AnalyzedDropSnapshot;
@@ -52,6 +53,7 @@ import io.crate.analyze.AnalyzedRefreshTable;
 import io.crate.analyze.AnalyzedResetStatement;
 import io.crate.analyze.AnalyzedRestoreSnapshot;
 import io.crate.analyze.AnalyzedSetStatement;
+import io.crate.analyze.AnalyzedSetTransaction;
 import io.crate.analyze.AnalyzedShowCreateTable;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
@@ -630,6 +632,16 @@ public final class AccessControlImpl implements AccessControl {
                     user,
                     defaultSchema);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitDiscard(AnalyzedDiscard discard, User context) {
+            return null;
+        }
+
+        @Override
+        public Void visitSetTransaction(AnalyzedSetTransaction setTransaction, User context) {
             return null;
         }
     }

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -199,6 +199,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_kill_is_allowed_for_any_user() throws Exception {
         // Only kills their own statements
         analyze("kill all");
+        assertThat(validationCallArguments.size(), is(0));
     }
 
     @Test
@@ -484,6 +485,18 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_a_user_with_al_can_revoke_privileges_from_users() {
         analyze("REVOKE DQL ON SCHEMA foo FROM joe");
         assertAskedForCluster(Privilege.Type.AL);
+    }
+
+    @Test
+    public void test_any_user_can_execute_discard() throws Exception {
+        analyze("discard all");
+        assertThat(validationCallArguments.size(), is(0));
+    }
+
+    @Test
+    public void test_any_user_can_execute_set_transaction() throws Exception {
+        analyze("SET TRANSACTION READ ONLY");
+        assertThat(validationCallArguments.size(), is(0));
     }
 }
 


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)