### PR TITLE
Unify mutable long, double and float state classes in aggregations.

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/MutableFloat.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableFloat.java
@@ -21,15 +21,12 @@
 
 package io.crate.common;
 
+public final class MutableFloat {
 
-import java.util.Objects;
-
-public final class MutableLong {
-
-    private long value;
+    private float value;
     private boolean hasValue = false;
 
-    public MutableLong(long value) {
+    public MutableFloat(float value) {
         this.value = value;
     }
 
@@ -37,45 +34,12 @@ public final class MutableLong {
         return hasValue;
     }
 
-    public long value() {
+    public float value() {
         return value;
     }
 
-    public void setValue(long value) {
+    public void setValue(float value) {
         this.hasValue = true;
         this.value = value;
-    }
-
-    public MutableLong add(long value) {
-        setValue(this.value + value);
-        return this;
-    }
-
-    public MutableLong sub(long value) {
-        setValue(this.value - value);
-        return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        MutableLong that = (MutableLong) o;
-        return value == that.value &&
-               hasValue == that.hasValue;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(value, hasValue);
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import io.crate.common.MutableLong;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
@@ -125,12 +126,12 @@ public class CountAggregationTest extends AggregationTest {
 
     @Test
     public void testStreaming() throws Exception {
-        CountAggregation.LongState l1 = new CountAggregation.LongState(12345L);
+        MutableLong l1 = new MutableLong(12345L);
         BytesStreamOutput out = new BytesStreamOutput();
         var streamer = CountAggregation.LongStateType.INSTANCE.streamer();
         streamer.writeValueTo(out, l1);
         StreamInput in = out.bytes().streamInput();
-        CountAggregation.LongState l2 = streamer.readValueFrom(in);
-        assertThat(l1.value, is(l2.value));
+        MutableLong l2 = streamer.readValueFrom(in);
+        assertThat(l1.value(), is(l2.value()));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We used multiple private static nested classes in each aggregation
functions to represent the aggregation state of some functions. e.g.
sum, min, max, etc. The classes share the same logic, therefore, it
makes sense to extract them into the `common` package and reuse across
the above-mentioned functions.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
