### PR TITLE
Fix performance regression; execute ORDER BY w/o LIMIT with QTF

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -57,6 +57,9 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression introduced in 4.2.0 which caused queries with
+  a ``ORDER BY`` but without ``LIMIT`` to execute slower than they used to.
+
 - Fixed an issue that prevented queries executed using a ``query-then-fetch``
   strategy from being labelled correctly in the :ref:`sys.jobs_metrics
   <sys-jobs-metrics>` and :ref:`sys.jobs_log <sys-logs>` tables.

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -98,11 +98,11 @@ public final class InsertFromSubQueryPlanner {
             outputs,
             statement.outputs() == null ? List.of() : statement.outputs()
         );
-        LogicalPlan plannedSubQuery = logicalPlanner.normalizeAndPlan(
+        LogicalPlan plannedSubQuery = logicalPlanner.plan(
             statement.subQueryRelation(),
             plannerContext,
             subqueryPlanner,
-            EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP)
+            EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP, PlanHint.AVOID_TOP_LEVEL_FETCH)
         );
         EvalProjection castOutputs = createCastProjection(statement.columns(), plannedSubQuery.outputs());
         return new Insert(plannedSubQuery, indexWriterProjection, castOutputs);

--- a/server/src/main/java/io/crate/planner/operators/PlanHint.java
+++ b/server/src/main/java/io/crate/planner/operators/PlanHint.java
@@ -23,5 +23,6 @@
 package io.crate.planner.operators;
 
 public enum PlanHint {
-    PREFER_SOURCE_LOOKUP;
+    PREFER_SOURCE_LOOKUP,
+    AVOID_TOP_LEVEL_FETCH;
 }

--- a/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
@@ -63,7 +63,7 @@ public class ExplainAnalyzeIntegrationTest extends SQLTransportIntegrationTest {
 
         Map<String, Map<String, Object>> phasesAnalysis = (Map<String, Map<String, Object>>) executeAnalysis.get("Phases");
         assertThat(phasesAnalysis, is(notNullValue()));
-        assertThat(phasesAnalysis.keySet(), contains("0-collect", "1-mergeOnHandler"));
+        assertThat(phasesAnalysis.keySet(), contains("0-collect", "1-mergeOnHandler", "2-fetchPhase"));
 
         DiscoveryNodes nodes = clusterService().state().nodes();
         for (DiscoveryNode discoveryNode : nodes) {

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -38,10 +38,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
-
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
+
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -68,6 +68,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.SymbolMatchers;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -111,7 +111,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.from(),
             mss.where(),
             mss.joinPairs(),
-            rel -> logicalPlanner.normalizeAndPlan(rel, plannerCtx, subqueryPlanner, Set.of()),
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, Set.of()),
             txnCtx.sessionContext().isHashJoinEnabled()
         );
     }
@@ -202,7 +202,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.from(),
             mss.where(),
             mss.joinPairs(),
-            rel -> logicalPlanner.normalizeAndPlan(rel, plannerCtx, subqueryPlanner, Set.of()),
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, Set.of()),
             false
         );
         Join nl = (Join) operator.build(

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -108,8 +108,9 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testQTFWithOrderBy() throws Exception {
         LogicalPlan plan = plan("select a, x from t1 order by a");
         assertThat(plan, isPlan(
-            "OrderBy[a ASC]\n" +
-            "  └ Collect[doc.t1 | [a, x] | true]"
+            "Fetch[a, x]\n" +
+            "  └ OrderBy[a ASC]\n" +
+            "    └ Collect[doc.t1 | [_fetchid, a] | true]"
         ));
     }
 
@@ -117,9 +118,11 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testQTFWithOrderByAndAlias() throws Exception {
         LogicalPlan plan = plan("select a, x from t1 as t order by a");
         assertThat(plan, isPlan(
-            "Rename[a, x] AS t\n" +
-            "  └ OrderBy[a ASC]\n" +
-            "    └ Collect[doc.t1 | [a, x] | true]"));
+            "Fetch[a, x]\n" +
+            "  └ Rename[t._fetchid, a] AS t\n" +
+            "    └ OrderBy[a ASC]\n" +
+            "      └ Collect[doc.t1 | [_fetchid, a] | true]"
+        ));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -159,9 +159,11 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
     public void testFilterIsMovedBeneathOrder() {
         LogicalPlan plan = plan("select * from (select * from t1 order by a) tt where a > '10'");
         assertThat(plan, isPlan(
-            "Rename[a, x, i] AS tt\n" +
-            "  └ OrderBy[a ASC]\n" +
-            "    └ Collect[doc.t1 | [a, x, i] | (a > '10')]"));
+            "Fetch[a, x, i]\n" +
+            "  └ Rename[tt._fetchid, a] AS tt\n" +
+            "    └ OrderBy[a ASC]\n" +
+            "      └ Collect[doc.t1 | [_fetchid, a] | (a > '10')]"
+        ));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -68,7 +68,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         plan = e.logicalPlan("SELECT * FROM users ORDER BY id");
         classification = StatementClassifier.classify(plan);
         assertThat(classification.type(), is(Plan.StatementType.SELECT));
-        assertThat(classification.labels(), contains("Collect", "Order"));
+        assertThat(classification.labels(), contains("Collect", "Fetch", "Order"));
 
         plan = e.logicalPlan("SELECT a.id, b.id FROM users a, users b WHERE a.id = b.id");
         classification = StatementClassifier.classify(plan);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In theory a normal `Order -> Collect` should be just as fast or faster
than a `Fetch -> Order -> Collect`, but it turns out that due to how
currently the sorted merge, it is more expensive on a full row than a
narrow row with just the fetch id.

Part of the reason is that the `*SortedMergeIterator` implementations
use a `peek`, which triggers multiple evaluations of a `Row`. For
example the `apply` of the `ScoreDocRowFunction` is called multiple
times.

Fixing this in the execution layer may be a bit more involved, so this
applies the fetch-rewrite also to some more patterns.

    V1: 4.3.0-d162b7a8731762aacd4bdfcf6df20e6342ed6154
    V2: 4.3.0-1ed3aa43bd5cd671fc332fbcc8c7432671a3b48b

    Q: select * from uservisits where "searchWord" = 'hardnose' order by "visitDate" desc
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      265.018 ±   21.618 |    222.775 |    262.301 |    271.916 |    641.156 |
    |   V2    |       55.767 ±   23.288 |     45.291 |     52.272 |     58.345 |    552.883 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 130.46%                           - 133.53%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 130.46%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |  504     4.28     3.93 |  490    43.76    45.05 |     2147      387 |   751.03     103980
     V2 |   37     6.19     5.45 |   27    45.51    44.09 |     2147      800 |   823.33      27122

(The ~55 mean here is about the same we had in 4.1)




## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)