### PR TITLE
Supress tech writing notifications for es-backports.rst

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 *.rst @crate/tech-writing
 docs/ @crate/tech-writing
 docs/appendices/release-notes/unreleased.rst
+devs/docs/es-backports.rst


### PR DESCRIPTION
@crate/tech-writing doesn't need to review changes for es-backports.rst
