### PR TITLE
Add doc-values aggregators for the array and collect set aggregations.

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -27,12 +27,32 @@ import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
+import io.crate.types.IpType;
+import io.crate.types.LongType;
+import io.crate.types.ShortType;
+import io.crate.types.StringType;
+import io.crate.types.TimestampType;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,5 +127,229 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
     @Override
     public DataType<?> partialType() {
         return boundSignature.getReturnType().createType();
+    }
+
+    @Nullable
+    @Override
+    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
+                                                       List<MappedFieldType> fieldTypes) {
+        var dataType = argumentTypes.get(0);
+        switch (dataType.id()) {
+            case ByteType.ID:
+            case ShortType.ID:
+            case IntegerType.ID:
+            case LongType.ID:
+            case TimestampType.ID_WITH_TZ:
+            case TimestampType.ID_WITHOUT_TZ:
+                return new LongArrayAggNumericDocValueAggregator(
+                    fieldTypes.get(0).name(),
+                    dataType,
+                    sizeEstimator
+                );
+            case FloatType.ID:
+                return new FloatArrayAggNumericDocValueAggregator(
+                    fieldTypes.get(0).name(),
+                    sizeEstimator
+                );
+            case DoubleType.ID:
+                return new DoubleArrayAggNumericDocValueAggregator(
+                    fieldTypes.get(0).name(),
+                    sizeEstimator
+                );
+            case IpType.ID:
+            case StringType.ID:
+                return new ArrayAggBinaryDocValueAggregator(
+                    fieldTypes.get(0).name(),
+                    sizeEstimator
+                );
+            default:
+                return null;
+        }
+    }
+
+    private static class LongArrayAggNumericDocValueAggregator implements DocValueAggregator<ArrayList<Object>> {
+
+        private final String columnName;
+        private final DataType<?> dataType;
+        private final SizeEstimator<Object> sizeEstimator;
+
+        private SortedNumericDocValues values;
+
+        public LongArrayAggNumericDocValueAggregator(String columnName,
+                                                     DataType<?> dataType,
+                                                     SizeEstimator<Object> sizeEstimator) {
+            this.columnName = columnName;
+            this.dataType = dataType;
+            this.sizeEstimator = sizeEstimator;
+        }
+
+        @Override
+        public ArrayList<Object> initialState(RamAccounting ramAccounting) {
+            var state = new ArrayList<>();
+            ramAccounting.addBytes(RamUsageEstimator.sizeOfCollection(state));
+            return state;
+        }
+
+        @Override
+        public void loadDocValues(LeafReader reader) throws IOException {
+            values = DocValues.getSortedNumeric(reader, columnName);
+        }
+
+        @Override
+        public void apply(RamAccounting ramAccounting, int doc, ArrayList<Object> state) throws IOException {
+            if (values.advanceExact(doc)) {
+                if (values.docValueCount() == 1) {
+                    var value = dataType.sanitizeValue(values.nextValue());
+                    ramAccounting.addBytes(sizeEstimator.estimateSize(value));
+                    state.add(value);
+                }
+            } else {
+                state.add(null);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Object partialResult(RamAccounting ramAccounting, ArrayList<Object> state) {
+            return state;
+        }
+    }
+
+    private static class FloatArrayAggNumericDocValueAggregator implements DocValueAggregator<ArrayList<Float>> {
+
+        private final String columnName;
+        private final SizeEstimator<Object> sizeEstimator;
+
+        private SortedNumericDocValues values;
+
+
+        public FloatArrayAggNumericDocValueAggregator(String columnName,
+                                                      SizeEstimator<Object> sizeEstimator) {
+            this.columnName = columnName;
+            this.sizeEstimator = sizeEstimator;
+        }
+
+        @Override
+        public ArrayList<Float> initialState(RamAccounting ramAccounting) {
+            var state = new ArrayList<Float>();
+            ramAccounting.addBytes(RamUsageEstimator.sizeOfCollection(state));
+            return state;
+        }
+
+        @Override
+        public void loadDocValues(LeafReader reader) throws IOException {
+            values = DocValues.getSortedNumeric(reader, columnName);
+        }
+
+        @Override
+        public void apply(RamAccounting ramAccounting, int doc, ArrayList<Float> state) throws IOException {
+            if (values.advanceExact(doc)) {
+                if (values.docValueCount() == 1) {
+                    var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
+                    ramAccounting.addBytes(sizeEstimator.estimateSize(value));
+                    state.add(value);
+                }
+            } else {
+                state.add(null);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Object partialResult(RamAccounting ramAccounting, ArrayList<Float> state) {
+            return state;
+        }
+    }
+
+    private static class DoubleArrayAggNumericDocValueAggregator implements DocValueAggregator<ArrayList<Double>> {
+
+        private final String columnName;
+        private final SizeEstimator<Object> sizeEstimator;
+
+        private SortedNumericDocValues values;
+
+
+        public DoubleArrayAggNumericDocValueAggregator(String columnName,
+                                                       SizeEstimator<Object> sizeEstimator) {
+            this.columnName = columnName;
+            this.sizeEstimator = sizeEstimator;
+        }
+
+        @Override
+        public ArrayList<Double> initialState(RamAccounting ramAccounting) {
+            var state = new ArrayList<Double>();
+            ramAccounting.addBytes(RamUsageEstimator.sizeOfCollection(state));
+            return state;
+        }
+
+        @Override
+        public void loadDocValues(LeafReader reader) throws IOException {
+            values = DocValues.getSortedNumeric(reader, columnName);
+        }
+
+        @Override
+        public void apply(RamAccounting ramAccounting, int doc, ArrayList<Double> state) throws IOException {
+            if (values.advanceExact(doc)) {
+                if (values.docValueCount() == 1) {
+                    var value = NumericUtils.sortableLongToDouble(values.nextValue());
+                    ramAccounting.addBytes(sizeEstimator.estimateSize(value));
+                    state.add(value);
+
+                }
+            } else {
+                state.add(null);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Object partialResult(RamAccounting ramAccounting, ArrayList<Double> state) {
+            return state;
+        }
+    }
+
+    private static class ArrayAggBinaryDocValueAggregator implements DocValueAggregator<ArrayList<String>> {
+
+        private final String columnName;
+        private final SizeEstimator<Object> sizeEstimator;
+
+        private SortedBinaryDocValues values;
+
+        public ArrayAggBinaryDocValueAggregator(String columnName,
+                                                SizeEstimator<Object> sizeEstimator) {
+            this.columnName = columnName;
+            this.sizeEstimator = sizeEstimator;
+        }
+
+        @Override
+        public ArrayList<String> initialState(RamAccounting ramAccounting) {
+            var state = new ArrayList<String>();
+            ramAccounting.addBytes(RamUsageEstimator.sizeOfCollection(state));
+            return state;
+        }
+
+        @Override
+        public void loadDocValues(LeafReader reader) throws IOException {
+            values = FieldData.toString(DocValues.getSortedSet(reader, columnName));
+        }
+
+        @Override
+        public void apply(RamAccounting ramAccounting, int doc, ArrayList<String> state) throws IOException {
+            if (values.advanceExact(doc)) {
+                if (values.docValueCount() == 1) {
+                    String value = values.nextValue().utf8ToString();
+                    ramAccounting.addBytes(sizeEstimator.estimateSize(value));
+                    state.add(value);
+                }
+            } else {
+                state.add(null);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Object partialResult(RamAccounting ramAccounting, ArrayList<String> state) {
+            return state;
+        }
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
@@ -47,7 +46,7 @@ public class CollectSetAggregationTest extends AggregationTest {
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                "collect_set",
+                CollectSetAggregation.NAME,
                 argumentType.getTypeSignature(),
                 new ArrayType<>(argumentType).getTypeSignature()
             ),
@@ -56,23 +55,47 @@ public class CollectSetAggregationTest extends AggregationTest {
     }
 
     @Test
-    public void testReturnType() throws Exception {
+    public void testReturnType() {
         FunctionImplementation collectSet = functions.get(
-            null, "collect_set", ImmutableList.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
-        assertEquals(new ArrayType<>(DataTypes.INTEGER), collectSet.info().returnType());
+            null,
+            CollectSetAggregation.NAME,
+            List.of(Literal.of(DataTypes.INTEGER, null)),
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
+        assertThat(collectSet.boundSignature().getReturnType().createType(), is(DataTypes.INTEGER_ARRAY));
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_numeric_types() {
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            assertHasDocValueAggregator(CountAggregation.NAME, List.of(dataType));
+        }
+    }
+
+    @Test
+    public void test_function_implements_doc_values_aggregator_for_string_based_types() {
+        for (var dataType : List.of(DataTypes.STRING, DataTypes.IP)) {
+            assertHasDocValueAggregator(CountAggregation.NAME, List.of(dataType));
+        }
     }
 
     @Test
     public void testDouble() throws Exception {
         assertThat(
-            (List<Object>) executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.7d}, {0.3d}, {0.3d}}),
-            is(Matchers.containsInAnyOrder(0.3d, 0.7d)));
+            (List<?>) executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.7d}, {0.3d}, {0.3d}}),
+            containsInAnyOrder(0.3d, 0.7d)
+        );
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void testLongSerialization() throws Exception {
         AggregationFunction impl = (AggregationFunction) functions.get(
-                null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+                null,
+                CollectSetAggregation.NAME,
+                List.of(Literal.of(DataTypes.LONG, null)),
+                SearchPath.pathWithPGCatalogAndDoc()
+        );
 
         Object state = impl.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
 
@@ -80,13 +103,18 @@ public class CollectSetAggregationTest extends AggregationTest {
         impl.partialType().streamer().writeValueTo(streamOutput, state);
 
         Object newState = impl.partialType().streamer().readValueFrom(streamOutput.bytes().streamInput());
-        assertEquals(state, newState);
+        assertThat(state, is(newState));
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void test_value_adding_and_removal() {
         AggregationFunction impl = (AggregationFunction) functions.get(
-            null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+            null,
+            CollectSetAggregation.NAME,
+            List.of(Literal.of(DataTypes.LONG, null)),
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
         AggregationFunction aggregationFunction = impl.optimizeForExecutionAsWindowFunction();
 
         Object state = aggregationFunction.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
@@ -97,50 +125,62 @@ public class CollectSetAggregationTest extends AggregationTest {
         aggregationFunction.removeFromAggregatedState(RAM_ACCOUNTING, state, new Input[] { Literal.of(10) });
 
         Object values = aggregationFunction.terminatePartial(RAM_ACCOUNTING, state);
-        assertThat((List<Object>) values, Matchers.empty());
+        assertThat((List<?>) values, Matchers.empty());
     }
 
     @Test
     public void testFloat() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}, {0.3f}}),
-                   is(containsInAnyOrder(0.3f, 0.7f)));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}, {0.3f}}),
+            containsInAnyOrder(0.3f, 0.7f)
+        );
     }
 
     @Test
     public void testInteger() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.INTEGER, new Object[][]{{7}, {3}, {3}}),
