### PR TITLE
Fix statement classification to include sources of fetch operators

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented queries executed using a ``query-then-fetch``
+  strategy from being labelled correctly in the :ref:`sys.jobs_metrics
+  <sys-jobs-metrics>` and :ref:`sys.jobs_log <sys-logs>` tables.
+
 - Fixed a regression introduced in 4.2.0 which caused queries including a
   virtual table, and both a ``ORDER BY`` and ``LIMIT`` clause to fail.
 

--- a/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
+++ b/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
@@ -109,6 +109,9 @@ public final class StatementClassifier extends LogicalPlanVisitor<Set<String>, V
 
     @Override
     protected Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
+        for (var source : logicalPlan.sources()) {
+            source.accept(this, context);
+        }
         context.add(logicalPlan.getClass().getSimpleName());
         return null;
     }
@@ -117,51 +120,6 @@ public final class StatementClassifier extends LogicalPlanVisitor<Set<String>, V
     public Void visitRootRelationBoundary(RootRelationBoundary logicalPlan, Set<String> context) {
         logicalPlan.source.accept(this, context);
         return null;
-    }
-
-    @Override
-    public Void visitLimit(Limit limit, Set<String> context) {
-        limit.source.accept(this, context);
-        return visitPlan(limit, context);
-    }
-
-    @Override
-    public Void visitEval(Eval eval, Set<String> context) {
-        eval.source.accept(this, context);
-        return visitPlan(eval, context);
-    }
-
-    @Override
-    public Void visitHashJoin(HashJoin logicalPlan, Set<String> context) {
-        logicalPlan.lhs.accept(this, context);
-        logicalPlan.rhs.accept(this, context);
-        return visitPlan(logicalPlan, context);
-    }
-
-    @Override
-    public Void visitNestedLoopJoin(NestedLoopJoin logicalPlan, Set<String> context) {
-        logicalPlan.lhs.accept(this, context);
-        logicalPlan.rhs.accept(this, context);
-        return visitPlan(logicalPlan, context);
-    }
-
-    @Override
-    public Void visitUnion(Union logicalPlan, Set<String> context) {
-        logicalPlan.lhs.accept(this, context);
-        logicalPlan.rhs.accept(this, context);
-        return visitPlan(logicalPlan, context);
-    }
-
-    @Override
-    public Void visitGroupHashAggregate(GroupHashAggregate logicalPlan, Set<String> context) {
-        logicalPlan.source.accept(this, context);
-        return visitPlan(logicalPlan, context);
-    }
-
-    @Override
-    public Void visitHashAggregate(HashAggregate logicalPlan, Set<String> context) {
-        logicalPlan.source.accept(this, context);
-        return visitPlan(logicalPlan, context);
     }
 
     @Override
@@ -183,34 +141,10 @@ public final class StatementClassifier extends LogicalPlanVisitor<Set<String>, V
     }
 
     @Override
-    public Void visitOrder(Order logicalPlan, Set<String> context) {
-        logicalPlan.source.accept(this, context);
-        return visitPlan(logicalPlan, context);
-    }
-
-    @Override
     public Void visitMultiPhase(MultiPhase logicalPlan, Set<String> context) {
         for (LogicalPlan plan : logicalPlan.dependencies().keySet()) {
             plan.accept(this, context);
         }
         return visitPlan(logicalPlan, context);
-    }
-
-    @Override
-    public Void visitFilter(Filter filter, Set<String> context) {
-        filter.source.accept(this, context);
-        return visitPlan(filter, context);
-    }
-
-    @Override
-    public Void visitProjectSet(ProjectSet projectSet, Set<String> context) {
-        projectSet.source.accept(this, context);
-        return visitPlan(projectSet, context);
-    }
-
-    @Override
-    public Void visitWindowAgg(WindowAgg windowAgg, Set<String> context) {
-        windowAgg.source.accept(this, context);
-        return visitPlan(windowAgg, context);
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -46,6 +46,14 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_classify_qtf_statement_contains_fetch_limit_and_collect() throws Exception {
+        LogicalPlan plan = e.logicalPlan("SELECT * FROM users LIMIT 10");
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), contains("Collect", "Fetch", "Limit"));
+    }
+
+    @Test
     public void testClassifySelectStatements() {
         LogicalPlan plan = e.logicalPlan("SELECT 1");
         StatementClassifier.Classification classification = StatementClassifier.classify(plan);
@@ -90,7 +98,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         plan = e.logicalPlan("SELECT * FROM users WHERE id = (SELECT 1) OR name = (SELECT 'Arthur')");
         classification = StatementClassifier.classify(plan);
         assertThat(classification.type(), is(Plan.StatementType.SELECT));
-        assertThat(classification.labels(), contains("Eval", "Limit", "MultiPhase", "TableFunction"));
+        assertThat(classification.labels(), contains("Collect", "Eval", "Limit", "MultiPhase", "TableFunction"));
     }
 
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If the plan contained a `Fetch` operator its sources were never included in the
statement classification. This fixes it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)