### PR TITLE
Fix regression that caused unknown key errors on ignored objects

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2.0 that caused subscript lookups on
+  ignored object columns to raise an error instead of a null value if the key
+  doesn't exist.
+
 - Fixed a performance regression introduced in 4.2.0 which caused queries with
   a ``ORDER BY`` but without ``LIMIT`` to execute slower than they used to.
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -904,7 +904,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.outputs().size(), is(1));
         Symbol s = relation.outputs().get(0);
         assertThat(s, notNullValue());
-        assertThat(s, isFunction(SubscriptFunction.NAME, isField("friends"), isLiteral("id")));
+        assertThat(s, isField("friends['id']"));
     }
 
     @Test
@@ -1942,7 +1942,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         QueriedSelectRelation relation = analyze("select s.friends['id'] from (select friends from doc.users) s");
         assertThat(
             relation.outputs(),
-            contains(isFunction(SubscriptFunction.NAME, isField("friends"), isLiteral("id")))
+            contains(isField("friends['id']"))
         );
     }
 
@@ -1959,7 +1959,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_can_access_element_within_object_array_of_derived_table_containing_a_join_with_ambiguous_column_name() {
         expectedException.expect(AmbiguousColumnException.class);
-        expectedException.expectMessage("Column \"friends\" is ambiguous");
+        expectedException.expectMessage("Column \"friends['id']\" is ambiguous");
         analyze("select joined.friends['id'] from " +
                 "(select u1.friends, u2.friends from doc.users u1, doc.users u2) joined");
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1764,4 +1764,17 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
                "doc| metrics| x| 23| false| -1| 4| 2| NULL| NULL| 0| b\n")
         );
     }
+
+    @Test
+    public void test_subscript_on_ignored_object_does_not_raise_missing_key_error() throws Exception {
+        execute("create table tbl (obj object (ignored))");
+        execute("insert into tbl (obj) values ({a = 10})");
+        execute("refresh table tbl");
+
+        execute("select * from tbl where obj['b'] = 10");
+        assertThat(printedTable(response.rows()), is(""));
+
+        execute("select * from (select * from tbl) as t where obj['b'] = 10");
+        assertThat(printedTable(response.rows()), is(""));
+    }
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -505,8 +505,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         expectedPlan =
             "Eval[name]\n" +
             "  └ HashJoin[(a = address['postcode'])]\n" +
-            "    ├ Rename[name, address] AS u\n" +
-            "    │  └ Collect[doc.users | [name, address] | true]\n" +
+            "    ├ Rename[name, address['postcode']] AS u\n" +
+            "    │  └ Collect[doc.users | [name, address['postcode']] | true]\n" +
             "    └ Collect[doc.t1 | [a] | true]";
         assertThat(logicalPlan, is(isPlan(expectedPlan)));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/10255

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)