-                   is(containsInAnyOrder(3, 7)));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.INTEGER, new Object[][]{{7}, {3}, {3}}),
+            containsInAnyOrder(3, 7)
+        );
     }
 
     @Test
     public void testLong() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.LONG, new Object[][]{{7L}, {3L}, {3L}}),
-                   is(containsInAnyOrder(3L, 7L)));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.LONG, new Object[][]{{7L}, {3L}, {3L}}),
+            containsInAnyOrder(3L, 7L)
+        );
     }
 
     @Test
     public void testShort() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.SHORT,
-                                                 new Object[][]{{(short) 7}, {(short) 3}, {(short) 3}}),
-                   is(containsInAnyOrder((short) 3, (short) 7)));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 7}, {(short) 3}, {(short) 3}}),
+            containsInAnyOrder((short) 3, (short) 7));
     }
 
     @Test
     public void testString() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}, {"Ruben"}}),
-                   is(containsInAnyOrder("Youri", "Ruben")));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}, {"Ruben"}}),
+            containsInAnyOrder("Youri", "Ruben")
+        );
     }
 
     @Test
     public void testBoolean() throws Exception {
-        assertThat((List<Object>) executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}, {false}}),
-                   is(containsInAnyOrder(true, false)));
+        assertThat(
+            (List<?>) executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}, {false}}),
+            containsInAnyOrder(true, false)
+        );
     }
 
     @Test
     public void testNullValue() throws Exception {
-        assertThat("null values currently ignored",
-                   (List<Object>) executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}, {null}}),
-                   is(containsInAnyOrder("Youri", "Ruben")));
+        assertThat(
+            "null values currently ignored",
+            (List<?>) executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}, {null}}),
+            containsInAnyOrder("Youri", "Ruben")
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits.

