### PR TITLE
Fix clustered-by column validation for inserts

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression that caused ``INSERT INTO`` statements in tables with a
+  nested ``CLUSTERED BY`` column to fail.
+
 - Fixed a regression introduced in 4.2.0 that caused subscript lookups on
   ignored object columns to raise an error instead of a null value if the key
   doesn't exist.

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -414,7 +414,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         };
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column \"pk_col\" is required but is missing from the insert statement");
+        expectedException.expectMessage("Column `pk_col` is required but is missing from the insert statement");
 
         execute("insert into test (message) values (?)", args);
     }
@@ -435,10 +435,9 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     public void testInsertWithClusteredByWithoutValue() throws Exception {
         execute("create table quotes (id integer, quote string) clustered by(id) " +
                 "with (number_of_replicas=0)");
-        ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Clustered by value is required but is missing from the insert statement");
+        expectedException.expectMessage("Column `id` is required but is missing from the insert statement");
         execute("insert into quotes (quote) values(?)",
             new Object[]{"I'd far rather be happy than right any day."});
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression introduced in https://github.com/crate/crate/pull/9465

Closes https://github.com/crate/crate/issues/10270

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)