### PR TITLE
Fix predicate evaluation for the sys.nodes table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -76,4 +76,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a issue that resulted in incorrect results when querying the
+  ``sys.nodes`` table. Predicates used in the ``WHERE`` clause on columns that
+  were absent in the select-list never matched.

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
@@ -117,7 +117,10 @@ public final class NodeStats {
 
         private CompletableFuture<List<NodeStatsContext>> getNodeStatsContexts() {
             Set<ColumnIdent> toCollect = getRootColumns(collectPhase.toCollect());
-            return dataAvailableInClusterState(toCollect) ? getStatsFromLocalState() : getStatsFromRemote(toCollect);
+            toCollect.addAll(getRootColumns(List.of(collectPhase.where())));
+            return dataAvailableInClusterState(toCollect)
+                ? getStatsFromLocalState()
+                : getStatsFromRemote(toCollect);
         }
 
         private CompletableFuture<List<NodeStatsContext>> getStatsFromLocalState() {

--- a/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -33,7 +33,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-@ESIntegTestCase.ClusterScope(numClientNodes = 0)
+@ESIntegTestCase.ClusterScope(numClientNodes = 0, supportsDedicatedMasters = false)
 public class SysNodesITest extends SQLTransportIntegrationTest {
 
     @Override
@@ -63,4 +63,10 @@ public class SysNodesITest extends SQLTransportIntegrationTest {
         assertThat((String) response.rows()[0][0], startsWith("127.0.0.1:"));
     }
 
+
+    @Test
+    public void test_filter_on_not_selected_column_on_sys_nodes_returns_record() throws Exception {
+        execute("select fs from sys.nodes where name = 'node_s0'");
+        assertThat(response.rowCount(), is(1L));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The values for columns only used in the `WHERE` clause and not in the
select-list were not fetched from the remote node, so those predicates
never resulted in a match.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)