### PR TITLE
Avoid wrapping errors in UnhandledServerException in ShardCollectSource

### DIFF
--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -67,7 +67,7 @@ When a not indexed column is queried the query will return an error.
 ::
 
     cr> select * from table_a where first_column = 'hello';
-    UnhandledServerException[java.lang.IllegalArgumentException: Cannot search on field [first_column] since it is not indexed.]
+    SQLParseException[Cannot search on field [first_column] since it is not indexed.]
 
 .. _sql_ddl_index_plain:
 

--- a/docs/general/occ.rst
+++ b/docs/general/occ.rst
@@ -107,7 +107,7 @@ Known limitations
     cr> DELETE FROM sensors WHERE type = 'DHT11' 
     ...   AND "_seq_no" = 3
     ...   AND "_primary_term" = 1;
-    UnhandledServerException[io.crate.exceptions.UnsupportedFeatureException: "_seq_no" and "_primary_term" columns can only be used together in the WHERE clause with equals comparisons and if there are also equals comparisons on primary key columns]
+    UnsupportedFeatureException["_seq_no" and "_primary_term" columns can only be used together in the WHERE clause with equals comparisons and if there are also equals comparisons on primary key columns]
 
  - In order to use the optimistic concurrency control mechanism both the
    ``_seq_no`` and ``_primary_term`` columns need to be specified. It is not

--- a/server/src/main/java/io/crate/exceptions/UnhandledServerException.java
+++ b/server/src/main/java/io/crate/exceptions/UnhandledServerException.java
@@ -30,9 +30,4 @@ public class UnhandledServerException extends RuntimeException implements Unscop
     public UnhandledServerException(String message, Throwable cause) {
         super(message, cause);
     }
-
-    public UnhandledServerException(Throwable cause) {
-        super(cause);
-    }
-
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -33,7 +33,7 @@ import io.crate.data.CompositeBatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.SentinelRow;
-import io.crate.exceptions.UnhandledServerException;
+import io.crate.exceptions.Exceptions;
 import io.crate.execution.TransportActionProvider;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
@@ -358,10 +358,6 @@ public class ShardCollectSource implements CollectSource {
                         break;
                     }
                     throw e;
-                } catch (Throwable t) {
-                    UnhandledServerException unhandledServerException = new UnhandledServerException(t);
-                    unhandledServerException.setStackTrace(t.getStackTrace());
-                    throw unhandledServerException;
                 }
             }
         }
@@ -443,10 +439,8 @@ public class ShardCollectSource implements CollectSource {
                 } catch (IndexNotFoundException e) {
                     // Prevent wrapping this to not break retry-detection
                     throw e;
-                } catch (Exception e) {
-                    UnhandledServerException unhandledServerException = new UnhandledServerException(e);
-                    unhandledServerException.setStackTrace(e.getStackTrace());
-                    throw unhandledServerException;
+                } catch (Throwable t) {
+                    Exceptions.rethrowRuntimeException(t);
                 }
             }
         }
@@ -487,8 +481,6 @@ public class ShardCollectSource implements CollectSource {
                     shardRowContexts.add(shardCollectorProvider.shardRowContext());
                 } catch (ShardNotFoundException | IllegalIndexShardStateException e) {
                     unassignedShards.add(toUnassignedShard(index.getName(), shard.value));
-                } catch (Throwable t) {
-                    throw new UnhandledServerException(t);
                 }
             }
         }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -295,11 +295,15 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into quotes (id, quote) values (?, ?)", new Object[]{1, quote});
         execute("refresh table quotes");
 
-        assertThrows(() -> execute("select quote from quotes where quote = ?", new Object[]{quote}),
-            isSQLError(containsString("Cannot search on field [quote] since it is not indexed."),
-                       INTERNAL_ERROR,
-                       INTERNAL_SERVER_ERROR,
-                       5000));
+        assertThrows(
+            () -> execute("select quote from quotes where quote = ?", new Object[]{quote}),
+            isSQLError(
+                containsString("Cannot search on field [quote] since it is not indexed."),
+                INTERNAL_ERROR,
+                BAD_REQUEST,
+                4000
+            )
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -208,22 +208,30 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     public void testInvalidWhereClause() throws Exception {
         setUpSimple();
 
-        assertThrows(() -> execute("delete from t1 where byte_field=129"),
-                     isSQLError(containsString("Cannot cast `129` of type `integer` to type `char`"),
-                         INTERNAL_ERROR,
-                         INTERNAL_SERVER_ERROR,
-                         5000));
+        assertThrows(
+            () -> execute("delete from t1 where byte_field=129"),
+            isSQLError(
+                containsString("Cannot cast `129` of type `integer` to type `char`"),
+                INTERNAL_ERROR,
+                BAD_REQUEST,
+                4000
+            )
+        );
     }
 
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         setUpSimple();
 
-        assertThrows(() -> execute("update t1 set byte_field=0 where byte_field in (129)"),
-                     isSQLError(containsString("Cannot cast `[129]` of type `integer_array` to type `char_array`"),
-                         INTERNAL_ERROR,
-                         INTERNAL_SERVER_ERROR,
-                         5000));
+        assertThrows(
+            () -> execute("update t1 set byte_field=0 where byte_field in (129)"),
+            isSQLError(
+                containsString("Cannot cast `[129]` of type `integer_array` to type `char_array`"),
+                INTERNAL_ERROR,
+                BAD_REQUEST,
+                4000
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

UnhandledServerException is not registered for proper serialization and
causes us to loose more specific exception information.

This is also in preparation for
https://github.com/crate/crate/pull/10373, which by-passed the wrapping
due to the use of futures - which led to test failures because a
`IllegalArgumentException` started being recognized in the error-code
translation layer, leading to a bad-request error instead of
internal-server-error.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)