### PR TITLE
Debounce computations in TableHealthService

### DIFF
--- a/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -207,9 +207,7 @@ public class TableHealthService {
         }
     }
 
-    private static class HealthResultReceiver implements ResultReceiver {
-
-        private static final Logger LOGGER = LogManager.getLogger(TableHealthService.HealthResultReceiver.class);
+    private static class HealthResultReceiver implements ResultReceiver<Map<TablePartitionIdent, ShardsInfo>> {
 
         private final CompletableFuture<Map<TablePartitionIdent, ShardsInfo>> result;
         private final Map<TablePartitionIdent, ShardsInfo> tables = new HashMap<>();
@@ -239,7 +237,6 @@ public class TableHealthService {
 
         @Override
         public void fail(@Nonnull Throwable t) {
-            LOGGER.error("error retrieving tables health", t);
             result.completeExceptionally(t);
         }
 
@@ -248,7 +245,7 @@ public class TableHealthService {
         }
 
         @Override
-        public CompletableFuture<?> completionFuture() {
+        public CompletableFuture<Map<TablePartitionIdent, ShardsInfo>> completionFuture() {
             return result;
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Makes sure that there is only a single active computation at a time. 
Improves the performance in case of concurrent queries:

Before:

    cr8 timeit -s "select * from sys.health" -w 0 -r 5000 -c 25
    Runtime (in ms):
        mean:    53.955 ± 0.557
        min/max: 51.546 → 436.973
    Percentile:
        50:   52.646 ± 20.100 (stdev)
        95:   54.556
        99.9: 436.960

After:

    cr8 timeit -s "select * from sys.health" -w 0 -r 5000 -c 25
    Runtime (in ms):
        mean:    27.546 ± 0.580
        min/max: 0.174 → 58.555
    Percentile:
        50:   19.214 ± 20.935 (stdev)
        95:   54.996
        99.9: 57.777


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
