### PR TITLE
Fix serialization of DecomissionNodeRequest

### DIFF
--- a/blackbox/test_decommission.py
+++ b/blackbox/test_decommission.py
@@ -230,7 +230,7 @@ class TestGracefulStopFull(GracefulStopTest):
         node1, node2, node3 = self.node_names
         client1, client2, client3 = self.clients
         self.set_settings({"cluster.graceful_stop.min_availability": "full"})
-        decommission(client1, node1)
+        decommission(client2, node1)
         self.assertEqual(wait_for_cluster_size(client2, TestGracefulStopFull.NUM_SERVERS - 1), True)
 
         stmt = "select table_name, id from sys.shards where state = 'UNASSIGNED'"

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -76,6 +76,9 @@ Changes
 Fixes
 =====
 
-- Fixed a issue that resulted in incorrect results when querying the
+- Fixed an issue that led to a ``Message not fully read`` error when trying to
+  decommission a node using ``ALTER CLUSTER DECOMMISSION``.
+
+- Fixed an issue that resulted in incorrect results when querying the
   ``sys.nodes`` table. Predicates used in the ``WHERE`` clause on columns that
   were absent in the select-list never matched.

--- a/server/src/main/java/io/crate/cluster/decommission/DecommissionNodeRequest.java
+++ b/server/src/main/java/io/crate/cluster/decommission/DecommissionNodeRequest.java
@@ -22,12 +22,29 @@
 
 package io.crate.cluster.decommission;
 
+import java.io.IOException;
+
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.transport.TransportRequest;
 
 public class DecommissionNodeRequest extends TransportRequest {
 
-    public static final DecommissionNodeRequest INSTANCE = new DecommissionNodeRequest();
+    public DecommissionNodeRequest() {
+        super();
+    }
 
-    private DecommissionNodeRequest() {
+    public DecommissionNodeRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public int hashCode() {
+        return getParentTask().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this
+            || (obj instanceof DecommissionNodeRequest && ((DecommissionNodeRequest) obj).getParentTask().equals(getParentTask()));
     }
 }

--- a/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
+++ b/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
@@ -51,9 +51,9 @@ public class TransportDecommissionNodeAction implements NodeAction<DecommissionN
                                            Transports transports) {
         this.decommissioningService = decommissioningService;
         this.transports = transports;
-
-        transportService.registerRequestHandler(ACTION_NAME,
-            in -> DecommissionNodeRequest.INSTANCE,
+        transportService.registerRequestHandler(
+            ACTION_NAME,
+            DecommissionNodeRequest::new,
             EXECUTOR,
             new NodeActionRequestHandler<>(this)
         );

--- a/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
+++ b/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
@@ -71,7 +71,7 @@ public final class DecommissionNodePlan implements Plan {
             .transportDecommissionNodeAction()
             .execute(
                 targetNodeId,
-                DecommissionNodeRequest.INSTANCE,
+                new DecommissionNodeRequest(),
                 new OneRowActionListener<>(
                     consumer,
                     r -> r.isAcknowledged() ? new Row1(1L) : new Row1(0L))

--- a/server/src/test/java/io/crate/cluster/decommission/DecommissionNodeRequestTest.java
+++ b/server/src/test/java/io/crate/cluster/decommission/DecommissionNodeRequestTest.java
@@ -1,0 +1,17 @@
+package io.crate.cluster.decommission;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class DecommissionNodeRequestTest extends AbstractWireSerializingTestCase<DecommissionNodeRequest> {
+
+    @Override
+    protected DecommissionNodeRequest createTestInstance() {
+        return new DecommissionNodeRequest();
+    }
+
+    @Override
+    protected Reader<DecommissionNodeRequest> instanceReader() {
+        return DecommissionNodeRequest::new;
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`writeTo` of `TransportRequest` writes the parent taskId, the `reader`
for `DecomissionNodeRequest` used in the
`TransportDecomissionNodeAction` never read the taskId but returned a
singleton.

This led to a error:

    IllegalStateException: Message not fully read (request) for requestId [135130976], action [internal:crate:sql/decommission/node], available [0]; resetting

The blackbox tests never caught this issue because we always used the
client connected to the node we wanted to decommission, so the
serialization was never used.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)