### PR TITLE
Avoid plan re-creation for no-op optimizer passes

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Lists2.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Lists2.java
@@ -76,11 +76,28 @@ public final class Lists2 {
         if (list.isEmpty()) {
             return List.of();
         }
-        List<O> copy = new ArrayList<>(list.size());
+        ArrayList<O> copy = new ArrayList<>(list.size());
         for (I item : list) {
             copy.add(mapper.apply(item));
         }
         return copy;
+    }
+
+    /**
+     * Like `map` but ensures that the same list is returned if no elements changed
+     */
+    public static <T> List<T> mapIfChange(List<T> list, Function<? super T, ? extends T> mapper) {
+        if (list.isEmpty()) {
+            return list;
+        }
+        ArrayList<T> copy = new ArrayList<>(list.size());
+        boolean changed = false;
+        for (T item : list) {
+            T mapped = mapper.apply(item);
+            changed = changed || item != mapped;
+            copy.add(mapped);
+        }
+        return changed ? copy : list;
     }
 
     /**

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -54,8 +54,9 @@ public class Optimizer {
 
     public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, TransactionContext txnCtx) {
         LogicalPlan optimizedRoot = tryApplyRules(plan, tableStats, txnCtx);
+        var optimizedSources = Lists2.mapIfChange(optimizedRoot.sources(), x -> optimize(x, tableStats, txnCtx));
         return tryApplyRules(
-            optimizedRoot.replaceSources(Lists2.map(optimizedRoot.sources(), x -> optimize(x, tableStats, txnCtx))),
+            optimizedSources == optimizedRoot.sources() ? optimizedRoot : optimizedRoot.replaceSources(optimizedSources),
             tableStats,
             txnCtx
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`optimizedRoot.replaceSources` always created a new plan node, even if
the sources weren't changed at all.

This adds some change detection to avoid re-creation of nodes. It will
also allow us to use identity comparison in other places to detect if
the optimizer changed a plan node or not


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)