### PR TITLE
Fix min, max, avg, sum and variance aggregations for float and double types

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2.0 that caused ``sum`` and ``avg``
+  global aggregates to return incorrect results when used on columns of
+  ``real`` or ``double precision`` data types.
+
 - Fixed an issue that caused primary key lookups to return an empty result
   instead of the row identified by the primary key values, if the primary key
   consists of multiple columns and if one of them is of type ``BOOLEAN``.

--- a/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -25,6 +25,7 @@ import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.module.EnterpriseFunctionsModule;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -35,7 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
@@ -49,13 +49,27 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
             .createInjector().getInstance(Functions.class);
     }
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation(HyperLogLogDistinctAggregation.NAME, dataType, data, Collections.singletonList(dataType));
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                HyperLogLogDistinctAggregation.NAME,
+                argumentType.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature()
+            ),
+            data
+        );
     }
 
-    private Object executeAggregationWithPrecision(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation(HyperLogLogDistinctAggregation.NAME, dataType, data,
-            List.of(dataType, DataTypes.INTEGER));
+    private Object executeAggregationWithPrecision(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                HyperLogLogDistinctAggregation.NAME,
+                argumentType.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature()
+            ),
+            data
+        );
     }
 
     private Object[][] createTestData(int numRows, @Nullable Integer precision) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -179,6 +179,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                 return new SumLong(fieldTypes.get(0).name());
 
             case FloatType.ID:
+                return new SumFloat(fieldTypes.get(0).name());
             case DoubleType.ID:
                 return new SumDouble(fieldTypes.get(0).name());
 
