### PR TITLE
Add doc-value aggregator for variance aggregation.

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -80,7 +80,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                     supportedType.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature()),
                 (signature, boundSignature) ->
-                    new SumAggregation<>(supportedType, DataTypes.LONG, add, sub, signature, boundSignature)
+                    new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
             );
         }
     }
@@ -98,15 +98,6 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                            final BinaryOperator<T> subtraction,
                            Signature signature,
                            Signature boundSignature) {
-        this(returnType, returnType, addition, subtraction, signature, boundSignature);
-    }
-
-    private SumAggregation(final DataType<?> inputType,
-                           final DataType<T> returnType,
-                           final BinaryOperator<T> addition,
-                           final BinaryOperator<T> subtraction,
-                           Signature signature,
-                           Signature boundSignature) {
         this.addition = addition;
         this.subtraction = subtraction;
         this.returnType = returnType;
@@ -120,7 +111,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         this.signature = signature;
-        this.boundSignature = signature;
+        this.boundSignature = boundSignature;
     }
 
     @Nullable

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
@@ -30,29 +29,38 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
 public class SumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
+    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
         return executeAggregation("sum", dataType, data);
     }
 
     @Test
     public void testReturnType() throws Exception {
-        DataType type = DataTypes.DOUBLE;
-        assertEquals(type, getSum(type).info().returnType());
+        DataType<?> type = DataTypes.DOUBLE;
+        assertThat(getSum(type).boundSignature().getReturnType(), is(type.getTypeSignature()));
 
         type = DataTypes.FLOAT;
-        assertEquals(type, getSum(type).info().returnType());
+        assertThat(getSum(type).boundSignature().getReturnType(), is(type.getTypeSignature()));
 
         type = DataTypes.LONG;
-        assertEquals(type, getSum(type).info().returnType());
-        assertEquals(type, getSum(DataTypes.INTEGER).info().returnType());
-        assertEquals(type, getSum(DataTypes.SHORT).info().returnType());
-        assertEquals(type, getSum(DataTypes.BYTE).info().returnType());
+        assertThat(getSum(type).boundSignature().getReturnType(), is(type.getTypeSignature()));
+        assertThat(getSum(DataTypes.INTEGER).boundSignature().getReturnType(), is(type.getTypeSignature()));
+        assertThat(getSum(DataTypes.SHORT).boundSignature().getReturnType(), is(type.getTypeSignature()));
+        assertThat(getSum(DataTypes.BYTE).boundSignature().getReturnType(), is(type.getTypeSignature()));
     }
 
-    private FunctionImplementation getSum(DataType type) {
-        return functions.get(null, "sum", ImmutableList.of(Literal.of(type, null)), SearchPath.pathWithPGCatalogAndDoc());
+    private FunctionImplementation getSum(DataType<?> type) {
+        return functions.get(
+            null,
+            "sum",
+            List.of(Literal.of(type, null)),
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
@@ -33,6 +32,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.is;
+
 public class VarianceAggregationTest extends AggregationTest {
 
     private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
@@ -41,15 +42,18 @@ public class VarianceAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMPZ))) {
+        for (DataType<?> type : Iterables.concat(
+            DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE,
-                getVariance(type).info().returnType());
+            assertThat(
+                getVariance(type).boundSignature().getReturnType(),
+                is(DataTypes.DOUBLE.getTypeSignature())
+            );
         }
     }
 
     private FunctionImplementation getVariance(DataType<?> type) {
-        return functions.get(null, "variance", ImmutableList.of(Literal.of(type, null)), SearchPath.pathWithPGCatalogAndDoc());
+        return functions.get(null, "variance", List.of(Literal.of(type, null)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Before:
```
# Running setUp
# Running benchmark

## Running Query:
   Name: global variance-long
   Statement:
     select variance(duration) from uservisits
   Concurrency: 1
   Iterations: 500
100%|███████████████████████████████████████████████████████████| 500/500 [00:30<00:00, 16.62 requests/s]
Runtime (in ms):
    mean:    58.263 ± 3.359
    min/max: 37.833 → 730.229
Percentile:
    50:   48.920 ± 38.327 (stdev)
    95:   104.321
    99.9: 730.229

## Running Query:
   Name: global variance-double
   Statement:
     select variance("adRevenue") from uservisits
   Concurrency: 1
   Iterations: 500
100%|███████████████████████████████████████████████████████████| 500/500 [00:33<00:00, 14.98 requests/s]
Runtime (in ms):
    mean:    64.909 ± 2.987
    min/max: 46.892 → 540.260
Percentile:
    50:   58.078 ± 34.077 (stdev)
    95:   89.473
    99.9: 540.260
```

After:
```
# Running setUp
# Running benchmark

## Running Query:
   Name: global variance-long
   Statement:
     select variance(duration) from uservisits
   Concurrency: 1
   Iterations: 500
100%|███████████████████████████████████████████████████████████| 500/500 [00:11<00:00, 43.70 requests/s]
Runtime (in ms):
    mean:    21.141 ± 0.333
    min/max: 16.002 → 42.931
Percentile:
    50:   20.051 ± 3.797 (stdev)
    95:   29.713
    99.9: 42.931

## Running Query:
   Name: global variance-double
   Statement:
     select variance("adRevenue") from uservisits
   Concurrency: 1
   Iterations: 500
100%|███████████████████████████████████████████████████████████| 500/500 [00:12<00:00, 38.94 requests/s]
Runtime (in ms):
    mean:    24.418 ± 2.144
    min/max: 17.440 → 329.129
Percentile:
    50:   21.321 ± 24.460 (stdev)
    95:   30.445
    99.9: 329.129
```

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
