### PR TITLE
bp: Use current term in initial leases in engine test

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -521,3 +521,4 @@ not present in CrateDB.
 - [s] 0cc8b123b14 Fix GeoHash PrefixTree BWC (#38584)
 - [x] 514a762d8dc Specialize pre-closing checks for engine implementations (#38702)
 - [x] 9b75a709a2c Concurrent file chunk fetching for CCR restore (#38495)
+- [x] ed73bb7b013 Use current term in initial leases in engine test (#38285)

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5023,7 +5023,8 @@ public class InternalEngineTests extends EngineTestCase {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final long primaryTerm = randomLongBetween(1, Long.MAX_VALUE);
         final AtomicLong retentionLeasesVersion = new AtomicLong();
-        final AtomicReference<RetentionLeases> retentionLeasesHolder = new AtomicReference<>(RetentionLeases.EMPTY);
+        final AtomicReference<RetentionLeases> retentionLeasesHolder = new AtomicReference<>(
+            new RetentionLeases(primaryTerm, retentionLeasesVersion.get(), Collections.emptyList()));
         final List<Engine.Operation> operations = generateSingleDocHistory(
             true, randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL), false, 2, 10, 300, "2");
         Randomness.shuffle(operations);


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/ed73bb7b013cc3914feb25f5504eb1b6c3d35a46
