### PR TITLE
Initialize a single query profile per index searcher.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that occasionally caused :ref:`EXPLAIN ANALYZE <ref-explain>`
+  to return invalid query breakdown results or fail with the index out of
+  bound exception.
+
 - Fixed a regression that caused ``INSERT INTO`` statements in tables with a
   nested ``CLUSTERED BY`` column to fail.
 

--- a/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
@@ -34,7 +34,7 @@ import io.crate.sql.tree.Node;
 import io.crate.sql.tree.Query;
 import io.crate.sql.tree.Statement;
 
-import java.util.Collections;
+import java.util.List;
 
 public class ExplainStatementAnalyzer {
 
@@ -51,7 +51,7 @@ public class ExplainStatementAnalyzer {
         final AnalyzedStatement subStatement;
         ProfilingContext profilingContext;
         if (node.isAnalyze()) {
-            profilingContext = new ProfilingContext(Collections::emptyList);
+            profilingContext = new ProfilingContext(List.of());
             Timer timer = profilingContext.createAndStartTimer(ExplainPlan.Phase.Analyze.name());
             subStatement = analyzer.analyzedStatement(statement, analysis);
             profilingContext.stopTimerAndStoreDuration(timer);

--- a/server/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/server/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -259,12 +259,16 @@ public final class JobLauncher {
 
     private SharedShardContexts maybeInstrumentProfiler(RootTask.Builder builder) {
         if (enableProfiling) {
-            QueryProfiler queryProfiler = new QueryProfiler();
-            ProfilingContext profilingContext = new ProfilingContext(queryProfiler::getTree);
+            var profilers = new ArrayList<QueryProfiler>();
+            ProfilingContext profilingContext = new ProfilingContext(profilers);
             builder.profilingContext(profilingContext);
             return new SharedShardContexts(
                 indicesService,
-                indexSearcher -> new InstrumentedIndexSearcher(indexSearcher.getIndexReader(), queryProfiler)
+                indexSearcher -> {
+                    var queryProfiler = new QueryProfiler();
+                    profilers.add(queryProfiler);
+                    return new InstrumentedIndexSearcher(indexSearcher.getIndexReader(), queryProfiler);
+                }
             );
         } else {
             return new SharedShardContexts(indicesService, UnaryOperator.identity());

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -44,7 +44,6 @@ public class SharedShardContexts {
         this.wrapSearcher = wrapSearcher;
     }
 
-
     public SharedShardContext createContext(ShardId shardId, int readerId) {
         assert !allocatedShards.containsKey(shardId) : "shardId shouldn't have been allocated yet";
         SharedShardContext sharedShardContext = new SharedShardContext(indicesService, shardId, readerId, wrapSearcher);

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 
@@ -181,7 +182,7 @@ public class RootTaskTest extends CrateUnitTest {
     public void testEnablingProfilingGathersExecutionTimes() throws Throwable {
         RootTask.Builder builder =
             new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
-        ProfilingContext profilingContext = new ProfilingContext(Collections::emptyList);
+        ProfilingContext profilingContext = new ProfilingContext(List.of());
         builder.profilingContext(profilingContext);
 
         AbstractTaskTest.TestingTask ctx1 = new AbstractTaskTest.TestingTask(1);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
