### PR TITLE
Fix _id value computation for  PK lookups

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,4 +62,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that caused primary key lookups to return an empty result
+  instead of the row identified by the primary key values, if the primary key
+  consists of multiple columns and if one of them is of type ``BOOLEAN``.

--- a/server/src/main/java/io/crate/analyze/where/DocKeys.java
+++ b/server/src/main/java/io/crate/analyze/where/DocKeys.java
@@ -23,6 +23,7 @@ package io.crate.analyze.where;
 
 import io.crate.analyze.Id;
 import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.StringUtils;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
@@ -62,7 +63,7 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
             return idFunction.apply(
                 Lists2.mapLazy(
                     key.subList(0, width),
-                    s -> DataTypes.STRING.implicitCast(SymbolEvaluator.evaluate(txnCtx, functions, s, params, subQueryResults))
+                    s -> StringUtils.nullOrString(SymbolEvaluator.evaluate(txnCtx, functions, s, params, subQueryResults))
                 )
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
@@ -86,9 +86,6 @@ public class RowShardResolver {
     }
 
     private static List<String> pkValues(List<Input<?>> primaryKeyInputs) {
-        if (primaryKeyInputs.isEmpty()) {
-            return List.of(); // avoid object creation in Lists.transform if the list is empty
-        }
         return Lists2.map(primaryKeyInputs, input -> nullOrString(input.value()));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1776,4 +1776,28 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select * from (select * from tbl) as t where obj['b'] = 10");
         assertThat(printedTable(response.rows()), is(""));
     }
+
+
+    @Test
+    public void test_primary_key_lookup_on_multiple_columns() throws Exception {
+        execute(
+            "CREATE TABLE doc.test (" +
+            "   id TEXT, " +
+            "   region_level_1 TEXT, " +
+            "   marker_type TEXT, " +
+            "   is_auto BOOLEAN," +
+            "   PRIMARY KEY (id, region_level_1, marker_type, is_auto) " +
+            ") clustered into 1 shards "
+        );
+        execute("insert into doc.test (id, region_level_1, marker_type, is_auto) values ('1', '2', '3', false)");
+        execute("refresh table doc.test");
+        execute("explain select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
+        assertThat(printedTable(response.rows()), is(
+            "Get[doc.test | id | DocKeys{'1', '2', '3', false}]\n"
+        ));
+        execute("select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
+        assertThat(printedTable(response.rows()), is(
+            "1\n"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `RowShardResolver` uses `nullOrString` to turn all values to a
string before computing the final `_id` value.

`DocKeys#getId` insted used `DataTypes.STRING.implicitCast`.

Due to this boolean values were treated differently. One used `'true'`
while the other used `'t'`, leading to different `_id` value on primary
lookups than what was inserted.

We cannot change the insert part, because the data has already been
persisted in many installations, so this changed the lookup instead.

Closes https://github.com/crate/crate/issues/10302

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)