### PR TITLE
Don't acquire searchers in prepare if FetchTask is done already

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -186,9 +186,8 @@ public class FetchTask implements Task {
     @Override
     public void kill(Throwable throwable) {
         synchronized (jobId) {
-            if (borrowed > 0) {
-                killed = throwable;
-            } else {
+            killed = throwable;
+            if (borrowed == 0) {
                 closeSearchers();
                 result.completeExceptionally(throwable);
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Some tests were still flaky. Hopefully this fixes it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)