### PR TITLE
Fix fetch planning bug with aliased columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2.0 which caused queries including a
+  virtual table, and both a ``ORDER BY`` and ``LIMIT`` clause to fail.
+
 - Fixed a regression introduced in 4.2.0 that resulted in ``NULL`` values being
   returned for columns used in the ``PARTITIONED BY`` clause instead of the
   actual values.


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)