@@ -260,6 +261,45 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public Object partialResult(SumDoubleState state) {
+            return state.hadValue ? state.sum : null;
+        }
+    }
+
+    static class SumFloatState {
+
+        private float sum = .0f;
+        private boolean hadValue = false;
+    }
+
+    static class SumFloat implements DocValueAggregator<SumFloatState> {
+
+        private final String columnName;
+        private SortedNumericDocValues values;
+
+        SumFloat(String columnName) {
+            this.columnName = columnName;
+        }
+
+        @Override
+        public SumFloatState initialState() {
+            return new SumFloatState();
+        }
+
+        @Override
+        public void loadDocValues(LeafReader reader) throws IOException {
+            values = DocValues.getSortedNumeric(reader, columnName);
+        }
+
+        @Override
+        public void apply(SumFloatState state, int doc) throws IOException {
+            if (values.advanceExact(doc) && values.docValueCount() == 1) {
+                state.sum += NumericUtils.sortableIntToFloat((int) values.nextValue());
+                state.hadValue = true;
+            }
+        }
+
+        @Override
+        public Object partialResult(SumFloatState state) {
             return state.hadValue ? state.sum : null;
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class Variance implements Writeable, Comparable<Variance> {
 
@@ -80,5 +81,22 @@ public class Variance implements Writeable, Comparable<Variance> {
     @Override
     public int compareTo(Variance o) {
         return Double.compare(result(), o.result());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Variance variance = (Variance) o;
+        return Objects.equals(variance.result(), result());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result());
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -35,8 +36,15 @@ import static org.hamcrest.Matchers.oneOf;
 
 public class ArbitraryAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation("arbitrary", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "arbitrary",
+                argumentType.getTypeSignature(),
+                argumentType.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -36,12 +36,17 @@ public class ArrayAggTest extends AggregationTest {
 
     @Test
     public void test_array_agg_adds_all_items_to_array() throws Exception {
-        var result = executeAggregation("array_agg", DataTypes.INTEGER, new Object[][] {
-            new Object[] { 20 },
-            new Object[] { null },
-            new Object[] { 42 },
-            new Object[] { 24 }
-        }, List.of(DataTypes.INTEGER));
+        var result = executeAggregation(
+            ArrayAgg.SIGNATURE,
+            List.of(DataTypes.INTEGER),
+            new ArrayType<>(DataTypes.INTEGER),
+            new Object[][]{
+                new Object[]{20},
+                new Object[]{null},
+                new Object[]{42},
+                new Object[]{24}
+            }
+        );
         assertThat((List<Object>) result, Matchers.contains(20, null, 42, 24));
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -32,8 +33,15 @@ import org.junit.Test;
 
 public class AverageAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("avg", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "avg",
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -27,6 +27,7 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -43,8 +44,15 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class CollectSetAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation("collect_set", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "collect_set",
+                argumentType.getTypeSignature(),
+                new ArrayType<>(argumentType).getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -33,13 +33,20 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.List;
+
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
 public class CountAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation("count", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            CountAggregation.SIGNATURE,
+            List.of(argumentType),
+            DataTypes.LONG,
+            data
+        );
     }
 
     @Test
@@ -104,7 +111,9 @@ public class CountAggregationTest extends AggregationTest {
     @Test
     public void testNoInput() throws Exception {
         // aka. COUNT(*)
-        Object result = executeAggregation(null, new Object[][]{{}, {}});
+        Object result = executeAggregation(
+            CountAggregation.COUNT_STAR_SIGNATURE,
+            new Object[][]{{}, {}});
         assertEquals(2L, result);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterables;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -35,8 +36,15 @@ import java.util.List;
 
 public class GeometricMeanAggregationtest extends AggregationTest {
 
-    private Object executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation("geometric_mean", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "geometric_mean",
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -28,8 +29,15 @@ import org.junit.Test;
 
 public class MaximumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("max", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "max",
+                argumentType.getTypeSignature(),
+                argumentType.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -28,8 +29,15 @@ import org.junit.Test;
 
 public class MinimumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("min", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "min",
+                argumentType.getTypeSignature(),
+                argumentType.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -43,12 +43,28 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class PercentileAggregationTest extends AggregationTest {
 
-    private Object execSingleFractionPercentile(DataType<?> valueType, Object[][] rows) throws Exception {
-        return executeAggregation(PercentileAggregation.NAME, valueType, rows, List.of(valueType, DataTypes.DOUBLE));
+    private Object execSingleFractionPercentile(DataType<?> argumentType, Object[][] rows) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                PercentileAggregation.NAME,
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            rows
+        );
     }
 
-    private Object execArrayFractionPercentile(DataType<?> valueType, Object[][] rows) throws Exception {
-        return executeAggregation(PercentileAggregation.NAME, valueType, rows, List.of(valueType, DataTypes.DOUBLE_ARRAY));
+    private Object execArrayFractionPercentile(DataType<?> argumentType, Object[][] rows) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                PercentileAggregation.NAME,
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
+                DataTypes.DOUBLE_ARRAY.getTypeSignature()
+            ),
+            rows
+        );
     }
 
     private PercentileAggregation singleArgPercentile;
@@ -85,22 +101,29 @@ public class PercentileAggregationTest extends AggregationTest {
     }
 
     @Test
-    public void testAllTypesReturnSameResult() throws Exception {
-        for (DataType valueType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+    public void testSignleFractionAllTypesReturnSameResult() throws Exception {
+        for (DataType<?> valueType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             List<Double> fractions = Arrays.asList(0.5, 0.8);
             Object[][] rowsWithSingleFraction = new Object[10][];
-            Object[][] rowsWithFractionsArray = new Object[10][];
             for (int i = 0; i < rowsWithSingleFraction.length; i++) {
                 rowsWithSingleFraction[i] = new Object[]{ valueType.sanitizeValue(i), fractions.get(0) };
+            }
+            assertThat(execSingleFractionPercentile(valueType, rowsWithSingleFraction), is(4.5));
+        }
+    }
+
+    @Test
+    public void testWithFractionsAllTypesReturnSameResult() throws Exception {
+        for (DataType<?> valueType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            List<Double> fractions = Arrays.asList(0.5, 0.8);
+            Object[][] rowsWithFractionsArray = new Object[10][];
+            for (int i = 0; i < rowsWithFractionsArray.length; i++) {
                 rowsWithFractionsArray[i] = new Object[]{ valueType.sanitizeValue(i), fractions };
             }
-            Object result = execSingleFractionPercentile(valueType, rowsWithSingleFraction);
-            assertEquals(4.5, result);
-            result = execArrayFractionPercentile(valueType, rowsWithFractionsArray);
-            assertThat(result, instanceOf(List.class));
-            assertEquals(2, ((List) result).size());
-            assertEquals(4.5, ((List) result).get(0));
-            assertEquals(7.5, ((List) result).get(1));
+            assertThat(
+                execArrayFractionPercentile(valueType, rowsWithFractionsArray),
+                is(List.of(4.5, 7.5))
+            );
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterables;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -35,8 +36,15 @@ import java.util.List;
 
 public class StdDevAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("stddev", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "stddev",
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -24,12 +24,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.operation.aggregation.AggregationTest;
-import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 
@@ -37,31 +34,35 @@ public class StringAggTest extends AggregationTest {
 
     @Test
     public void testAllValuesAreNull() throws Exception {
-        var result = executeAggregation("string_agg", DataTypes.STRING, new Object[][] {
-            new Object[] { null, null },
-            new Object[] { null, null },
-            new Object[] { null, null },
-        }, List.of(DataTypes.STRING, DataTypes.STRING));
+        var result = executeAggregation(
+            StringAgg.SIGNATURE, new Object[][]{
+                new Object[]{null, null},
+                new Object[]{null, null},
+                new Object[]{null, null},
+            }
+        );
         assertThat(result, Matchers.nullValue());
     }
 
     @Test
     public void testOneDelimiterIsNull() throws Exception {
-        var result = executeAggregation("string_agg", DataTypes.STRING, new Object[][] {
-            new Object[] { "a", "," },
-            new Object[] { "b", null },
-            new Object[] { "c", "," },
-        }, List.of(DataTypes.STRING, DataTypes.STRING));
+        var result = executeAggregation(
+            StringAgg.SIGNATURE, new Object[][]{
+                new Object[]{"a", ","},
+                new Object[]{"b", null},
+                new Object[]{"c", ","},
+            });
         assertThat(result, is("ab,c"));
     }
 
     @Test
     public void testOneExpressionIsNull() throws Exception {
-        var result = executeAggregation("string_agg", DataTypes.STRING, new Object[][] {
-            new Object[] { "a", ";" },
-            new Object[] { null, "," },
-            new Object[] { "c", "," },
-        }, List.of(DataTypes.STRING, DataTypes.STRING));
+        var result = executeAggregation(
+            StringAgg.SIGNATURE, new Object[][]{
+                new Object[]{"a", ";"},
+                new Object[]{null, ","},
+                new Object[]{"c", ","},
+            });
         assertThat(result, is("a,c"));
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -35,8 +36,17 @@ import static org.hamcrest.Matchers.is;
 
 public class SumAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("sum", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType,
+                                      DataType<?> returnType,
+                                      Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "sum",
+                argumentType.getTypeSignature(),
+                returnType.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test
@@ -65,52 +75,52 @@ public class SumAggregationTest extends AggregationTest {
 
     @Test
     public void testDouble() throws Exception {
-        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.7d}, {0.3d}});
+        Object result = executeAggregation(DataTypes.DOUBLE, DataTypes.DOUBLE, new Object[][]{{0.7d}, {0.3d}});
 
         assertEquals(1.0d, result);
     }
 
     @Test
     public void testFloat() throws Exception {
-        Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}});
+        Object result = executeAggregation(DataTypes.FLOAT, DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}});
 
         assertEquals(1.0f, result);
     }
 
     @Test
     public void testLong() throws Exception {
-        Object result = executeAggregation(DataTypes.LONG, new Object[][]{{7L}, {3L}});
+        Object result = executeAggregation(DataTypes.LONG, DataTypes.LONG, new Object[][]{{7L}, {3L}});
 
         assertEquals(10L, result);
     }
 
     @Test(expected = ArithmeticException.class)
     public void testLongOverflow() throws Exception {
-        executeAggregation(DataTypes.LONG, new Object[][]{{Long.MAX_VALUE}, {1}});
+        executeAggregation(DataTypes.LONG, DataTypes.LONG, new Object[][]{{Long.MAX_VALUE}, {1}});
     }
 
     @Test(expected = ArithmeticException.class)
     public void testLongUnderflow() throws Exception {
-        executeAggregation(DataTypes.LONG, new Object[][]{{Long.MIN_VALUE}, {-1}});
+        executeAggregation(DataTypes.LONG, DataTypes.LONG, new Object[][]{{Long.MIN_VALUE}, {-1}});
     }
 
     @Test
     public void testInteger() throws Exception {
-        Object result = executeAggregation(DataTypes.INTEGER, new Object[][]{{7}, {3}});
+        Object result = executeAggregation(DataTypes.INTEGER, DataTypes.LONG, new Object[][]{{7}, {3}});
 
         assertEquals(10L, result);
     }
 
     @Test
     public void testShort() throws Exception {
-        Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 7}, {(short) 3}});
+        Object result = executeAggregation(DataTypes.SHORT, DataTypes.LONG, new Object[][]{{(short) 7}, {(short) 3}});
 
         assertEquals(10L, result);
     }
 
     @Test
     public void testByte() throws Exception {
-        Object result = executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 7}, {(byte) 3}});
+        Object result = executeAggregation(DataTypes.BYTE, DataTypes.LONG, new Object[][]{{(byte) 7}, {(byte) 3}});
 
         assertEquals(10L, result);
     }
@@ -118,8 +128,9 @@ public class SumAggregationTest extends AggregationTest {
     @Test
     public void testUnsupportedType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unknown function: sum(INPUT(0))," +
-                                        " no overload found for matching argument types: (geo_point).");
-        executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
+        expectedException.expectMessage(
+            "Unknown function: sum(NULL)," +
+            " no overload found for matching argument types: (geo_point).");
+        getSum(DataTypes.GEO_POINT);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,8 +37,15 @@ import static org.hamcrest.Matchers.is;
 
 public class VarianceAggregationTest extends AggregationTest {
 
-    private Object executeAggregation(DataType<?> dataType, Object[][] data) throws Exception {
-        return executeAggregation("variance", dataType, data);
+    private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
+        return executeAggregation(
+            Signature.aggregate(
+                "variance",
+                argumentType.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            data
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -21,34 +21,114 @@
 
 package io.crate.operation.aggregation;
 
-import com.google.common.collect.ImmutableList;
+import io.crate.Constants;
 import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
+import io.crate.common.io.IOUtils;
 import io.crate.data.ArrayBucket;
+import io.crate.data.BatchIterators;
 import io.crate.data.Row;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.AggregationProjection;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.collect.CollectTask;
+import io.crate.execution.engine.collect.DocValuesAggregates;
 import io.crate.execution.engine.collect.InputCollectExpression;
-import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.execution.engine.collect.MapSideDataCollectOperation;
+import io.crate.execution.jobs.SharedShardContexts;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.functions.Signature;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.TestingRowConsumer;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
 import org.elasticsearch.Version;
-import org.junit.Before;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingHelper;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.MapperTestUtils;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.cache.IndexCache;
+import org.elasticsearch.index.cache.query.DisabledQueryCache;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.InternalEngineFactory;
+import org.elasticsearch.index.mapper.ArrayMapper;
+import org.elasticsearch.index.mapper.ArrayTypeParser;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.test.DummyShardLock;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
+import static io.crate.metadata.RelationName.fromIndexName;
 import static io.crate.testing.TestingHelpers.getFunctions;
+import static org.elasticsearch.index.mapper.MapperService.MergeReason.MAPPING_RECOVERY;
+import static org.elasticsearch.index.shard.IndexShardTestCase.EMPTY_EVENT_LISTENER;
+import static org.elasticsearch.index.translog.Translog.UNSET_AUTO_GENERATED_TIMESTAMP;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AggregationTest extends CrateUnitTest {
 
@@ -56,63 +136,373 @@ public abstract class AggregationTest extends CrateUnitTest {
 
     protected Functions functions;
     protected MemoryManager memoryManager;
-    protected EvaluatingNormalizer evaluatingNormalizer;
+    private ThreadPool threadPool;
 
-    @Before
-    public void prepare() throws Exception {
+    private IndicesModule indicesModule;
+    private IndicesService indexServices;
+    private IndexService indexService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         functions = getFunctions();
+        threadPool = new TestThreadPool(getClass().getName(), Settings.EMPTY);
         memoryManager = new OnHeapMemoryManager(RAM_ACCOUNTING::addBytes);
-        evaluatingNormalizer = EvaluatingNormalizer.functionOnlyNormalizer(
-            functions,
-            Function::isDeterministic
+        indicesModule = new IndicesModule(List.of(new MapperPlugin() {
+            @Override
+            public Map<String, Mapper.TypeParser> getMappers() {
+                return Map.of(ArrayMapper.CONTENT_TYPE, new ArrayTypeParser());
+            }
+        }));
+        indexServices = mock(IndicesService.class);
+        indexService = mock(IndexService.class);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public Object executeAggregation(Signature boundSignature,
+                                     Object[][] data) throws Exception {
+        return executeAggregation(
+            boundSignature,
+            Lists2.map(boundSignature.getArgumentTypes(), TypeSignature::createType),
+            boundSignature.getReturnType().createType(),
+            data
         );
     }
 
-    public Object executeAggregation(String name, DataType dataType, Object[][] data) throws Exception {
-        if (dataType == null) {
-            return executeAggregation(name, dataType, data, ImmutableList.of());
-        } else {
-            return executeAggregation(name, dataType, data, ImmutableList.of(dataType));
-        }
-    }
-
-    public Object executeAggregation(String name, DataType dataType, Object[][] data, List<DataType> argumentTypes) throws Exception {
-        InputCollectExpression[] inputs;
-
-        if (dataType != null) {
-            inputs = new InputCollectExpression[argumentTypes.size()];
-            for (int i = 0; i < argumentTypes.size(); i++) {
-                inputs[i] = new InputCollectExpression(i);
-            }
-        } else {
-            inputs = new InputCollectExpression[0];
-        }
-        AggregationFunction impl = (AggregationFunction) functions.get(
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Object executeAggregation(Signature maybeUnboundSignature,
+                                     List<DataType<?>> actualArgumentTypes,
+                                     DataType<?> actualReturnType,
+                                     Object[][] data) throws Exception {
+        var aggregationFunction = (AggregationFunction) functions.get(
             null,
-            name,
-            Lists2.map(argumentTypes, t -> new InputColumn(0, t)),
+            maybeUnboundSignature.getName().name(),
+            Lists2.map(actualArgumentTypes, t -> new InputColumn(0, t)),
             SearchPath.pathWithPGCatalogAndDoc()
         );
-        List<Object> states = new ArrayList<>();
+        Object partialResultWithoutDocValues = execPartialAggregationWithoutDocValues(
+            aggregationFunction,
+            data
+        );
+
+        var shard = newStartedPrimaryShard(Settings.EMPTY, buildMapping(actualArgumentTypes));
+        when(indexService.getShard(shard.shardId().id()))
+            .thenReturn(shard);
+        when(indexServices.indexServiceSafe(shard.routingEntry().index()))
+            .thenReturn(indexService);
+        try {
+            insertDataIntoShard(shard, data);
+            shard.refresh("test");
+
+            List<Row> partialResultWithDocValues = execPartialAggregationWithDocValues(
+                maybeUnboundSignature,
+                actualArgumentTypes,
+                actualReturnType,
+                shard
+            );
+            // assert that aggregations with/-out doc values yield the
+            // same result, if a doc value aggregator exists.
+            if (partialResultWithDocValues != null) {
+                assertThat(partialResultWithDocValues.size(), is(1));
+                assertThat(
+                    partialResultWithoutDocValues,
+                    is(partialResultWithDocValues.get(0).get(0))
+                );
+            }
+        } finally {
+            closeShard(shard);
+        }
+        return aggregationFunction.terminatePartial(
+            RAM_ACCOUNTING,
+            partialResultWithoutDocValues
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Object execPartialAggregationWithoutDocValues(AggregationFunction function,
+                                                          Object[][] data) {
+        var argumentsSize = function.signature().getArgumentTypes().size();
+        InputCollectExpression[] inputs = new InputCollectExpression[argumentsSize];
+        for (int i = 0; i < argumentsSize; i++) {
+            inputs[i] = new InputCollectExpression(i);
+        }
+
+        ArrayList<Object> states = new ArrayList<>();
         Version minNodeVersion = randomBoolean()
             ? Version.CURRENT
             : Version.V_4_0_9;
-        states.add(impl.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
+        states.add(function.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
         for (Row row : new ArrayBucket(data)) {
             for (InputCollectExpression input : inputs) {
                 input.setNextRow(row);
             }
             if (randomIntBetween(1, 4) == 1) {
-                states.add(impl.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
+                states.add(function.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
             }
             int idx = states.size() - 1;
-            states.set(idx, impl.iterate(RAM_ACCOUNTING, memoryManager, states.get(idx), inputs));
+            states.set(idx, function.iterate(RAM_ACCOUNTING, memoryManager, states.get(idx), inputs));
         }
         Object state = states.get(0);
         for (int i = 1; i < states.size(); i++) {
-            state = impl.reduce(RAM_ACCOUNTING, state, states.get(i));
+            state = function.reduce(RAM_ACCOUNTING, state, states.get(i));
         }
-        return impl.terminatePartial(RAM_ACCOUNTING, state);
+        return state;
+    }
+
+    @Nullable
+    private List<Row> execPartialAggregationWithDocValues(Signature signature,
+                                                          List<DataType<?>> argumentTypes,
+                                                          DataType<?> actualReturnType,
+                                                          IndexShard shard) throws Exception {
+        var aggregation = new Aggregation(
+            signature,
+            actualReturnType,
+            InputColumn.mapToInputColumns(argumentTypes)
+        );
+        var toCollectRefs = new ArrayList<Symbol>(argumentTypes.size());
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            toCollectRefs.add(
+                new Reference(
+                    new ReferenceIdent(
+                        fromIndexName(shard.routingEntry().getIndexName()),
+                        Integer.toString(i)),
+                    RowGranularity.DOC,
+                    argumentTypes.get(i),
+                    null,
+                    null)
+            );
+        }
+        var collectPhase = new RoutedCollectPhase(
+            UUID.randomUUID(),
+            1,
+            "collect",
+            new Routing(Map.of()),
+            RowGranularity.SHARD,
+            toCollectRefs,
+            List.of(
+                new AggregationProjection(
+                    List.of(aggregation),
+                    RowGranularity.SHARD,
+                    AggregateMode.ITER_PARTIAL
+                )
+            ),
+            WhereClause.MATCH_ALL.queryOrFallback(),
+            DistributionInfo.DEFAULT_BROADCAST
+        );
+        var collectTask = new CollectTask(
+            collectPhase,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            mock(MapSideDataCollectOperation.class),
+            RamAccounting.NO_ACCOUNTING,
+            ramAccounting -> memoryManager,
+            new TestingRowConsumer(),
+            new SharedShardContexts(indexServices, UnaryOperator.identity()),
+            Version.CURRENT,
+            4096);
+
+        var batchIterator = DocValuesAggregates.tryOptimize(
+            functions,
+            shard,
+            mock(DocTableInfo.class),
+            new LuceneQueryBuilder(functions),
+            shard.mapperService()::fullName,
+            collectPhase,
+            collectTask
+        );
+        List<Row> result;
+        if (batchIterator != null) {
+            result = BatchIterators.collect(batchIterator, Collectors.toList()).get();
+        } else {
+            result = null;
+        }
+        // required to close searchers
+        collectTask.kill(new InterruptedException("kill"));
+        return result;
+
+    }
+
+    private void insertDataIntoShard(IndexShard shard,
+                                     Object[][] data) throws IOException {
+        for (int i = 0; i < data.length; i++) {
+            var cell = data[i];
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            for (int j = 0; j < cell.length; j++) {
+                builder.field(Integer.toString(j), cell[j]);
+            }
+            builder.endObject();
+
+            var result = shard.applyIndexOperationOnPrimary(
+                Versions.MATCH_ANY,
+                VersionType.INTERNAL,
+                new SourceToParse(
+                    shard.shardId().getIndexName(),
+                    Integer.toString(i),
+                    new BytesArray(Strings.toString(builder)),
+                    XContentType.JSON,
+                    null
+                ),
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                0,
+                UNSET_AUTO_GENERATED_TIMESTAMP,
+                false);
+            assertThat(result.getResultType(), is(Engine.Result.Type.SUCCESS));
+        }
+    }
+
+    private XContentBuilder buildMapping(List<DataType<?>> argumentTypes) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties");
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            var type = argumentTypes.get(i);
+            builder
+                .startObject(Integer.toString(i));
+            if (DataTypes.isArray(type)) {
+                builder
+                    .field("type", "array")
+                    .startObject("inner")
+                    .field(
+                        "type",
+                        DataTypes.esMappingNameFrom(
+                            ((ArrayType<?>) type).innerType().id()))
+                    .endObject();
+            } else {
+                builder
+                    .field("type", DataTypes.esMappingNameFrom(type.id()));
+            }
+            builder.endObject();
+        }
+        return builder.endObject().endObject();
+    }
+
+    /**
+     * Creates a new empty primary shard and starts it.
+     */
+    private IndexShard newStartedPrimaryShard(Settings settings,
+                                              XContentBuilder mapping) throws IOException {
+        IndexShard shard = newPrimaryShard(settings, mapping);
+        shard.markAsRecovering(
+            "store",
+            new RecoveryState(
+                shard.routingEntry(),
+                new DiscoveryNode(
+                    shard.routingEntry().currentNodeId(),
+                    shard.routingEntry().currentNodeId(),
+                    buildNewFakeTransportAddress(),
+                    Map.of(),
+                    EnumSet.allOf(DiscoveryNode.Role.class),
+                    Version.CURRENT),
+                null)
+        );
+        shard.recoverFromStore();
+
+        var newRouting = ShardRoutingHelper.moveToStarted(shard.routingEntry());
+        var newRoutingTable = new IndexShardRoutingTable.Builder(newRouting.shardId())
+            .addShard(newRouting)
+            .build();
+        assert newRouting.allocationId() != null;
+        shard.updateShardState(
+            newRouting,
+            shard.getPendingPrimaryTerm(),
+            null,
+            0,
+            Set.of(newRouting.allocationId().getId()),
+            newRoutingTable
+        );
+        return shard;
+    }
+
+    /**
+     * Creates a new initializing primary shard.
+     * The shard will have its own unique data path.
+     */
+    private IndexShard newPrimaryShard(Settings settings, XContentBuilder mapping) throws IOException {
+        ShardRouting routing = TestShardRouting.newShardRouting(
+            new ShardId("index", "_na_", 0),
+            randomAlphaOfLength(10),
+            true,
+            ShardRoutingState.INITIALIZING,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE
+        );
+        var indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(settings)
+            .build();
+        var indexMetadata = IndexMetadata.builder(routing.getIndexName())
+            .settings(indexSettings)
+            .putMapping(Constants.DEFAULT_MAPPING_TYPE, Strings.toString(mapping))
+            .build();
+        var shardId = routing.shardId();
+        var nodePath = new NodeEnvironment.NodePath(createTempDir());
+        var shardPath = new ShardPath(
+            false,
+            nodePath.resolve(shardId),
+            nodePath.resolve(shardId),
+            shardId
+        );
+        return newPrimaryShard(routing, shardPath, indexMetadata);
+    }
+
+    private IndexShard newPrimaryShard(ShardRouting routing,
+                                       ShardPath shardPath,
+                                       IndexMetadata indexMetadata) throws IOException {
+        var indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+        var indexCache = new IndexCache(
+            indexSettings,
+            new DisabledQueryCache(indexSettings)
+        );
+        var store = new Store(
+            shardPath.getShardId(),
+            indexSettings,
+            newFSDirectory(shardPath.resolveIndex()),
+            new DummyShardLock(shardPath.getShardId())
+        );
+        var mapperService = MapperTestUtils.newMapperService(
+            xContentRegistry(),
+            createTempDir(),
+            indexSettings.getSettings(),
+            indicesModule,
+            routing.getIndexName()
+        );
+        mapperService.merge(indexMetadata, MAPPING_RECOVERY, true);
+        IndexShard shard = null;
+        try {
+            shard = new IndexShard(
+                routing,
+                indexSettings,
+                shardPath,
+                store,
+                indexCache,
+                mapperService,
+                new InternalEngineFactory(),
+                EMPTY_EVENT_LISTENER,
+                null,
+                threadPool,
+                BigArrays.NON_RECYCLING_INSTANCE,
+                List.of(),
+                () -> { },
+                RetentionLeaseSyncer.EMPTY,
+                new NoneCircuitBreakerService()
+            );
+        } catch (IOException e) {
+            IOUtils.close(store);
+            fail("cannot create a new shard");
+        }
+        return shard;
+    }
+
+    private void closeShard(IndexShard shard) throws IOException {
+        IOUtils.close(() -> shard.close("test", false), shard.store());
     }
 
     protected Symbol normalize(String functionName, Object value, DataType type) {
@@ -121,10 +511,15 @@ public abstract class AggregationTest extends CrateUnitTest {
 
     protected Symbol normalize(String functionName, Symbol... args) {
         List<Symbol> arguments = Arrays.asList(args);
-        AggregationFunction function =
-            (AggregationFunction) functions.get(null, functionName, arguments, SearchPath.pathWithPGCatalogAndDoc());
+        AggregationFunction function = (AggregationFunction) functions.get(
+            null,
+            functionName,
+            arguments,
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
         return function.normalizeSymbol(
             new Function(function.signature(), arguments, function.partialType()),
-            new CoordinatorTxnCtx(SessionContext.systemSessionContext()));
+            new CoordinatorTxnCtx(SessionContext.systemSessionContext())
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/10292. The 039c9867131e70b0709d932df17500de52ffd07a and 105cf964447a6bd6dbdcab5dd1ae9cf90d2a8c5c commits are going to be backported to `4.2`. The min and max
doc values aggregators were not released yet.

For more information see commits and https://github.com/crate/crate/pull/10048 that introduces the global aggregations on doc values approach. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
