### PR TITLE
Expose blocks.read_only_allow_delete in information_schema tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,10 @@ Breaking Changes
 Changes
 =======
 
+- Added the ``read_only_allow_delete`` setting to the ``settings['blocks']``
+  column of the :ref:`information_schema.tables <information_schema_tables>`
+  and :ref:`information_schema.table_partitions <is_table_partitions>` tables.
+
 - Changed the error code for dropping a missing view from the undefined 4040
   to 4041.
 

--- a/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -77,6 +77,7 @@ public class InformationPartitionsTableInfo {
                     .add("read", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_READ_SETTING))
                     .add("write", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING))
                     .add("metadata", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_METADATA_SETTING))
+                    .add("read_only_allow_delete", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING))
                 .endObject()
 
                 .add("codec", STRING, fromSetting(INDEX_CODEC_SETTING))

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -175,6 +175,7 @@ public class InformationTablesTableInfo {
                     .add("read", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_READ_SETTING))
                     .add("write", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING))
                     .add("metadata", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_METADATA_SETTING))
+                    .add("read_only_allow_delete", BOOLEAN, fromSetting(IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING))
                 .endObject()
                 .add("codec", STRING, fromSetting(INDEX_CODEC_SETTING))
                 .startObject("store")

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -520,7 +520,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(815, response.rowCount());
+        assertEquals(817, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/10391

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)