### PR TITLE
Add pg_function_is_visible scalar required to run conn.getMetaData().getFunctions

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -50,7 +50,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -64,7 +64,7 @@ public class AggregateCollectorBenchmark {
     @Setup
     public void setup() {
         InputCollectExpression inExpr0 = new InputCollectExpression(0);
-        SumAggregation<?> sumAggregation = (SumAggregation<?>) getFunctions().getQualified(
+        SumAggregation<?> sumAggregation = (SumAggregation<?>) createNodeContext().functions().getQualified(
             Signature.aggregate(
                 SumAggregation.NAME,
                 DataTypes.INTEGER.getTypeSignature(),

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
-import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.netty.util.collection.LongObjectHashMap;
@@ -58,7 +57,6 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.inject.ModulesBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -76,8 +74,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static io.crate.data.SentinelRow.SENTINEL;
-import static io.crate.testing.TestingHelpers.getFunctions;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -95,9 +93,8 @@ public class GroupingLongCollectorBenchmark {
     @Setup
     public void createGroupingCollector() throws Exception {
         IndexWriter iw = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
-        Functions functions = new ModulesBuilder().add(new AggregationImplModule())
-            .createInjector().getInstance(Functions.class);
-        SumAggregation<?> sumAgg = (SumAggregation<?>) getFunctions().getQualified(
+        SumAggregation<?> sumAgg = (SumAggregation<?>) createNodeContext(new AggregationImplModule())
+            .functions().getQualified(
             Signature.aggregate(
                 SumAggregation.NAME,
                 DataTypes.INTEGER.getTypeSignature(),

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -1,6 +1,7 @@
 package io.crate.execution.engine.reader;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.data.BatchIterator;
@@ -52,8 +53,8 @@ public class CsvReaderBenchmark {
 
     @Setup
     public void create_temp_file_and_uri() throws IOException {
-        Functions functions = new Functions(Map.of());
-        inputFactory = new InputFactory(functions);
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()));
+        inputFactory = new InputFactory(nodeCtx);
         tempFile = File.createTempFile("temp", null);
         fileUri = tempFile.toURI().getPath();
         try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8)) {

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -1,6 +1,7 @@
 package io.crate.execution.engine.reader;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.data.BatchIterator;
@@ -52,8 +53,8 @@ public class JsonReaderBenchmark {
 
     @Setup
     public void create_temp_file_and_uri() throws IOException {
-        Functions functions = new Functions(Map.of());
-        inputFactory = new InputFactory(functions);
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()));
+        inputFactory = new InputFactory(nodeCtx);
         tempFile = File.createTempFile("temp", null);
         fileUri = tempFile.toURI().getPath();
         try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8)) {

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,8 @@ Breaking Changes
 Changes
 =======
 
+- Added scalar function :ref:`pg_function_is_visible <pg_function_is_visible>`.
+
 - Added the ``read_only_allow_delete`` setting to the ``settings['blocks']``
   column of the :ref:`information_schema.tables <information_schema_tables>`
   and :ref:`information_schema.table_partitions <is_table_partitions>` tables.

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -2642,6 +2642,33 @@ Example:
     +---------------+
     SELECT 1 row in set (... sec)
 
+.. _pg_function_is_visible:
+
+``pg_function_is_visible``
+--------------------------
+
+The function ``pg_function_is_visible`` returns true for OIDs that refer to a system
+or a user defined function.
+
+
+Returns: ``boolean``
+
+Synopsis::
+
+   pg_function_is_visible(OID)
+
+Example:
+
+::
+
+    cr> select pg_function_is_visible(-919555782) as pg_function_is_visible;
+    +------------------------+
+    | pg_function_is_visible |
+    +------------------------+
+    | TRUE                   |
+    +------------------------+
+    SELECT 1 row in set (... sec)
+
 .. _version:
 
 ``version``

--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -22,14 +22,11 @@ import io.crate.Streamer;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionName;
-import io.crate.metadata.Functions;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Before;
@@ -38,15 +35,14 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.is;
 
 public class HyperLogLogDistinctAggregationTest extends AggregationTest {
 
     @Before
     public void prepareFunctions() throws Exception {
-        functions = new ModulesBuilder()
-            .add(new EnterpriseFunctionsModule())
-            .createInjector().getInstance(Functions.class);
+        nodeCtx = createNodeContext(new EnterpriseFunctionsModule());
     }
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
@@ -87,14 +83,14 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
     @Test
     public void testReturnTypeIsAlwaysLong() {
         // Return type is fixed to Long
-        FunctionImplementation func = functions.get(
+        FunctionImplementation func = nodeCtx.functions().get(
             null,
             HyperLogLogDistinctAggregation.NAME,
             List.of(Literal.of(1)),
             SearchPath.pathWithPGCatalogAndDoc()
         );
         assertEquals(DataTypes.LONG, func.info().returnType());
-        func = functions.get(
+        func = nodeCtx.functions().get(
             null,
             HyperLogLogDistinctAggregation.NAME,
             List.of(Literal.of(1), Literal.of(2)),

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -20,6 +20,7 @@ package io.crate.operation.language;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -60,7 +61,7 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
             var function = resolvePolyglotFunctionValue(signature.getName().name(), script);
             var polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(args);
@@ -96,7 +97,7 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
         }
 
         @Override
-        public final Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+        public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
             var polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(args);
             try {
                 return toCrateObject(

--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -64,7 +64,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
         super.setUp();
         udfService = new UserDefinedFunctionService(
             mock(ClusterService.class),
-            functions);
+            sqlExpressions.nodeCtx);
         udfService.registerLanguage(new JavaScriptLanguage(udfService));
     }
 
@@ -86,7 +86,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
             var resolvers = functionImplementations.computeIfAbsent(
                 functionName, k -> new ArrayList<>());
             resolvers.add(udfService.buildFunctionResolver(udf));
-            functions.registerUdfFunctionImplementationsForSchema(
+            sqlExpressions.nodeCtx.functions().registerUdfFunctionImplementationsForSchema(
                 Schemas.DOC_SCHEMA_NAME,
                 functionImplementations);
         } else {

--- a/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
+++ b/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
@@ -22,6 +22,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -71,13 +72,13 @@ public class UserFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
         return txnCtx.sessionSettings().userName();
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx, NodeContext nodeCtx) {
         if (txnCtx == null) {
             return Literal.NULL;
         }

--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -23,6 +23,7 @@ import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.scalar.UsersScalarFunctionModule;
 import io.crate.testing.SqlExpressions;
+import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -32,32 +33,28 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
 
     private static final User TEST_USER = User.of("testUser");
 
-    private void setupFunctionsFor(User user) {
-        sqlExpressions = new SqlExpressions(tableSources, null, user, new UsersScalarFunctionModule());
-        functions = sqlExpressions.functions();
+    @Before
+    private void prepare() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, new UsersScalarFunctionModule());
     }
 
     @Test
     public void testNormalizeCurrentUser() {
-        setupFunctionsFor(TEST_USER);
         assertNormalize("current_user", isLiteral("testUser"), false);
     }
 
     @Test
     public void testNormalizeSessionUser() {
-        setupFunctionsFor(TEST_USER);
         assertNormalize("session_user", isLiteral("testUser"), false);
     }
 
     @Test
     public void testNormalizeUser() {
-        setupFunctionsFor(TEST_USER);
         assertNormalize("user", isLiteral("testUser"), false);
     }
 
     @Test
     public void testFormatFunctionsWithoutBrackets() {
-        setupFunctionsFor(TEST_USER);
         sqlExpressions.context().allowEagerNormalize(false);
         Symbol f = sqlExpressions.asSymbol("current_user");
         assertThat(f.toString(), is("CURRENT_USER"));

--- a/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
@@ -64,7 +64,7 @@ public class CreateAnalyzerAnalyzerTest extends CrateDummyClusterServiceUnitTest
         return CreateAnalyzerPlan.createRequest(
             analyzedStatement,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY,
             e.fulltextAnalyzerResolver());

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryAnalyzerTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryAnalyzerTest.java
@@ -63,7 +63,7 @@ public class AzureRepositoryAnalyzerTest extends CrateDummyClusterServiceUnitTes
             return (S) CreateRepositoryPlan.createRequest(
                 (AnalyzedCreateRepository) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
                 repositoryParamValidator);

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -89,7 +89,7 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
             return (S) CreateRepositoryPlan.createRequest(
                 (AnalyzedCreateRepository) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
                 repositoryParamValidator);

--- a/server/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/server/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -26,6 +26,7 @@ import io.crate.analyze.Analyzer;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
 import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -48,6 +49,7 @@ public class SQLOperations {
         false,
         Setting.Property.NodeScope);
 
+    private final NodeContext nodeCtx;
     private final Analyzer analyzer;
     private final Planner planner;
     private final Provider<DependencyCarrier> executorProvider;
@@ -58,13 +60,15 @@ public class SQLOperations {
     private volatile boolean disabled;
 
     @Inject
-    public SQLOperations(Analyzer analyzer,
+    public SQLOperations(NodeContext nodeCtx,
+                         Analyzer analyzer,
                          Planner planner,
                          Provider<DependencyCarrier> executorProvider,
                          JobsLogs jobsLogs,
                          Settings settings,
                          ClusterService clusterService,
                          Provider<UserManager> userManagerProvider) {
+        this.nodeCtx = nodeCtx;
         this.analyzer = analyzer;
         this.planner = planner;
         this.executorProvider = executorProvider;
@@ -79,6 +83,7 @@ public class SQLOperations {
             throw new NodeDisconnectedException(clusterService.localNode(), "sql");
         }
         return new Session(
+            nodeCtx,
             analyzer,
             planner,
             jobsLogs,

--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -30,7 +30,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -54,12 +54,12 @@ import static java.util.Collections.singletonList;
 class AlterTableAddColumnAnalyzer {
 
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
     AlterTableAddColumnAnalyzer(Schemas schemas,
-                                Functions functions) {
+                                NodeContext nodeCtx) {
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedAlterTableAddColumn analyze(AlterTableAddColumn<Expression> alterTable,
@@ -76,9 +76,9 @@ class AlterTableAddColumnAnalyzer {
         TableReferenceResolver referenceResolver = new TableReferenceResolver(tableInfo.columns(), tableInfo.ident());
 
         var exprAnalyzerWithReferenceResolver = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, referenceResolver, null);
+            txnCtx, nodeCtx, paramTypeHints, referenceResolver, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         AddColumnDefinition<Expression> tableElement = alterTable.tableElement();
@@ -109,8 +109,8 @@ class AlterTableAddColumnAnalyzer {
             singletonList(addColumnDefinitionWithExpression), tableInfo.ident(), tableInfo);
         // now analyze possible check expressions
         var checkColumnConstraintsAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             paramTypeHints,
             new SelfReferenceFieldProvider(
                 tableInfo.ident(), referenceResolver, analyzedTableElements.columns()),

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
@@ -46,18 +46,18 @@ import java.util.List;
 class AlterTableAnalyzer {
 
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    AlterTableAnalyzer(Schemas schemas, Functions functions) {
+    AlterTableAnalyzer(Schemas schemas, NodeContext nodeCtx) {
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     AnalyzedAlterTable analyze(AlterTable<Expression> node,
                                ParamTypeHints paramTypeHints,
                                CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
@@ -77,7 +77,7 @@ class AlterTableAnalyzer {
         RelationName relationName = RelationName.fromBlobTable(node.table());
 
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
@@ -118,7 +118,7 @@ class AlterTableAnalyzer {
                                                ParamTypeHints paramTypeHints,
                                                CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsStrings = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         Table<Symbol> table = node.table().map(x -> exprAnalyzerWithFieldsAsStrings.convert(x, exprCtx));

--- a/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -29,7 +29,7 @@ import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.table.Operation;
@@ -50,12 +50,12 @@ import static io.crate.metadata.RelationName.fromBlobTable;
 
 public class AlterTableRerouteAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Schemas schemas;
     private final RerouteOptionVisitor rerouteOptionVisitor;
 
-    AlterTableRerouteAnalyzer(Functions functions, Schemas schemas) {
-        this.functions = functions;
+    AlterTableRerouteAnalyzer(NodeContext nodeCtx, Schemas schemas) {
+        this.nodeCtx = nodeCtx;
         this.schemas = schemas;
         this.rerouteOptionVisitor = new RerouteOptionVisitor();
     }
@@ -80,8 +80,8 @@ public class AlterTableRerouteAnalyzer {
             new Context(
                 tableInfo,
                 alterTableReroute.table().partitionProperties(),
-                functions,
                 transactionContext,
+                nodeCtx,
                 paramTypeHints
             ));
     }
@@ -96,16 +96,16 @@ public class AlterTableRerouteAnalyzer {
 
         private Context(ShardedTable tableInfo,
                         List<Assignment<Expression>> partitionProperties,
-                        Functions functions,
                         CoordinatorTxnCtx txnCtx,
+                        NodeContext nodeCtx,
                         ParamTypeHints paramTypeHints) {
             this.tableInfo = tableInfo;
             this.partitionProperties = partitionProperties;
             this.exprCtx = new ExpressionAnalysisContext();
             this.exprAnalyzer = new ExpressionAnalyzer(
-                functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+                txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
             this.exprAnalyzerWithFields = new ExpressionAnalyzer(
-                functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+                txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         }
     }
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
@@ -23,7 +23,6 @@
 package io.crate.analyze;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 
@@ -61,7 +60,7 @@ public class AnalyzedAlterTableAddColumn implements DDLStatement {
      * metadata in order to evaluate it on every write (generated expression) or read (default expression).
      *
      * Putting all together is done by the
-     * {@link AnalyzedTableElements#finalizeAndValidate(RelationName, AnalyzedTableElements, AnalyzedTableElements, Functions)}
+     * {@link AnalyzedTableElements#finalizeAndValidate(RelationName, AnalyzedTableElements, AnalyzedTableElements)}
      * method which adds the serialized (printed) symbol tree of these expressions to the evaluated table elements.
      */
     public AnalyzedTableElements<Symbol> analyzedTableElementsWithExpressions() {

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -31,7 +31,7 @@ import io.crate.common.collections.Lists2;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
@@ -46,11 +46,11 @@ import io.crate.sql.tree.Table;
 class CopyAnalyzer {
 
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    CopyAnalyzer(Schemas schemas, Functions functions) {
+    CopyAnalyzer(Schemas schemas, NodeContext nodeCtx) {
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     AnalyzedCopyFrom analyzeCopyFrom(CopyFrom<Expression> node,
@@ -65,12 +65,12 @@ class CopyAnalyzer {
         var exprCtx = new ExpressionAnalysisContext();
 
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
 
         var normalizer = new EvaluatingNormalizer(
-            functions,
+            nodeCtx,
             RowGranularity.CLUSTER,
             null,
             new TableRelation(tableInfo));
@@ -111,21 +111,21 @@ class CopyAnalyzer {
         DocTableRelation tableRelation = new DocTableRelation((DocTableInfo) tableInfo);
 
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
-            functions,
+            nodeCtx,
             RowGranularity.CLUSTER,
             null,
             tableRelation);
 
         var exprCtx = new ExpressionAnalysisContext();
         var expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             paramTypeHints,
             new NameFieldProvider(tableRelation),
             null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             paramTypeHints,
             FieldProvider.FIELDS_AS_LITERAL,
             null);

--- a/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.AnalyzerElement;
 import io.crate.sql.tree.CharFilters;
 import io.crate.sql.tree.CreateAnalyzer;
@@ -48,12 +48,12 @@ import java.util.Map;
 class CreateAnalyzerStatementAnalyzer {
 
     private final FulltextAnalyzerResolver ftResolver;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
     CreateAnalyzerStatementAnalyzer(FulltextAnalyzerResolver ftResolver,
-                                    Functions functions) {
+                                    NodeContext nodeCtx) {
         this.ftResolver = ftResolver;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     private static class Context {
@@ -67,8 +67,8 @@ class CreateAnalyzerStatementAnalyzer {
         private final ExpressionAnalyzer exprAnalyzerWithFieldsAsString;
         private final ExpressionAnalysisContext exprContext;
 
-        Context(Functions functions,
-                CoordinatorTxnCtx transactionContext,
+        Context(CoordinatorTxnCtx transactionContext,
+                NodeContext nodeCtx,
                 ParamTypeHints paramTypeHints) {
             this.genericAnalyzerProperties = new GenericProperties<>();
             this.charFilters = new HashMap<>();
@@ -76,8 +76,8 @@ class CreateAnalyzerStatementAnalyzer {
 
             this.exprContext = new ExpressionAnalysisContext();
             this.exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-                functions,
                 transactionContext,
+                nodeCtx,
                 paramTypeHints,
                 FieldProvider.FIELDS_AS_LITERAL,
                 null);
@@ -108,8 +108,8 @@ class CreateAnalyzerStatementAnalyzer {
         }
 
         var context = new Context(
-            functions,
             transactionContext,
+            nodeCtx,
             paramTypeHints
         );
 

--- a/server/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.sql.tree.CreateBlobTable;
@@ -36,18 +36,18 @@ import io.crate.sql.tree.Expression;
 public class CreateBlobTableAnalyzer {
 
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    public CreateBlobTableAnalyzer(Schemas schemas, Functions functions) {
+    public CreateBlobTableAnalyzer(Schemas schemas, NodeContext nodeCtx) {
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateBlobTable analyze(CreateBlobTable<Expression> node,
                                            ParamTypeHints paramTypeHints,
                                            CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         CreateBlobTable<Symbol> createBlobTable = node.map(x -> exprAnalyzerWithoutFields.convert(x, exprCtx));

--- a/server/src/main/java/io/crate/analyze/CreateFunctionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateFunctionAnalyzer.java
@@ -31,7 +31,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.sql.tree.CreateFunction;
 import io.crate.sql.tree.Expression;
@@ -42,10 +42,10 @@ import static io.crate.analyze.FunctionArgumentDefinition.toFunctionArgumentDefi
 
 public class CreateFunctionAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    CreateFunctionAnalyzer(Functions functions) {
-        this.functions = functions;
+    CreateFunctionAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateFunction analyze(CreateFunction<Expression> node,
@@ -53,7 +53,7 @@ public class CreateFunctionAnalyzer {
                                           CoordinatorTxnCtx txnCtx,
                                           SearchPath searchPath) {
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         CreateFunction<Symbol> createFunction = node.map(x -> exprAnalyzerWithoutFields.convert(x, exprCtx));

--- a/server/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
@@ -28,7 +28,7 @@ import io.crate.exceptions.RepositoryAlreadyExistsException;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.CreateRepository;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
@@ -36,11 +36,11 @@ import io.crate.sql.tree.GenericProperties;
 class CreateRepositoryAnalyzer {
 
     private final RepositoryService repositoryService;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    CreateRepositoryAnalyzer(RepositoryService repositoryService, Functions functions) {
+    CreateRepositoryAnalyzer(RepositoryService repositoryService, NodeContext nodeCtx) {
         this.repositoryService = repositoryService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateRepository analyze(CreateRepository<Expression> createRepository,
@@ -52,7 +52,7 @@ class CreateRepositoryAnalyzer {
         }
 
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
         GenericProperties<Symbol> genericProperties = createRepository.properties()
             .map(p -> exprAnalyzerWithFieldsAsString.convert(p, exprCtx));

--- a/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -29,7 +29,7 @@ import io.crate.common.collections.Lists2;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.CreateSnapshot;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
@@ -45,11 +45,11 @@ import java.util.UUID;
 class CreateSnapshotAnalyzer {
 
     private final RepositoryService repositoryService;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    CreateSnapshotAnalyzer(RepositoryService repositoryService, Functions functions) {
+    CreateSnapshotAnalyzer(RepositoryService repositoryService, NodeContext nodeCtx) {
         this.repositoryService = repositoryService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateSnapshot analyze(CreateSnapshot<Expression> createSnapshot,
@@ -68,9 +68,9 @@ class CreateSnapshotAnalyzer {
 
         var exprCtx = new ExpressionAnalysisContext();
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
 
         List<Table<Symbol>> tables = Lists2.map(
             createSnapshot.tables(),

--- a/server/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.expressions.TableReferenceResolver;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.EnsureNoMatchPredicate;
 import io.crate.sql.tree.CheckColumnConstraint;
@@ -46,10 +46,10 @@ import java.util.function.Function;
 
 public final class CreateTableStatementAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    public CreateTableStatementAnalyzer(Functions functions) {
-        this.functions = functions;
+    public CreateTableStatementAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateTable analyze(CreateTable<Expression> createTable,
@@ -60,9 +60,9 @@ public final class CreateTableStatementAnalyzer {
         relationName.ensureValidForRelationCreation();
 
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
         Function<Expression, Symbol> exprMapper = y -> exprAnalyzerWithFieldsAsString.convert(y, exprCtx);
 
@@ -124,7 +124,7 @@ public final class CreateTableStatementAnalyzer {
         //   - check constraints
         TableReferenceResolver referenceResolver = analyzedTableElements.referenceResolver(relationName);
         var exprAnalyzerWithReferences = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, referenceResolver, null);
+            txnCtx, nodeCtx, paramTypeHints, referenceResolver, null);
         List<TableElement<Symbol>> tableElementsWithExpressions = new ArrayList<>();
         for (int i = 0; i < analyzedCreateTable.tableElements().size(); i++) {
             TableElement<Symbol> elementSymbol = analyzedCreateTable.tableElements().get(i);

--- a/server/src/main/java/io/crate/analyze/DecommissionNodeAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DecommissionNodeAnalyzer.java
@@ -27,24 +27,24 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.DecommissionNodeStatement;
 import io.crate.sql.tree.Expression;
 
 public class DecommissionNodeAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    DecommissionNodeAnalyzer(Functions functions) {
-        this.functions = functions;
+    DecommissionNodeAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedDecommissionNode analyze(DecommissionNodeStatement<Expression> decommissionNode,
                                             CoordinatorTxnCtx txnCtx,
                                             ParamTypeHints typeHints) {
         var expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             typeHints,
             FieldProvider.UNSUPPORTED,
             null);

--- a/server/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -34,7 +34,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Delete;
@@ -43,11 +43,11 @@ import java.util.Objects;
 
 final class DeleteAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final RelationAnalyzer relationAnalyzer;
 
-    DeleteAnalyzer(Functions functions, RelationAnalyzer relationAnalyzer) {
-        this.functions = functions;
+    DeleteAnalyzer(NodeContext nodeCtx, RelationAnalyzer relationAnalyzer) {
+        this.nodeCtx = nodeCtx;
         this.relationAnalyzer = relationAnalyzer;
     }
 
@@ -64,10 +64,10 @@ final class DeleteAnalyzer {
             throw new UnsupportedOperationException("Cannot delete from relations other than base tables");
         }
         DocTableRelation table = (DocTableRelation) relation;
-        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, table);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, table);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnContext,
+            nodeCtx,
             typeHints,
             new FullQualifiedNameFieldProvider(
                 relationCtx.sources(),

--- a/server/src/main/java/io/crate/analyze/KillAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/KillAnalyzer.java
@@ -26,16 +26,16 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.KillStatement;
 
 public class KillAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    KillAnalyzer(Functions functions) {
-        this.functions = functions;
+    KillAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedKill analyze(KillStatement<Expression> killStatement,
@@ -44,7 +44,7 @@ public class KillAnalyzer {
         Symbol jobId;
         if (killStatement.jobId() != null) {
             var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-                functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+                txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
             jobId = exprAnalyzerWithoutFields.convert(
                 killStatement.jobId(),
                 new ExpressionAnalysisContext());

--- a/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
@@ -40,18 +40,18 @@ import java.util.HashMap;
 public class OptimizeTableAnalyzer {
 
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    OptimizeTableAnalyzer(Schemas schemas, Functions functions) {
+    OptimizeTableAnalyzer(Schemas schemas, NodeContext nodeCtx) {
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedOptimizeTable analyze(OptimizeStatement<Expression> statement,
                                          ParamTypeHints paramTypeHints,
                                          CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
 
         var exprCtx = new ExpressionAnalysisContext();
         OptimizeStatement<Symbol> analyzedStatement =

--- a/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -26,7 +26,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -38,11 +38,11 @@ import java.util.HashMap;
 
 class RefreshTableAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Schemas schemas;
 
-    RefreshTableAnalyzer(Functions functions, Schemas schemas) {
-        this.functions = functions;
+    RefreshTableAnalyzer(NodeContext nodeCtx, Schemas schemas) {
+        this.nodeCtx = nodeCtx;
         this.schemas = schemas;
     }
 
@@ -50,7 +50,7 @@ class RefreshTableAnalyzer {
                                         ParamTypeHints paramTypeHints,
                                         CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
         var exprCtx = new ExpressionAnalysisContext();
 
         HashMap<Table<Symbol>, DocTableInfo> analyzedTables = new HashMap<>();

--- a/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
@@ -26,7 +26,7 @@ import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.ResetStatement;
 
@@ -34,18 +34,18 @@ import java.util.HashSet;
 
 public class ResetStatementAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    public ResetStatementAnalyzer(Functions functions) {
-        this.functions = functions;
+    public ResetStatementAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedResetStatement analyze(ResetStatement<Expression> node,
                                           ParamTypeHints typeHints,
                                           CoordinatorTxnCtx txnCtx) {
         var exprAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             typeHints,
             FieldProvider.FIELDS_AS_LITERAL,
             null

--- a/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -29,7 +29,7 @@ import io.crate.common.collections.Lists2;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.RestoreSnapshot;
@@ -40,11 +40,11 @@ import java.util.List;
 class RestoreSnapshotAnalyzer {
 
     private final RepositoryService repositoryService;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    RestoreSnapshotAnalyzer(RepositoryService repositoryService, Functions functions) {
+    RestoreSnapshotAnalyzer(RepositoryService repositoryService, NodeContext nodeCtx) {
         this.repositoryService = repositoryService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedRestoreSnapshot analyze(RestoreSnapshot<Expression> restoreSnapshot,
@@ -61,9 +61,9 @@ class RestoreSnapshotAnalyzer {
 
         var exprCtx = new ExpressionAnalysisContext();
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
-            functions, txnCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
+            txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
 
         List<Table<Symbol>> tables = Lists2.map(
             restoreSnapshot.tables(),

--- a/server/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -26,16 +26,16 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.SetStatement;
 
 class SetStatementAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    SetStatementAnalyzer(Functions functions) {
-        this.functions = functions;
+    SetStatementAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedStatement analyze(SetStatement<Expression> node,
@@ -43,8 +43,8 @@ class SetStatementAnalyzer {
                                      CoordinatorTxnCtx txnCtx) {
         boolean isPersistent = node.settingType().equals(SetStatement.SettingType.PERSISTENT);
         var exprAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             typeHints,
             FieldProvider.FIELDS_AS_LITERAL,
             null

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -29,7 +29,7 @@ import io.crate.auth.user.User;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.doc.DocTableInfo;
@@ -42,11 +42,11 @@ import java.util.HashMap;
 public final class SwapTableAnalyzer {
 
     public static final String DROP_SOURCE = "drop_source";
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Schemas schemas;
 
-    SwapTableAnalyzer(Functions functions, Schemas schemas) {
-        this.functions = functions;
+    SwapTableAnalyzer(NodeContext nodeCtx, Schemas schemas) {
+        this.nodeCtx = nodeCtx;
         this.schemas = schemas;
     }
 
@@ -64,7 +64,7 @@ public final class SwapTableAnalyzer {
             dropSource = Literal.BOOLEAN_FALSE;
         } else {
             ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
-                functions, txnCtx, typeHints, FieldProvider.UNSUPPORTED, null);
+                txnCtx, nodeCtx, typeHints, FieldProvider.UNSUPPORTED, null);
             dropSource = exprAnalyzer.convert(dropSourceExpr, new ExpressionAnalysisContext());
         }
         SearchPath searchPath = txnCtx.sessionContext().searchPath();

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -31,7 +31,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataType;
@@ -50,21 +50,21 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
 
     private final SubQueryResults subQueryResults;
 
-    public SymbolEvaluator(TransactionContext txnCtx, Functions functions, SubQueryResults subQueryResults) {
-        super(txnCtx, functions);
+    public SymbolEvaluator(TransactionContext txnCtx, NodeContext nodeCtx, SubQueryResults subQueryResults) {
+        super(txnCtx, nodeCtx);
         this.subQueryResults = subQueryResults;
     }
 
-    public static Object evaluateWithoutParams(TransactionContext txn, Functions functions, Symbol symbol) {
-        return evaluate(txn, functions, symbol, Row.EMPTY, SubQueryResults.EMPTY);
+    public static Object evaluateWithoutParams(TransactionContext txn, NodeContext nodeCtx, Symbol symbol) {
+        return evaluate(txn, nodeCtx, symbol, Row.EMPTY, SubQueryResults.EMPTY);
     }
 
     public static Object evaluate(TransactionContext txnCtx,
-                                  Functions functions,
+                                  NodeContext nodeCtx,
                                   Symbol symbol,
                                   Row params,
                                   SubQueryResults subQueryValues) {
-        SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, functions, subQueryValues);
+        SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, subQueryValues);
         return symbol.accept(symbolEval, params).value();
     }
 

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -40,7 +40,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.Operation;
@@ -71,11 +71,11 @@ public final class UpdateAnalyzer {
         input -> input.valueType().id() == ArrayType.ID
                  && ((ArrayType<?>) input.valueType()).innerType().id() == ObjectType.ID;
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final RelationAnalyzer relationAnalyzer;
 
-    UpdateAnalyzer(Functions functions, RelationAnalyzer relationAnalyzer) {
-        this.functions = functions;
+    UpdateAnalyzer(NodeContext nodeCtx, RelationAnalyzer relationAnalyzer) {
+        this.nodeCtx = nodeCtx;
         this.relationAnalyzer = relationAnalyzer;
     }
 
@@ -101,13 +101,13 @@ public final class UpdateAnalyzer {
             throw new UnsupportedOperationException("UPDATE is only supported on base-tables");
         }
         AbstractTableRelation<?> table = (AbstractTableRelation<?>) relation;
-        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, table);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, table);
         SubqueryAnalyzer subqueryAnalyzer =
             new SubqueryAnalyzer(relationAnalyzer, new StatementAnalysisContext(typeHints, Operation.READ, txnCtx));
 
         ExpressionAnalyzer sourceExprAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             typeHints,
             new FullQualifiedNameFieldProvider(
                 relCtx.sources(),
@@ -153,8 +153,8 @@ public final class UpdateAnalyzer {
                                                       ExpressionAnalysisContext exprCtx) {
         HashMap<Reference, Symbol> assignmentByTargetCol = new HashMap<>();
         ExpressionAnalyzer targetExprAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnCtx,
+            nodeCtx,
             typeHints,
             new NameFieldProvider(table),
             subqueryAnalyzer,

--- a/server/src/main/java/io/crate/analyze/UserAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UserAnalyzer.java
@@ -27,7 +27,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.Expression;
@@ -35,10 +35,10 @@ import io.crate.sql.tree.GenericProperties;
 
 public class UserAnalyzer {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    UserAnalyzer(Functions functions) {
-        this.functions = functions;
+    UserAnalyzer(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AnalyzedCreateUser analyze(CreateUser<Expression> node,
@@ -62,8 +62,8 @@ public class UserAnalyzer {
                                                        CoordinatorTxnCtx txnContext) {
         ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             txnContext,
+            nodeCtx,
             paramTypeHints,
             FieldProvider.UNSUPPORTED,
             null

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -54,7 +54,7 @@ import io.crate.expression.tablefunctions.TableFunctionFactory;
 import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
@@ -109,7 +109,7 @@ import java.util.Optional;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Schemas schemas;
 
     private static final List<Relation> EMPTY_ROW_TABLE_RELATION = ImmutableList.of(
@@ -117,8 +117,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     );
 
     @Inject
-    public RelationAnalyzer(Functions functions, Schemas schemas) {
-        this.functions = functions;
+    public RelationAnalyzer(NodeContext nodeCtx, Schemas schemas) {
+        this.nodeCtx = nodeCtx;
         this.schemas = schemas;
     }
 
@@ -151,8 +151,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         List<Symbol> childRelationFields = childRelation.outputs();
         var coordinatorTxnCtx = statementContext.transactionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             coordinatorTxnCtx,
+            nodeCtx,
             statementContext.paramTyeHints(),
             new FullQualifiedNameFieldProvider(
                 relationAnalysisContext.sources(),
@@ -170,7 +170,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
-            functions,
+            nodeCtx,
             f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.isDeterministic()
         );
 
@@ -264,8 +264,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             if (joinCriteria instanceof JoinOn || joinCriteria instanceof JoinUsing) {
                 final CoordinatorTxnCtx coordinatorTxnCtx = statementContext.transactionContext();
                 ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-                    functions,
                     coordinatorTxnCtx,
+                    nodeCtx,
                     statementContext.paramTyeHints(),
                     new FullQualifiedNameFieldProvider(
                         relationContext.sources(),
@@ -319,8 +319,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         RelationAnalysisContext context = statementContext.currentRelationContext();
         CoordinatorTxnCtx coordinatorTxnCtx = statementContext.transactionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             coordinatorTxnCtx,
+            nodeCtx,
             statementContext.paramTyeHints(),
             new FullQualifiedNameFieldProvider(
                 context.sources(),
@@ -352,7 +352,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         WhereClauseValidator.validate(where);
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
-            functions,
+            nodeCtx,
             f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.isDeterministic()
         );
 
@@ -626,8 +626,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     public AnalyzedRelation visitTableFunction(TableFunction node, StatementAnalysisContext statementContext) {
         RelationAnalysisContext context = statementContext.currentRelationContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             statementContext.transactionContext(),
+            nodeCtx,
             statementContext.paramTyeHints(),
             FieldProvider.UNSUPPORTED,
             null
@@ -648,7 +648,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     "Symbol '%s' is not supported in FROM clause", node.name()));
         }
         Function function = (Function) symbol;
-        FunctionImplementation functionImplementation = functions.getQualified(
+        FunctionImplementation functionImplementation = nodeCtx.functions().getQualified(
             function,
             statementContext.sessionContext().searchPath()
         );
@@ -670,8 +670,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     @Override
     public AnalyzedRelation visitValues(Values values, StatementAnalysisContext context) {
         var expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             context.transactionContext(),
+            nodeCtx,
             context.paramTyeHints(),
             FieldProvider.UNSUPPORTED,
             new SubqueryAnalyzer(this, context)
@@ -731,7 +731,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
-            functions,
+            nodeCtx,
             f -> f.isDeterministic()
         );
 
@@ -749,7 +749,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 arrayType
             ));
         }
-        FunctionImplementation implementation = functions.getQualified(
+        FunctionImplementation implementation = nodeCtx.functions().getQualified(
             ValuesFunction.SIGNATURE,
             Symbols.typeView(arrays),
             RowType.EMPTY

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -22,8 +22,8 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
@@ -43,7 +43,7 @@ public interface InsertSourceGen {
     Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException;
 
     static InsertSourceGen of(TransactionContext txnCtx,
-                              Functions functions,
+                              NodeContext nodeCtx,
                               DocTableInfo table,
                               String indexName,
                               GeneratedColumns.Validation validation,
@@ -52,9 +52,9 @@ public interface InsertSourceGen {
             if (table.generatedColumns().isEmpty() && table.defaultExpressionColumns().isEmpty()) {
                 return new FromRawInsertSource();
             } else {
-                return new GeneratedColsFromRawInsertSource(txnCtx, functions, table.generatedColumns(), table.defaultExpressionColumns());
+                return new GeneratedColsFromRawInsertSource(txnCtx, nodeCtx, table.generatedColumns(), table.defaultExpressionColumns());
             }
         }
-        return new InsertSourceFromCells(txnCtx, functions, table, indexName, validation, targets);
+        return new InsertSourceFromCells(txnCtx, nodeCtx, table, indexName, validation, targets);
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ReturnValueGen.java
@@ -28,7 +28,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.DocRefResolver;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 
@@ -41,8 +41,8 @@ final class ReturnValueGen {
     private final List<CollectExpression<Doc, ?>> expressions;
     private final List<Input<?>> inputs;
 
-    ReturnValueGen(Functions functions, TransactionContext txnCtx, DocTableInfo table, Symbol[] returnValues) {
-        InputFactory.Context<CollectExpression<Doc, ?>> cntx = new InputFactory(functions).ctxForRefs(
+    ReturnValueGen(TransactionContext txnCtx, NodeContext nodeCtx, DocTableInfo table, Symbol[] returnValues) {
+        InputFactory.Context<CollectExpression<Doc, ?>> cntx = new InputFactory(nodeCtx).ctxForRefs(
             txnCtx, new DocRefResolver(table.partitionedBy()));
         cntx.add(List.of(returnValues));
         this.expressions = cntx.expressions();

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -34,7 +34,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
@@ -80,10 +80,10 @@ final class UpdateSourceGen {
     private final ArrayList<Reference> updateColumns;
     private final CheckConstraints<Doc, CollectExpression<Doc, ?>> checks;
 
-    UpdateSourceGen(Functions functions, TransactionContext txnCtx, DocTableInfo table, String[] updateColumns) {
+    UpdateSourceGen(TransactionContext txnCtx, NodeContext nodeCtx, DocTableInfo table, String[] updateColumns) {
         DocRefResolver refResolver = new DocRefResolver(table.partitionedBy());
-        this.eval = new Evaluator(functions, txnCtx, refResolver);
-        InputFactory inputFactory = new InputFactory(functions);
+        this.eval = new Evaluator(txnCtx, nodeCtx, refResolver);
+        InputFactory inputFactory = new InputFactory(nodeCtx);
         this.checks = new CheckConstraints<>(txnCtx, inputFactory, refResolver, table);
         this.updateColumns = new ArrayList<>(updateColumns.length);
         for (String updateColumn : updateColumns) {
@@ -153,10 +153,10 @@ final class UpdateSourceGen {
 
         private final ReferenceResolver<CollectExpression<Doc, ?>> refResolver;
 
-        private Evaluator(Functions functions,
-                          TransactionContext txnCtx,
+        private Evaluator(TransactionContext txnCtx,
+                          NodeContext nodeCtx,
                           ReferenceResolver<CollectExpression<Doc, ?>> refResolver) {
-            super(txnCtx, functions);
+            super(txnCtx, nodeCtx);
             this.refResolver = refResolver;
         }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -38,7 +38,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
 import io.crate.types.DataType;
@@ -51,10 +51,10 @@ import java.util.Map;
 
 public class ProjectionBuilder {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    public ProjectionBuilder(Functions functions) {
-        this.functions = functions;
+    public ProjectionBuilder(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public AggregationProjection aggregationProjection(Collection<? extends Symbol> inputs,
@@ -113,7 +113,7 @@ public class ProjectionBuilder {
                     throw new AssertionError("Invalid mode: " + mode.name());
             }
 
-            AggregationFunction<?, ?> aggregationFunction = (AggregationFunction<?, ?>) this.functions.getQualified(
+            AggregationFunction<?, ?> aggregationFunction = (AggregationFunction<?, ?>) nodeCtx.functions().getQualified(
                 function,
                 searchPath
             );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -31,6 +31,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -130,7 +131,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert function.arguments().size() <= 1 : "function's number of arguments must be 0 or 1";
 
         if (function.arguments().size() == 1) {

--- a/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -37,7 +37,7 @@ import io.crate.execution.jobs.SharedShardContext;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.blob.BlobReferenceResolver;
 import io.crate.expression.reference.sys.shard.ShardRowContext;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -56,7 +56,7 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
                                       ClusterService clusterService,
                                       Schemas schemas,
                                       NodeJobsCounter nodeJobsCounter,
-                                      Functions functions,
+                                      NodeContext nodeCtx,
                                       ThreadPool threadPool,
                                       Settings settings,
                                       TransportActionProvider transportActionProvider) {
@@ -64,14 +64,14 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
             clusterService,
             schemas,
             nodeJobsCounter,
-            functions,
+            nodeCtx,
             threadPool,
             settings,
             transportActionProvider,
             blobShard.indexShard(),
             new ShardRowContext(blobShard, clusterService)
         );
-        inputFactory = new InputFactory(functions);
+        inputFactory = new InputFactory(nodeCtx);
         this.blobShard = blobShard;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
@@ -27,7 +27,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.OrderByCollectorExpression;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 
@@ -41,9 +41,9 @@ public class DocInputFactory {
     private final ReferenceResolver<? extends LuceneCollectorExpression<?>> referenceResolver;
     private final InputFactory inputFactory;
 
-    public DocInputFactory(Functions functions,
+    public DocInputFactory(NodeContext nodeCtx,
                            ReferenceResolver<? extends LuceneCollectorExpression<?>> referenceResolver) {
-        this.inputFactory = new InputFactory(functions);
+        this.inputFactory = new InputFactory(nodeCtx);
         this.referenceResolver = referenceResolver;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -44,7 +44,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.doc.DocTableInfo;
@@ -75,7 +75,7 @@ import java.util.function.Function;
 public class DocValuesAggregates {
 
     @Nullable
-    public static BatchIterator<Row> tryOptimize(Functions functions,
+    public static BatchIterator<Row> tryOptimize(NodeContext nodeCtx,
                                                  IndexShard indexShard,
                                                  DocTableInfo table,
                                                  LuceneQueryBuilder luceneQueryBuilder,
@@ -88,7 +88,7 @@ public class DocValuesAggregates {
             return null;
         }
         var aggregators = createAggregators(
-            functions,
+            nodeCtx,
             aggregateProjection,
             fieldTypeLookup,
             phase.toCollect(),
@@ -158,7 +158,7 @@ public class DocValuesAggregates {
 
     @Nullable
     @SuppressWarnings("rawtypes")
-    private static List<DocValueAggregator> createAggregators(Functions functions,
+    private static List<DocValueAggregator> createAggregators(NodeContext nodeCtx,
                                                               AggregationProjection aggregateProjection,
                                                               FieldTypeLookup fieldTypeLookup,
                                                               List<Symbol> toCollect,
@@ -179,7 +179,7 @@ public class DocValuesAggregates {
                 return null;
             }
 
-            FunctionImplementation func = functions.getQualified(aggregation, searchPath);
+            FunctionImplementation func = nodeCtx.functions().getQualified(aggregation, searchPath);
             if (!(func instanceof AggregationFunction)) {
                 throw new IllegalStateException(
                     "Expected an aggregationFunction for " + aggregation + " got: " + func);

--- a/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
@@ -28,8 +28,8 @@ import io.crate.data.Row;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.Functions;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -52,12 +52,12 @@ public class RowShardResolver {
 
 
     public RowShardResolver(TransactionContext txnCtx,
-                            Functions functions,
+                            NodeContext nodeCtx,
                             List<ColumnIdent> pkColumns,
                             List<? extends Symbol> primaryKeySymbols,
                             @Nullable ColumnIdent clusteredByColumn,
                             @Nullable Symbol routingSymbol) {
-        InputFactory inputFactory = new InputFactory(functions);
+        InputFactory inputFactory = new InputFactory(nodeCtx);
         InputFactory.Context<CollectExpression<Row, ?>> context = inputFactory.ctxForInputColumns(txnCtx);
         idFunction = Id.compileWithNullValidation(pkColumns, clusteredByColumn);
         if (routingSymbol == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
+import io.crate.metadata.NodeContext;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
@@ -48,7 +49,6 @@ import io.crate.execution.jobs.SharedShardContext;
 import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.reference.sys.shard.ShardRowContext;
-import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.shard.ShardReferenceResolver;
@@ -63,7 +63,7 @@ public abstract class ShardCollectorProvider {
     ShardCollectorProvider(ClusterService clusterService,
                            Schemas schemas,
                            NodeJobsCounter nodeJobsCounter,
-                           Functions functions,
+                           NodeContext nodeCtx,
                            ThreadPool threadPool,
                            Settings settings,
                            TransportActionProvider transportActionProvider,
@@ -72,7 +72,7 @@ public abstract class ShardCollectorProvider {
         this.indexShard = indexShard;
         this.shardRowContext = shardRowContext;
         shardNormalizer = new EvaluatingNormalizer(
-            functions,
+            nodeCtx,
             RowGranularity.SHARD,
             new ShardReferenceResolver(schemas, shardRowContext),
             null
@@ -80,11 +80,11 @@ public abstract class ShardCollectorProvider {
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
-            functions,
+            nodeCtx,
             threadPool,
             settings,
             transportActionProvider,
-            new InputFactory(functions),
+            new InputFactory(nodeCtx),
             shardNormalizer,
             t -> null,
             t -> null,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
@@ -40,8 +40,8 @@ import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.information.InformationSchemaInfo;
@@ -74,7 +74,7 @@ public class CollectSourceResolver {
     @Inject
     public CollectSourceResolver(ClusterService clusterService,
                                  NodeJobsCounter nodeJobsCounter,
-                                 Functions functions,
+                                 NodeContext nodeCtx,
                                  Settings settings,
                                  ThreadPool threadPool,
                                  TransportActionProvider transportActionProvider,
@@ -88,15 +88,15 @@ public class CollectSourceResolver {
                                  NodeStatsCollectSource nodeStatsCollectSource) {
         this.clusterService = clusterService;
 
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
-            functions,
+            nodeCtx,
             threadPool,
             settings,
             transportActionProvider,
-            new InputFactory(functions),
+            new InputFactory(nodeCtx),
             normalizer,
             systemCollectSource::getRowUpdater,
             systemCollectSource::tableDefinition

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
@@ -30,7 +30,7 @@ import io.crate.execution.engine.collect.LuceneShardCollectorProvider;
 import io.crate.execution.engine.collect.ShardCollectorProvider;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.lucene.LuceneQueryBuilder;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -48,7 +48,7 @@ public class ShardCollectorProviderFactory {
     private final TransportActionProvider transportActionProvider;
     private final BlobIndicesService blobIndicesService;
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final LuceneQueryBuilder luceneQueryBuilder;
     private final NodeJobsCounter nodeJobsCounter;
     private final BigArrays bigArrays;
@@ -60,7 +60,7 @@ public class ShardCollectorProviderFactory {
                                   ThreadPool threadPool,
                                   TransportActionProvider transportActionProvider,
                                   BlobIndicesService blobIndicesService,
-                                  Functions functions,
+                                  NodeContext nodeCtx,
                                   LuceneQueryBuilder luceneQueryBuilder,
                                   NodeJobsCounter nodeJobsCounter,
                                   BigArrays bigArrays) {
@@ -70,7 +70,7 @@ public class ShardCollectorProviderFactory {
         this.threadPool = threadPool;
         this.transportActionProvider = transportActionProvider;
         this.blobIndicesService = blobIndicesService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.luceneQueryBuilder = luceneQueryBuilder;
         this.nodeJobsCounter = nodeJobsCounter;
         this.bigArrays = bigArrays;
@@ -84,7 +84,7 @@ public class ShardCollectorProviderFactory {
                 clusterService,
                 schemas,
                 nodeJobsCounter,
-                functions,
+                nodeCtx,
                 threadPool,
                 settings,
                 transportActionProvider
@@ -95,7 +95,7 @@ public class ShardCollectorProviderFactory {
                 luceneQueryBuilder,
                 clusterService,
                 nodeJobsCounter,
-                functions,
+                nodeCtx,
                 threadPool,
                 settings,
                 transportActionProvider,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -41,7 +41,7 @@ import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.StaticTableDefinition;
 import io.crate.expression.reference.sys.SysRowUpdater;
 import io.crate.expression.reference.sys.check.node.SysNodeChecks;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.information.InformationSchemaInfo;
@@ -78,14 +78,14 @@ public class SystemCollectSource implements CollectSource {
 
     @Inject
     public SystemCollectSource(ClusterService clusterService,
-                               Functions functions,
+                               NodeContext nodeCtx,
                                UserManager userManager,
                                InformationSchemaTableDefinitions informationSchemaTables,
                                SysTableDefinitions sysTableDefinitions,
                                SysNodeChecks sysNodeChecks,
                                PgCatalogTableDefinitions pgCatalogTables) {
         this.clusterService = clusterService;
-        inputFactory = new InputFactory(functions);
+        inputFactory = new InputFactory(nodeCtx);
         this.userLookup = userManager;
         this.informationSchemaTables = informationSchemaTables;
         this.sysTables = sysTableDefinitions;

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -36,7 +36,7 @@ import io.crate.execution.engine.collect.ValueAndInputRow;
 import io.crate.expression.InputCondition;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.RowType;
@@ -50,11 +50,13 @@ import java.util.concurrent.CompletableFuture;
 @Singleton
 public class TableFunctionCollectSource implements CollectSource {
 
+    private final NodeContext nodeCtx;
     private final InputFactory inputFactory;
 
     @Inject
-    public TableFunctionCollectSource(Functions functions) {
-        inputFactory = new InputFactory(functions);
+    public TableFunctionCollectSource(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
+        inputFactory = new InputFactory(nodeCtx);
     }
 
     @Override
@@ -87,7 +89,7 @@ public class TableFunctionCollectSource implements CollectSource {
             topLevelInputs.add(ctx.add(symbol));
         }
 
-        Iterable<Row> result = functionImplementation.evaluate(txnCtx, inputs.toArray(new Input[0]));
+        Iterable<Row> result = functionImplementation.evaluate(txnCtx, nodeCtx, inputs.toArray(new Input[0]));
         Iterable<Row> rows = Iterables.transform(
             result,
             new ValueAndInputRow<>(topLevelInputs, ctx.expressions()));

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
@@ -28,18 +28,18 @@ import io.crate.data.BatchIterators;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.FetchProjection;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 
 public final class FetchProjector {
 
     public static Projector create(FetchProjection projection,
                                    TransactionContext txnCtx,
-                                   Functions functions,
+                                   NodeContext nodeCtx,
                                    FetchOperation fetchOperation) {
         final FetchRows fetchRows = FetchRows.create(
             txnCtx,
-            functions,
+            nodeCtx,
             projection.fetchSources(),
             projection.outputSymbols()
         );

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchRows.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchRows.java
@@ -39,7 +39,7 @@ import io.crate.expression.InputRow;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.fetch.FetchSource;
@@ -83,7 +83,7 @@ import io.crate.planner.node.fetch.FetchSource;
 public final class FetchRows {
 
     public static FetchRows create(TransactionContext txnCtx,
-                                   Functions functions,
+                                   NodeContext nodeCtx,
                                    Map<RelationName, FetchSource> fetchSourceByTable,
                                    List<Symbol> outputSymbols) {
         IntArrayList fetchIdPositions = new IntArrayList();
@@ -98,7 +98,7 @@ public final class FetchRows {
             }
         }
         final UnsafeArrayRow inputRow = new UnsafeArrayRow();
-        var visitor = new BaseImplementationSymbolVisitor<Void>(txnCtx, functions) {
+        var visitor = new BaseImplementationSymbolVisitor<Void>(txnCtx, nodeCtx) {
 
             @Override
             public Input<?> visitInputColumn(final InputColumn inputColumn, final Void context) {

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -37,7 +37,7 @@ import io.crate.expression.InputRow;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -61,7 +61,7 @@ public class ColumnIndexWriterProjector implements Projector {
                                       ScheduledExecutorService scheduler,
                                       Executor executor,
                                       TransactionContext txnCtx,
-                                      Functions functions,
+                                      NodeContext nodeCtx,
                                       Settings settings,
                                       int targetTableNumShards,
                                       int targetTableNumReplicas,
@@ -82,7 +82,7 @@ public class ColumnIndexWriterProjector implements Projector {
                                       UUID jobId
                                       ) {
         RowShardResolver rowShardResolver = new RowShardResolver(
-            txnCtx, functions, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
+            txnCtx, nodeCtx, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
         assert columnReferences.size() == insertInputs.size()
             : "number of insert inputs must be equal to the number of columns";
 
@@ -92,7 +92,7 @@ public class ColumnIndexWriterProjector implements Projector {
             updateColumnNames = null;
             assignments = null;
         } else {
-            Assignments convert = Assignments.convert(updateAssignments, functions);
+            Assignments convert = Assignments.convert(updateAssignments, nodeCtx);
             updateColumnNames = convert.targetNames();
             assignments = convert.sources();
         }

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -34,7 +34,7 @@ import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.apache.logging.log4j.LogManager;
@@ -69,7 +69,7 @@ public class IndexWriterProjector implements Projector {
                                 ScheduledExecutorService scheduler,
                                 Executor executor,
                                 TransactionContext txnCtx,
-                                Functions functions,
+                                NodeContext nodeCtx,
                                 Settings settings,
                                 int targetTableNumShards,
                                 int targetTableNumReplicas,
@@ -99,7 +99,7 @@ public class IndexWriterProjector implements Projector {
             source = new MapInput((Input<Map<String, Object>>) sourceInput, includes, excludes);
         }
         RowShardResolver rowShardResolver = new RowShardResolver(
-            txnCtx, functions, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
+            txnCtx, nodeCtx, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),

--- a/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -32,6 +32,7 @@ import io.crate.expression.ExpressionsInput;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import org.elasticsearch.Version;
@@ -86,8 +87,8 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, @Nullable TransactionContext txnCtx) {
-        return aggregationFunction.normalizeSymbol(function, txnCtx);
+    public Symbol normalizeSymbol(Function function, @Nullable TransactionContext txnCtx, NodeContext nodeCtx) {
+        return aggregationFunction.normalizeSymbol(function, txnCtx, nodeCtx);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -85,7 +85,7 @@ import io.crate.expression.RowFilter;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.MemoryManagerFactory;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Routing;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
@@ -157,7 +157,7 @@ public class JobSetup {
                     DistributingConsumerFactory distributingConsumerFactory,
                     TransportActionProvider transportActionProvider,
                     IndicesService indicesService,
-                    Functions functions,
+                    NodeContext nodeCtx,
                     SystemCollectSource systemCollectSource,
                     ShardCollectSource shardCollectSource,
                     MemoryManagerFactory memoryManagerFactory) {
@@ -171,13 +171,13 @@ public class JobSetup {
         this.pkLookupOperation = new PKLookupOperation(indicesService, shardCollectSource);
         this.distributingConsumerFactory = distributingConsumerFactory;
         innerPreparer = new InnerPreparer();
-        inputFactory = new InputFactory(functions);
+        inputFactory = new InputFactory(nodeCtx);
         searchTp = threadPool.executor(ThreadPool.Names.SEARCH);
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         this.projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
-            functions,
+            nodeCtx,
             threadPool,
             settings,
             transportActionProvider,

--- a/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -33,7 +33,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -44,17 +44,17 @@ import java.util.Locale;
 public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?>> {
 
     protected final TransactionContext txnCtx;
-    protected final Functions functions;
+    protected final NodeContext nodeCtx;
 
-    public BaseImplementationSymbolVisitor(TransactionContext txnCtx, Functions functions) {
+    public BaseImplementationSymbolVisitor(TransactionContext txnCtx, NodeContext nodeCtx) {
         this.txnCtx = txnCtx;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     @Override
     public Input<?> visitFunction(Function function, C context) {
         Signature signature = function.signature();
-        FunctionImplementation functionImplementation = functions.getQualified(
+        FunctionImplementation functionImplementation = nodeCtx.functions().getQualified(
             function,
             txnCtx.sessionSettings().searchPath()
         );
@@ -68,7 +68,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
             for (Symbol argument : function.arguments()) {
                 argumentInputs[i++] = argument.accept(this, context);
             }
-            return new FunctionExpression<>(txnCtx, scalarImpl, argumentInputs);
+            return new FunctionExpression<>(txnCtx, nodeCtx, scalarImpl, argumentInputs);
         } else {
             throw new UnsupportedFeatureException(
                 String.format(

--- a/server/src/main/java/io/crate/expression/FunctionExpression.java
+++ b/server/src/main/java/io/crate/expression/FunctionExpression.java
@@ -23,6 +23,7 @@
 package io.crate.expression;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
 
@@ -33,16 +34,21 @@ public final class FunctionExpression<ReturnType, InputType> implements Input<Re
     private final Input<InputType>[] arguments;
     private final Scalar<ReturnType, InputType> scalar;
     private final TransactionContext txnCtx;
+    private final NodeContext nodeCtx;
 
-    public FunctionExpression(TransactionContext txnCtx, Scalar<ReturnType, InputType> scalar, Input<InputType>[] arguments) {
+    public FunctionExpression(TransactionContext txnCtx,
+                              NodeContext nodeCtx,
+                              Scalar<ReturnType, InputType> scalar,
+                              Input<InputType>[] arguments) {
         this.txnCtx = txnCtx;
+        this.nodeCtx = nodeCtx;
         this.scalar = scalar;
         this.arguments = arguments;
     }
 
     @Override
     public ReturnType value() {
-        return scalar.evaluate(txnCtx, arguments);
+        return scalar.evaluate(txnCtx, nodeCtx, arguments);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AllOperator.java
@@ -23,6 +23,7 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ComparisonExpression;
@@ -88,7 +89,7 @@ public final class AllOperator extends Operator<Object> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         var leftValue = args[0].value();
         var rightValues = (Collection) args[1].value();
         if (leftValue == null || rightValues == null) {

--- a/server/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -26,6 +26,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -70,7 +71,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert function != null : "function must not be null";
         assert function.arguments().size() == 2 : "number of args must be 2";
 
@@ -78,7 +79,7 @@ public class AndOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left instanceof Input && right instanceof Input) {
-            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, nodeCtx, (Input) left, (Input) right));
         }
 
         /**
@@ -112,7 +113,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Boolean>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd arguments must not be null";

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator;
 
 import io.crate.common.collections.Tuple;
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -106,7 +107,7 @@ public final class CIDROperator {
         }
 
         @Override
-        public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+        public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
             assert args.length == 2 : "number of args must be 2";
             String left = (String) args[0].value();
             if (null == left) {

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator;
 
 import io.crate.common.collections.MapComparator;
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
@@ -54,7 +55,7 @@ public final class CmpOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd argument must not be null";

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -22,6 +22,7 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
@@ -55,7 +56,7 @@ public final class EqOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         assert args.length == 2 : "number of args must be 2";
         Object left = args[0].value();
         if (left == null) {

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -71,7 +72,7 @@ public class LikeOperator extends Operator<String> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
 
@@ -106,7 +107,7 @@ public class LikeOperator extends Operator<String> {
 
         @SafeVarargs
         @Override
-        public final Boolean evaluate(TransactionContext txnCtx, Input<String>... args) {
+        public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>... args) {
             String value = args[0].value();
             if (value == null) {
                 return null;

--- a/server/src/main/java/io/crate/expression/operator/Operator.java
+++ b/server/src/main/java/io/crate/expression/operator/Operator.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.BooleanType;
@@ -37,7 +38,7 @@ public abstract class Operator<I> extends Scalar<Boolean, I> {
     public static final String PREFIX = "op_";
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         // all operators evaluates to NULL if one argument is NULL
         // let's handle this here to prevent unnecessary collect operations
         for (Symbol symbol : function.arguments()) {
@@ -45,6 +46,6 @@ public abstract class Operator<I> extends Scalar<Boolean, I> {
                 return Literal.of(RETURN_TYPE, null);
             }
         }
-        return super.normalizeSymbol(function, txnCtx);
+        return super.normalizeSymbol(function, txnCtx, nodeCtx);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -68,7 +69,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert function != null : "function must not be null";
         assert function.arguments().size() == 2 : "number of args must be 2";
 
@@ -76,7 +77,7 @@ public class OrOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left.symbolType().isValueSymbol() && right.symbolType().isValueSymbol()) {
-            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, nodeCtx, (Input) left, (Input) right));
         }
 
         /*
@@ -114,7 +115,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Boolean>... args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null && args[1] != null : "1st and 2nd argument must not be null";

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -22,6 +22,7 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -60,7 +61,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<String>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
         assert args.length == 2 : "invalid number of arguments";
         String source = args[0].value();
         if (source == null) {

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -22,6 +22,7 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -64,7 +65,7 @@ public class RegexpMatchOperator extends Operator<String> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<String>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
         assert args.length == 2 : "invalid number of arguments";
         String source = args[0].value();
         if (source == null) {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator.any;
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.TriPredicate;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -81,7 +82,7 @@ public class AnyLikeOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         Object value = args[0].value();
         Object collectionReference = args[1].value();
 

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator.any;
 
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -76,7 +77,7 @@ public final class AnyOperator extends Operator<Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         assert args != null : "args must not be null";
         assert args.length == 2 : "number of args must be 2";
         assert args[0] != null : "1st argument must not be null";

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -25,6 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -68,7 +69,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert symbol != null : "function must not be null";
         assert symbol.arguments().size() == 1 : "function's number of arguments must be 1";
 
@@ -82,7 +83,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 1 : "number of args must be 1";
         return args[0] == null || args[0].value() == null;
     }

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -25,6 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -64,7 +65,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert symbol != null : "function must not be null";
         assert symbol.arguments().size() == 1 : "function's number of arguments must be 1";
 
@@ -83,7 +84,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Boolean>... args) {
         assert args.length == 1 : "number of args must be 1";
         Boolean value = args[0].value();
         return value != null ? !value : null;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -73,7 +74,7 @@ class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
 
     @SafeVarargs
     @Override
-    public final List<Object> evaluate(TransactionContext txnCtx, Input<List<Object>>... args) {
+    public final List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... args) {
         DataType<?> innerType = ((ArrayType<?>) this.boundSignature.getReturnType().createType()).innerType();
         ArrayList<Object> resultList = new ArrayList<>();
         for (Input<List<Object>> arg : args) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -113,7 +114,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
     }
 
     @Override
-    public List<Object> evaluate(TransactionContext txnCtx, Input[] args) {
+    public List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         List<Object> inputValues = (List<Object>) args[0].value();
         if (inputValues == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -70,7 +71,7 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
     }
 
     @Override
-    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         @SuppressWarnings("unchecked")
         List<Object> values = (List<Object>) args[0].value();
         Object dimension1Indexed = args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -90,7 +91,7 @@ class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
     }
 
     @Override
-    public List<Object> evaluate(TransactionContext txnCtx, Input[] args) {
+    public List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         Set<Object> uniqueSet = new HashSet<>();
         ArrayList<Object> uniqueItems = new ArrayList<>();
         for (Input array : args) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -73,7 +74,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
     }
 
     @Override
-    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         @SuppressWarnings("unchecked")
         List<Object> values = (List<Object>) args[0].value();
         Object dimension1Indexed = args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -56,7 +57,7 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
     }
 
     @Override
-    public Double evaluate(TransactionContext txnCtx, Input<List<Object>>... args) {
+    public Double evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... args) {
         List<Object> values = args[0].value();
         if (values == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -56,7 +57,7 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
     }
 
     @Override
-    public Long evaluate(TransactionContext txnCtx, Input<List<Object>>... args) {
+    public Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... args) {
         List<Object> argArray = args[0].value();
         if (argArray == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -25,6 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -90,7 +91,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         if (anyNonLiterals(function.arguments())) {
             return function;
         }
@@ -99,7 +100,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             inputs[i] = ((Input) function.arguments().get(i));
         }
         //noinspection unchecked
-        return Literal.ofUnchecked(boundSignature.getReturnType().createType(), evaluate(txnCtx, inputs));
+        return Literal.ofUnchecked(boundSignature.getReturnType().createType(), evaluate(txnCtx, nodeCtx, inputs));
     }
 
     static class StringConcatFunction extends ConcatFunction {
@@ -109,7 +110,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         }
 
         @Override
-        public String evaluate(TransactionContext txnCtx, Input[] args) {
+        public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
             String firstArg = (String) args[0].value();
             String secondArg = (String) args[1].value();
             if (firstArg == null) {
@@ -132,7 +133,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         }
 
         @Override
-        public String evaluate(TransactionContext txnCtx, Input<String>[] args) {
+        public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < args.length; i++) {
                 String value = args[i].value();

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar;
 import io.crate.Constants;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -64,7 +65,7 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         return Constants.DB_NAME;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -82,7 +83,7 @@ public class DateFormatFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         String format;
         Input<?> timezoneLiteral = null;
         if (args.length == 1) {

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -135,7 +136,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert symbol.arguments().size() > 1 && symbol.arguments().size() < 4 : "Invalid number of arguments";
 
         if (anyNonLiterals(symbol.arguments())) {
@@ -156,12 +157,12 @@ public class DateTruncFunction extends Scalar<Long, Object> {
 
         return Literal.of(
             DataTypes.TIMESTAMPZ,
-            evaluate(txnCtx, new Input[]{interval, timezone, tsSymbol})
+            evaluate(txnCtx, nodeCtx, new Input[]{interval, timezone, tsSymbol})
         );
     }
 
     @Override
-    public final Long evaluate(TransactionContext txnCtx, Input[] args) {
+    public final Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length > 1 && args.length < 4 : "Invalid number of arguments";
         Object value;
         String timeZone = TimeZoneParser.DEFAULT_TZ_LITERAL.value();

--- a/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -59,7 +60,7 @@ public final class DoubleScalar extends Scalar<Double, Number> {
 
     @SafeVarargs
     @Override
-    public final Double evaluate(TransactionContext txnCtx, Input<Number>... args) {
+    public final Double evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Number>... args) {
         assert args.length == 1 : "DoubleScalar expects exactly 1 argument, got: " + args.length;
         Number value = args[0].value();
         if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -155,7 +156,7 @@ public class ExtractFunctions {
 
         @Override
         @SafeVarargs
-        public final Number evaluate(TransactionContext txnCtx, Input<Long>... args) {
+        public final Number evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Long>... args) {
             assert args.length == 1 : "extract only takes one argument";
             Long value = args[0].value();
             if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -61,7 +62,7 @@ public class FormatFunction extends Scalar<String, Object> {
 
     @SafeVarargs
     @Override
-    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length > 1 : "number of args must be > 1";
         Object arg0Value = args[0].value();
         assert arg0Value != null : "1st argument must not be null";

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -63,7 +64,7 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Boolean>... args) {
         assert args.length == 1 : "ignore3vl expects exactly 1 argument, got: " + args.length;
         Boolean value = args[0].value();
         if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -52,7 +53,7 @@ public final class PiFunction extends Scalar<Double, Object> {
 
     @Override
     @SafeVarargs
-    public final Double evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final Double evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         return Math.PI;
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -73,6 +73,7 @@ import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.systeminformation.FormatTypeFunction;
 import io.crate.expression.scalar.systeminformation.ObjDescriptionFunction;
+import io.crate.expression.scalar.systeminformation.PgFunctionIsVisibleFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
 import io.crate.expression.scalar.systeminformation.VersionFunction;
@@ -179,5 +180,6 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         VersionFunction.register(this);
         ObjDescriptionFunction.register(this);
         FormatTypeFunction.register(this);
+        PgFunctionIsVisibleFunction.register(this);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -79,7 +80,7 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
     }
 
     @Override
-    public List<String> evaluate(TransactionContext txnCtx, Input<String>[] args) {
+    public List<String> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
         assert args.length == 2 || args.length == 3 : "number of args must be 2 or 3";
 
         String str = args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -25,6 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -143,8 +144,8 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function func, TransactionContext txnCtx) {
-        Symbol result = evaluateIfLiterals(this, txnCtx, func);
+    public Symbol normalizeSymbol(Function func, TransactionContext txnCtx, NodeContext nodeCtx) {
+        Symbol result = evaluateIfLiterals(this, txnCtx, nodeCtx, func);
         if (result instanceof Literal) {
             return result;
         }
@@ -155,7 +156,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 : "invalid number of arguments";
         Object element = args[0].value();
         Object index = args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -79,8 +80,8 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
     }
 
     @Override
-    public Symbol normalizeSymbol(Function func, TransactionContext txnCtx) {
-        Symbol result = evaluateIfLiterals(this, txnCtx, func);
+    public Symbol normalizeSymbol(Function func, TransactionContext txnCtx, NodeContext nodeCtx) {
+        Symbol result = evaluateIfLiterals(this, txnCtx, nodeCtx, func);
         if (result instanceof Literal) {
             return result;
         }
@@ -127,7 +128,7 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
 
     @Override
     @SafeVarargs
-    public final Object evaluate(TransactionContext txnCtx, Input<Map<String, Object>>... args) {
+    public final Object evaluate(TransactionContext txnCtx, NodeContext ndeCtx, Input<Map<String, Object>>... args) {
         assert args.length >= 2 : NAME + " takes 2 or more arguments, got " + args.length;
         Object mapValue = args[0].value();
         for (var i = 1; i < args.length; i++) {

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -68,7 +69,7 @@ public final class SubscriptRecordFunction extends Scalar<Object, Object> {
 
     @Override
     @SafeVarargs
-    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         Row record = (Row) args[0].value();
         if (record == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -75,7 +76,7 @@ public class SubstrFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 || args.length == 3 : "number of arguments must be 2 or 3";
         String val = (String) args[0].value();
         if (val == null) {

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -65,7 +66,7 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
 
     @SafeVarargs
     @Override
-    public final R evaluate(TransactionContext txnCtx, Input<T>... args) {
+    public final R evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 3 : "TripleScalar expects exactly 3 arguments, got: " + args.length;
         T value1 = type.sanitizeValue(args[0].value());
         if (value1 == null) {

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -68,7 +69,7 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
 
     @SafeVarargs
     @Override
-    public final R evaluate(TransactionContext txnCtx, Input<T>... args) {
+    public final R evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 1 : "UnaryScalar expects exactly 1 argument, got: " + args.length;
         T value = type.sanitizeValue(args[0].value());
         if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.arithmetic;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionType;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -75,7 +76,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
 
     @SafeVarargs
     @Override
-    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         ArrayList<Object> values = new ArrayList<>(args.length);
         for (Input<Object> arg : args) {
             values.add(arg.value());

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -60,7 +61,7 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
     }
 
     @Override
-    public T evaluate(TransactionContext txnCtx, Input<T>[] args) {
+    public T evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>[] args) {
         T arg0Value = type.sanitizeValue(args[0].value());
         T arg1Value = type.sanitizeValue(args[1].value());
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticScalar.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -90,7 +91,7 @@ public class IntervalArithmeticScalar extends Scalar<Period, Object> {
     }
 
     @Override
-    public Period evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Period evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         Period fst = (Period) args[0].value();
         Period snd = (Period) args[1].value();
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -134,7 +135,7 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
     }
 
     @Override
-    public Long evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         final Long timestamp = (Long) args[timestampIdx].value();
         final Period period = (Period) args[periodIdx].value();
         return apply(timestamp, period);

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -93,7 +94,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         }
 
         @Override
-        public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
+        public Number evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Number>... args) {
             assert args.length == 2 : "number of args must be 2";
             Number value1 = args[0].value();
             Number value2 = args[1].value();
@@ -131,7 +132,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         }
 
         @Override
-        public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
+        public Number evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Number>... args) {
             assert args.length == 1 : "number of args must be 1";
             Number value = args[0].value();
             if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -91,7 +92,7 @@ public class MapFunction extends Scalar<Object, Object> {
 
     @SafeVarargs
     @Override
-    public final Object evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         Map<String, Object> m = new HashMap<>(args.length / 2, 1.0f);
         for (int i = 0; i < args.length - 1; i += 2) {
             m.put((String) args[i].value(), args[i + 1].value());

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -59,7 +60,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         /* There is no evaluation here, so the function is executed
            per row. Else every row would contain the same random value*/
         assert symbol.arguments().size() == 0 : "function's number of arguments must be 0";
@@ -78,7 +79,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Double evaluate(TransactionContext txnCtx, Input[] args) {
+    public Double evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 0 : "number of args must be 0";
         return this.random.nextDouble();
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -93,7 +94,7 @@ public final class TruncFunction {
             }
 
             @Override
-            public Number evaluate(TransactionContext txnCtx, Input<Number>... args) {
+            public Number evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Number>... args) {
                 Number n = args[0].value();
                 Number nd = args[1].value();
                 if (null == n || null == nd) {

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -63,7 +64,7 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
             return returnType.explicitCast(args[0].value());
         } catch (ClassCastException | IllegalArgumentException e) {
@@ -83,7 +84,8 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
 
     @Override
     public Symbol normalizeSymbol(io.crate.expression.symbol.Function symbol,
-                                  TransactionContext txnCtx) {
+                                  TransactionContext txnCtx,
+                                  NodeContext nodeCtx) {
         Symbol argument = symbol.arguments().get(0);
         if (argument.valueType().equals(returnType)) {
             return argument;

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -60,7 +61,7 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         var targetTypeSignature = parseTypeSignature((String) args[1].value());
         var targetType = targetTypeSignature.createType();
         try {
@@ -82,7 +83,8 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
 
     @Override
     public Symbol normalizeSymbol(io.crate.expression.symbol.Function symbol,
-                                  TransactionContext txnCtx) {
+                                  TransactionContext txnCtx,
+                                  NodeContext nodeCtx) {
         Symbol argument = symbol.arguments().get(0);
 
         var targetTypeAsString = (String) ((Input<?>) symbol.arguments().get(1)).value();

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -62,7 +63,7 @@ public class TryCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
             return returnType.explicitCast(args[0].value());
         } catch (ClassCastException | IllegalArgumentException e) {
@@ -82,7 +83,8 @@ public class TryCastFunction extends Scalar<Object, Object> {
 
     @Override
     public Symbol normalizeSymbol(io.crate.expression.symbol.Function symbol,
-                                  TransactionContext txnCtx) {
+                                  TransactionContext txnCtx,
+                                  NodeContext nodeCtx) {
         Symbol argument = symbol.arguments().get(0);
         if (argument.valueType().equals(returnType)) {
             return argument;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -67,7 +68,7 @@ public class CoalesceFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         for (Input<?> input : args) {
             Object value = input.value();
             if (value != null) {

--- a/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -50,7 +51,7 @@ abstract class ConditionalCompareFunction extends Scalar<Object, Object> impleme
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         assert args != null : "args must not be null";
         assert args.length > 0 : "number of args must be > 1";
 

--- a/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -96,7 +97,7 @@ public class IfFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         Boolean condition = (Boolean) args[0].value();
         if (condition != null && condition) {
             return args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -65,7 +66,7 @@ public class NullIfFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Object evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         Object arg0Value = args[0].value();
         return arg0Value != null && arg0Value.equals(args[1].value()) ? null : arg0Value;
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -26,6 +26,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -73,7 +74,7 @@ public class DistanceFunction extends Scalar<Double, Point> {
     }
 
     @Override
-    public Double evaluate(TransactionContext txnCtx, Input<Point>[] args) {
+    public Double evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Point>[] args) {
         assert args.length == 2 : "number of args must be 2";
         return evaluate(args[0], args[1]);
     }
@@ -91,7 +92,7 @@ public class DistanceFunction extends Scalar<Double, Point> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         Symbol arg1 = symbol.arguments().get(0);
         Symbol arg2 = symbol.arguments().get(1);
         DataType<?> arg1Type = arg1.valueType();

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -61,7 +62,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 2 : "Invalid number of Arguments";
         Object left = args[0].value();
         if (left == null) {
@@ -87,7 +88,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
         int numLiterals = 0;
@@ -101,7 +102,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
         }
 
         if (numLiterals == 2) {
-            return Literal.of(evaluate(txnCtx, (Input) left, (Input) right));
+            return Literal.of(evaluate(txnCtx, nodeCtx, (Input) left, (Input) right));
         }
 
         return symbol;

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -27,6 +27,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -78,7 +79,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, Input[] args) {
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 : "number of args must be 2";
         return evaluate(args[0], args[1]);
     }
@@ -130,7 +131,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
 

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.postgres;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -94,7 +95,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 1 || args.length == 2 : "number of args must be 1 or 2";
 
         final String settingName = (String) args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -60,7 +61,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert symbol.arguments().size() == 0 : "function's number of arguments must be 0";
         return Literal.of(-1);
     }
@@ -76,7 +77,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
     }
 
     @Override
-    public Integer evaluate(TransactionContext txnCtx, Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 0 : "number of args must be 0";
         return -1;
     }

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -25,6 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -92,8 +93,8 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
-        return evaluateIfLiterals(this, txnCtx, symbol);
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
+        return evaluateIfLiterals(this, txnCtx, nodeCtx, symbol);
     }
 
     @Override
@@ -118,7 +119,7 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<String>[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
         assert args.length == 3 || args.length == 4 : "number of args must be 3 or 4";
         String value = args[0].value();
         String pattern = args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -51,7 +52,7 @@ public final class ChrFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         assert args.length == 1 : "chr takes exactly one argument";
         var value = args[0].value();
         if (value == null) {

--- a/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -80,7 +81,7 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 : String.format(Locale.ENGLISH,
                                                 "number of arguments must be 2, got %d instead",
                                                 args.length);

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.string;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.ThreeParametersFunction;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -127,7 +128,7 @@ public class StringPaddingFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 || args.length == 3 : String.format(
             Locale.ENGLISH,
             "number of arguments must be 2 (optionally 3), got %d instead",

--- a/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -52,7 +53,7 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>[] args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         assert args.length == 2 : "repeat takes exactly two arguments";
         var text = (String) args[0].value();
         var repetitions = (Integer) args[1].value();

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -27,6 +27,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -178,7 +179,7 @@ public final class TrimFunctions {
         }
 
         @Override
-        public String evaluate(TransactionContext txnCtx, Input<String>[] args) {
+        public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
             assert args.length == 3 : "number of args must be 3";
             String target = args[0].value();
             if (target == null) {
@@ -218,7 +219,7 @@ public final class TrimFunctions {
         }
 
         @Override
-        public String evaluate(TransactionContext txnCtx, Input<String>[] args) {
+        public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
             String target = args[0].value();
             if (target == null) {
                 return null;
@@ -264,7 +265,7 @@ public final class TrimFunctions {
         }
 
         @Override
-        public String evaluate(TransactionContext txnCtx, Input<String>[] args) {
+        public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
             assert args.length == 1 || args.length == 2 : "number of args must be 1 or 2";
 
             String target = args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -72,13 +73,13 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 0 : "number of args must be 0";
         return txnCtx.sessionSettings().currentSchema();
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, @Nullable TransactionContext txnCtx, NodeContext nodeCtx) {
         if (txnCtx == null) {
             return Literal.NULL;
         }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -70,7 +71,7 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
 
     @SafeVarargs
     @Override
-    public final List<String> evaluate(TransactionContext txnCtx, Input<Boolean>... args) {
+    public final List<String> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Boolean>... args) {
         assert args.length == 1 : "expecting 1 boolean argument";
 
         Boolean includeImplicitSchemas = args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -69,7 +70,7 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
 
     @Override
     @SafeVarargs
-    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         var typeOid = (Integer) args[0].value();
         if (typeOid == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -58,7 +59,7 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
 
     @SafeVarargs
     @Override
-    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         // CrateDB doesn't support comments for database objects, so always return null
         return null;
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public final class PgFunctionIsVisibleFunction extends Scalar<Boolean, Integer> {
+
+    public static final String NAME = "pg_function_is_visible";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ),
+            PgFunctionIsVisibleFunction::new);
+    }
+
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public PgFunctionIsVisibleFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Integer>... args) {
+        assert args.length == 1 : NAME + " expects exactly 1 argument, got " + args.length;
+        Integer oid = args[0].value();
+        if (oid == null) {
+            return null;
+        }
+        return nodeCtx.functions().findFunctionSignatureByOid(oid) != null;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -57,7 +58,7 @@ public class PgGetExpr extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         return null;
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -73,7 +74,7 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
 
     @SafeVarargs
     @Override
-    public final String evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 1 : "typeof expects exactly 1 argument, got: " + args.length;
         return type;
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -25,6 +25,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -91,7 +92,7 @@ public class VersionFunction extends Scalar<String, Void> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, Input<Void>... args) {
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Void>... args) {
         return VERSION;
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.timestamp;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -66,7 +67,7 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
 
     @Override
     @SafeVarargs
-    public final TimeTZ evaluate(TransactionContext txnCtx, Input<Integer>... args) {
+    public final TimeTZ evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Integer>... args) {
         Integer precision = MICRO_PRECISION;
         if (args.length == 1) {
             precision = args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.timestamp;
 import com.google.common.math.LongMath;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -67,7 +68,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
 
     @Override
     @SafeVarargs
-    public final Long evaluate(TransactionContext txnCtx, Input<Integer>... args) {
+    public final Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Integer>... args) {
         Integer precision = DEFAULT_PRECISION;
         if (args.length == 1) {
             precision = args[0].value();

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.timestamp;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -56,7 +57,7 @@ public final class NowFunction extends Scalar<Long, Object> {
 
     @Override
     @SafeVarargs
-    public final Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public final Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         return ChronoUnit.MILLIS.between(Instant.EPOCH, txnCtx.currentInstant());
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.timestamp;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -89,7 +90,7 @@ public class TimezoneFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Long evaluate(TransactionContext txnCtx, Input<Object>... args) {
+    public Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 2 : String.format(Locale.ENGLISH,
                                                 "number of arguments must be 2, got %d instead",
                                                 args.length);

--- a/server/src/main/java/io/crate/expression/symbol/Assignments.java
+++ b/server/src/main/java/io/crate/expression/symbol/Assignments.java
@@ -28,7 +28,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.SubQueryAndParamBinder;
@@ -61,7 +61,7 @@ public final class Assignments {
      *
      * @return a tuple or null if the input is null.
      */
-    public static Assignments convert(@Nonnull Map<Reference, ? extends Symbol> assignments, Functions functions) {
+    public static Assignments convert(@Nonnull Map<Reference, ? extends Symbol> assignments, NodeContext nodeCtx) {
         String[] targetNames = new String[assignments.size()];
         Reference[] targetColumns = new Reference[assignments.size()];
         Symbol[] assignmentSymbols = new Symbol[assignments.size()];
@@ -73,14 +73,14 @@ public final class Assignments {
             targetColumns[i] = key;
             i++;
         }
-        return new Assignments(targetNames, targetColumns, assignmentSymbols, functions);
+        return new Assignments(targetNames, targetColumns, assignmentSymbols, nodeCtx);
     }
 
-    private Assignments(String[] targetNames, Reference[] targetColumns, Symbol[] sources, Functions functions) {
+    private Assignments(String[] targetNames, Reference[] targetColumns, Symbol[] sources, NodeContext nodeCtx) {
         this.targetNames = targetNames;
         this.targetColumns = targetColumns;
         this.sources = sources;
-        this.normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
+        this.normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
     }
 
     public String[] targetNames() {

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.tablefunctions;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -67,7 +68,7 @@ public class EmptyRowTableFunction {
 
         @Override
         @SafeVarargs
-        public final Iterable<Row> evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        public final Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
             return List.of(Row.EMPTY);
         }
 

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -25,6 +25,7 @@ package io.crate.expression.tablefunctions;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -184,7 +185,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
     }
 
     @Override
-    public Iterable<Row> evaluate(TransactionContext txnCtx, Input<T>... args) {
+    public Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 2 || args.length == 3 :
             "Signature must ensure that there are either two or three arguments";
 
@@ -251,7 +252,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         }
 
         @Override
-        public Iterable<Row> evaluate(TransactionContext txnCtx, Input<Object>... args) {
+        public Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
             Long startInclusive = (Long) args[0].value();
             Long stopInclusive = (Long) args[1].value();
             Period step = (Period) args[2].value();

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
@@ -25,6 +25,7 @@ package io.crate.expression.tablefunctions;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -117,7 +118,7 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
 
     @SafeVarargs
     @Override
-    public final Iterable<Row> evaluate(TransactionContext txnCtx, Input<T>... args) {
+    public final Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 2 || args.length == 3 :
             "Signature must ensure that there are either two or three arguments";
 

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -28,6 +28,7 @@ import io.crate.data.RowN;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -139,7 +140,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
     }
 
     @Override
-    public Iterable<Row> evaluate(TransactionContext txnCtx, Input[] args) {
+    public Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
         assert args.length == 2 || args.length == 3 : "number of args must be 2 or 3";
 
         String value = (String) args[0].value();

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.information.InformationSchemaInfo;
@@ -72,7 +73,7 @@ public final class PgExpandArray extends TableFunctionImplementation<List<Object
 
     @Override
     @SafeVarargs
-    public final Iterable<Row> evaluate(TransactionContext txnCtx, Input<List<Object>>... args) {
+    public final Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... args) {
         List<Object> values = args[0].value();
         if (values == null) {
             return List.of();

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -26,6 +26,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -68,7 +69,7 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
     }
 
     @Override
-    public Iterable<Row> evaluate(TransactionContext txnCtx, Input<List<Object>>[] args) {
+    public Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>[] args) {
         return () -> Identifiers.KEYWORDS.stream()
             .map(new Function<Identifiers.Keyword, Row>() {
 

--- a/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -31,6 +31,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -107,8 +108,8 @@ public class TableFunctionFactory {
         }
 
         @Override
-        public Iterable<Row> evaluate(TransactionContext txnCtx, Input<T>[] args) {
-            return List.of(new Row1(functionImplementation.evaluate(txnCtx, args)));
+        public Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>[] args) {
+            return List.of(new Row1(functionImplementation.evaluate(txnCtx, nodeCtx, args)));
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterators;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -149,7 +150,7 @@ public class UnnestFunction {
          */
         @SafeVarargs
         @Override
-        public final Iterable<Row> evaluate(TransactionContext txnCtx, Input<List<Object>>... arguments) {
+        public final Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... arguments) {
             ArrayList<List<Object>> valuesPerColumn = new ArrayList<>(arguments.length);
             for (Input<List<Object>> argument : arguments) {
                 valuesPerColumn.add(argument.value());

--- a/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.tablefunctions;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -93,6 +94,7 @@ public class ValuesFunction {
 
         @Override
         public final Iterable<Row> evaluate(TransactionContext txnCtx,
+                                            NodeContext nodeCtx,
                                             Input<List<Object>>[] arguments) {
             return new ColumnOrientedRowsIterator(() -> iteratorsFrom(arguments));
         }

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -29,7 +29,7 @@ import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -61,13 +61,13 @@ public class UserDefinedFunctionService {
     private static final Logger LOGGER = LogManager.getLogger(UserDefinedFunctionService.class);
 
     private final ClusterService clusterService;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Map<String, UDFLanguage> languageRegistry = new HashMap<>();
 
     @Inject
-    public UserDefinedFunctionService(ClusterService clusterService, Functions functions) {
+    public UserDefinedFunctionService(ClusterService clusterService, NodeContext nodeCtx) {
         this.clusterService = clusterService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public UDFLanguage getLanguage(String languageName) throws IllegalArgumentException {
@@ -214,7 +214,7 @@ public class UserDefinedFunctionService {
                 functionName, k -> new ArrayList<>());
             resolvers.add(resolver);
         }
-        functions.registerUdfFunctionImplementationsForSchema(schema, implementations);
+        nodeCtx.functions().registerUdfFunctionImplementationsForSchema(schema, implementations);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -59,7 +59,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.DocReferences;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
@@ -101,11 +101,11 @@ public class LuceneQueryBuilder {
 
     private static final Logger LOGGER = LogManager.getLogger(LuceneQueryBuilder.class);
     private static final Visitor VISITOR = new Visitor();
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
     @Inject
-    public LuceneQueryBuilder(Functions functions) {
-        this.functions = functions;
+    public LuceneQueryBuilder(NodeContext nodeCtx) {
+        this.nodeCtx = nodeCtx;
     }
 
     public Context convert(Symbol query,
@@ -120,10 +120,10 @@ public class LuceneQueryBuilder {
             mapperService::fullName,
             table.partitionedByColumns()
         );
-        var normalizer = new EvaluatingNormalizer(functions, RowGranularity.PARTITION, refResolver, null);
+        var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.PARTITION, refResolver, null);
         Context ctx = new Context(
             txnCtx,
-            functions,
+            nodeCtx,
             mapperService,
             indexCache,
             queryShardContext,
@@ -165,7 +165,7 @@ public class LuceneQueryBuilder {
         final QueryShardContext queryShardContext;
 
         Context(TransactionContext txnCtx,
-                Functions functions,
+                NodeContext nodeCtx,
                 MapperService mapperService,
                 IndexCache indexCache,
                 QueryShardContext queryShardContext,
@@ -175,7 +175,7 @@ public class LuceneQueryBuilder {
             this.queryShardContext = queryShardContext;
             FieldTypeLookup typeLookup = mapperService::fullName;
             this.docInputFactory = new DocInputFactory(
-                functions,
+                nodeCtx,
                 new LuceneReferenceResolver(
                     indexName,
                     typeLookup,

--- a/server/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/server/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -64,8 +64,11 @@ public interface FunctionImplementation {
      * @param txnCtx context which is shared across normalizeSymbol calls during a statement-lifecycle.
      *                This will only be present if normalizeSymbol is called on the handler node.
      *                normalizeSymbol calls during execution won't receive a StmtCtx
+     *
+     * @param nodeCtx context which is shared across normalizeSymbol calls during a statement-lifecycle.
+     *                Contains a reference to Functions.
      */
-    default Symbol normalizeSymbol(Function function, @Nullable TransactionContext txnCtx) {
+    default Symbol normalizeSymbol(Function function, @Nullable TransactionContext txnCtx, NodeContext nodeCtx) {
         return function;
     }
 }

--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
+@Singleton
+public class NodeContext {
+
+    private final Functions functions;
+
+    @Inject
+    public NodeContext(Functions functions) {
+        this.functions = functions;
+    }
+
+    public Functions functions() {
+        return functions;
+    }
+}

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -69,7 +69,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     /**
      * Evaluate the function using the provided arguments
      */
-    public abstract ReturnType evaluate(TransactionContext txnCtx, Input<InputType>... args);
+    public abstract ReturnType evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<InputType>... args);
 
     /**
      * Called to return a "optimized" version of a scalar implementation.
@@ -78,17 +78,17 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      * (or rather, a subset of a single query if executed distributed).
      *
      * @param arguments arguments in symbol form. If any symbols are literals, any arguments passed to
-     *                  {@link #evaluate(TransactionContext, Input[])} will have the same value as those literals.
-     *                  (Within the scope of a single operation)
+     *                  {@link #evaluate(TransactionContext, NodeContext, Input[])} will have the same
+     *                  value as those literals. (Within the scope of a single operation)
      */
     public Scalar<ReturnType, InputType> compile(List<Symbol> arguments) {
         return this;
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
         try {
-            return evaluateIfLiterals(this, txnCtx, symbol);
+            return evaluateIfLiterals(this, txnCtx, nodeCtx, symbol);
         } catch (Throwable t) {
             return symbol;
         }
@@ -109,6 +109,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      */
     protected static <ReturnType, InputType> Symbol evaluateIfLiterals(Scalar<ReturnType, InputType> scalar,
                                                                        TransactionContext txnCtx,
+                                                                       NodeContext nodeCtx,
                                                                        Function function) {
         List<Symbol> arguments = function.arguments();
         for (Symbol argument : arguments) {
@@ -123,7 +124,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             idx++;
         }
         //noinspection unchecked
-        return Literal.ofUnchecked(function.valueType(), scalar.evaluate(txnCtx, inputs));
+        return Literal.ofUnchecked(function.valueType(), scalar.evaluate(txnCtx, nodeCtx, inputs));
     }
 
     public enum Feature {

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -39,10 +39,10 @@ import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -95,7 +95,7 @@ public class DocIndexMetadata {
     private final List<Reference> nestedColumns = new ArrayList<>();
     private final ImmutableList.Builder<GeneratedReference> generatedColumnReferencesBuilder = ImmutableList.builder();
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final RelationName ident;
     private final int numberOfShards;
     private final String numberOfReplicas;
@@ -128,8 +128,8 @@ public class DocIndexMetadata {
      */
     private final ExpressionAnalyzer expressionAnalyzer;
 
-    DocIndexMetadata(Functions functions, IndexMetadata metadata, RelationName ident) throws IOException {
-        this.functions = functions;
+    DocIndexMetadata(NodeContext nodeCtx, IndexMetadata metadata, RelationName ident) throws IOException {
+        this.nodeCtx = nodeCtx;
         this.ident = ident;
         this.numberOfShards = metadata.getNumberOfShards();
         Settings settings = metadata.getSettings();
@@ -150,8 +150,8 @@ public class DocIndexMetadata {
         closed = state == IndexMetadata.State.CLOSE;
 
         this.expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             CoordinatorTxnCtx.systemTransactionContext(),
+            nodeCtx,
             ParamTypeHints.EMPTY,
             FieldProvider.UNSUPPORTED,
             null);
@@ -591,7 +591,7 @@ public class DocIndexMetadata {
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
         ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
-            functions, CoordinatorTxnCtx.systemTransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            CoordinatorTxnCtx.systemTransactionContext(), nodeCtx, ParamTypeHints.EMPTY, tableReferenceResolver, null);
         ExpressionAnalysisContext analysisCtx = new ExpressionAnalysisContext();
 
         ImmutableList.Builder<CheckConstraint<Symbol>> checkConstraintsBuilder = null;

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -29,8 +29,8 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -118,7 +118,7 @@ public class DocSchemaInfo implements SchemaInfo {
     private final ClusterService clusterService;
     private final DocTableInfoFactory docTableInfoFactory;
     private final ViewInfoFactory viewInfoFactory;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final UserDefinedFunctionService udfService;
 
     private final ConcurrentHashMap<String, DocTableInfo> docTableByName = new ConcurrentHashMap<>();
@@ -133,11 +133,11 @@ public class DocSchemaInfo implements SchemaInfo {
      */
     public DocSchemaInfo(final String schemaName,
                          ClusterService clusterService,
-                         Functions functions,
+                         NodeContext nodeCtx,
                          UserDefinedFunctionService udfService,
                          ViewInfoFactory viewInfoFactory,
                          DocTableInfoFactory docTableInfoFactory) {
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.schemaName = schemaName;
         this.clusterService = clusterService;
         this.udfService = udfService;
@@ -333,6 +333,6 @@ public class DocSchemaInfo implements SchemaInfo {
 
     @Override
     public void close() throws Exception {
-        functions.deregisterUdfResolversForSchema(schemaName);
+        nodeCtx.functions().deregisterUdfResolversForSchema(schemaName);
     }
 }

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
@@ -22,8 +22,8 @@
 
 package io.crate.metadata.doc;
 
-import io.crate.metadata.Functions;
 import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.view.ViewInfoFactory;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -34,21 +34,21 @@ public class DocSchemaInfoFactory {
 
     private final DocTableInfoFactory docTableInfoFactory;
     private final ViewInfoFactory viewInfoFactory;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final UserDefinedFunctionService udfService;
 
     @Inject
     public DocSchemaInfoFactory(DocTableInfoFactory docTableInfoFactory,
                                 ViewInfoFactory viewInfoFactory,
-                                Functions functions,
+                                NodeContext nodeCtx,
                                 UserDefinedFunctionService udfService) {
         this.docTableInfoFactory = docTableInfoFactory;
         this.viewInfoFactory = viewInfoFactory;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.udfService = udfService;
     }
 
     public DocSchemaInfo create(String schemaName, ClusterService clusterService) {
-        return new DocSchemaInfo(schemaName, clusterService, functions, udfService, viewInfoFactory, docTableInfoFactory);
+        return new DocSchemaInfo(schemaName, clusterService, nodeCtx, udfService, viewInfoFactory, docTableInfoFactory);
     }
 }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -24,8 +24,8 @@ package io.crate.metadata.doc;
 import io.crate.Constants;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnhandledServerException;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import org.apache.logging.log4j.Logger;
@@ -52,18 +52,18 @@ class DocTableInfoBuilder {
 
     private final RelationName ident;
     private final ClusterState state;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Metadata metadata;
     private String[] concreteIndices;
     private String[] concreteOpenIndices;
     private static final Logger LOGGER = LogManager.getLogger(DocTableInfoBuilder.class);
 
-    DocTableInfoBuilder(Functions functions,
+    DocTableInfoBuilder(NodeContext nodeCtx,
                         RelationName ident,
                         ClusterState state,
                         IndexNameExpressionResolver indexNameExpressionResolver) {
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.ident = ident;
         this.state = state;
@@ -103,7 +103,7 @@ class DocTableInfoBuilder {
         DocIndexMetadata docIndexMetadata;
         IndexMetadata indexMetadata = metadata.index(indexName);
         try {
-            docIndexMetadata = new DocIndexMetadata(functions, indexMetadata, ident);
+            docIndexMetadata = new DocIndexMetadata(nodeCtx, indexMetadata, ident);
         } catch (IOException e) {
             throw new UnhandledServerException("Unable to build DocIndexMetadata", e);
         }
@@ -135,7 +135,7 @@ class DocTableInfoBuilder {
             builder.settings(settings);
             builder.numberOfShards(settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));
             builder.numberOfReplicas(settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
-            docIndexMetadata = new DocIndexMetadata(functions, builder.build(), ident);
+            docIndexMetadata = new DocIndexMetadata(nodeCtx, builder.build(), ident);
         } catch (IOException e) {
             throw new UnhandledServerException("Unable to build DocIndexMetadata from template", e);
         }

--- a/server/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.doc;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -32,20 +32,20 @@ import org.elasticsearch.common.inject.Singleton;
 @Singleton
 public class InternalDocTableInfoFactory implements DocTableInfoFactory {
 
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Inject
-    public InternalDocTableInfoFactory(Functions functions,
+    public InternalDocTableInfoFactory(NodeContext nodeCtx,
                                        IndexNameExpressionResolver indexNameExpressionResolver) {
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override
     public DocTableInfo create(RelationName ident, ClusterState state) {
         DocTableInfoBuilder builder = new DocTableInfoBuilder(
-            functions,
+            nodeCtx,
             ident,
             state,
             indexNameExpressionResolver

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -58,7 +58,7 @@ public class PgProcTable {
 
     public static SystemTable<Entry> create() {
         return SystemTable.<Entry>builder(IDENT)
-            .add("oid", INTEGER, x -> OidHash.functionOid(x.functionName))
+            .add("oid", INTEGER, x -> OidHash.regprocOid(x.functionName))
             .add("proname", STRING, x -> x.signature.getName().name())
             .add("pronamespace", INTEGER, x -> OidHash.schemaOid(x.functionName.schema()))
             .add("proowner", INTEGER, x -> null)

--- a/server/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
+++ b/server/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
@@ -26,6 +26,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.RowType;
@@ -98,7 +99,7 @@ public abstract class TableFunctionImplementation<T> extends Scalar<Iterable<Row
     public abstract boolean hasLazyResultSet();
 
     @Override
-    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         // Never normalize table functions;
         // The RelationAnalyzer expects a function symbol and can't deal with Literals
         return function;

--- a/server/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/server/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -34,7 +34,7 @@ import io.crate.execution.ddl.views.CreateViewRequest;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.SqlFormatter;
@@ -71,7 +71,7 @@ public final class CreateViewPlan implements Plan {
         User owner = createViewStmt.owner();
         String formattedQuery = SqlFormatter.formatSql(createViewStmt.query(), makeExpressions(params));
         ensureFormattedQueryCanStillBeAnalyzed(
-            dependencies.functions(), dependencies.schemas(), plannerContext.transactionContext(), formattedQuery);
+            dependencies.nodeContext(), dependencies.schemas(), plannerContext.transactionContext(), formattedQuery);
         CreateViewRequest request = new CreateViewRequest(
             createViewStmt.name(),
             formattedQuery,
@@ -86,11 +86,11 @@ public final class CreateViewPlan implements Plan {
         }));
     }
 
-    private static void ensureFormattedQueryCanStillBeAnalyzed(Functions functions,
+    private static void ensureFormattedQueryCanStillBeAnalyzed(NodeContext nodeCtx,
                                                                Schemas schemas,
                                                                CoordinatorTxnCtx txnCtx,
                                                                String formattedQuery) {
-        RelationAnalyzer analyzer = new RelationAnalyzer(functions, schemas);
+        RelationAnalyzer analyzer = new RelationAnalyzer(nodeCtx, schemas);
         Query query = (Query) SqlParser.createStatement(formattedQuery);
         analyzer.analyze(query, txnCtx, new ParamTypeHints(List.of()) {
 

--- a/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
+++ b/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
@@ -31,7 +31,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataTypes;
 
@@ -57,7 +57,7 @@ public final class DecommissionNodePlan implements Plan {
         var boundedNodeIdOrName = boundNodeIdOrName(
             analyzedDecommissionNode,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             params,
             subQueryResults);
 
@@ -81,12 +81,12 @@ public final class DecommissionNodePlan implements Plan {
     @VisibleForTesting
     public static String boundNodeIdOrName(AnalyzedDecommissionNode decommissionNode,
                                            CoordinatorTxnCtx txnCtx,
-                                           Functions functions,
+                                           NodeContext nodeCtx,
                                            Row parameters,
                                            SubQueryResults subQueryResults) {
         var boundedNodeIdOrName = SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             decommissionNode.nodeIdOrName(),
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -26,6 +26,7 @@ import io.crate.action.sql.DCLStatementDispatcher;
 import io.crate.analyze.repositories.RepositoryParamValidator;
 import io.crate.execution.TransportActionProvider;
 import io.crate.execution.ddl.RepositoryService;
+import io.crate.metadata.NodeContext;
 import io.crate.statistics.TransportAnalyzeAction;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.tables.AlterTableOperation;
@@ -38,7 +39,6 @@ import io.crate.expression.udf.TransportCreateUserDefinedFunctionAction;
 import io.crate.expression.udf.TransportDropUserDefinedFunctionAction;
 import io.crate.license.LicenseService;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -61,7 +61,7 @@ public class DependencyCarrier {
     private final PhasesTaskFactory phasesTaskFactory;
     private final ThreadPool threadPool;
     private final Schemas schemas;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final ClusterService clusterService;
     private final DCLStatementDispatcher dclStatementDispatcher;
     private final TransportDropTableAction transportDropTableAction;
@@ -85,7 +85,7 @@ public class DependencyCarrier {
                              PhasesTaskFactory phasesTaskFactory,
                              ThreadPool threadPool,
                              Schemas schemas,
-                             Functions functions,
+                             NodeContext nodeCtx,
                              ClusterService clusterService,
                              LicenseService licenseService,
                              DCLStatementDispatcher dclStatementDispatcher,
@@ -106,12 +106,12 @@ public class DependencyCarrier {
         this.phasesTaskFactory = phasesTaskFactory;
         this.threadPool = threadPool;
         this.schemas = schemas;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.clusterService = clusterService;
         this.licenseService = licenseService;
         this.dclStatementDispatcher = dclStatementDispatcher;
         this.transportDropTableAction = transportDropTableAction;
-        projectionBuilder = new ProjectionBuilder(functions);
+        projectionBuilder = new ProjectionBuilder(nodeCtx);
         this.createViewAction = createViewAction;
         this.dropViewAction = dropViewAction;
         this.swapRelationsAction = swapRelationsAction;
@@ -137,8 +137,8 @@ public class DependencyCarrier {
         return dclStatementDispatcher;
     }
 
-    public Functions functions() {
-        return functions;
+    public NodeContext nodeContext() {
+        return nodeCtx;
     }
 
     public TransportActionProvider transportActionProvider() {

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -26,7 +26,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.data.Row;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.table.TableInfo;
@@ -47,8 +47,8 @@ public class PlannerContext {
             context.clusterState,
             context.routingProvider,
             UUID.randomUUID(),
-            context.functions,
             context.coordinatorTxnCtx,
+            context.nodeCtx,
             fetchSize,
             context.params
         );
@@ -59,7 +59,7 @@ public class PlannerContext {
     private final int fetchSize;
     private final RoutingBuilder routingBuilder;
     private final RoutingProvider routingProvider;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final ClusterState clusterState;
     private int executionPhaseId = 0;
     private final String handlerNode;
@@ -72,12 +72,12 @@ public class PlannerContext {
     public PlannerContext(ClusterState clusterState,
                           RoutingProvider routingProvider,
                           UUID jobId,
-                          Functions functions,
                           CoordinatorTxnCtx coordinatorTxnCtx,
+                          NodeContext nodeCtx,
                           int fetchSize,
                           @Nullable Row params) {
         this.routingProvider = routingProvider;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.params = params;
         this.routingBuilder = new RoutingBuilder(clusterState, routingProvider);
         this.clusterState = clusterState;
@@ -131,8 +131,8 @@ public class PlannerContext {
         return routingBuilder.buildReaderAllocations();
     }
 
-    public Functions functions() {
-        return functions;
+    public NodeContext nodeContext() {
+        return nodeCtx;
     }
 
     public ClusterState clusterState() {

--- a/server/src/main/java/io/crate/planner/SwapTablePlan.java
+++ b/server/src/main/java/io/crate/planner/SwapTablePlan.java
@@ -63,7 +63,7 @@ public class SwapTablePlan implements Plan {
         boolean dropSource = Objects.requireNonNull(
             DataTypes.BOOLEAN.sanitizeValue(SymbolEvaluator.evaluate(
                 plannerContext.transactionContext(),
-                dependencies.functions(),
+                dependencies.nodeContext(),
                 swapTable.dropSource(),
                 params,
                 subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterBlobTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterBlobTablePlan.java
@@ -64,7 +64,7 @@ public class AlterBlobTablePlan implements Plan {
                               Row params, SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -36,7 +36,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
@@ -82,7 +82,7 @@ public class AlterTableAddColumnPlan implements Plan {
         BoundAddColumn stmt = bind(
             alterTable,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults,
             dependencies.fulltextAnalyzerResolver());
@@ -94,13 +94,13 @@ public class AlterTableAddColumnPlan implements Plan {
     @VisibleForTesting
     public static BoundAddColumn bind(AnalyzedAlterTableAddColumn alterTable,
                                       CoordinatorTxnCtx txnCtx,
-                                      Functions functions,
+                                      NodeContext nodeCtx,
                                       Row params,
                                       SubQueryResults subQueryResults,
                                       FulltextAnalyzerResolver fulltextAnalyzerResolver) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -60,7 +60,7 @@ public class AlterTableOpenClosePlan implements Plan {
                               Row params, SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
@@ -35,7 +35,7 @@ import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -74,7 +74,7 @@ public class AlterTablePlan implements Plan {
         BoundAlterTable stmt = bind(
             alterTable,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults);
 
@@ -85,12 +85,12 @@ public class AlterTablePlan implements Plan {
 
     public static BoundAlterTable bind(AnalyzedAlterTable analyzedAlterTable,
                                        CoordinatorTxnCtx txnCtx,
-                                       Functions functions,
+                                       NodeContext nodeCtx,
                                        Row params,
                                        SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterUserPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterUserPlan.java
@@ -59,7 +59,7 @@ public class AlterUserPlan implements Plan {
                 alterUser.properties(),
                 params,
                 plannerContext.transactionContext(),
-                plannerContext.functions());
+                plannerContext.nodeContext());
 
         userManager.alterUser(alterUser.userName(), newPassword)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -80,7 +80,7 @@ public class CreateAnalyzerPlan implements Plan {
         ClusterUpdateSettingsRequest request = createRequest(
             createAnalyzer,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults,
             dependencies.fulltextAnalyzerResolver());
@@ -94,13 +94,13 @@ public class CreateAnalyzerPlan implements Plan {
     @VisibleForTesting
     public static ClusterUpdateSettingsRequest createRequest(AnalyzedCreateAnalyzer createAnalyzer,
                                                              CoordinatorTxnCtx txnCtx,
-                                                             Functions functions,
+                                                             NodeContext nodeCtx,
                                                              Row parameters,
                                                              SubQueryResults subQueryResults,
                                                              FulltextAnalyzerResolver ftResolver) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateBlobTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateBlobTablePlan.java
@@ -35,7 +35,7 @@ import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
@@ -79,7 +79,7 @@ public class CreateBlobTablePlan implements Plan {
         Settings settings = buildSettings(
             analyzedBlobTable.createBlobTable(),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults,
             numberOfShards);
@@ -94,13 +94,13 @@ public class CreateBlobTablePlan implements Plan {
     @VisibleForTesting
     public static Settings buildSettings(CreateBlobTable<Symbol> createBlobTable,
                                          CoordinatorTxnCtx txnCtx,
-                                         Functions functions,
+                                         NodeContext nodeCtx,
                                          Row params,
                                          SubQueryResults subQueryResults,
                                          NumberOfShards numberOfShards) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateFunctionPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateFunctionPlan.java
@@ -61,7 +61,7 @@ public class CreateFunctionPlan implements Plan {
                               SubQueryResults subQueryResults) throws Exception {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRepositoryPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRepositoryPlan.java
@@ -32,7 +32,7 @@ import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -65,7 +65,7 @@ public class CreateRepositoryPlan implements Plan {
         PutRepositoryRequest request = createRequest(
             createRepository,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             parameters,
             subQueryResults,
             dependencies.repositoryParamValidator());
@@ -78,13 +78,13 @@ public class CreateRepositoryPlan implements Plan {
     @VisibleForTesting
     public static PutRepositoryRequest createRequest(AnalyzedCreateRepository createRepository,
                                                      CoordinatorTxnCtx txnCtx,
-                                                     Functions functions,
+                                                     NodeContext nodeCtx,
                                                      Row parameters,
                                                      SubQueryResults subQueryResults,
                                                      RepositoryParamValidator repositoryParamValidator) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
@@ -37,7 +37,7 @@ import io.crate.exceptions.ResourceUnknownException;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -89,7 +89,7 @@ public class CreateSnapshotPlan implements Plan {
         CreateSnapshotRequest request = createRequest(
             createSnapshot,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             parameters,
             subQueryResults,
             dependencies.schemas());
@@ -118,13 +118,13 @@ public class CreateSnapshotPlan implements Plan {
     @VisibleForTesting
     public static CreateSnapshotRequest createRequest(AnalyzedCreateSnapshot createSnapshot,
                                                       CoordinatorTxnCtx txnCtx,
-                                                      Functions functions,
+                                                      NodeContext nodeCtx,
                                                       Row parameters,
                                                       SubQueryResults subQueryResults,
                                                       Schemas schemas) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
@@ -42,7 +42,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.planner.DependencyCarrier;
@@ -97,7 +97,7 @@ public class CreateTablePlan implements Plan {
         BoundCreateTable boundCreateTable = bind(
             createTable,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults,
             numberOfShards,
@@ -116,7 +116,7 @@ public class CreateTablePlan implements Plan {
     @VisibleForTesting
     public static BoundCreateTable bind(AnalyzedCreateTable createTable,
                                         CoordinatorTxnCtx txnCtx,
-                                        Functions functions,
+                                        NodeContext nodeCtx,
                                         Row params,
                                         SubQueryResults subQueryResults,
                                         NumberOfShards numberOfShards,
@@ -124,7 +124,7 @@ public class CreateTablePlan implements Plan {
                                         FulltextAnalyzerResolver fulltextAnalyzerResolver) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateUserPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateUserPlan.java
@@ -59,7 +59,7 @@ public class CreateUserPlan implements Plan {
             createUser.properties(),
             params,
             plannerContext.transactionContext(),
-            plannerContext.functions());
+            plannerContext.nodeContext());
 
         userManager.createUser(createUser.userName(), newPassword)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));

--- a/server/src/main/java/io/crate/planner/node/ddl/OptimizeTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/OptimizeTablePlan.java
@@ -34,7 +34,7 @@ import io.crate.exceptions.PartitionUnknownException;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.blob.BlobTableInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
@@ -91,7 +91,7 @@ public class OptimizeTablePlan implements Plan {
         BoundOptimizeTable stmt = bind(
             optimizeTable,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             parameters,
             subQueryResults
         );
@@ -125,12 +125,12 @@ public class OptimizeTablePlan implements Plan {
     @VisibleForTesting
     public static BoundOptimizeTable bind(AnalyzedOptimizeTable optimizeTable,
                                           CoordinatorTxnCtx txnCtx,
-                                          Functions functions,
+                                          NodeContext nodeCtx,
                                           Row parameters,
                                           SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/RefreshTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RefreshTablePlan.java
@@ -70,7 +70,7 @@ public class RefreshTablePlan implements Plan {
 
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/ResetSettingsPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/ResetSettingsPlan.java
@@ -86,7 +86,7 @@ public final class ResetSettingsPlan implements Plan {
                               SubQueryResults subQueryResults) {
 
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(plannerContext.transactionContext(),
-                                                                              plannerContext.functions(),
+                                                                              plannerContext.nodeContext(),
                                                                               x,
                                                                               params,
                                                                               subQueryResults);

--- a/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
@@ -40,8 +40,8 @@ import io.crate.exceptions.SchemaUnknownException;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -95,7 +95,7 @@ public class RestoreSnapshotPlan implements Plan {
         BoundRestoreSnapshot stmt = bind(
             restoreSnapshot,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             parameters,
             subQueryResults,
             dependencies.schemas()
@@ -143,13 +143,13 @@ public class RestoreSnapshotPlan implements Plan {
     @VisibleForTesting
     public static BoundRestoreSnapshot bind(AnalyzedRestoreSnapshot restoreSnapshot,
                                             CoordinatorTxnCtx txnCtx,
-                                            Functions functions,
+                                            NodeContext nodeCtx,
                                             Row parameters,
                                             SubQueryResults subQueryResults,
                                             Schemas schemas) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/ddl/UpdateSettingsPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/UpdateSettingsPlan.java
@@ -75,7 +75,7 @@ public final class UpdateSettingsPlan implements Plan {
                               SubQueryResults subQueryResults) {
 
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(plannerContext.transactionContext(),
-                                                                              plannerContext.functions(),
+                                                                              plannerContext.nodeContext(),
                                                                               x,
                                                                               params,
                                                                               subQueryResults);

--- a/server/src/main/java/io/crate/planner/node/dml/DeleteById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/DeleteById.java
@@ -90,7 +90,7 @@ public class DeleteById implements Plan {
         return new ShardRequestExecutor<>(
             clusterService,
             plannerContext.transactionContext(),
-            dependencies.functions(),
+            dependencies.nodeContext(),
             table,
             new DeleteRequests(plannerContext.jobId(), requestTimeout),
             dependencies.transportActionProvider().transportShardDeleteAction()::execute,

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -32,7 +32,7 @@ import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.DependencyCarrier;
@@ -60,9 +60,9 @@ public final class UpdateById implements Plan {
                       Map<Reference, Symbol> assignmentByTargetCol,
                       DocKeys docKeys,
                       @Nullable List<Symbol> returnValues,
-                      Functions functions) {
+                      NodeContext nodeCtx) {
         this.table = table;
-        this.assignments = Assignments.convert(assignmentByTargetCol, functions);
+        this.assignments = Assignments.convert(assignmentByTargetCol, nodeCtx);
         this.assignmentByTargetCol = assignmentByTargetCol;
         this.docKeys = docKeys;
         this.returnValues = returnValues == null ? null : returnValues.toArray(new Symbol[0]);
@@ -126,7 +126,7 @@ public final class UpdateById implements Plan {
         return new ShardRequestExecutor<>(
             clusterService,
             txnCtx,
-            dependencies.functions(),
+            dependencies.nodeContext(),
             table,
             updateRequests,
             dependencies.transportActionProvider().transportShardUpsertAction()::execute,

--- a/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
@@ -38,7 +38,7 @@ import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ShardedTable;
@@ -86,7 +86,7 @@ public class AlterTableReroutePlan implements Plan {
         var rerouteCommand = createRerouteCommand(
             rerouteStatement,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            dependencies.nodeContext(),
             params,
             subQueryResults,
             dependencies.clusterService().state().nodes());
@@ -103,13 +103,13 @@ public class AlterTableReroutePlan implements Plan {
     @VisibleForTesting
     public static AllocationCommand createRerouteCommand(AnalyzedStatement reroute,
                                                          CoordinatorTxnCtx txnCtx,
-                                                         Functions functions,
+                                                         NodeContext nodeCtx,
                                                          Row parameters,
                                                          SubQueryResults subQueryResults,
                                                          DiscoveryNodes nodes) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -33,7 +33,7 @@ import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -68,7 +68,7 @@ public class KillPlan implements Plan {
             boundJobId(
                 jobId,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                dependencies.nodeContext(),
                 params,
                 subQueryResults),
             plannerContext.transactionContext().sessionSettings().userName(),
@@ -82,7 +82,7 @@ public class KillPlan implements Plan {
     @Nullable
     public static UUID boundJobId(@Nullable Symbol jobId,
                                   CoordinatorTxnCtx txnCtx,
-                                  Functions functions,
+                                  NodeContext nodeCtx,
                                   Row parameters,
                                   SubQueryResults subQueryResults) {
         if (jobId != null) {
@@ -91,7 +91,7 @@ public class KillPlan implements Plan {
                     DataTypes.STRING.sanitizeValue(
                         SymbolEvaluator.evaluate(
                             txnCtx,
-                            functions,
+                            nodeCtx,
                             jobId,
                             parameters,
                             subQueryResults

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -138,7 +138,7 @@ public class Collect implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             RowGranularity.CLUSTER,
             null,
             relation
@@ -237,8 +237,8 @@ public class Collect implements LogicalPlan {
         where = WhereClauseAnalyzer.resolvePartitions(
             where.map(binder),
             relation,
-            plannerContext.functions(),
-            plannerContext.transactionContext());
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext());
         if (where.hasVersions()) {
             throw VersioninigValidationException.versionInvalidUsage();
         } else if (where.hasSeqNoAndPrimaryTerm()) {

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -78,7 +78,7 @@ public class Count implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         var normalizer = new EvaluatingNormalizer(
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             RowGranularity.CLUSTER,
             null,
             tableRelation
@@ -91,9 +91,8 @@ public class Count implements LogicalPlan {
         WhereClause boundWhere = WhereClauseAnalyzer.resolvePartitions(
             where.map(binder),
             tableRelation,
-            plannerContext.functions(),
-            plannerContext.transactionContext()
-        );
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext());
         Routing routing = plannerContext.allocateRouting(
             tableRelation.tableInfo(),
             boundWhere,

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -88,16 +88,16 @@ public class Get implements LogicalPlan {
         List<Symbol> boundOutputs = Lists2.map(
             outputs, s -> SubQueryAndParamBinder.convert(s, params, subQueryResults));
         for (DocKeys.DocKey docKey : docKeys) {
-            String id = docKey.getId(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
+            String id = docKey.getId(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults);
             if (id == null) {
                 continue;
             }
             List<String> partitionValues = docKey.getPartitionValues(
-                plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
+                plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults);
             String indexName = indexName(docTableInfo, partitionValues);
 
             String routing = docKey.getRouting(
-                plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults);
+                plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults);
             ShardRouting shardRouting;
             try {
                 shardRouting = plannerContext.resolveShard(indexName, id, routing);
@@ -127,11 +127,11 @@ public class Get implements LogicalPlan {
                 idsByShard.put(shardRouting.shardId(), pkAndVersions);
             }
             long version = docKey
-                .version(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults)
+                .version(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(Versions.MATCH_ANY);
-            long sequenceNumber = docKey.sequenceNo(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults)
+            long sequenceNumber = docKey.sequenceNo(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(SequenceNumbers.UNASSIGNED_SEQ_NO);
-            long primaryTerm = docKey.primaryTerm(plannerContext.transactionContext(), plannerContext.functions(), params, subQueryResults)
+            long primaryTerm = docKey.primaryTerm(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
             pkAndVersions.add(new PKAndVersion(id, version, sequenceNumber, primaryTerm));
         }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -162,7 +162,7 @@ public class InsertFromValues implements LogicalPlan {
         //   column      +-------------------+     |          symbols
         //   symbols     +-------------------------+
 
-        InputFactory inputFactory = new InputFactory(dependencies.functions());
+        InputFactory inputFactory = new InputFactory(dependencies.nodeContext());
         InputFactory.Context<CollectExpression<Row, ?>> context =
             inputFactory.ctxForInputColumns(plannerContext.transactionContext());
 
@@ -200,7 +200,7 @@ public class InsertFromValues implements LogicalPlan {
         } else {
             Assignments assignments = Assignments.convert(
                 writerProjection.onDuplicateKeyAssignments(),
-                plannerContext.functions()
+                dependencies.nodeContext()
             );
             assignmentSources = assignments.bindSources(tableInfo, params, subQueryResults);
             updateColumnNames = assignments.targetNames();
@@ -309,11 +309,11 @@ public class InsertFromValues implements LogicalPlan {
             assignments = null;
             updateColumnNames = null;
         } else {
-            assignments = Assignments.convert(writerProjection.onDuplicateKeyAssignments(), plannerContext.functions());
+            assignments = Assignments.convert(writerProjection.onDuplicateKeyAssignments(), dependencies.nodeContext());
             updateColumnNames = assignments.targetNames();
         }
 
-        InputFactory inputFactory = new InputFactory(dependencies.functions());
+        InputFactory inputFactory = new InputFactory(dependencies.nodeContext());
         InputFactory.Context<CollectExpression<Row, ?>> context =
             inputFactory.ctxForInputColumns(plannerContext.transactionContext());
 
@@ -461,7 +461,7 @@ public class InsertFromValues implements LogicalPlan {
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             writerProjection.primaryKeys(),
             writerProjection.ids(),
             writerProjection.clusteredByIdent(),
@@ -500,7 +500,7 @@ public class InsertFromValues implements LogicalPlan {
             indexName,
             index -> new InsertSourceFromCells(
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 tableInfo,
                 index,
                 GeneratedColumns.Validation.VALUE_MATCH,
@@ -517,7 +517,7 @@ public class InsertFromValues implements LogicalPlan {
                                                             SubQueryResults subQueryResults) {
         SymbolEvaluator symbolEval = new SymbolEvaluator(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             subQueryResults);
         Function<? super Symbol, Input<?>> eval = (symbol) -> symbol.accept(symbolEval, params);
 
@@ -528,6 +528,7 @@ public class InsertFromValues implements LogicalPlan {
         //noinspection unchecked
         Iterable<Row> rows = funcImplementation.evaluate(
             plannerContext.transactionContext(),
+            plannerContext.nodeContext(),
             boundArguments.toArray(new Input[0]));
 
         return StreamSupport.stream(rows.spliterator(), false)

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -90,7 +90,7 @@ public class Limit extends ForwardingLogicalPlan {
         int limit = Objects.requireNonNullElse(
             DataTypes.INTEGER.sanitizeValue(evaluate(
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 this.limit,
                 params,
                 subQueryResults)),
@@ -98,7 +98,7 @@ public class Limit extends ForwardingLogicalPlan {
         int offset = Objects.requireNonNullElse(
             DataTypes.INTEGER.sanitizeValue(evaluate(
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 this.offset,
                 params,
                 subQueryResults)),

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import io.crate.metadata.NodeContext;
 import org.elasticsearch.Version;
 
 import io.crate.analyze.AnalyzedInsertStatement;
@@ -68,7 +69,6 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.DependencyCarrier;
@@ -115,9 +115,9 @@ public class LogicalPlanner {
     private final Optimizer writeOptimizer;
     private final Optimizer fetchOptimizer;
 
-    public LogicalPlanner(Functions functions, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {
+    public LogicalPlanner(NodeContext nodeCtx, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {
         this.optimizer = new Optimizer(
-            functions,
+            nodeCtx,
             minNodeVersionInCluster,
             List.of(
                 new RemoveRedundantFetchOrEval(),
@@ -144,12 +144,12 @@ public class LogicalPlanner {
             )
         );
         this.fetchOptimizer = new Optimizer(
-            functions,
+            nodeCtx,
             minNodeVersionInCluster,
             List.of(new RewriteToQueryThenFetch())
         );
         this.writeOptimizer = new Optimizer(
-            functions,
+            nodeCtx,
             minNodeVersionInCluster,
             List.of(new RewriteInsertFromSubQueryToInsertFromValues())
         );

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -23,7 +23,7 @@
 package io.crate.planner.operators;
 
 import io.crate.expression.tablefunctions.ValuesFunction;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -55,7 +55,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -81,7 +81,7 @@ public final class TableFunction implements LogicalPlan {
         List<Symbol> args = relation.function().arguments();
         ArrayList<Literal<?>> functionArguments = new ArrayList<>(args.size());
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             RowGranularity.CLUSTER,
             null,
             relation
@@ -94,7 +94,7 @@ public final class TableFunction implements LogicalPlan {
                 Literal.ofUnchecked(
                     arg.valueType(),
                     SymbolEvaluator.evaluate(
-                        plannerContext.transactionContext(), plannerContext.functions(), arg, params, subQueryResults)
+                        plannerContext.transactionContext(), plannerContext.nodeContext(), arg, params, subQueryResults)
                 )
             );
         }

--- a/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
@@ -99,7 +99,7 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
         int limit = DataTypes.INTEGER.sanitizeValue(
             evaluate(
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 this.limit,
                 params,
                 subQueryResults
@@ -108,7 +108,7 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
         int offset = DataTypes.INTEGER.sanitizeValue(
             evaluate(
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 this.offset,
                 params,
                 subQueryResults

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -45,14 +45,14 @@ public class Optimizer {
 
     private final List<Rule<?>> rules;
     private final Supplier<Version> minNodeVersionInCluster;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
 
-    public Optimizer(Functions functions,
+    public Optimizer(NodeContext nodeCtx,
                      Supplier<Version> minNodeVersionInCluster,
                      List<Rule<?>> rules) {
         this.rules = rules;
         this.minNodeVersionInCluster = minNodeVersionInCluster;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
     }
 
     public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, TransactionContext txnCtx) {
@@ -106,7 +106,7 @@ public class Optimizer {
                         LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
                     }
                     @SuppressWarnings("unchecked")
-                    LogicalPlan transformedPlan = rule.apply(match.value(), match.captures(), tableStats, txnCtx, functions);
+                    LogicalPlan transformedPlan = rule.apply(match.value(), match.captures(), tableStats, txnCtx, nodeCtx);
                     if (transformedPlan != null) {
                         if (isTraceEnabled) {
                             LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the logical plan");

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -34,7 +34,7 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, Functions functions);
+    LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.LogicalPlan;
@@ -69,7 +69,7 @@ public final class DeduplicateOrder implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Order childOrder = captures.get(this.childOrder);
         return plan.replaceSources(childOrder.sources());
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.common.collections.Lists2;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.statistics.TableStats;
@@ -64,7 +64,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                        Captures captures,
                        TableStats tableStats,
                        TransactionContext txnCtx,
-                       Functions functions) {
+                       NodeContext nodeCtx) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.analyze.WhereClause;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
@@ -60,7 +60,7 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Collect collect = captures.get(collectCapture);
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -72,7 +72,7 @@ public class MergeFilters implements Rule<Filter> {
                         Captures captures,
                         TableStats tableStats,
                         TransactionContext txnCtx,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
@@ -58,7 +58,7 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, Functions functions) {
+    public LogicalPlan apply(Filter plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx) {
         Eval eval = captures.get(fetchOrEvalCapture);
         List<Symbol> outputsOfFetchSource = eval.source().outputs();
         if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -33,7 +33,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.GroupHashAggregate;
@@ -78,7 +78,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
         // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
         Symbol predicate = filter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -58,7 +58,7 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         HashJoin hashJoin = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), hashJoin);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -64,7 +64,7 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         NestedLoopJoin join = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), join);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -82,7 +82,7 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         return transpose(filter, captures.get(orderCapture));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -27,7 +27,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -67,7 +67,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         var projectSet = captures.get(projectSetCapture);
 
         var queryParts = AndOperator.split(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.FieldReplacer;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -60,7 +60,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
             rename.source(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -61,7 +61,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Union union = captures.get(unionCapture);
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.analyze.WindowDefinition;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         if (windowDefinition.partitions().containsAll(extractColumns(plan.query()))) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
@@ -62,7 +62,7 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Eval eval = captures.get(fetchCapture);
         List<Symbol> outputsOfSourceOfFetch = eval.source().outputs();
         List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -27,7 +27,7 @@ import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
@@ -82,7 +82,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<RelationName> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -25,7 +25,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.analyze.OrderBy;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -82,7 +82,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Rename rename = captures.get(renameCapture);
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
         OrderBy mappedOrderBy = plan.orderBy().map(mapField);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.LogicalPlan;
@@ -60,7 +60,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         Union union = captures.get(unionCapture);
         List<LogicalPlan> unionSources = union.sources();
         assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Eval;
@@ -55,7 +55,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         return plan.source();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteCollectToGet.java
@@ -27,7 +27,7 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.where.DocKeys;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
@@ -67,16 +67,16 @@ public final class RewriteCollectToGet implements Rule<Collect> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         var relation = (DocTableRelation) collect.relation();
-        var normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, null, relation);
+        var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
         WhereClause where = collect.where();
         var detailedQuery = WhereClauseOptimizer.optimize(
             normalizer,
             where.queryOrFallback(),
             relation.tableInfo(),
             txnCtx,
-            functions
+            nodeCtx
         );
         Optional<DocKeys> docKeys = detailedQuery.docKeys();
         //noinspection OptionalIsPresent no capturing lambda allocation

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -30,7 +30,7 @@ import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.dql.join.JoinType;
@@ -122,8 +122,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
+                             NodeContext nodeCtx) {
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         NestedLoopJoin nl = captures.get(nlCapture);
         Symbol query = filter.query();
         Map<Set<RelationName>, Symbol> splitQueries = QuerySplitter.split(query);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToTopNDistinct.java
@@ -25,7 +25,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import org.elasticsearch.Version;
 
 import io.crate.expression.symbol.Literal;
@@ -164,7 +164,7 @@ public final class RewriteGroupByKeysLimitToTopNDistinct implements Rule<Limit> 
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
         if (!eagerTerminateIsLikely(limit, groupBy)) {
             return null;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
@@ -79,7 +79,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             Functions functions) {
+                             NodeContext nodeCtx) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
@@ -23,7 +23,7 @@
 package io.crate.planner.optimizer.symbol;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import org.elasticsearch.Version;
@@ -32,7 +32,7 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    Symbol apply(T symbol, Captures captures, Functions functions);
+    Symbol apply(T symbol, Captures captures, NodeContext nodeCtx);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -26,7 +26,7 @@ import io.crate.expression.scalar.ArrayUpperFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -72,7 +72,7 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
     @Override
     public Symbol apply(Function operator,
                         Captures captures,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         var literal = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var function = castFunction.arguments().get(0);

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastInsideOperators.java
@@ -27,7 +27,7 @@ import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -77,7 +77,7 @@ public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Funct
     @Override
     public Symbol apply(Function operator,
                         Captures captures,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         var literal = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
@@ -26,7 +26,7 @@ import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -68,7 +68,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
     @Override
     public Symbol apply(Function operator,
                         Captures captures,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         var literal = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -26,7 +26,7 @@ import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -68,7 +68,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
     @Override
     public Symbol apply(Function operator,
                         Captures captures,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         var literal = operator.arguments().get(0);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -26,7 +26,7 @@ import io.crate.expression.scalar.SubscriptFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -71,7 +71,7 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
     @Override
     public Symbol apply(Function operator,
                         Captures captures,
-                        Functions functions) {
+                        NodeContext nodeCtx) {
         var literal = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var subscript = castFunction.arguments().get(0);

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -51,8 +51,8 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -126,12 +126,12 @@ public final class CopyFromPlan implements Plan {
     @VisibleForTesting
     public static BoundCopyFrom bind(AnalyzedCopyFrom copyFrom,
                                      CoordinatorTxnCtx txnCtx,
-                                     Functions functions,
+                                     NodeContext nodeCtx,
                                      Row parameters,
                                      SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults
@@ -176,7 +176,7 @@ public final class CopyFromPlan implements Plan {
         var boundedCopyFrom = bind(
             copyFrom,
             context.transactionContext(),
-            context.functions(),
+            context.nodeContext(),
             params,
             subQueryResults);
 

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -45,8 +45,8 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.DocReferences;
-import io.crate.metadata.Functions;
 import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
@@ -132,7 +132,7 @@ public final class CopyToPlan implements Plan {
         var boundedCopyTo = bind(
             copyTo,
             context.transactionContext(),
-            context.functions(),
+            context.nodeContext(),
             params,
             subQueryResults);
 
@@ -176,7 +176,7 @@ public final class CopyToPlan implements Plan {
                                                          match.captures(),
                                                          tableStats,
                                                          context.transactionContext(),
-                                                         context.functions());
+                                                         context.nodeContext());
             return plan == null ? collect : plan;
         }
         return collect;
@@ -185,12 +185,12 @@ public final class CopyToPlan implements Plan {
     @VisibleForTesting
     public static BoundCopyTo bind(AnalyzedCopyTo copyTo,
                                    CoordinatorTxnCtx txnCtx,
-                                   Functions functions,
+                                   NodeContext nodeCtx,
                                    Row parameters,
                                    SubQueryResults subQueryResults) {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -42,7 +42,6 @@ import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Routing;
@@ -78,20 +77,19 @@ import static java.util.Objects.requireNonNull;
 
 public final class DeletePlanner {
 
-    public static Plan planDelete(Functions functions,
-                                  AnalyzedDeleteStatement delete,
+    public static Plan planDelete(AnalyzedDeleteStatement delete,
                                   SubqueryPlanner subqueryPlanner,
                                   PlannerContext context) {
-        Plan plan = planDelete(functions, delete, context);
+        Plan plan = planDelete(delete, context);
         return MultiPhasePlan.createIfNeeded(plan, subqueryPlanner.planSubQueries(delete));
     }
 
-    private static Plan planDelete(Functions functions, AnalyzedDeleteStatement delete, PlannerContext context) {
+    private static Plan planDelete(AnalyzedDeleteStatement delete, PlannerContext context) {
         DocTableRelation tableRel = delete.relation();
         DocTableInfo table = tableRel.tableInfo();
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(context.nodeContext());
         WhereClauseOptimizer.DetailedQuery detailedQuery = WhereClauseOptimizer.optimize(
-            normalizer, delete.query(), table, context.transactionContext(), context.functions());
+            normalizer, delete.query(), table, context.transactionContext(), context.nodeContext());
 
         if (!detailedQuery.partitions().isEmpty()) {
             return new DeletePartitions(table.ident(), detailedQuery.partitions());
@@ -131,11 +129,10 @@ public final class DeletePlanner {
 
             WhereClause where = detailedQuery.toBoundWhereClause(
                 table.tableInfo(),
-                executor.functions(),
                 params,
                 subQueryResults,
-                plannerContext.transactionContext()
-            );
+                plannerContext.transactionContext(),
+                executor.nodeContext());
             if (!where.partitions().isEmpty() && !where.hasQuery()) {
                 DeleteIndexRequest request = new DeleteIndexRequest(where.partitions().toArray(new String[0]));
                 request.indicesOptions(IndicesOptions.lenientExpandOpen());
@@ -160,10 +157,10 @@ public final class DeletePlanner {
             for (Row params : bulkParams) {
                 WhereClause where = detailedQuery.toBoundWhereClause(
                     table.tableInfo(),
-                    executor.functions(),
                     params,
                     subQueryResults,
-                    plannerContext.transactionContext());
+                    plannerContext.transactionContext(),
+                    executor.nodeContext());
                 ExecutionPlan executionPlan = deleteByQuery(table, plannerContext, where);
                 nodeOperationTreeList.add(NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId()));
             }

--- a/server/src/main/java/io/crate/planner/statement/SetLicensePlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetLicensePlan.java
@@ -54,7 +54,7 @@ public class SetLicensePlan implements Plan {
                               SubQueryResults subQueryResults) {
         Object license = SymbolEvaluator.evaluate(
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             stmt.licenseKey(),
             params,
             subQueryResults

--- a/server/src/main/java/io/crate/planner/statement/SetSessionPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetSessionPlan.java
@@ -72,7 +72,7 @@ public class SetSessionPlan implements Plan {
                               SubQueryResults subQueryResults) throws Exception {
 
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(plannerContext.transactionContext(),
-                                                                              plannerContext.functions(),
+                                                                              plannerContext.nodeContext(),
                                                                               x,
                                                                               params,
                                                                               subQueryResults);

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
 
+import io.crate.metadata.NodeContext;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.Collector;
@@ -68,7 +69,6 @@ import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -79,19 +79,19 @@ import io.crate.types.DataTypes;
 public final class ReservoirSampler {
 
     private final ClusterService clusterService;
-    private final Functions functions;
+    private final NodeContext nodeCtx;
     private final Schemas schemas;
     private CircuitBreakerService circuitBreakerService;
     private final IndicesService indicesService;
 
     @Inject
     public ReservoirSampler(ClusterService clusterService,
-                            Functions functions,
+                            NodeContext nodeCtx,
                             Schemas schemas,
                             CircuitBreakerService circuitBreakerService,
                             IndicesService indicesService) {
         this.clusterService = clusterService;
-        this.functions = functions;
+        this.nodeCtx = nodeCtx;
         this.schemas = schemas;
         this.circuitBreakerService = circuitBreakerService;
         this.indicesService = indicesService;
@@ -163,7 +163,7 @@ public final class ReservoirSampler {
             var mapperService = indexService.mapperService();
             FieldTypeLookup fieldTypeLookup = mapperService::fullName;
             var ctx = new DocInputFactory(
-                functions,
+                nodeCtx,
                 new LuceneReferenceResolver(
                     indexService.index().getName(),
                     fieldTypeLookup,

--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -33,7 +33,7 @@ public class Regproc {
     private final String name;
 
     public static Regproc of(@Nonnull String name) {
-        return new Regproc(OidHash.functionOid(name), name);
+        return new Regproc(OidHash.regprocOid(name), name);
     }
 
     public static Regproc of(int functionOid, @Nonnull String name) {

--- a/server/src/main/java/io/crate/user/UserActions.java
+++ b/server/src/main/java/io/crate/user/UserActions.java
@@ -26,7 +26,7 @@ import io.crate.analyze.SymbolEvaluator;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.GenericProperties;
@@ -48,8 +48,8 @@ public final class UserActions {
     public static SecureHash generateSecureHash(GenericProperties<Symbol> userStmtProperties,
                                                 Row parameters,
                                                 TransactionContext txnCtx,
-                                                Functions functions) throws GeneralSecurityException, IllegalArgumentException {
-        try (SecureString pw = getUserPasswordProperty(userStmtProperties, parameters, txnCtx, functions)) {
+                                                NodeContext nodeCtx) throws GeneralSecurityException, IllegalArgumentException {
+        try (SecureString pw = getUserPasswordProperty(userStmtProperties, parameters, txnCtx, nodeCtx)) {
             if (pw != null) {
                 if (pw.length() == 0) {
                     throw new IllegalArgumentException("Password must not be empty");
@@ -65,10 +65,10 @@ public final class UserActions {
     static SecureString getUserPasswordProperty(GenericProperties<Symbol> userStmtProperties,
                                                 Row parameters,
                                                 TransactionContext txnCtx,
-                                                Functions functions) throws IllegalArgumentException {
+                                                NodeContext nodeCtx) throws IllegalArgumentException {
         Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
             txnCtx,
-            functions,
+            nodeCtx,
             x,
             parameters,
             SubQueryResults.EMPTY

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -128,6 +128,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier executor = mock(DependencyCarrier.class);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -155,6 +156,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     public void test_select_query_executed_on_session_execute_method() {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
         Session session = Mockito.spy(new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -326,6 +328,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier executor = mock(DependencyCarrier.class);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -361,6 +364,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         DependencyCarrier executor = mock(DependencyCarrier.class);
         when(executor.threadPool()).thenReturn(mock(ThreadPool.class));
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -388,6 +392,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         DependencyCarrier executor = mock(DependencyCarrier.class);
         when(executor.threadPool()).thenReturn(mock(ThreadPool.class));
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -414,6 +419,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
         DependencyCarrier executor = mock(DependencyCarrier.class, Answers.RETURNS_MOCKS);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -438,6 +444,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
         DependencyCarrier executor = mock(DependencyCarrier.class, Answers.RETURNS_MOCKS);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             sqlExecutor.planner,
             new JobsLogs(() -> false),
@@ -487,6 +494,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             );
         JobsLogs jobsLogs = new JobsLogs(() -> true);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             planner,
             jobsLogs,

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -72,7 +72,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         return AlterTableAddColumnPlan.bind(
             e.analyze(stmt),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             Row.EMPTY,
             SubQueryResults.EMPTY,
             e.fulltextAnalyzerResolver()

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -65,7 +65,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         return (S) AlterTableReroutePlan.createRerouteCommand(
             analyzedStatement,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY,
             DiscoveryNodes.builder()

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -71,7 +71,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         return CreateBlobTablePlan.buildSettings(
             blobTable.createBlobTable(),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY,
             new NumberOfShards(clusterService));

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -75,7 +75,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             return (S) CopyFromPlan.bind(
                 (AnalyzedCopyFrom) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY
             );
@@ -83,7 +83,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             return (S) CopyToPlan.bind(
                 (AnalyzedCopyTo) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY
             );

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -99,7 +99,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             return (S) CreateTablePlan.bind(
                 (AnalyzedCreateTable) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY,
                 new NumberOfShards(clusterService),
@@ -110,7 +110,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             return (S) AlterTablePlan.bind(
                 (AnalyzedAlterTable) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY
             );

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -116,7 +116,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             return (S) CreateTablePlan.bind(
                 (AnalyzedCreateTable) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY,
                 new NumberOfShards(clusterService),
@@ -127,7 +127,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             return (S) AlterTablePlan.bind(
                 (AnalyzedAlterTable) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY
             );
@@ -135,7 +135,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             return (S) AlterTableAddColumnPlan.bind(
                 (AnalyzedAlterTableAddColumn) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 new RowN(arguments),
                 SubQueryResults.EMPTY,
                 null
@@ -723,7 +723,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         CreateBlobTablePlan.buildSettings(
             blobTable.createBlobTable(),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(new Object[0]),
             SubQueryResults.EMPTY,
             new NumberOfShards(clusterService));

--- a/server/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -85,7 +85,7 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
             return (S) CreateRepositoryPlan.createRequest(
                 (AnalyzedCreateRepository) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
                 repositoryParamValidator);

--- a/server/src/test/java/io/crate/analyze/DecommissionNodeAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DecommissionNodeAnalyzerTest.java
@@ -49,7 +49,7 @@ public class DecommissionNodeAnalyzerTest extends CrateDummyClusterServiceUnitTe
         return DecommissionNodePlan.boundNodeIdOrName(
             analyzedStatement,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY
         );

--- a/server/src/test/java/io/crate/analyze/KillAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/KillAnalyzerTest.java
@@ -52,7 +52,7 @@ public class KillAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         return KillPlan.boundJobId(
             analyzedStatement.jobId(),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY
         );

--- a/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -62,7 +62,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
         return OptimizeTablePlan.bind(
             analyzedStatement,
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             new RowN(arguments),
             SubQueryResults.EMPTY
         );

--- a/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
@@ -21,14 +21,11 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.symbol.Literal;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.QualifiedName;
-import io.crate.sql.tree.QualifiedNameReference;
-import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.hamcrest.Matchers;

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2586,7 +2586,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         DocTableInfo table = executor.resolveTableInfo("test");
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
-            executor.functions(),
+            executor.nodeCtx,
             RowGranularity.DOC,
             null,
             new DocTableRelation(table)

--- a/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -99,7 +99,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
             return (T) CreateSnapshotPlan.createRequest(
                 (AnalyzedCreateSnapshot) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
                 e.schemas());
@@ -107,7 +107,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
             return (T) RestoreSnapshotPlan.bind(
                 (AnalyzedRestoreSnapshot) analyzedStatement,
                 plannerContext.transactionContext(),
-                plannerContext.functions(),
+                plannerContext.nodeContext(),
                 Row.EMPTY,
                 SubQueryResults.EMPTY,
                 e.schemas());

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -219,7 +219,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(ref, not(instanceOf(DynamicReference.class)));
         assertEquals(DataTypes.LONG, ref.valueType());
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         Symbol[] sources = assignments.bindSources(
             ((DocTableInfo) update.table().tableInfo()), Row.EMPTY, SubQueryResults.EMPTY);
         assertThat(sources[0], isLiteral(9L));
@@ -282,7 +282,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new Long[]{1L, 2L, 3L}};
         AnalyzedUpdateStatement update = analyze("update users set name=?, friends=? where other_id=?");
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot cast [{}] to type TEXT");
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
@@ -293,7 +293,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Object[] params = {new Map[0], 0};
         AnalyzedUpdateStatement update = analyze("update users set friends=? where other_id=0");
 
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         Symbol[] sources = assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
 
 
@@ -404,7 +404,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             }
         };
         AnalyzedUpdateStatement update = analyze("update users set new=? where id=1");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         Symbol[] sources = assignments.bindSources(
             ((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
 
@@ -423,7 +423,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot cast [a, b] to type TEXT");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }
 

--- a/server/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -88,7 +88,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
                       "clustered by (id)")
             .build();
         userTableInfo = e.resolveTableInfo("doc.test1");
-        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(e.functions());
+        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(e.nodeCtx);
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
@@ -29,7 +29,6 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;

--- a/server/src/test/java/io/crate/analyze/where/DocKeysTest.java
+++ b/server/src/test/java/io/crate/analyze/where/DocKeysTest.java
@@ -26,6 +26,7 @@ import io.crate.data.Row;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.operators.SubQueryResults;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -33,11 +34,12 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Optional;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.core.Is.is;
 
 public class DocKeysTest extends ESTestCase {
 
+    private NodeContext nodeCtx = createNodeContext();
 
     @Test
     public void testClusteredIsFirstInId() throws Exception {
@@ -48,8 +50,8 @@ public class DocKeysTest extends ESTestCase {
         DocKeys docKeys = new DocKeys(pks, false, false, 1, null);
         DocKeys.DocKey key = docKeys.getOnlyKey();
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
-        assertThat(key.getRouting(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("Ford"));
-        assertThat(key.getId(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY), is("AgRGb3JkATE="));
+        assertThat(key.getRouting(txnCtx, nodeCtx, Row.EMPTY, SubQueryResults.EMPTY), is("Ford"));
+        assertThat(key.getId(txnCtx, nodeCtx, Row.EMPTY, SubQueryResults.EMPTY), is("AgRGb3JkATE="));
     }
 
     @Test
@@ -61,10 +63,10 @@ public class DocKeysTest extends ESTestCase {
                                       null);
         DocKeys.DocKey key = docKeys.getOnlyKey();
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
-        Optional<Long> sequenceNo = key.sequenceNo(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY);
+        Optional<Long> sequenceNo = key.sequenceNo(txnCtx, nodeCtx, Row.EMPTY, SubQueryResults.EMPTY);
         assertThat(sequenceNo.isPresent(), is(true));
         assertThat(sequenceNo.get(), is(22L));
-        Optional<Long> primaryTerm = key.primaryTerm(txnCtx, getFunctions(), Row.EMPTY, SubQueryResults.EMPTY);
+        Optional<Long> primaryTerm = key.primaryTerm(txnCtx, nodeCtx, Row.EMPTY, SubQueryResults.EMPTY);
         assertThat(primaryTerm.isPresent(), is(true));
         assertThat(primaryTerm.get(), is(5L));
     }

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
@@ -52,8 +51,8 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
 
     private CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(SessionContext.systemSessionContext());
     private SqlExpressions expressions;
-    private EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
-    private EqualityExtractor ee = new EqualityExtractor(normalizer);
+    private EvaluatingNormalizer normalizer;
+    private EqualityExtractor ee;
     private ColumnIdent x = new ColumnIdent("x");
     private ColumnIdent i = new ColumnIdent("i");
 
@@ -63,6 +62,8 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
 
         DocTableRelation tr1 = (DocTableRelation) sources.get(T3.T1);
         expressions = new SqlExpressions(sources, tr1);
+        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(expressions.nodeCtx);
+        ee = new EqualityExtractor(normalizer);
     }
 
     private List<List<Symbol>> analyzeParentX(Symbol query) {

--- a/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 
 import java.util.function.Function;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.is;
 
 public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
@@ -51,7 +50,7 @@ public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private void assertReplacedAndNormalized(String expression, String expectedString) {
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(sqlExpressions.nodeCtx);
         assertReplaced(expression, expectedString,  s -> normalizer.normalize(s, CoordinatorTxnCtx.systemTransactionContext()));
     }
 

--- a/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
@@ -61,7 +61,7 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
         BoundAddColumn addXLong = AlterTableAddColumnPlan.bind(
             e.analyze("alter table t add column x long"),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             Row.EMPTY,
             SubQueryResults.EMPTY,
             null
@@ -69,7 +69,7 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
         BoundAddColumn addXString = AlterTableAddColumnPlan.bind(
             e.analyze("alter table t add column x string"),
             plannerContext.transactionContext(),
-            plannerContext.functions(),
+            plannerContext.nodeContext(),
             Row.EMPTY,
             SubQueryResults.EMPTY,
             null

--- a/server/src/test/java/io/crate/execution/dml/upsert/CheckConstraintsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/CheckConstraintsTest.java
@@ -60,7 +60,7 @@ public class CheckConstraintsTest extends CrateDummyClusterServiceUnitTest {
         TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         checkConstraints = new CheckConstraints(
             txnCtx,
-            new InputFactory(sqlExecutor.functions()),
+            new InputFactory(sqlExecutor.nodeCtx),
             FromSourceRefResolver.WITHOUT_PARTITIONED_BY_REFS,
             docTableInfo);
     }

--- a/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColsFromRawInsertSourceTest.java
@@ -45,7 +45,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
             .build();
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
-            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+            txnCtx, e.nodeCtx, t.generatedColumns(), t.defaultExpressionColumns());
         Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
@@ -58,7 +58,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
             .build();
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         GeneratedColsFromRawInsertSource insertSource = new GeneratedColsFromRawInsertSource(
-            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+            txnCtx, e.nodeCtx, t.generatedColumns(), t.defaultExpressionColumns());
         Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
         assertThat(Maps.getByPath(map, "x"), is(2));
         assertThat(Maps.getByPath(map, "y"), is(3));
@@ -71,7 +71,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
             .build();
         DocTableInfo t = e.resolveTableInfo("t");
         var insertSource = new GeneratedColsFromRawInsertSource(
-            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+            txnCtx, e.nodeCtx, t.generatedColumns(), t.defaultExpressionColumns());
         Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
         assertThat(Maps.getByPath(map, "x"), is("ab"));
     }
@@ -83,7 +83,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
             .build();
         DocTableInfo t = e.resolveTableInfo("t");
         var insertSource = new GeneratedColsFromRawInsertSource(
-            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+            txnCtx, e.nodeCtx, t.generatedColumns(), t.defaultExpressionColumns());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'abc' is too long for the text type of length: 2");
         insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
@@ -96,7 +96,7 @@ public class GeneratedColsFromRawInsertSourceTest extends CrateDummyClusterServi
             .build();
         DocTableInfo t = e.resolveTableInfo("t");
         var insertSource = new GeneratedColsFromRawInsertSource(
-            txnCtx, e.functions(), t.generatedColumns(), t.defaultExpressionColumns());
+            txnCtx, e.nodeCtx, t.generatedColumns(), t.defaultExpressionColumns());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'abc' is too long for the text type of length: 2");
         insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});

--- a/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -55,7 +55,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation query = e.analyze("select obj, arr from t");
         DocTableInfo table = ((DocTableRelation) query.from().get(0)).tableInfo();
         GeneratedColumns<Doc> generatedColumns = new GeneratedColumns<>(
-            new InputFactory(e.functions()),
+            new InputFactory(e.nodeCtx),
             CoordinatorTxnCtx.systemTransactionContext(),
             GeneratedColumns.Validation.NONE,
             new DocRefResolver(Collections.emptyList()),

--- a/server/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/ReturnValueGenTest.java
@@ -86,8 +86,8 @@ public class ReturnValueGenTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.builder(clusterService).addTable(CREATE_TEST_TABLE).build();
         AnalyzedUpdateStatement update = executor.analyze(stmt);
         tableInfo = (DocTableInfo) update.table().tableInfo();
-        returnValueGen = new ReturnValueGen(executor.functions(),
-                                            txnCtx,
+        returnValueGen = new ReturnValueGen(txnCtx,
+                                            executor.nodeCtx,
                                             tableInfo,
                                             update.outputs() == null ? null : update.outputs().toArray(new Symbol[0]));
     }

--- a/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -85,7 +85,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
+            txnCtx, e.nodeCtx, t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
         var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
         assertThat(source, is(Map.of("x", 1, "y", 2, "z", 3)));
     }
@@ -93,7 +93,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGenerateSourceRaisesAnErrorIfGeneratedColumnValueIsSuppliedByUserAndDoesNotMatch() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y, z));
+            txnCtx, e.nodeCtx, t1, "t1", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y, z));
 
         expectedException.expectMessage("Given value 8 for generated column z does not match calculation (x + y) = 3");
         sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2, 8});
@@ -102,7 +102,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGeneratedColumnGenerationThatDependsOnNestedColumnOfObject() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
+            txnCtx, e.nodeCtx, t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
         var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
@@ -118,7 +118,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         PartitionName partitionName = new PartitionName(t3.ident(), singletonList(null));
 
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
+            txnCtx, e.nodeCtx, t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
 
         expectedException.expectMessage("\"p\" must not be null");
         sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
@@ -131,7 +131,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         PartitionName partitionName = new PartitionName(t3.ident(), singletonList("10"));
 
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
+            txnCtx, e.nodeCtx, t3, partitionName.asIndexName(), GeneratedColumns.Validation.VALUE_MATCH, emptyList());
 
         // this must pass without error
         sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
@@ -144,7 +144,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         Reference x = (Reference) relation.outputs().get(0);
 
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x));
+            txnCtx, e.nodeCtx, t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x));
 
         Object[] input = new Object[]{1};
         var source = sourceFromCells.generateSourceAndCheckConstraints(input);
@@ -159,7 +159,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         Reference y = (Reference) relation.outputs().get(1);
 
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
+            txnCtx, e.nodeCtx, t4, "t4", GeneratedColumns.Validation.VALUE_MATCH, Arrays.asList(x, y));
 
         Object[] input = {1, "cr8"};
         var source = sourceFromCells.generateSourceAndCheckConstraints(input);
@@ -173,7 +173,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         // b as obj['a'] + 1
         List<Reference> targets = List.of(obj);
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, targets);
+            txnCtx, e.nodeCtx, t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 13);
@@ -192,7 +192,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         // b as obj['a'] + 1
         List<Reference> targets = List.of(obj);
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, targets);
+            txnCtx, e.nodeCtx, t2, "t2", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 14);
@@ -209,7 +209,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(obj, Matchers.notNullValue());
         List<Reference> targets = List.of(obj);
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
+            txnCtx, e.nodeCtx, t5, "t4", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("y", 2);
         var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
@@ -225,7 +225,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(obj, Matchers.notNullValue());
         List<Reference> targets = List.of(obj);
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
+            txnCtx, e.nodeCtx, t5, "t5", GeneratedColumns.Validation.VALUE_MATCH, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
         var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
@@ -236,7 +236,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     public void test_generated_based_on_default() throws Exception {
         DocTableInfo t6 = e.resolveTableInfo("t6");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
-            txnCtx, e.functions(), t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
+            txnCtx, e.nodeCtx, t6, "t6", GeneratedColumns.Validation.VALUE_MATCH, List.of());
         var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
         assertThat(Maps.getByPath(source, "x"), is(1));
         assertThat(Maps.getByPath(source, "y"), is(2));
@@ -250,7 +250,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("t");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             tableInfo,
             "t",
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -272,7 +272,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         PartitionName partition = new PartitionName(tableInfo.ident(), singletonList(null));
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             tableInfo,
             partition.asIndexName(),
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -291,7 +291,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         InsertSourceGen sourceGen = InsertSourceGen.of(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             tableInfo,
             tableInfo.concreteIndices()[0],
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -313,7 +313,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
         InsertSourceGen sourceGen = InsertSourceGen.of(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             table,
             table.concreteIndices()[0],
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -334,7 +334,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t = e.resolveTableInfo("tbl");
         InsertSourceGen sourceGen = InsertSourceGen.of(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             t,
             t.concreteIndices()[0],
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -352,7 +352,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t = e.resolveTableInfo("tbl");
         InsertSourceGen sourceGen = InsertSourceGen.of(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             t,
             t.concreteIndices()[0],
             GeneratedColumns.Validation.VALUE_MATCH,
@@ -371,7 +371,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t = e.resolveTableInfo("tbl");
         InsertSourceGen sourceGen = InsertSourceGen.of(
             txnCtx,
-            e.functions(),
+            e.nodeCtx,
             t,
             t.concreteIndices()[0],
             GeneratedColumns.Validation.VALUE_MATCH,

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -27,7 +27,7 @@ import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.jobs.TasksService;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -71,7 +71,7 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -108,11 +108,11 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                                  TasksService tasksService,
                                                  IndicesService indicesService,
                                                  ShardStateAction shardStateAction,
-                                                 Functions functions,
+                                                 NodeContext nodeCtx,
                                                  Schemas schemas,
                                                  IndexNameExpressionResolver indexNameExpressionResolver) {
             super(threadPool, clusterService, transportService, schemaUpdateClient,
-                tasksService, indicesService, shardStateAction, functions, schemas, indexNameExpressionResolver);
+                tasksService, indicesService, shardStateAction, nodeCtx, schemas, indexNameExpressionResolver);
         }
 
         @Override
@@ -134,7 +134,6 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     @Before
     public void prepare() throws Exception {
-        Functions functions = getFunctions();
 
         charactersIndexUUID = UUIDs.randomBase64UUID();
         partitionIndexUUID = UUIDs.randomBase64UUID();
@@ -163,7 +162,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             mock(TasksService.class),
             indicesService,
             mock(ShardStateAction.class),
-            functions,
+            createNodeContext(),
             schemas,
             mock(IndexNameExpressionResolver.class)
         );

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateSourceGenTest.java
@@ -63,11 +63,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         AnalyzedUpdateStatement update = e.analyze("update t set x = x + p");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -102,11 +102,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (y int)")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set y = _id::integer * 2");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -138,11 +138,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as x + 1))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -170,11 +170,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, gen as current_schema)")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 1");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen sourceGen = new UpdateSourceGen(
-            e.functions(),
             TransactionContext.of(DUMMY_SESSION_INFO),
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -194,11 +194,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as 'foo'))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4, obj = {y='bar'}");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -227,11 +227,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (x int, obj object as (y as 'foo'))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set x = 4, obj = {y='foo'}");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );
@@ -258,11 +258,11 @@ public class UpdateSourceGenTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table t (obj object as (x int))")
             .build();
         AnalyzedUpdateStatement update = e.analyze("update t set obj['x'] = 10");
-        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.functions());
+        Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         DocTableInfo table = (DocTableInfo) update.table().tableInfo();
         UpdateSourceGen updateSourceGen = new UpdateSourceGen(
-            e.functions(),
             txnCtx,
+            e.nodeCtx,
             table,
             assignments.targetNames()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -49,7 +49,7 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void test_return_type_must_be_equal_to_argument_type() {
-        var arbitraryFunction = functions.get(
+        var arbitraryFunction = nodeCtx.functions().get(
             null,
             ArbitraryAggregation.NAME,
             List.of(Literal.of(DataTypes.INTEGER, null)),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -52,7 +52,7 @@ public class ArrayAggTest extends AggregationTest {
 
     @Test
     public void test_array_agg_return_type_is_array_of_argument_type() {
-        DataType<?> returnType = functions.getQualified(
+        DataType<?> returnType = nodeCtx.functions().getQualified(
             ArrayAgg.SIGNATURE,
             List.of(DataTypes.LONG),
             DataTypes.BIGINT_ARRAY

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -63,7 +63,7 @@ public class AverageAggregationTest extends AggregationTest {
     }
 
     private FunctionImplementation getFunction(String name) {
-        return functions.get(
+        return nodeCtx.functions().get(
             null, name, ImmutableList.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -57,7 +57,7 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionImplementation collectSet = functions.get(
+        FunctionImplementation collectSet = nodeCtx.functions().get(
             null, "collect_set", ImmutableList.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
         assertEquals(new ArrayType<>(DataTypes.INTEGER), collectSet.info().returnType());
     }
@@ -71,7 +71,7 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testLongSerialization() throws Exception {
-        AggregationFunction impl = (AggregationFunction) functions.get(
+        AggregationFunction impl = (AggregationFunction) nodeCtx.functions().get(
                 null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
 
         Object state = impl.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
@@ -85,7 +85,7 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void test_value_adding_and_removal() {
-        AggregationFunction impl = (AggregationFunction) functions.get(
+        AggregationFunction impl = (AggregationFunction) nodeCtx.functions().get(
             null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
         AggregationFunction aggregationFunction = impl.optimizeForExecutionAsWindowFunction();
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -50,7 +50,7 @@ public class CountAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() {
-        var countFunction = functions.get(
+        var countFunction = nodeCtx.functions().get(
             null,
             CountAggregation.NAME,
             List.of(Literal.of(DataTypes.INTEGER, null)),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -56,7 +56,7 @@ public class GeometricMeanAggregationtest extends AggregationTest {
             DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
             Stream.of(DataTypes.TIMESTAMPZ)).collect(Collectors.toList())) {
 
-            FunctionImplementation stddev = functions.get(
+            FunctionImplementation stddev = nodeCtx.functions().get(
                 null,
                 GeometricMeanAggregation.NAME,
                 List.of(Literal.of(type, null)),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -72,7 +72,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Before
     public void initFunctions() throws Exception {
-        singleArgPercentile = (PercentileAggregation) functions.getQualified(
+        singleArgPercentile = (PercentileAggregation) nodeCtx.functions().getQualified(
             Signature.aggregate(
                 PercentileAggregation.NAME,
                 DataTypes.DOUBLE.getTypeSignature(),
@@ -82,7 +82,7 @@ public class PercentileAggregationTest extends AggregationTest {
             List.of(DataTypes.DOUBLE, DataTypes.DOUBLE),
             DataTypes.DOUBLE
         );
-        arraysPercentile = (PercentileAggregation) functions.getQualified(
+        arraysPercentile = (PercentileAggregation) nodeCtx.functions().getQualified(
             Signature.aggregate(
                 PercentileAggregation.NAME,
                 DataTypes.DOUBLE.getTypeSignature(),
@@ -225,7 +225,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test
     public void testSingleItemFractionsArgumentResultsInArrayResult() {
-        AggregationFunction impl = (AggregationFunction<?, ?>) functions.getQualified(
+        AggregationFunction impl = (AggregationFunction<?, ?>) nodeCtx.functions().getQualified(
             Signature.aggregate(
                 PercentileAggregation.NAME,
                 DataTypes.LONG.getTypeSignature(),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -56,7 +56,7 @@ public class StdDevAggregationTest extends AggregationTest {
             DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
             Stream.of(DataTypes.TIMESTAMPZ)).collect(Collectors.toList())) {
 
-            FunctionImplementation stddev = functions.get(
+            FunctionImplementation stddev = nodeCtx.functions().get(
                 null,
                 StandardDeviationAggregation.NAME,
                 List.of(Literal.of(type, null)),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -72,7 +72,7 @@ public class SumAggregationTest extends AggregationTest {
     }
 
     private FunctionImplementation getSum(DataType<?> type) {
-        return functions.get(
+        return nodeCtx.functions().get(
             null,
             "sum",
             List.of(Literal.of(type, null)),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -57,7 +57,7 @@ public class VarianceAggregationTest extends AggregationTest {
     public void testReturnType() throws Exception {
         for (var dataType : VarianceAggregation.SUPPORTED_TYPES) {
             // Return type is fixed to Double
-            var varianceFunction = functions.get(
+            var varianceFunction = nodeCtx.functions().get(
                 null,
                 VarianceAggregation.NAME,
                 List.of(Literal.of(dataType, null)),

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -32,6 +32,7 @@ import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.NodeContext;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.BatchIteratorTester;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -62,7 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -76,6 +77,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
 
     @Before
     public void prepare() throws Exception {
+        NodeContext nodeCtx = createNodeContext();
         IndexWriter iw = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
         columnName = "x";
         expectedResult = new ArrayList<>(20);
@@ -90,7 +92,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
 
         inExpr = new InputCollectExpression(0);
-        CountAggregation aggregation = (CountAggregation) getFunctions().getQualified(
+        CountAggregation aggregation = (CountAggregation) nodeCtx.functions().getQualified(
             CountAggregation.COUNT_STAR_SIGNATURE,
             Collections.emptyList(),
             CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType()

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -29,7 +29,6 @@ import io.crate.execution.engine.collect.sources.FileCollectSource;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
@@ -47,11 +46,12 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static io.crate.testing.TestingHelpers.createReference;
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.mock;
+
 
 public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUnitTest {
 
@@ -60,8 +60,7 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
 
     @Test
     public void testFileUriCollect() throws Exception {
-        Functions functions = getFunctions();
-        FileCollectSource fileCollectSource = new FileCollectSource(functions, clusterService, Collections.emptyMap());
+        FileCollectSource fileCollectSource = new FileCollectSource(createNodeContext(), clusterService, Collections.emptyMap());
 
         File tmpFile = temporaryFolder.newFile("fileUriCollectOperation.json");
         try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {

--- a/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
@@ -28,14 +28,14 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.Functions;
 import org.elasticsearch.test.ESTestCase;
-import io.crate.testing.TestingHelpers;
 import org.junit.Test;
 
 import java.util.List;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.core.Is.is;
 
 public class RowShardResolverTest extends ESTestCase {
@@ -53,14 +53,14 @@ public class RowShardResolverTest extends ESTestCase {
         return new ColumnIdent(ident);
     }
 
-    private Functions functions = TestingHelpers.getFunctions();
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    private NodeContext nodeCtx = createNodeContext();
 
 
     @Test
     public void testNoPrimaryKeyNoRouting() {
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), null, null);
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), null, null);
         rowShardResolver.setNextRow(row());
 
         // auto-generated id, no special routing
@@ -71,7 +71,7 @@ public class RowShardResolverTest extends ESTestCase {
     @Test
     public void testNoPrimaryKeyButRouting() {
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), ID_IDENT, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), ID_IDENT, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // auto-generated id, special routing
@@ -83,7 +83,7 @@ public class RowShardResolverTest extends ESTestCase {
     public void testPrimaryKeyNoRouting() {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, null);
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, null);
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, no special routing
@@ -95,7 +95,7 @@ public class RowShardResolverTest extends ESTestCase {
     public void testPrimaryKeyAndRouting() {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, special routing
@@ -107,7 +107,7 @@ public class RowShardResolverTest extends ESTestCase {
     public void testMultipleRows() {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
 
         rowShardResolver.setNextRow(row(1, "hoschi"));
         assertThat(rowShardResolver.id(), is("AgZob3NjaGkBMQ=="));
@@ -122,7 +122,7 @@ public class RowShardResolverTest extends ESTestCase {
     public void testIdPrimaryKeyNull() {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(2));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ID_IDENT), primaryKeySymbols, null, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ID_IDENT), primaryKeySymbols, null, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi", null));
 
         // generated _id, special routing
@@ -137,7 +137,7 @@ public class RowShardResolverTest extends ESTestCase {
 
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ci("id")), primaryKeySymbols, null, null);
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id")), primaryKeySymbols, null, null);
         rowShardResolver.setNextRow(row(new Object[]{null}));
     }
 
@@ -148,7 +148,7 @@ public class RowShardResolverTest extends ESTestCase {
 
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(1), new InputColumn(0));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, functions, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, null));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -31,6 +31,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
@@ -53,7 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -71,6 +72,7 @@ public class NodeStatsTest extends ESTestCase {
     private Reference idRef;
     private Reference nameRef;
     private Reference hostnameRef;
+    private NodeContext nodeCtx;
 
     @Before
     public void prepare() {
@@ -100,6 +102,7 @@ public class NodeStatsTest extends ESTestCase {
 
         nodes.add(newNode("nodeOne"));
         nodes.add(newNode("nodeTwo"));
+        nodeCtx = createNodeContext();
     }
 
     @Test
@@ -114,7 +117,7 @@ public class NodeStatsTest extends ESTestCase {
             collectPhase,
             nodes,
             txnCtx,
-            new InputFactory(getFunctions())
+            new InputFactory(nodeCtx)
         );
         iterator.loadNextBatch();
 
@@ -134,7 +137,7 @@ public class NodeStatsTest extends ESTestCase {
             collectPhase,
             nodes,
             txnCtx,
-            new InputFactory(getFunctions())
+            new InputFactory(nodeCtx)
         );
         iterator.loadNextBatch();
         verifyNoMoreInteractions(transportNodeStatsAction);
@@ -153,7 +156,7 @@ public class NodeStatsTest extends ESTestCase {
             collectPhase,
             nodes,
             txnCtx,
-            new InputFactory(getFunctions())
+            new InputFactory(nodeCtx)
         );
         iterator.loadNextBatch();
 
@@ -182,7 +185,7 @@ public class NodeStatsTest extends ESTestCase {
             collectPhase,
             nodes,
             txnCtx,
-            new InputFactory(getFunctions())
+            new InputFactory(nodeCtx)
         ));
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateObserverTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/ShardStateObserverTest.java
@@ -30,8 +30,6 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Test;

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -39,6 +39,7 @@ import io.crate.expression.reference.file.SourceLineExpression;
 import io.crate.expression.reference.file.SourceUriFailureExpression;
 import io.crate.external.S3ClientHelper;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
@@ -116,8 +117,8 @@ public class FileReadingCollectorTest extends ESTestCase {
 
     @Before
     public void prepare() throws Exception {
-        Functions functions = new Functions(Map.of());
-        inputFactory = new InputFactory(functions);
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()));
+        inputFactory = new InputFactory(nodeCtx);
     }
 
     @AfterClass

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -29,6 +29,7 @@ import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
@@ -68,8 +69,8 @@ public class FileReadingIteratorTest extends ESTestCase {
 
     @Before
     public void prepare() {
-        Functions functions = new Functions(Map.of());
-        inputFactory = new InputFactory(functions);
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()));
+        inputFactory = new InputFactory(nodeCtx);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
@@ -25,16 +25,11 @@ package io.crate.execution.engine.collect.sources;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.metadata.table.TableInfo;
 import org.elasticsearch.test.ESTestCase;
 import io.crate.testing.SqlExpressions;
-import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.is;
 
 public class NodeStatsCollectSourceTest extends ESTestCase {
@@ -72,7 +66,7 @@ public class NodeStatsCollectSourceTest extends ESTestCase {
         List<DiscoveryNode> nodes = new ArrayList<>(NodeStatsCollectSource.filterNodes(
             discoveryNodes,
             query,
-            getFunctions()));
+            sqlExpressions.nodeCtx));
         nodes.sort(Comparator.comparing(DiscoveryNode::getId));
         return nodes;
     }

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static org.hamcrest.Matchers.is;
@@ -68,7 +69,7 @@ public class FetchRowsTest extends CrateDummyClusterServiceUnitTest {
         );
         var fetchRows = FetchRows.create(
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.functions(),
+            createNodeContext(),
             fetchSources,
             List.of(
                 new FetchReference(new InputColumn(0, DataTypes.LONG), x),

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -39,6 +39,7 @@ import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -87,7 +88,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             CoordinatorTxnCtx.systemTransactionContext(),
-            internalCluster().getInstance(Functions.class),
+            new NodeContext(internalCluster().getInstance(Functions.class)),
             Settings.EMPTY,
             IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(tableSettings),
             NumberOfReplicas.fromSettings(tableSettings, state.getNodes().getSize()),

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -39,7 +39,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -57,6 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static io.crate.data.SentinelRow.SENTINEL;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -101,7 +101,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
             scheduler,
             executor,
             CoordinatorTxnCtx.systemTransactionContext(),
-            TestingHelpers.getFunctions(),
+            createNodeContext(),
             Settings.EMPTY,
             5,
             1,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.core.Is.is;
 
 public class MapRowUsingInputsTest extends ESTestCase {
@@ -55,7 +55,7 @@ public class MapRowUsingInputsTest extends ESTestCase {
 
     @Before
     public void createInputs() throws Exception {
-        InputFactory inputFactory = new InputFactory(getFunctions());
+        InputFactory inputFactory = new InputFactory(createNodeContext());
         InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         var addFunction = new Function(
             Signature.scalar(

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
@@ -50,7 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -59,21 +59,22 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
 
     private ProjectionToProjectorVisitor projectorFactory;
     private OnHeapMemoryManager memoryManager;
+    private NodeContext nodeCtx;
 
     @Before
     public void prepare() throws Exception {
-        Functions functions = getFunctions();
+        nodeCtx = createNodeContext();
         memoryManager = new OnHeapMemoryManager(bytes -> {});
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             new NodeJobsCounter(),
-            functions,
+            nodeCtx,
             THREAD_POOL,
             Settings.EMPTY,
             mock(TransportActionProvider.class, Answers.RETURNS_DEEP_STUBS),
-            new InputFactory(functions),
+            new InputFactory(nodeCtx),
             new EvaluatingNormalizer(
-                functions,
+                nodeCtx,
                 RowGranularity.SHARD,
                 r -> Literal.ofUnchecked(r.valueType(), r.valueType().sanitizeValue("1")),
                 null),

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -35,7 +35,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.RelationName;
@@ -80,7 +79,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
 
         DocTableRelation tr1 = (DocTableRelation) sources.get(T3.T1);
         expressions = new SqlExpressions(sources, tr1);
-        factory = new InputFactory(expressions.functions());
+        factory = new InputFactory(expressions.nodeCtx);
     }
 
     @Test
@@ -190,7 +189,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         FunctionImplementation impl = (FunctionImplementation) f.get(expression);
         assertThat(impl.signature(), is(function.signature()));
 
-        FunctionImplementation uncompiled = expressions.functions().getQualified(
+        FunctionImplementation uncompiled = expressions.nodeCtx.functions().getQualified(
             function,
             txnCtx.sessionSettings().searchPath()
         );

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -27,8 +27,8 @@ import io.crate.expression.reference.sys.shard.ShardRowContext;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.license.CeLicenseService;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
@@ -68,7 +68,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static io.crate.testing.TestingHelpers.refInfo;
 import static io.crate.testing.TestingHelpers.resolveCanonicalString;
 import static org.hamcrest.Matchers.is;
@@ -88,14 +88,14 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare()  {
+        NodeContext nodeCtx = createNodeContext();
         indexShard = mockIndexShard();
-        Functions functions = getFunctions();
         CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
-        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
+        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, nodeCtx);
         schemas = new Schemas(
             Map.of("sys", new SysSchemaInfo(this.clusterService, crateSettings, new CeLicenseService())),
             clusterService,
-            new DocSchemaInfoFactory(new TestingDocTableInfoFactory(Collections.emptyMap()), (ident, state) -> null , functions, udfService)
+            new DocSchemaInfoFactory(new TestingDocTableInfoFactory(Collections.emptyMap()), (ident, state) -> null , nodeCtx, udfService)
         );
         resolver = new ShardReferenceResolver(schemas, new ShardRowContext(indexShard, clusterService));
         sysShards = schemas.getTableInfo(SysShardsTableInfo.IDENT);

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
@@ -33,7 +33,7 @@ public class AddFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTimestampTypeValidation() {
-        functions.get(
+        sqlExpressions.nodeCtx.functions().get(
             null,
             ArithmeticFunctions.Names.ADD,
             List.of(Literal.of(DataTypes.TIMESTAMPZ, null), Literal.of(DataTypes.TIMESTAMPZ, null)),

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -46,20 +46,20 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepareRandom() {
-        random = (RandomFunction) functions.get(
+        random = (RandomFunction) sqlExpressions.nodeCtx.functions().get(
             null, RandomFunction.NAME, Collections.emptyList(), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test
     public void testEvaluateRandom() {
-        assertThat(random.evaluate(txnCtx, new Input[0]),
+        assertThat(random.evaluate(txnCtx, sqlExpressions.nodeCtx, new Input[0]),
             is(allOf(greaterThanOrEqualTo(0.0), lessThan(1.0))));
     }
 
     @Test
     public void normalizeReference() {
         Function function = new Function(random.signature(), Collections.emptyList(), DataTypes.DOUBLE);
-        Function normalized = (Function) random.normalizeSymbol(function, txnCtx);
+        Function normalized = (Function) random.normalizeSymbol(function, txnCtx, sqlExpressions.nodeCtx);
         assertThat(normalized, sameInstance(function));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -256,7 +256,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
             parseTypeSignature("V"),
             parseTypeSignature("V")
         ).withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
-        var functionImpl = functions.getQualified(
+        var functionImpl = sqlExpressions.nodeCtx.functions().getQualified(
             signature,
             List.of(DataTypes.UNTYPED_OBJECT, returnType),
             returnType

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -23,7 +23,6 @@
 package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import io.crate.metadata.Functions;
 import io.crate.testing.SqlExpressions;
 import org.junit.Test;
 
@@ -35,7 +34,6 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeCurrentSchemaDefaultSchema() throws Exception {
         sqlExpressions = new SqlExpressions(tableSources);
-        functions = sqlExpressions.getInstance(Functions.class);
         assertNormalize("current_schema()", isLiteral("doc"), false);
     }
 
@@ -43,7 +41,6 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeCurrentSchemaCustomSchema() throws Exception {
         sqlExpressions = new SqlExpressions(tableSources);
         sqlExpressions.setDefaultSchema("custom_schema");
-        functions = sqlExpressions.getInstance(Functions.class);
         assertNormalize("current_schema()", isLiteral("custom_schema"), false);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunctionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.metadata.FunctionProvider;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.OidHash;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PgFunctionIsVisibleFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void test_null_oid_results_in_null() {
+        assertEvaluate("pg_function_is_visible(null)", null);
+    }
+
+    @Test
+    public void test_system_function_visibility() {
+        assertEvaluate("pg_function_is_visible(0)",false);
+        assertEvaluate("pg_function_is_visible(-14)",false);
+        for (List<FunctionProvider> providers : sqlExpressions.nodeCtx.functions().functionResolvers().values()) {
+            for (FunctionProvider sysFunc : providers) {
+                Signature signature = sysFunc.getSignature();
+                Integer funcOid = OidHash.functionOid(signature);
+                assertEvaluate("pg_function_is_visible(" + funcOid + ")", true);
+            }
+        }
+    }
+}

--- a/server/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/UnnestFunctionTest.java
@@ -93,7 +93,7 @@ public class UnnestFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_unnest_bound_signature_return_type_resolves_correct_row_type_parameters() {
         var function = (Function) sqlExpressions.asSymbol("unnest([1], ['a'], [{}])");
-        var functionImplementation = (TableFunctionImplementation<?>) functions.getQualified(
+        var functionImplementation = (TableFunctionImplementation<?>) sqlExpressions.nodeCtx.functions().getQualified(
             function,
             txnCtx.sessionSettings().searchPath()
         );

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -96,7 +96,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     public void test_function_return_type_of_the_next_nested_item() {
         Function function = (Function) sqlExpressions.asSymbol("_values([['a', 'b']])");
 
-        var funcImplementation = (TableFunctionImplementation<?>) functions.getQualified(
+        var funcImplementation = (TableFunctionImplementation<?>) sqlExpressions.nodeCtx.functions().getQualified(
             function,
             txnCtx.sessionSettings().searchPath()
         );
@@ -117,7 +117,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_bound_signature_return_type_resolves_correct_row_type_parameters() {
         var function = (Function) sqlExpressions.asSymbol("_values([1], ['a'], [{}])");
-        var functionImplementation = (TableFunctionImplementation<?>) functions.getQualified(
+        var functionImplementation = (TableFunctionImplementation<?>) sqlExpressions.nodeCtx.functions().getQualified(
             function,
             txnCtx.sessionSettings().searchPath()
         );

--- a/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -23,6 +23,7 @@
 package io.crate.expression.udf;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -32,12 +33,12 @@ import org.elasticsearch.cluster.service.ClusterService;
 import javax.annotation.Nullable;
 import javax.script.ScriptException;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.mockito.Mockito.mock;
 
 public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
-    UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class), getFunctions());
+    UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class), createNodeContext());
 
     static final UDFLanguage DUMMY_LANG = new UDFLanguage() {
         @Override
@@ -79,7 +80,7 @@ public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
         }
 
         @Override
-        public Integer evaluate(TransactionContext txnCtx, Input<Integer>[] args) {
+        public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Integer>[] args) {
             return RESULT;
         }
     }

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
@@ -27,7 +27,6 @@ import io.crate.analyze.TableDefinitions;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.FunctionName;
-import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.testing.SQLExecutor;
@@ -45,10 +44,8 @@ import java.util.Map;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static java.util.stream.Collectors.toList;
 
-
 public class UserDefinedFunctionsTest extends UdfUnitTest {
 
-    private Functions functions;
     private SqlExpressions sqlExpressions;
 
     private Map<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
@@ -60,7 +57,6 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
             .build();
         DocTableInfo users = sqlExecutor.schemas().getTableInfo(new RelationName("doc", "users"));
         sqlExpressions = new SqlExpressions(Map.of(users.ident(), new DocTableRelation(users)));
-        functions = sqlExpressions.functions();
         udfService.registerLanguage(DUMMY_LANG);
     }
 
@@ -84,7 +80,7 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
         var resolvers = functionImplementations.computeIfAbsent(
             functionName, k -> new ArrayList<>());
         resolvers.add(udfService.buildFunctionResolver(udf));
-        functions.registerUdfFunctionImplementationsForSchema(
+        sqlExpressions.nodeCtx.functions().registerUdfFunctionImplementationsForSchema(
             schema,
             functionImplementations);
     }

--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -52,6 +52,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
@@ -449,6 +450,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
 
         Analyzer analyzer = internalCluster().getInstance(Analyzer.class, nodeName);
         Planner planner = internalCluster().getInstance(Planner.class, nodeName);
+        NodeContext nodeCtx = internalCluster().getInstance(NodeContext.class, nodeName);
 
         SessionContext sessionContext = new SessionContext(
             Option.NONE, User.CRATE_USER, sqlExecutor.getCurrentSchema());
@@ -458,8 +460,8 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
             planner.currentClusterState(),
             routingProvider,
             UUID.randomUUID(),
-            planner.functions(),
             coordinatorTxnCtx,
+            nodeCtx,
             0,
             null
         );

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -25,7 +25,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.auth.user.User;
-import io.crate.exceptions.ConversionException;
 import io.crate.lucene.match.CrateRegexQuery;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -27,7 +27,7 @@ import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -45,19 +45,19 @@ import javax.script.ScriptException;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static io.crate.metadata.SearchPath.pathWithPGCatalogAndDoc;
-import static io.crate.testing.TestingHelpers.getFunctions;
 
 public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
     private DocSchemaInfo docSchemaInfo;
-    private Functions functions;
     private UserDefinedFunctionService udfService;
+    private NodeContext nodeCtx;
 
     @Before
     public void setup() throws Exception {
-        functions = getFunctions();
-        udfService = new UserDefinedFunctionService(clusterService, functions);
+        nodeCtx = createNodeContext();
+        udfService = new UserDefinedFunctionService(clusterService, nodeCtx);
         udfService.registerLanguage(new UDFLanguage() {
             @Override
             public Scalar createFunctionImplementation(UserDefinedFunctionMetadata metadata,
@@ -68,7 +68,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
                 }
                 return new Scalar<>() {
                     @Override
-                    public Object evaluate(TransactionContext txnCtx, Input[] args) {
+                    public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
                         return null;
                     }
 
@@ -98,7 +98,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
                 return "burlesque";
             }
         });
-        docSchemaInfo = new DocSchemaInfo("doc", clusterService, functions, udfService,
+        docSchemaInfo = new DocSchemaInfo("doc", clusterService, nodeCtx, udfService,
             (ident, state) -> null, new TestingDocTableInfoFactory(Map.of()));
     }
 
@@ -117,10 +117,10 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
         udfService.updateImplementations("my_schema", metadata.functionsMetadata().stream());
 
-        assertThat(functions.get("my_schema", "valid", List.of(), pathWithPGCatalogAndDoc()), Matchers.notNullValue());
+        assertThat(nodeCtx.functions().get("my_schema", "valid", List.of(), pathWithPGCatalogAndDoc()), Matchers.notNullValue());
 
         expectedException.expectMessage("Unknown function: my_schema.invalid()");
-        functions.get("my_schema", "invalid", List.of(), pathWithPGCatalogAndDoc());
+        nodeCtx.functions().get("my_schema", "invalid", List.of(), pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
@@ -24,7 +24,7 @@ package io.crate.metadata.doc;
 
 import io.crate.Constants;
 import io.crate.exceptions.RelationUnknown;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.test.ESTestCase;
@@ -41,12 +41,12 @@ import java.util.Collections;
 import java.util.Locale;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 
 
 public class DocTableInfoBuilderTest extends ESTestCase {
 
-    private Functions functions = getFunctions();
+    private NodeContext nodeCtx = createNodeContext();
 
     private String randomSchema() {
         if (randomBoolean()) {
@@ -82,7 +82,7 @@ public class DocTableInfoBuilderTest extends ESTestCase {
 
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
         DocTableInfoBuilder builder = new DocTableInfoBuilder(
-            functions,
+            nodeCtx,
             new RelationName(schemaName, "test"),
             state,
             new IndexNameExpressionResolver()

--- a/server/src/test/java/io/crate/metadata/doc/TestingDocTableInfoFactory.java
+++ b/server/src/test/java/io/crate/metadata/doc/TestingDocTableInfoFactory.java
@@ -23,7 +23,7 @@
 package io.crate.metadata.doc;
 
 import io.crate.exceptions.RelationUnknown;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -41,10 +41,10 @@ public class TestingDocTableInfoFactory implements DocTableInfoFactory {
     }
 
     public TestingDocTableInfoFactory(Map<RelationName, DocTableInfo> tables,
-                                      Functions functions,
+                                      NodeContext nodeCtx,
                                       IndexNameExpressionResolver indexNameExpressionResolver) {
         this.tables = tables;
-        this.internalFactory = new InternalDocTableInfoFactory(functions, indexNameExpressionResolver);
+        this.internalFactory = new InternalDocTableInfoFactory(nodeCtx, indexNameExpressionResolver);
     }
 
     @Override

--- a/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
+++ b/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
@@ -28,10 +28,13 @@ import io.crate.metadata.table.ConstraintInfo;
 import io.crate.metadata.view.ViewInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static io.crate.metadata.pgcatalog.OidHash.constraintOid;
 import static io.crate.metadata.pgcatalog.OidHash.relationOid;
@@ -69,5 +72,16 @@ public class OidHashTest extends CrateDummyClusterServiceUnitTest {
     public void testConstraintOid() {
         assertThat(constraintOid(T1.fqn(), "id_pk", ConstraintInfo.Type.PRIMARY_KEY.toString()),
             is(279835673));
+    }
+
+    @Test
+    public void test_argTypesToStr() {
+        assertThat(OidHash
+                       .argTypesToStr(List.of(
+                           TypeSignature.parseTypeSignature("array(array(E))"),
+                           TypeSignature.parseTypeSignature("array(Q)"),
+                           TypeSignature.parseTypeSignature("P"),
+                           DataTypes.INTEGER.getTypeSignature()
+                       )), is("array_array_E array_Q P integer"));
     }
 }

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.SymbolEvaluator;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.LoadedRules;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,23 +39,20 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 public class SessionSettingRegistryTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     private SessionContext sessionContext = SessionContext.systemSessionContext();
-
-    private Functions functions = getFunctions();
+    private NodeContext nodeCtx = createNodeContext();
     private Function<Symbol, Object> eval = s -> SymbolEvaluator.evaluateWithoutParams(
         CoordinatorTxnCtx.systemTransactionContext(),
-        functions,
+        nodeCtx,
         s
     );
 

--- a/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -48,7 +48,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.Routing;
@@ -122,7 +122,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static io.crate.metadata.RelationName.fromIndexName;
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.elasticsearch.index.mapper.MapperService.MergeReason.MAPPING_RECOVERY;
 import static org.elasticsearch.index.shard.IndexShardTestCase.EMPTY_EVENT_LISTENER;
 import static org.elasticsearch.index.translog.Translog.UNSET_AUTO_GENERATED_TIMESTAMP;
@@ -136,7 +136,7 @@ public abstract class AggregationTest extends ESTestCase {
 
     protected static final RamAccounting RAM_ACCOUNTING = RamAccounting.NO_ACCOUNTING;
 
-    protected Functions functions;
+    protected NodeContext nodeCtx;
     protected MemoryManager memoryManager;
     private ThreadPool threadPool;
 
@@ -147,7 +147,7 @@ public abstract class AggregationTest extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        functions = getFunctions();
+        nodeCtx = createNodeContext();
         threadPool = new TestThreadPool(getClass().getName(), Settings.EMPTY);
         memoryManager = new OnHeapMemoryManager(RAM_ACCOUNTING::addBytes);
         indicesModule = new IndicesModule(List.of(new MapperPlugin() {
@@ -184,7 +184,7 @@ public abstract class AggregationTest extends ESTestCase {
                                      List<DataType<?>> actualArgumentTypes,
                                      DataType<?> actualReturnType,
                                      Object[][] data) throws Exception {
-        var aggregationFunction = (AggregationFunction) functions.get(
+        var aggregationFunction = (AggregationFunction) nodeCtx.functions().get(
             null,
             maybeUnboundSignature.getName().name(),
             Lists2.map(actualArgumentTypes, t -> new InputColumn(0, t)),
@@ -311,10 +311,10 @@ public abstract class AggregationTest extends ESTestCase {
             4096);
 
         var batchIterator = DocValuesAggregates.tryOptimize(
-            functions,
+            nodeCtx,
             shard,
             mock(DocTableInfo.class),
-            new LuceneQueryBuilder(functions),
+            new LuceneQueryBuilder(nodeCtx),
             shard.mapperService()::fullName,
             collectPhase,
             collectTask
@@ -513,7 +513,7 @@ public abstract class AggregationTest extends ESTestCase {
 
     protected Symbol normalize(String functionName, Symbol... args) {
         List<Symbol> arguments = Arrays.asList(args);
-        AggregationFunction<?,?> function = (AggregationFunction<?, ?>) functions.get(
+        AggregationFunction<?,?> function = (AggregationFunction<?, ?>) nodeCtx.functions().get(
             null,
             functionName,
             arguments,
@@ -521,12 +521,13 @@ public abstract class AggregationTest extends ESTestCase {
         );
         return function.normalizeSymbol(
             new Function(function.signature(), arguments, function.partialType()),
-            new CoordinatorTxnCtx(SessionContext.systemSessionContext())
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext()),
+            nodeCtx
         );
     }
 
     public void assertHasDocValueAggregator(String functionName, List<DataType<?>> argumentTypes) {
-        var aggregationFunction = (AggregationFunction<?, ?>) functions.get(
+        var aggregationFunction = (AggregationFunction<?, ?>) nodeCtx.functions().get(
             null,
             functionName,
             InputColumn.mapToInputColumns(argumentTypes),

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -88,7 +88,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan.docKeys().size(), is(2));
         List<String> docKeys = Lists.newArrayList(plan.docKeys())
             .stream()
-            .map(x -> x.getId(txnCtx, e.functions(), Row.EMPTY, SubQueryResults.EMPTY))
+            .map(x -> x.getId(txnCtx, e.nodeCtx, Row.EMPTY, SubQueryResults.EMPTY))
             .collect(Collectors.toList());
 
         assertThat(docKeys, Matchers.containsInAnyOrder("1", "2"));

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -26,29 +26,21 @@ import com.google.common.collect.ImmutableList;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.node.management.ExplainPlan;
-import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
 

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -54,8 +54,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             clusterService.state(),
             new RoutingProvider(Randomness.get().nextInt(), Collections.emptyList()),
             UUID.randomUUID(),
-            e.functions(),
             new CoordinatorTxnCtx(SessionContext.systemSessionContext()),
+            e.nodeCtx,
             0,
             null
         );

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -68,7 +68,6 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.testing.SymbolMatchers;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -126,7 +126,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(updateById.assignmentByTargetCol().values(), contains(isLiteral("Vogon lyric fan")));
         assertThat(updateById.docKeys().size(), is(1));
 
-        assertThat(updateById.docKeys().getOnlyKey().getId(txnCtx, e.functions(), Row.EMPTY, SubQueryResults.EMPTY), is("1"));
+        assertThat(updateById.docKeys().getOnlyKey().getId(txnCtx, e.nodeCtx, Row.EMPTY, SubQueryResults.EMPTY), is("1"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -73,7 +73,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
         QueriedSelectRelation queriedTable = e.analyze(statement);
         DocTableRelation table = ((DocTableRelation) queriedTable.from().get(0));
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
-            e.functions(),
+            e.nodeCtx,
             RowGranularity.CLUSTER,
             null,
             table
@@ -83,7 +83,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
             queriedTable.where(),
             table.tableInfo(),
             e.getPlannerContext(clusterService.state()).transactionContext(),
-            e.functions()
+            e.nodeCtx
         );
     }
 

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -52,7 +52,6 @@ import io.crate.planner.Merge;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.join.Join;
-import io.crate.planner.operators.LogicalPlannerTest;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SymbolMatchers;
@@ -60,7 +59,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/server/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -30,6 +30,7 @@ import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.distribution.DistributionInfo;
@@ -44,13 +45,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class RoutedCollectPhaseTest extends ESTestCase {
+
+    private NodeContext nodeCtx = createNodeContext();
 
     @Test
     public void testStreaming() throws Exception {
@@ -98,7 +101,7 @@ public class RoutedCollectPhaseTest extends ESTestCase {
             DistributionInfo.DEFAULT_SAME_NODE
         );
         collect.orderBy(new OrderBy(Collections.singletonList(toInt10)));
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         RoutedCollectPhase normalizedCollect = collect.normalize(
             normalizer, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
 
@@ -120,7 +123,7 @@ public class RoutedCollectPhaseTest extends ESTestCase {
             DistributionInfo.DEFAULT_SAME_NODE
         );
         collect.nodePageSizeHint(10);
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         RoutedCollectPhase normalizedCollect = collect.normalize(
             normalizer, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
 
@@ -140,7 +143,7 @@ public class RoutedCollectPhaseTest extends ESTestCase {
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_SAME_NODE
         );
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         RoutedCollectPhase normalizedCollect = collect.normalize(
             normalizer, new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
 

--- a/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
@@ -52,12 +52,12 @@ public class DeletePartitionsTest extends CrateDummyClusterServiceUnitTest {
 
         Object[] args1 = {"1395874800000"};
         assertThat(
-            plan.getIndices(txnCtx, e.functions(), new RowN(args1), SubQueryResults.EMPTY),
+            plan.getIndices(txnCtx, e.nodeCtx, new RowN(args1), SubQueryResults.EMPTY),
             Matchers.containsInAnyOrder(".partitioned.parted_pks.04732cpp6ks3ed1o60o30c1g"));
 
         Object[] args2 = {"1395961200000"};
         assertThat(
-            plan.getIndices(txnCtx, e.functions(), new RowN(args2), SubQueryResults.EMPTY),
+            plan.getIndices(txnCtx, e.nodeCtx, new RowN(args2), SubQueryResults.EMPTY),
             Matchers.containsInAnyOrder(".partitioned.parted_pks.04732cpp6ksjcc9i60o30c1g"));
     }
 

--- a/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
@@ -27,6 +27,7 @@ import io.crate.data.Row;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
@@ -111,7 +112,7 @@ public class ResetSettingsPlanTest extends ESTestCase {
     private Function<Symbol, Object> symbolEvaluator(Row row) {
         return x -> SymbolEvaluator.evaluate(
             TransactionContext.of(new SessionSettings("", SearchPath.createSearchPathFrom(""))),
-            new Functions(Map.of()),
+            new NodeContext(new Functions(Map.of())),
             x,
             row,
             SubQueryResults.EMPTY);

--- a/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static io.crate.planner.node.ddl.UpdateSettingsPlan.buildSettingsFrom;
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
@@ -54,7 +54,7 @@ public class UpdateSettingsPlanTest extends ESTestCase {
     private Function<Symbol, Object> symbolEvaluator(Row row) {
         return x -> SymbolEvaluator.evaluate(
             TransactionContext.of(new SessionSettings("", SearchPath.createSearchPathFrom(""))),
-            getFunctions(),
+            createNodeContext(),
             x,
             row,
             SubQueryResults.EMPTY);

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -77,7 +77,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(
             ctx,
-            new ProjectionBuilder(e.functions()),
+            new ProjectionBuilder(e.nodeCtx),
             TopN.NO_LIMIT,
             0,
             null,

--- a/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -26,7 +26,6 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.hamcrest.Matchers;

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -28,7 +28,7 @@ import io.crate.auth.user.User;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.planner.optimizer.rule.MergeFilters;
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static  io.crate.analyze.SymbolEvaluator.evaluateWithoutParams;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -46,10 +46,11 @@ import static org.hamcrest.Matchers.is;
 
 public class OptimizerRuleSessionSettingProviderTest {
 
-    private Functions functions = getFunctions();
+    private NodeContext nodeCtx = createNodeContext();
+
     private Function<Symbol, Object> eval = x -> evaluateWithoutParams(
         CoordinatorTxnCtx.systemTransactionContext(),
-        functions,
+        nodeCtx,
         x
     );
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -26,7 +26,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
@@ -43,14 +42,12 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Map;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
 
 public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     private SqlExpressions e;
     private AbstractTableRelation tr1;
-    private Functions functions = getFunctions();
 
     @Before
     public void setUp() throws Exception {
@@ -72,7 +69,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
         assertThat(match.isPresent(), Matchers.is(true));
         assertThat(match.value(), Matchers.sameInstance(parentFilter));
 
-        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures(), new TableStats(), CoordinatorTxnCtx.systemTransactionContext(), functions);
+        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures(), new TableStats(), CoordinatorTxnCtx.systemTransactionContext(), e.nodeCtx);
         assertThat(mergedFilter.query(), isSQL("((doc.t2.y > 10) AND (doc.t1.x > 10))"));
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -36,7 +36,6 @@ import io.crate.expression.operator.Operators;
 import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
-import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -54,14 +53,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.is;
 
 public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest {
 
     private SqlExpressions e;
-    private Functions functions = getFunctions();
     private AbstractTableRelation<?> tr1;
     private PlannerContext plannerContext;
 
@@ -102,7 +99,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         );
         var plan = (io.crate.planner.node.dql.Collect) collect.build(
             plannerContext,
-            new ProjectionBuilder(functions),
+            new ProjectionBuilder(e.nodeCtx),
             TopN.NO_LIMIT,
             0,
             null,

--- a/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -1,5 +1,24 @@
-
-
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
 
 package io.crate.planner.selectivity;
 

--- a/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
@@ -85,7 +85,7 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
             plan.copyTo(),
             e.getPlannerContext(clusterService.state()),
             new TableStats(),
-            new ProjectionBuilder(e.functions()),
+            new ProjectionBuilder(e.nodeCtx),
             Row.EMPTY,
             SubQueryResults.EMPTY);
     }

--- a/server/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -59,6 +59,7 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testEachStatementReceivesCorrectParams() throws Throwable {
+
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
             .addTable("create table t1 (x int)")
             .build();
@@ -81,7 +82,7 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
         Planner planner = new Planner(
             Settings.EMPTY,
             clusterService,
-            sqlExecutor.functions(),
+            sqlExecutor.nodeCtx,
             new TableStats(),
             null,
             null,
@@ -99,6 +100,7 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier executor = mock(DependencyCarrier.class, Answers.RETURNS_MOCKS);
         Session session = new Session(
+            sqlExecutor.nodeCtx,
             sqlExecutor.analyzer,
             planner,
             new JobsLogs(() -> false),

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -88,6 +88,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() {
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
         sqlOperations = new SQLOperations(
+            e.nodeCtx,
             e.analyzer,
             e.planner,
             () -> mock(DependencyCarrier.class),

--- a/server/src/test/java/io/crate/protocols/postgres/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/RegprocTypeTest.java
@@ -43,8 +43,8 @@ public class RegprocTypeTest extends BasePGTypeTest<Regproc> {
     @Test
     public void test_write_binary_value_writes_only_oid() {
         var regproc = Regproc.of(
-            OidHash.functionOid("test"),
-            String.valueOf(OidHash.functionOid("test"))
+            OidHash.regprocOid("test"),
+            String.valueOf(OidHash.regprocOid("test"))
         );
         assertBytesWritten(
             regproc,
@@ -54,7 +54,7 @@ public class RegprocTypeTest extends BasePGTypeTest<Regproc> {
 
     @Test
     public void test_read_binary_value_reads_only_oid() {
-        var oid = OidHash.functionOid("func");
+        var oid = OidHash.regprocOid("func");
         var regproc = Regproc.of(oid, String.valueOf(oid));
         assertBytesReadBinary(
             ByteBuffer.allocate(4).putInt(regproc.oid()).array(),

--- a/server/src/test/java/io/crate/testing/SleepScalarFunction.java
+++ b/server/src/test/java/io/crate/testing/SleepScalarFunction.java
@@ -22,6 +22,7 @@
 package io.crate.testing;
 
 import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -51,7 +52,7 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
 
     @SafeVarargs
     @Override
-    public final Boolean evaluate(TransactionContext txnCtx, Input<Long>... args) {
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Long>... args) {
         long millis = (args.length > 0) ? args[0].value() : 1000L;
         try {
             Thread.sleep(millis);

--- a/server/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/test/java/io/crate/testing/SqlExpressions.java
@@ -35,28 +35,21 @@ import io.crate.analyze.relations.ParentRelations;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.auth.user.User;
-import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
-import io.crate.execution.engine.window.WindowFunctionModule;
 import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.expression.operator.OperatorModule;
-import io.crate.expression.predicate.PredicateModule;
-import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.tablefunctions.TableFunctionModule;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.settings.session.SessionSettingModule;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.parser.SqlParser;
 import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.inject.Injector;
-import org.elasticsearch.common.inject.ModulesBuilder;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+
+import static io.crate.testing.TestingHelpers.createNodeContext;
 
 import static org.mockito.Mockito.mock;
 
@@ -64,54 +57,40 @@ public class SqlExpressions {
 
     private final ExpressionAnalyzer expressionAnalyzer;
     private final ExpressionAnalysisContext expressionAnalysisCtx;
-    private final Injector injector;
     private final CoordinatorTxnCtx coordinatorTxnCtx;
     private final EvaluatingNormalizer normalizer;
-    private final Functions functions;
+    public final NodeContext nodeCtx;
 
-    public SqlExpressions(Map<RelationName, AnalyzedRelation> sources) {
-        this(sources, null, User.CRATE_USER);
+    public SqlExpressions(Map<RelationName, AnalyzedRelation> sources, AbstractModule... additionalModules) {
+        this(sources, null, User.CRATE_USER, additionalModules);
     }
 
     public SqlExpressions(Map<RelationName, AnalyzedRelation> sources,
-                          @Nullable FieldResolver fieldResolver) {
-        this(sources, fieldResolver, User.CRATE_USER);
+                          @Nullable FieldResolver fieldResolver,
+                          AbstractModule... additionalModules) {
+        this(sources, fieldResolver, User.CRATE_USER, additionalModules);
     }
 
     public SqlExpressions(Map<RelationName, AnalyzedRelation> sources,
                           @Nullable FieldResolver fieldResolver,
                           User user,
                           AbstractModule... additionalModules) {
-        ModulesBuilder modulesBuilder = new ModulesBuilder()
-            .add(new SessionSettingModule())
-            .add(new OperatorModule())
-            .add(new AggregationImplModule())
-            .add(new ScalarFunctionModule())
-            .add(new WindowFunctionModule())
-            .add(new TableFunctionModule())
-            .add(new PredicateModule());
-        if (additionalModules != null) {
-            for (AbstractModule module : additionalModules) {
-                modulesBuilder.add(module);
-            }
-        }
-        injector = modulesBuilder.createInjector();
-        functions = injector.getInstance(Functions.class);
+        this.nodeCtx = createNodeContext(additionalModules);
         coordinatorTxnCtx = new CoordinatorTxnCtx(new SessionContext(Option.NONE, user));
         expressionAnalyzer = new ExpressionAnalyzer(
-            functions,
             coordinatorTxnCtx,
+            nodeCtx,
             ParamTypeHints.EMPTY,
             new FullQualifiedNameFieldProvider(
                 sources,
                 ParentRelations.NO_PARENTS,
                 coordinatorTxnCtx.sessionContext().searchPath().currentSchema()),
             new SubqueryAnalyzer(
-                new RelationAnalyzer(functions, mock(Schemas.class)),
+                new RelationAnalyzer(nodeCtx, mock(Schemas.class)),
                 new StatementAnalysisContext(ParamTypeHints.EMPTY, Operation.READ, coordinatorTxnCtx)
             )
         );
-        normalizer = new EvaluatingNormalizer(functions, RowGranularity.DOC, null, fieldResolver);
+        normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.DOC, null, fieldResolver);
         expressionAnalysisCtx = new ExpressionAnalysisContext();
     }
 
@@ -125,14 +104,6 @@ public class SqlExpressions {
 
     public Symbol normalize(Symbol symbol) {
         return normalizer.normalize(symbol, coordinatorTxnCtx);
-    }
-
-    public <T> T getInstance(Class<T> clazz) {
-        return injector.getInstance(clazz);
-    }
-
-    public Functions functions() {
-        return functions;
     }
 
     public void setDefaultSchema(String schema) {

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -40,7 +40,7 @@ public class RegprocTypeTest extends ESTestCase {
     public void test_implicit_cast_regproc_to_integer() {
         assertThat(
             DataTypes.INTEGER.implicitCast(Regproc.of("func")),
-            is(OidHash.functionOid("func")));
+            is(OidHash.regprocOid("func")));
     }
 
     @Test


### PR DESCRIPTION
The function's OID is for internal use. In the case of functions, as they can be overloaded, we need to discriminate not only by schema/name but also by signature. 

System functions are registered on startup, it is appropriate to calculate their oid/signature mapping when the various modules do register them. For symmetry, user defined options are also oid/signature mapped, but this is done by monitoring the cluster registration/deregistration flow.  

Specifically, the query executed to retrieve function information:

```
SELECT current_database() AS FUNCTION_CAT, 
       n.nspname AS FUNCTION_SCHEM, 
       p.proname AS FUNCTION_NAME,  
       d.description AS REMARKS,  
       CASE    
           WHEN (format_type(p.prorettype, null) = 'unknown') THEN 0   
           WHEN (substring(pg_get_function_result(p.oid) from 0 for 6) = 'TABLE') OR (substring(pg_get_function_result(p.oid) from 0 for 6) = 'SETOF') THEN 2   
           ELSE 1 
       END AS FUNCTION_TYPE,  
       p.proname || '_' || p.oid AS SPECIFIC_NAME 
FROM pg_catalog.pg_proc p INNER JOIN pg_catalog.pg_namespace n ON p.pronamespace=n.oid LEFT JOIN pg_catalog.pg_description d ON p.oid=d.objoid 
WHERE pg_function_is_visible(p.oid) 
ORDER BY FUNCTION_SCHEM, FUNCTION_NAME, p.oid::text
```