### PR TITLE
Mute ConcurrentSeqNoVersioningIT#testSeqNoCASLinearizability

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
@@ -41,6 +41,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.FileInputStream;
@@ -127,6 +128,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
     // multiple threads doing CAS updates.
     // Wait up to 1 minute (+10s in thread to ensure it does not time out) for threads to complete previous round before initiating next
     // round.
+    @Ignore("https://github.com/crate/crate/issues/10364")
     @Test
     public void testSeqNoCASLinearizability() {
         final int disruptTimeSeconds = scaledRandomIntBetween(1, 8);


### PR DESCRIPTION
This mutes ConcurrentSeqNoVersioningIT#testSeqNoCASLinearizability
because it fails with the current state of master.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
