### PR TITLE
Account for memory usage in doc values aggregators.

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
@@ -26,19 +26,20 @@ import java.io.IOException;
 
 import javax.annotation.Nullable;
 
+import io.crate.breaker.RamAccounting;
 import org.apache.lucene.index.LeafReader;
 
 public interface DocValueAggregator<T> {
 
-    public T initialState();
+    public T initialState(RamAccounting ramAccounting);
 
     public void loadDocValues(LeafReader reader) throws IOException;
 
-    public void apply(T state, int doc) throws IOException;
+    public void apply(RamAccounting ramAccounting, int doc, T state) throws IOException;
 
     // Aggregations are executed on shard level,
     // that means there is always a final reduce step necessary
     // → never return final value, but always partial result
     @Nullable
-    public Object partialResult(T state);
+    public Object partialResult(RamAccounting ramAccounting, T state);
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -182,7 +182,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                 ) {
                     @Nullable
                     @Override
-                    public Object partialResult(MutableObject state) {
+                    public Object partialResult(RamAccounting ramAccounting, MutableObject state) {
                         if (state.hasValue()) {
                             return dataType.sanitizeValue(state.value());
                         } else {
@@ -210,7 +210,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
         @Nullable
         @Override
-        public Object partialResult(MutableObject state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableObject state) {
             if (state.hasValue()) {
                 return columnDataType.sanitizeValue(state.value());
             } else {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -281,7 +281,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case LongType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    AverageAggregation.AverageState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
+                        return new AverageState();
+                    },
                     (values, state) -> {
                         state.sum += values.nextValue();
                         state.count++;
@@ -290,7 +293,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    AverageAggregation.AverageState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
+                        return new AverageState();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.sum += value;
@@ -300,7 +306,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    AverageAggregation.AverageState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
+                        return new AverageState();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.sum += value;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/BinaryDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/BinaryDocValueAggregator.java
@@ -32,19 +32,18 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.function.Supplier;
-
+import java.util.function.Function;
 
 public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
 
     private final String columnName;
-    private final Supplier<T> stateInitializer;
+    private final Function<RamAccounting, T> stateInitializer;
     private final CheckedBiConsumer<SortedBinaryDocValues, T, IOException> docValuesConsumer;
 
     protected SortedBinaryDocValues values;
 
     public BinaryDocValueAggregator(String columnName,
-                                    Supplier<T> stateInitializer,
+                                    Function<RamAccounting, T> stateInitializer,
                                     CheckedBiConsumer<SortedBinaryDocValues, T, IOException> docValuesConsumer) {
         this.columnName = columnName;
         this.stateInitializer = stateInitializer;
@@ -53,7 +52,7 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
 
     @Override
     public T initialState(RamAccounting ramAccounting) {
-        return stateInitializer.get();
+        return stateInitializer.apply(ramAccounting);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/BinaryDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/BinaryDocValueAggregator.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -51,7 +52,7 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
     }
 
     @Override
-    public T initialState() {
+    public T initialState(RamAccounting ramAccounting) {
         return stateInitializer.get();
     }
 
@@ -61,7 +62,7 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
     }
 
     @Override
-    public void apply(T state, int doc) throws IOException {
+    public void apply(RamAccounting ramAccounting, int doc, T state) throws IOException {
         if (values.advanceExact(doc) && values.docValueCount() == 1) {
             docValuesConsumer.accept(values, state);
         }
@@ -69,7 +70,7 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
 
     @Nullable
     @Override
-    public Object partialResult(T state) {
+    public Object partialResult(RamAccounting ramAccounting, T state) {
         return state;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -250,14 +250,20 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                 case GeoPointType.ID:
                     return new SortedNumericDocValueAggregator<>(
                         fieldTypes.get(0).name(),
-                        () -> new MutableLong(0L),
+                        (ramAccounting) -> {
+                            ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+                            return new MutableLong(0L);
+                        },
                         (values, state) -> state.add(1L)
                     );
                 case IpType.ID:
                 case StringType.ID:
                     return new BinaryDocValueAggregator<>(
                         fieldTypes.get(0).name(),
-                        () -> new MutableLong(0L),
+                        (ramAccounting) -> {
+                            ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+                            return new MutableLong(0L);
+                        },
                         (values, state) -> state.add(1L)
                     );
                 default:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -300,13 +300,19 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    GeometricMeanState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
+                        return new GeometricMeanState();
+                    },
                     (values, state) -> state.addValue(values.nextValue())
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    GeometricMeanState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
+                        return new GeometricMeanState();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.addValue(value);
@@ -315,7 +321,10 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    GeometricMeanState::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
+                        return new GeometricMeanState();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.addValue(value);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -90,6 +90,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(Long.MIN_VALUE);
         }
 
@@ -130,6 +131,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(Double.MIN_VALUE);
         }
 
@@ -170,6 +172,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(Float.MIN_VALUE);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -89,7 +89,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableLong initialState() {
+        public MutableLong initialState(RamAccounting ramAccounting) {
             return new MutableLong(Long.MIN_VALUE);
         }
 
@@ -99,7 +99,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableLong state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableLong state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 long value = values.nextValue();
                 if (value > state.value()) {
@@ -109,7 +109,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableLong state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableLong state) {
             if (state.hasValue()) {
                 return partialType.sanitizeValue(state.value());
             } else {
@@ -129,7 +129,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableDouble initialState() {
+        public MutableDouble initialState(RamAccounting ramAccounting) {
             return new MutableDouble(Double.MIN_VALUE);
         }
 
@@ -139,7 +139,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableDouble state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableDouble state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 double value = NumericUtils.sortableLongToDouble(values.nextValue());
                 if (value > state.value()) {
@@ -149,7 +149,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableDouble state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableDouble state) {
             if (state.hasValue()) {
                 return state.value();
             } else {
@@ -169,7 +169,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableFloat initialState() {
+        public MutableFloat initialState(RamAccounting ramAccounting) {
             return new MutableFloat(Float.MIN_VALUE);
         }
 
@@ -179,7 +179,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableFloat state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableFloat state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 float value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                 if (value > state.value()) {
@@ -189,7 +189,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableFloat state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableFloat state) {
             if (state.hasValue()) {
                 return state.value();
             } else {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -88,7 +88,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableLong initialState() {
+        public MutableLong initialState(RamAccounting ramAccounting) {
             return new MutableLong(Long.MAX_VALUE);
         }
 
@@ -98,7 +98,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableLong state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableLong state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 long value = values.nextValue();
                 if (value < state.value()) {
@@ -108,7 +108,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableLong state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableLong state) {
             if (state.hasValue()) {
                 return partialType.sanitizeValue(state.value());
             } else {
@@ -128,7 +128,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableDouble initialState() {
+        public MutableDouble initialState(RamAccounting ramAccounting) {
             return new MutableDouble(Double.MAX_VALUE);
         }
 
@@ -138,7 +138,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableDouble state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableDouble state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 double value = NumericUtils.sortableLongToDouble(values.nextValue());
                 if (value < state.value()) {
@@ -148,7 +148,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableDouble state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableDouble state) {
             if (state.hasValue()) {
                 return state.value();
             } else {
@@ -167,7 +167,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableFloat initialState() {
+        public MutableFloat initialState(RamAccounting ramAccounting) {
             return new MutableFloat(Float.MAX_VALUE);
         }
 
@@ -177,7 +177,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public void apply(MutableFloat state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableFloat state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 float value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                 if (value < state.value()) {
@@ -187,7 +187,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public Object partialResult(MutableFloat state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableFloat state) {
             if (state.hasValue()) {
                 return state.value();
             } else {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -89,6 +89,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(Long.MAX_VALUE);
         }
 
@@ -129,6 +130,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(Double.MAX_VALUE);
         }
 
@@ -168,6 +170,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(Float.MAX_VALUE);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SortedNumericDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SortedNumericDocValueAggregator.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -49,7 +50,7 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
     }
 
     @Override
-    public T initialState() {
+    public T initialState(RamAccounting ramAccounting) {
         return stateInitializer.get();
     }
 
@@ -59,7 +60,7 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
     }
 
     @Override
-    public void apply(T state, int doc) throws IOException {
+    public void apply(RamAccounting ramAccounting, int doc, T state) throws IOException {
         if (values.advanceExact(doc) && values.docValueCount() == 1) {
             docValuesConsumer.accept(values, state);
         }
@@ -67,7 +68,7 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
 
     @Nullable
     @Override
-    public Object partialResult(T state) {
+    public Object partialResult(RamAccounting ramAccounting, T state) {
         return state;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SortedNumericDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SortedNumericDocValueAggregator.java
@@ -31,18 +31,18 @@ import org.elasticsearch.common.CheckedBiConsumer;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T> {
 
     private final String columnName;
-    private final Supplier<T> stateInitializer;
+    private final Function<RamAccounting, T> stateInitializer;
     private final CheckedBiConsumer<SortedNumericDocValues, T, IOException> docValuesConsumer;
 
     private SortedNumericDocValues values;
 
     public SortedNumericDocValueAggregator(String columnName,
-                                           Supplier<T> stateInitializer,
+                                           Function<RamAccounting, T> stateInitializer,
                                            CheckedBiConsumer<SortedNumericDocValues, T, IOException> docValuesConsumer) {
         this.columnName = columnName;
         this.stateInitializer = stateInitializer;
@@ -51,7 +51,7 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
 
     @Override
     public T initialState(RamAccounting ramAccounting) {
-        return stateInitializer.get();
+        return stateInitializer.apply(ramAccounting);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -221,13 +221,19 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    StandardDeviation::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
+                        return new StandardDeviation();
+                    },
                     (values, state) -> state.increment(values.nextValue())
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    StandardDeviation::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
+                        return new StandardDeviation();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.increment(value);
@@ -236,7 +242,10 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    StandardDeviation::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
+                        return new StandardDeviation();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.increment(value);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -204,6 +204,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(0L);
         }
 
@@ -236,6 +237,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(.0d);
         }
 
@@ -269,6 +271,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting) {
+            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(.0f);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -203,7 +203,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableLong initialState() {
+        public MutableLong initialState(RamAccounting ramAccounting) {
             return new MutableLong(0L);
         }
 
@@ -213,14 +213,14 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public void apply(MutableLong state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableLong state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 state.setValue(Math.addExact(state.value(), values.nextValue()));
             }
         }
 
         @Override
-        public Long partialResult(MutableLong state) {
+        public Long partialResult(RamAccounting ramAccounting, MutableLong state) {
             return state.hasValue() ? state.value() : null;
         }
     }
@@ -235,7 +235,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableDouble initialState() {
+        public MutableDouble initialState(RamAccounting ramAccounting) {
             return new MutableDouble(.0d);
         }
 
@@ -245,7 +245,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public void apply(MutableDouble state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableDouble state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 var value = state.value() + NumericUtils.sortableLongToDouble(values.nextValue());
                 state.setValue(value);
@@ -253,7 +253,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public Object partialResult(MutableDouble state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableDouble state) {
             return state.hasValue() ? state.value() : null;
         }
     }
@@ -268,7 +268,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableFloat initialState() {
+        public MutableFloat initialState(RamAccounting ramAccounting) {
             return new MutableFloat(.0f);
         }
 
@@ -278,14 +278,14 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public void apply(MutableFloat state, int doc) throws IOException {
+        public void apply(RamAccounting ramAccounting, int doc, MutableFloat state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 state.setValue(state.value() + NumericUtils.sortableIntToFloat((int) values.nextValue()));
             }
         }
 
         @Override
-        public Object partialResult(MutableFloat state) {
+        public Object partialResult(RamAccounting ramAccounting, MutableFloat state) {
             return state.hasValue() ? state.value() : null;
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -223,13 +223,19 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    Variance::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
+                        return new Variance();
+                    },
                     (values, state) -> state.increment(values.nextValue())
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    Variance::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
+                        return new Variance();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.increment(value);
@@ -238,7 +244,10 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    Variance::new,
+                    (ramAccounting) -> {
+                        ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
+                        return new Variance();
+                    },
                     (values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.increment(value);

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.collect;
 
+import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -119,6 +120,7 @@ public class DocValuesAggregates {
                 () -> {
                     try {
                         return CompletableFuture.completedFuture(getRow(
+                            collectTask.getRamAccounting(),
                             killed,
                             searcher,
                             queryContext.query(),
@@ -197,7 +199,8 @@ public class DocValuesAggregates {
 
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static Iterable<Row> getRow(AtomicReference<Throwable> killed,
+    private static Iterable<Row> getRow(RamAccounting ramAccounting,
+                                        AtomicReference<Throwable> killed,
                                         Searcher searcher,
                                         Query query,
                                         List<DocValueAggregator> aggregators) throws IOException {
@@ -206,7 +209,7 @@ public class DocValuesAggregates {
         List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
         Object[] cells = new Object[aggregators.size()];
         for (int i = 0; i < aggregators.size(); i++) {
-            cells[i] = aggregators.get(i).initialState();
+            cells[i] = aggregators.get(i).initialState(ramAccounting);
         }
         for (var leaf : leaves) {
             Scorer scorer = weight.scorer(leaf);
@@ -227,12 +230,12 @@ public class DocValuesAggregates {
                     Exceptions.rethrowUnchecked(killCause);
                 }
                 for (int i = 0; i < aggregators.size(); i++) {
-                    aggregators.get(i).apply(cells[i], doc);
+                    aggregators.get(i).apply(ramAccounting, doc, cells[i]);
                 }
             }
         }
         for (int i = 0; i < aggregators.size(); i++) {
-            cells[i] = aggregators.get(i).partialResult(cells[i]);
+            cells[i] = aggregators.get(i).partialResult(ramAccounting, cells[i]);
         }
         return List.of(new RowN(cells));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits.

It should supersede https://github.com/crate/crate/pull/10396

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
