### PR TITLE
Add has doc values aggregator assertion and enable doc value aggregators for byte type for function that currently support doc value agg.

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -29,6 +29,7 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -276,6 +277,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes, List<MappedFieldType> fieldTypes) {
         switch (argumentTypes.get(0).id()) {
+            case ByteType.ID:
             case ShortType.ID:
             case IntegerType.ID:
             case LongType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -214,6 +215,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
                                                            List<MappedFieldType> fieldTypes) {
             DataType<?> arg = argumentTypes.get(0);
             switch (arg.id()) {
+                case ByteType.ID:
                 case ShortType.ID:
                 case IntegerType.ID:
                 case LongType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -250,6 +251,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
                                                            List<MappedFieldType> fieldTypes) {
             DataType<?> arg = argumentTypes.get(0);
             switch (arg.id()) {
+                case ByteType.ID:
                 case ShortType.ID:
                 case IntegerType.ID:
                 case LongType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -28,6 +28,7 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -173,6 +174,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes, List<MappedFieldType> fieldTypes) {
         switch (argumentTypes.get(0).id()) {
+            case ByteType.ID:
             case ShortType.ID:
             case IntegerType.ID:
             case LongType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -62,7 +62,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         DataTypes.register(VarianceStateType.ID, in -> VarianceStateType.INSTANCE);
     }
 
-    private static final List<DataType<?>> SUPPORTED_TYPES = Lists2.concat(
+    static final List<DataType<?>> SUPPORTED_TYPES = Lists2.concat(
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(AggregationImplModule mod) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -30,6 +30,7 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.Variance;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -217,6 +218,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
                                                        List<MappedFieldType> fieldTypes) {
         switch (argumentTypes.get(0).id()) {
+            case ByteType.ID:
             case ShortType.ID:
             case IntegerType.ID:
             case LongType.ID:

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -31,17 +31,28 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
 public class AverageAggregationTest extends AggregationTest {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                "avg",
+                AverageAggregation.NAME,
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
             data
         );
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_numeric_types() {
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            assertHasDocValueAggregator(AverageAggregation.NAME, List.of(dataType));
+        }
     }
 
     @Test
@@ -87,6 +98,11 @@ public class AverageAggregationTest extends AggregationTest {
         Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 7}, {(short) 3}});
 
         assertEquals(5d, result);
+    }
+
+    @Test
+    public void test_avg_with_byte_argument_type() throws Exception {
+        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 7}, {(byte) 3}}), is(5d));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -27,6 +27,10 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
 public class MaximumAggregationTest extends AggregationTest {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
@@ -38,6 +42,13 @@ public class MaximumAggregationTest extends AggregationTest {
             ),
             data
         );
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_numeric_types() {
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(dataType));
+        }
     }
 
     @Test
@@ -73,6 +84,11 @@ public class MaximumAggregationTest extends AggregationTest {
         Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 8}, {(short) 3}});
 
         assertEquals((short) 8, result);
+    }
+
+    @Test
+    public void test_max_with_byte_argument_type() throws Exception {
+        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}}), is((byte) 1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -27,17 +27,28 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
 public class MinimumAggregationTest extends AggregationTest {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                "min",
+                MinimumAggregation.NAME,
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
             ),
             data
         );
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_numeric_types() {
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(dataType));
+        }
     }
 
     @Test
@@ -73,6 +84,11 @@ public class MinimumAggregationTest extends AggregationTest {
         Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 8}, {(short) 3}});
 
         assertEquals((short) 3, result);
+    }
+
+    @Test
+    public void test_min_with_byte_argument_type() throws Exception {
+        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}}), is((byte) 0));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -41,12 +41,19 @@ public class SumAggregationTest extends AggregationTest {
                                       Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                "sum",
+                SumAggregation.NAME,
                 argumentType.getTypeSignature(),
                 returnType.getTypeSignature()
             ),
             data
         );
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_numeric_types() {
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            assertHasDocValueAggregator(SumAggregation.NAME, List.of(dataType));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

see commits

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