### array_agg
With doc values aggregator:

```
# Running setUp
# Running benchmark

## Running Query:
   Name: global array_agg on long
   Statement:
     select array_agg(duration) from uservisits
   Concurrency: 1
   Iterations: 400
100%| 400/400 [02:13<00:00,  2.99 requests/s]
Runtime (in ms):
    mean:    117.533 ± 5.925
    min/max: 70.763 → 1113.618
Percentile:
    50:   110.825 ± 60.463 (stdev)
    95:   162.934
    99.9: 1113.618

## Running Query:
   Name: global array_agg on float
   Statement:
     select array_agg("adRevenue") from uservisits
   Concurrency: 1
   Iterations: 400
100%| 400/400 [09:02<00:00,  1.36s/ requests]
Runtime (in ms):
    mean:    891.798 ± 33.724
    min/max: 346.824 → 3227.598
Percentile:
    50:   835.351 ± 344.117 (stdev)
    95:   1515.606
    99.9: 3227.598
```

Without doc values aggregator:
```
# Running setUp
# Running benchmark

## Running Query:
   Name: global array_agg on long
   Statement:
     select array_agg(duration) from uservisits
   Concurrency: 1
   Iterations: 400
100%| 400/400 [03:37<00:00,  1.84 requests/s]
Runtime (in ms):
    mean:    192.064 ± 10.599
    min/max: 94.740 → 1898.387
Percentile:
    50:   172.868 ± 108.148 (stdev)
    95:   329.987
    99.9: 1898.387

## Running Query:
   Name: global array_agg on float
   Statement:
     select array_agg("adRevenue") from uservisits
   Concurrency: 1
   Iterations: 400
100%| 400/400 [12:16<00:00,  1.84s/ requests]
Runtime (in ms):
    mean:    1181.211 ± 52.584
    min/max: 431.027 → 4477.084
Percentile:
    50:   1020.053 ± 536.576 (stdev)
    95:   2217.083
    99.9: 4477.084
```

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
