### PR TITLE
Prevent searchers that are in-use from being closed

### DIFF
--- a/server/src/main/java/io/crate/common/collections/BorrowedItem.java
+++ b/server/src/main/java/io/crate/common/collections/BorrowedItem.java
@@ -1,12 +1,12 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
  * license agreements.  See the NOTICE file distributed with this work for
  * additional information regarding copyright ownership.  Crate licenses
  * this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,30 +19,24 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.expression.reference.doc.lucene;
+package io.crate.common.collections;
 
-public class CollectorContext {
+public final class BorrowedItem<T> implements AutoCloseable {
 
-    private final int readerId;
+    private final T item;
+    private final Runnable onClose;
 
-    private SourceLookup sourceLookup;
-
-    public CollectorContext() {
-        this(-1);
+    public BorrowedItem(T item, Runnable onClose) {
+        this.item = item;
+        this.onClose = onClose;
     }
 
-    public CollectorContext(int readerId) {
-        this.readerId = readerId;
+    public T item() {
+        return item;
     }
 
-    public int readerId() {
-        return readerId;
-    }
-
-    public SourceLookup sourceLookup() {
-        if (sourceLookup == null) {
-            sourceLookup = new SourceLookup();
-        }
-        return sourceLookup;
+    @Override
+    public void close() {
+        onClose.run();
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -81,7 +81,7 @@ public class NodeFetchOperation {
             IndexService indexService = fetchTask.indexService(readerId);
             var mapperService = indexService.mapperService();
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
-                fetchTask.indexService(readerId).index().getName(),
+                indexService.index().getName(),
                 mapperService::fullName,
                 fetchTask.table(readerId).partitionedByColumns()
             );
@@ -92,7 +92,7 @@ public class NodeFetchOperation {
             return new FetchCollector(
                 exprs,
                 streamers,
-                fetchTask.searcher(readerId),
+                fetchTask,
                 ramAccounting,
                 readerId
             );

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
@@ -29,18 +29,18 @@ import java.io.IOException;
 public class FetchIdCollectorExpression extends LuceneCollectorExpression<Long> {
 
     private long fetchId;
-    private int jobSearchContextId;
+    private int readerId;
     private int docBase;
 
     @Override
     public void startCollect(CollectorContext context) {
         super.startCollect(context);
-        this.jobSearchContextId = context.jobSearchContextId();
+        this.readerId = context.readerId();
     }
 
     @Override
     public void setNextDocId(int doc) {
-        fetchId = FetchId.encode(jobSearchContextId, docBase + doc);
+        fetchId = FetchId.encode(readerId, docBase + doc);
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes a race condition where we closed a `Engine.Searcher` instance 
that was still in use.

If the `FetchTask` was killed we immediately closed the searcher, but that
very same searcher instance may already have been borrowed by a
`FetchCollector` and could be in active use.

With the change in

https://github.com/crate/crate/commit/e7695886044540030b1a50f82f33a52d99c9b1be#diff-003d11b6ca408fe80c9a325b80d681e7L61

this made it more visible and caused the
`ThreadPoolsExhaustedIntegrationTest` to ocassionaly fail because the
`readerIndex` in the `FetchCollector` could get negative.

This changes the state transition handling in the `FetchTask` and ensures
that borrowed searchers are not closed.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)