### PR TITLE
Revert removal of MatchQueryBuilder#newTermQuery.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2.0 which caused :ref:`fulltext search
+  <predicates_match>` queries of the ``phase`` match type to ignore the
+  ``fuzziness`` option.
+
 - Fixed a regression introduced in 4.2.0 that caused ``sum`` and ``avg``
   global aggregates to return incorrect results when used on columns of
   ``real`` or ``double precision`` data types.

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -71,14 +71,13 @@ public class FulltextITest extends SQLTransportIntegrationTest{
                "Outer Eastern Rim| 0.39226836\n" +
                "North West Ripple| 0.38249224\n"));
 
-        execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
+        execute("select name, _score from locations where match((kind, name_description_ft), 'galay') " +
                 "using best_fields with (fuzziness='AUTO') order by _score desc");
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is("End of the Galaxy| 0.74187315\n" +
-               "Altair| 0.63013375\n" +
-               "Galactic Sector QQ7 Active J Gamma| 0.5251115\n" +
-               "Outer Eastern Rim| 0.39226836\n" +
-               "North West Ripple| 0.38249224\n")
+                   is("End of the Galaxy| 0.5934985\n" +
+                      "Altair| 0.504107\n" +
+                      "Outer Eastern Rim| 0.3138147\n" +
+                      "North West Ripple| 0.3059938\n")
         );
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'gala') " +

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -306,6 +306,11 @@ public class MatchQuery {
         }
 
         @Override
+        protected Query newTermQuery(Term term, float boost) {
+            return blendTermQuery(term, mapper);
+        }
+
+        @Override
         protected Query analyzePhrase(String field, TokenStream stream, int slop) throws IOException {
             try {
                 checkForPositions(field);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The regression was introduced with the update to Lucene 8.5.0,
see https://github.com/crate/crate/pull/9795. Removing the `MatchQueryBuilder#newTermQuery`
would prevent the creation of fuzzy queries.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
