### PR TITLE
Backport changes for newest crate-docs-theme, plus RST fix

### DIFF
--- a/blackbox/docs/conf.py
+++ b/blackbox/docs/conf.py
@@ -1,4 +1,4 @@
-from crate.theme.rtd.conf.crate_server import *
+from crate.theme.rtd.conf.crate_reference import *
 
 exclude_patterns = ['out/**', 'tmp/**', 'eggs/**', 'requirements.txt']
 
@@ -6,3 +6,5 @@ extensions = ['crate.sphinx.csv']
 # crate.theme sets html_favicon to favicon.png which causes a warning because it should be a .ico
 # and in addition there is no favicon.png in this project so it can't find the file
 html_favicon = None
+
+source_suffix = '.txt'

--- a/blackbox/docs/sql/features.txt
+++ b/blackbox/docs/sql/features.txt
@@ -15,7 +15,7 @@ supports, what they are and how to use them.
 
 .. csv-table::
    :header: ID,Package,#,Description,Supported,Verified,Comments
-   :widths: 80,140,15,250,130
+   :widths: 80,140,15,250,1,1,130
    :delim: U+0009
    :file: ../../../sql/src/main/resources/sql_features.tsv
    :exclude: {4: '(?i)N\w*'}


### PR DESCRIPTION
@mfussenegger I noticed the 1.1 release branch was no longer building on RTD. this backport + RST syntax fixes sorts that out