### PR TITLE
Use junit assertions in assertThrows

### DIFF
--- a/server/src/test/java/io/crate/testing/Asserts.java
+++ b/server/src/test/java/io/crate/testing/Asserts.java
@@ -22,26 +22,22 @@
 
 package io.crate.testing;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
-import org.opentest4j.AssertionFailedError;
 
 public class Asserts {
 
     private Asserts() {}
 
-    public static <T extends Throwable> void assertThrows(Executable executable, Matcher<T> matcher) {
+    public static void assertThrows(Executable executable, Matcher<? super Throwable> matcher) {
         try {
             executable.execute();
+            Assertions.fail("Expected exception to be thrown, but nothing was thrown.");
         } catch (Throwable t) {
-            if (matcher.matches(t)) {
-                return;
-            }
-            throw new AssertionFailedError(
-                String.format("Unmatched %s type thrown with message '%s'",
-                              t.getClass().getCanonicalName(),
-                              t.getMessage()), t);
+            assertThat(t, matcher);
         }
-        throw new AssertionFailedError("Expected exception to be thrown, but nothing was thrown.");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I was wondering where a opentest4j error came from.
This changes the newly introduced assertThrows to use the same
verification mechanism we use everywhere else.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)