### PR TITLE
Backport NoOpEngine

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -395,4 +395,3 @@ listed anymore.
 - [d] c459ea828f6 Remove node.max_local_storage_nodes (#42428)
 - [d] 3af0c1746b3 Expose external refreshes through the stats API (#38643)
 - [d] ef18d3fb5b2 Add analysis modes to restrict token filter use contexts (#36103)
-- [d] 309a3e4ccbc Add support for replicating closed indices (#39499)

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -102,7 +102,11 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         this.indexShard = indexShard;
         this.localNodeId = () -> clusterService.localNode().getId();
         var mapperService = indexShard.mapperService();
-        fieldTypeLookup = mapperService::fullName;
+        if (mapperService == null) {
+            fieldTypeLookup = name -> null;
+        } else {
+            fieldTypeLookup = mapperService::fullName;
+        }
         var relationName = RelationName.fromIndexName(indexShard.shardId().getIndexName());
         this.table = schemas.getTableInfo(relationName, Operation.READ);
         this.docInputFactory = new DocInputFactory(

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -237,10 +237,15 @@ public class ShardCollectSource implements CollectSource {
              * So we wrap the creation in a supplier to create the providers lazy
              */
 
-            Supplier<ShardCollectorProvider> providerSupplier = Suppliers.memoize(() ->
-                shardCollectorProviderFactory.create(indexShard)
-            );
-            shards.put(indexShard.shardId(), providerSupplier);
+            // MapperService is null for closed indices
+            if (indexShard.mapperService() == null) {
+                LOGGER.warn("Index {} appears to be closed, skipping collector provider creation", indexShard.shardId().getIndexName());
+            } else {
+                Supplier<ShardCollectorProvider> providerSupplier = Suppliers.memoize(() ->
+                    shardCollectorProviderFactory.create(indexShard)
+                );
+                shards.put(indexShard.shardId(), providerSupplier);
+            }
         }
 
         @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -260,7 +260,10 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                 routing = Collections.emptySet();
             }
             routingMap = indexNameExpressionResolver.resolveSearchRouting(
-                state, routing, indices);
+                state,
+                routing,
+                indices
+            );
         }
 
         if (routingMap == null) {

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -81,6 +81,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.indices.IndexClosedException;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -666,6 +667,7 @@ public class InsertFromValues implements LogicalPlan {
                             // we want to report duplicate key exceptions
                             if (!SQLExceptions.isDocumentAlreadyExistsException(throwable) &&
                                 (partitionWasDeleted(throwable, request.index())
+                                 || throwable instanceof IndexClosedException
                                  || mixedArgumentTypesFailure(throwable))) {
                                 result.complete(compressedResult);
                             } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -34,6 +35,11 @@ public class ClusterHealthRequestBuilder extends MasterNodeReadOperationRequestB
 
     public ClusterHealthRequestBuilder setIndices(String... indices) {
         request.indices(indices);
+        return this;
+    }
+
+    public ClusterHealthRequestBuilder setIndicesOptions(final IndicesOptions indicesOptions) {
+        request.indicesOptions(indicesOptions);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.recovery;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -47,7 +48,7 @@ public class RecoveryRequest extends BroadcastRequest<RecoveryRequest> {
      * @param indices   Comma-separated list of indices about which to gather recovery information
      */
     public RecoveryRequest(String... indices) {
-        super(indices);
+        super(indices, IndicesOptions.STRICT_EXPAND_OPEN_CLOSED);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -116,11 +116,11 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
 
     @Override
     protected ClusterBlockException checkGlobalBlock(ClusterState state, RecoveryRequest request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, RecoveryRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, concreteIndices);
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, concreteIndices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -88,7 +88,11 @@ public class IndicesOptions implements ToXContentFragment {
     public static final IndicesOptions STRICT_EXPAND_OPEN =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES), EnumSet.of(WildcardStates.OPEN));
     public static final IndicesOptions LENIENT_EXPAND_OPEN =
-        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE), EnumSet.of(WildcardStates.OPEN));
+        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
+            EnumSet.of(WildcardStates.OPEN));
+    public static final IndicesOptions LENIENT_EXPAND_OPEN_CLOSED =
+        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
+            EnumSet.of(WildcardStates.OPEN, WildcardStates.CLOSED));
     public static final IndicesOptions STRICT_EXPAND_OPEN_CLOSED =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES), EnumSet.of(WildcardStates.OPEN, WildcardStates.CLOSED));
     public static final IndicesOptions STRICT_EXPAND_OPEN_FORBID_CLOSED =
@@ -376,6 +380,14 @@ public class IndicesOptions implements ToXContentFragment {
      */
     public static IndicesOptions lenientExpandOpen() {
         return LENIENT_EXPAND_OPEN;
+    }
+
+    /**
+     * @return indices options that ignores unavailable indices,  expands wildcards to both open and closed
+     * indices and allows that no indices are resolved from wildcard expressions (not returning an error).
+     */
+    public static IndicesOptions lenientExpand() {
+        return LENIENT_EXPAND_OPEN_CLOSED;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -39,6 +39,11 @@ public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends
         this.indices = indices;
     }
 
+    protected BroadcastRequest(String[] indices, IndicesOptions indicesOptions) {
+        this.indices = indices;
+        this.indicesOptions = indicesOptions;
+    }
+
     @Override
     public String[] indices() {
         return indices;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -247,6 +247,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Integer> INDEX_FORMAT_SETTING =
             Setting.intSetting(INDEX_FORMAT, 0, Setting.Property.IndexScope, Setting.Property.Final);
 
+
+    public static final Setting<Boolean> VERIFIED_BEFORE_CLOSE_SETTING =
+        Setting.boolSetting("index.verified_before_close", false, Setting.Property.IndexScope, Setting.Property.PrivateIndex);
+
     public static final String KEY_IN_SYNC_ALLOCATIONS = "in_sync_allocations";
     static final String KEY_VERSION = "version";
     static final String KEY_MAPPING_VERSION = "mapping_version";
@@ -1460,5 +1464,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             factor = 1;
         }
         return factor;
+    }
+
+
+    public static boolean isIndexVerifiedBeforeClosed(final IndexMetadata indexMetadata) {
+        return indexMetadata.getState() == IndexMetadata.State.CLOSE
+            && VERIFIED_BEFORE_CLOSE_SETTING.exists(indexMetadata.getSettings())
+            && VERIFIED_BEFORE_CLOSE_SETTING.get(indexMetadata.getSettings());
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -359,6 +359,13 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         }
 
         /**
+         * Initializes a new empty index, as as a result of closing an opened index.
+         */
+        public Builder initializeAsFromOpenToClose(IndexMetadata indexMetadata) {
+            return initializeEmpty(indexMetadata, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CLOSED, null));
+        }
+
+        /**
          * Initializes a new empty index, to be restored from a snapshot
          */
         public Builder initializeAsNewRestore(IndexMetadata indexMetadata, SnapshotRecoverySource recoverySource, IntSet ignoreShards) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -510,9 +510,9 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         }
 
         public Builder addAsRecovery(IndexMetadata indexMetadata) {
-            if (indexMetadata.getState() == IndexMetadata.State.OPEN) {
+            if (indexMetadata.getState() == IndexMetadata.State.OPEN || IndexMetadata.isIndexVerifiedBeforeClosed(indexMetadata)) {
                 IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
-                        .initializeAsRecovery(indexMetadata);
+                    .initializeAsRecovery(indexMetadata);
                 add(indexRoutingBuilder);
             }
             return this;
@@ -534,6 +534,13 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 add(indexRoutingBuilder);
             }
             return this;
+        }
+
+        public Builder addAsFromOpenToClose(IndexMetadata indexMetadata) {
+            assert IndexMetadata.isIndexVerifiedBeforeClosed(indexMetadata);
+            IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
+                .initializeAsFromOpenToClose(indexMetadata);
+            return add(indexRoutingBuilder);
         }
 
         public Builder addAsRestore(IndexMetadata indexMetadata, SnapshotRecoverySource recoverySource) {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -71,6 +71,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetadata.INDEX_PRIORITY_SETTING,
         IndexMetadata.INDEX_DATA_PATH_SETTING,
         IndexMetadata.INDEX_FORMAT_SETTING,
+        IndexMetadata.VERIFIED_BEFORE_CLOSE_SETTING,
         MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING,
         MergePolicyConfig.INDEX_MERGE_POLICY_DELETES_PCT_ALLOWED_SETTING,
         MergePolicyConfig.INDEX_MERGE_POLICY_EXPUNGE_DELETES_ALLOWED_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import java.io.Closeable;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import io.crate.common.unit.TimeValue;
+
+/**
+ * A base class for tasks that need to repeat.
+ */
+public abstract class AbstractAsyncTask implements Runnable, Closeable {
+
+    private final Logger logger;
+    private final ThreadPool threadPool;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final boolean autoReschedule;
+    private volatile Scheduler.Cancellable cancellable;
+    private volatile boolean isScheduledOrRunning;
+    private volatile Exception lastThrownException;
+    private volatile TimeValue interval;
+
+    protected AbstractAsyncTask(Logger logger, ThreadPool threadPool, TimeValue interval, boolean autoReschedule) {
+        this.logger = logger;
+        this.threadPool = threadPool;
+        this.interval = interval;
+        this.autoReschedule = autoReschedule;
+    }
+
+    /**
+     * Change the interval between runs.
+     * If a future run is scheduled then this will reschedule it.
+     * @param interval The new interval between runs.
+     */
+    public synchronized void setInterval(TimeValue interval) {
+        this.interval = interval;
+        if (cancellable != null) {
+            rescheduleIfNecessary();
+        }
+    }
+
+    public TimeValue getInterval() {
+        return interval;
+    }
+
+    /**
+     * Test any external conditions that determine whether the task
+     * should be scheduled.  This method does *not* need to test if
+     * the task is closed, as being closed automatically prevents
+     * scheduling.
+     * @return Should the task be scheduled to run?
+     */
+    protected abstract boolean mustReschedule();
+
+    /**
+     * Schedule the task to run after the configured interval if it
+     * is not closed and any further conditions imposed by derived
+     * classes are met.  Any previously scheduled invocation is
+     * cancelled.
+     */
+    public synchronized void rescheduleIfNecessary() {
+        if (isClosed()) {
+            return;
+        }
+        if (cancellable != null) {
+            cancellable.cancel();
+        }
+        if (interval.millis() > 0 && mustReschedule()) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("scheduling {} every {}", toString(), interval);
+            }
+            cancellable = threadPool.schedule(this, interval, getThreadPool());
+            isScheduledOrRunning = true;
+        } else {
+            logger.trace("scheduled {} disabled", toString());
+            cancellable = null;
+            isScheduledOrRunning = false;
+        }
+    }
+
+    public boolean isScheduled() {
+        // Currently running counts as scheduled to avoid an oscillating return value
+        // from this method when a task is repeatedly running and rescheduling itself.
+        return isScheduledOrRunning;
+    }
+
+    /**
+     * Cancel any scheduled run, but do not prevent subsequent restarts.
+     */
+    public synchronized void cancel() {
+        if (cancellable != null) {
+            cancellable.cancel();
+            cancellable = null;
+        }
+        isScheduledOrRunning = false;
+    }
+
+    /**
+     * Cancel any scheduled run
+     */
+    @Override
+    public synchronized void close() {
+        if (closed.compareAndSet(false, true)) {
+            cancel();
+        }
+    }
+
+    public boolean isClosed() {
+        return this.closed.get();
+    }
+
+    @Override
+    public final void run() {
+        synchronized (this) {
+            cancellable = null;
+            isScheduledOrRunning = autoReschedule;
+        }
+        try {
+            runInternal();
+        } catch (Exception ex) {
+            if (lastThrownException == null || sameException(lastThrownException, ex) == false) {
+                // prevent the annoying fact of logging the same stuff all the time with an interval of 1 sec will spam all your logs
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "failed to run task {} - suppressing re-occurring exceptions unless the exception changes",
+                        toString()),
+                    ex);
+                lastThrownException = ex;
+            }
+        } finally {
+            if (autoReschedule) {
+                rescheduleIfNecessary();
+            }
+        }
+    }
+
+    private static boolean sameException(Exception left, Exception right) {
+        if (left.getClass() == right.getClass()) {
+            if (Objects.equals(left.getMessage(), right.getMessage())) {
+                StackTraceElement[] stackTraceLeft = left.getStackTrace();
+                StackTraceElement[] stackTraceRight = right.getStackTrace();
+                if (stackTraceLeft.length == stackTraceRight.length) {
+                    for (int i = 0; i < stackTraceLeft.length; i++) {
+                        if (stackTraceLeft[i].equals(stackTraceRight[i]) == false) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected abstract void runInternal();
+
+    /**
+     * Use the same threadpool by default.
+     * Derived classes can change this if required.
+     */
+    protected String getThreadPool() {
+        return ThreadPool.Names.SAME;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -553,7 +553,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // once we change the refresh interval we schedule yet another refresh
                 // to ensure we are in a clean and predictable state.
                 // it doesn't matter if we move from or to <code>-1</code>  in both cases we want
-                // docs to become visible immediately. This also flushes all pending indexing / search reqeusts
+                // docs to become visible immediately. This also flushes all pending indexing / search requests
                 // that are waiting for a refresh.
                 threadPool.executor(ThreadPool.Names.REFRESH).execute(new AbstractRunnable() {
                     @Override
@@ -714,17 +714,20 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     }
 
     abstract static class BaseAsyncTask extends AbstractAsyncTask {
+
         protected final IndexService indexService;
 
-        BaseAsyncTask(IndexService indexService, TimeValue interval) {
+        BaseAsyncTask(final IndexService indexService, final TimeValue interval) {
             super(indexService.logger, indexService.threadPool, interval, true);
             this.indexService = indexService;
             rescheduleIfNecessary();
         }
 
+        @Override
         protected boolean mustReschedule() {
-            // don't re-schedule if its closed or if we don't have a single shard here..., we are done
-            return indexService.closed.get() == false;
+            // don't re-schedule if the IndexService instance is closed or if the index is closed
+            return indexService.closed.get() == false
+                && indexService.indexSettings.getIndexMetadata().getState() == IndexMetadata.State.OPEN;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * NoOpEngine is an engine implementation that does nothing but the bare minimum
+ * required in order to have an engine. All attempts to do something (search,
+ * index, get), throw {@link UnsupportedOperationException}.
+ */
+public final class NoOpEngine extends ReadOnlyEngine {
+
+    public NoOpEngine(EngineConfig config) {
+        super(config, null, null, true, Function.identity());
+    }
+
+    @Override
+    protected DirectoryReader open(final IndexCommit commit) throws IOException {
+        final Directory directory = commit.getDirectory();
+        final List<IndexCommit> indexCommits = DirectoryReader.listCommits(directory);
+        final IndexCommit indexCommit = indexCommits.get(indexCommits.size() - 1);
+        return new DirectoryReader(directory, new LeafReader[0]) {
+            @Override
+            protected DirectoryReader doOpenIfChanged() throws IOException {
+                return null;
+            }
+
+            @Override
+            protected DirectoryReader doOpenIfChanged(IndexCommit commit) throws IOException {
+                return null;
+            }
+
+            @Override
+            protected DirectoryReader doOpenIfChanged(IndexWriter writer, boolean applyAllDeletes) throws IOException {
+                return null;
+            }
+
+            @Override
+            public long getVersion() {
+                return 0;
+            }
+
+            @Override
+            public boolean isCurrent() throws IOException {
+                return true;
+            }
+
+            @Override
+            public IndexCommit getIndexCommit() throws IOException {
+                return indexCommit;
+            }
+
+            @Override
+            protected void doClose() throws IOException {
+            }
+
+            @Override
+            public CacheHelper getReaderCacheHelper() {
+                return null;
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -70,4 +70,24 @@ public final class DocsStats implements Writeable {
     public long getCount() {
         return this.count;
     }
+
+    public long getDeleted() {
+        return this.deleted;
+    }
+
+    /**
+     * Returns the total size in bytes of all documents in this stats.
+     * This value may be more reliable than {@link StoreStats#getSizeInBytes()} in estimating the index size.
+     */
+    public long getTotalSizeInBytes() {
+        return totalSizeInBytes;
+    }
+
+    /**
+     * Returns the average size in bytes of all documents in this stats.
+     */
+    public long getAverageSizeInBytes() {
+        long totalDocs = count + deleted;
+        return totalDocs == 0 ? 0 : totalSizeInBytes / totalDocs;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -88,6 +88,7 @@ import org.elasticsearch.index.IndexService.IndexCreationContext;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngineFactory;
+import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.IndexEventListener;
@@ -377,6 +378,12 @@ public class IndicesService extends AbstractLifecycleComponent
     }
 
     private EngineFactory getEngineFactory(final IndexSettings idxSettings) {
+        final IndexMetadata indexMetadata = idxSettings.getIndexMetadata();
+        if (indexMetadata != null && indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+            // NoOpEngine takes precedence as long as the index is closed
+            return NoOpEngine::new;
+        }
+
         final List<Optional<EngineFactory>> engineFactories =
                 engineFactoryProviders
                         .stream()

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -95,6 +95,7 @@ import static org.elasticsearch.indices.cluster.IndicesClusterStateService.Alloc
 import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED;
 import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.FAILURE;
 import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.NO_LONGER_ASSIGNED;
+import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.REOPENED;
 
 public class IndicesClusterStateService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
@@ -246,7 +247,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
         deleteIndices(event); // also deletes shards of deleted indices
 
-        removeUnallocatedIndices(event); // also removes shards of removed indices
+        removeIndices(event); // also removes shards of removed indices
 
         failMissingShards(state);
 
@@ -358,17 +359,18 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     }
 
     /**
-     * Removes indices that have no shards allocated to this node. This does not delete the shard data as we wait for enough
-     * shard copies to exist in the cluster before deleting shard data (triggered by {@link org.elasticsearch.indices.store.IndicesStore}).
+     * Removes indices that have no shards allocated to this node or indices whose state has changed. This does not delete the shard data
+     * as we wait for enough shard copies to exist in the cluster before deleting shard data (triggered by
+     * {@link org.elasticsearch.indices.store.IndicesStore}).
      *
      * @param event the cluster changed event
      */
-    private void removeUnallocatedIndices(final ClusterChangedEvent event) {
+    private void removeIndices(final ClusterChangedEvent event) {
         final ClusterState state = event.state();
         final String localNodeId = state.nodes().getLocalNodeId();
         assert localNodeId != null;
 
-        Set<Index> indicesWithShards = new HashSet<>();
+        final Set<Index> indicesWithShards = new HashSet<>();
         RoutingNode localRoutingNode = state.getRoutingNodes().node(localNodeId);
         if (localRoutingNode != null) { // null e.g. if we are not a data node
             for (ShardRouting shardRouting : localRoutingNode) {
@@ -377,20 +379,27 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         }
 
         for (AllocatedIndex<? extends Shard> indexService : indicesService) {
-            Index index = indexService.index();
-            if (indicesWithShards.contains(index) == false) {
+            final Index index = indexService.index();
+            final IndexMetadata indexMetadata = state.metadata().index(index);
+            final IndexMetadata existingMetadata = indexService.getIndexSettings().getIndexMetadata();
+
+            AllocatedIndices.IndexRemovalReason reason = null;
+            if (indexMetadata != null && indexMetadata.getState() != existingMetadata.getState()) {
+                reason = indexMetadata.getState() == IndexMetadata.State.CLOSE ? CLOSED : REOPENED;
+            } else if (indicesWithShards.contains(index) == false) {
                 // if the cluster change indicates a brand new cluster, we only want
                 // to remove the in-memory structures for the index and not delete the
                 // contents on disk because the index will later be re-imported as a
                 // dangling index
-                final IndexMetadata indexMetadata = state.metadata().index(index);
                 assert indexMetadata != null || event.isNewCluster() :
                     "index " + index + " does not exist in the cluster state, it should either " +
                         "have been deleted or the cluster must be new";
-                final AllocatedIndices.IndexRemovalReason reason =
-                    indexMetadata != null && indexMetadata.getState() == IndexMetadata.State.CLOSE ? CLOSED : NO_LONGER_ASSIGNED;
-                LOGGER.debug("{} removing index, [{}]", index, reason);
-                indicesService.removeIndex(index, reason, "removing index (no shards allocated)");
+                reason = indexMetadata != null && indexMetadata.getState() == IndexMetadata.State.CLOSE ? CLOSED : NO_LONGER_ASSIGNED;
+            }
+
+            if (reason != null) {
+                LOGGER.debug("{} removing index ({})", index, reason);
+                indicesService.removeIndex(index, reason, "removing index (" + reason + ")");
             }
         }
     }
@@ -601,7 +610,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                              ClusterState clusterState) {
         final ShardRouting currentRoutingEntry = shard.routingEntry();
         assert currentRoutingEntry.isSameAllocation(shardRouting) :
-            "local shard has a different allocation id but wasn't cleaning by removeShards. "
+            "local shard has a different allocation id but wasn't cleaned by removeShards. "
                 + "cluster state: " + shardRouting + " local: " + currentRoutingEntry;
 
         try {
@@ -713,7 +722,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private void sendFailShard(ShardRouting shardRouting, String message, @Nullable Exception failure, ClusterState state) {
         try {
             LOGGER.warn(() -> new ParameterizedMessage(
-                    "[{}] marking and sending shard failed due to [{}]", shardRouting.shardId(), message), failure);
+                    "{} marking and sending shard failed due to [{}]", shardRouting.shardId(), message), failure);
             failedShardsCache.put(shardRouting.shardId(), shardRouting);
             shardStateAction.localShardFailed(shardRouting, message, failure, SHARD_STATE_ACTION_LISTENER, state);
         } catch (Exception inner) {
@@ -901,7 +910,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             DELETED,
 
             /**
-             * The index have been closed. The index should be removed and all associated resources released. Persistent parts of the index
+             * The index has been closed. The index should be removed and all associated resources released. Persistent parts of the index
              * like the shards files, state and transaction logs are kept around in the case of a disaster recovery.
              */
             CLOSED,
@@ -911,7 +920,13 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
              * Persistent parts of the index like the shards files, state and transaction logs are kept around in the
              * case of a disaster recovery.
              */
-            FAILURE
+            FAILURE,
+
+            /**
+             * The index has been reopened. The index should be removed and all associated resources released. Persistent parts of the index
+             * like the shards files, state and transaction logs are kept around in the case of a disaster recovery.
+             */
+            REOPENED,
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.crate.common.unit.TimeValue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AbstractAsyncTaskTests extends ESTestCase {
+
+    private static ThreadPool threadPool;
+
+    @BeforeClass
+    public static void setUpThreadPool() {
+        threadPool = new TestThreadPool(AbstractAsyncTaskTests.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownThreadPool() {
+        terminate(threadPool);
+    }
+
+    @Test
+    public void testAutoRepeat() throws Exception {
+
+        boolean shouldRunThrowException = randomBoolean();
+        final CyclicBarrier barrier1 = new CyclicBarrier(2); // 1 for runInternal plus 1 for the test sequence
+        final CyclicBarrier barrier2 = new CyclicBarrier(2); // 1 for runInternal plus 1 for the test sequence
+        final AtomicInteger count = new AtomicInteger();
+        AbstractAsyncTask task = new AbstractAsyncTask(logger, threadPool, TimeValue.timeValueMillis(1), true) {
+
+            @Override
+            protected boolean mustReschedule() {
+                return true;
+            }
+
+            @Override
+            protected void runInternal() {
+                assertTrue("generic threadpool is configured", Thread.currentThread().getName().contains("[generic]"));
+                try {
+                    barrier1.await();
+                } catch (Exception e) {
+                    fail("interrupted");
+                }
+                count.incrementAndGet();
+                try {
+                    barrier2.await();
+                } catch (Exception e) {
+                    fail("interrupted");
+                }
+                if (shouldRunThrowException) {
+                    throw new RuntimeException("foo");
+                }
+            }
+
+            @Override
+            protected String getThreadPool() {
+                return ThreadPool.Names.GENERIC;
+            }
+        };
+
+        assertFalse(task.isScheduled());
+        task.rescheduleIfNecessary();
+        assertTrue(task.isScheduled());
+        barrier1.await();
+        assertTrue(task.isScheduled());
+        barrier2.await();
+        assertEquals(1, count.get());
+        barrier1.reset();
+        barrier2.reset();
+        barrier1.await();
+        assertTrue(task.isScheduled());
+        task.close();
+        barrier2.await();
+        assertEquals(2, count.get());
+        assertTrue(task.isClosed());
+        assertFalse(task.isScheduled());
+        assertEquals(2, count.get());
+    }
+
+    @Test
+    public void testManualRepeat() throws Exception {
+
+        boolean shouldRunThrowException = randomBoolean();
+        final CyclicBarrier barrier = new CyclicBarrier(2); // 1 for runInternal plus 1 for the test sequence
+        final AtomicInteger count = new AtomicInteger();
+        AbstractAsyncTask task = new AbstractAsyncTask(logger, threadPool, TimeValue.timeValueMillis(1), false) {
+
+            @Override
+            protected boolean mustReschedule() {
+                return true;
+            }
+
+            @Override
+            protected void runInternal() {
+                assertTrue("generic threadpool is configured", Thread.currentThread().getName().contains("[generic]"));
+                count.incrementAndGet();
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    fail("interrupted");
+                }
+                if (shouldRunThrowException) {
+                    throw new RuntimeException("foo");
+                }
+            }
+
+            @Override
+            protected String getThreadPool() {
+                return ThreadPool.Names.GENERIC;
+            }
+        };
+
+        assertFalse(task.isScheduled());
+        task.rescheduleIfNecessary();
+        barrier.await();
+        assertEquals(1, count.get());
+        assertFalse(task.isScheduled());
+        barrier.reset();
+        expectThrows(TimeoutException.class, () -> barrier.await(10, TimeUnit.MILLISECONDS));
+        assertEquals(1, count.get());
+        barrier.reset();
+        task.rescheduleIfNecessary();
+        barrier.await();
+        assertEquals(2, count.get());
+        assertFalse(task.isScheduled());
+        assertFalse(task.isClosed());
+        task.close();
+        assertTrue(task.isClosed());
+    }
+
+    @Test
+    public void testCloseWithNoRun() {
+
+        AbstractAsyncTask task = new AbstractAsyncTask(logger, threadPool, TimeValue.timeValueMinutes(10), true) {
+
+            @Override
+            protected boolean mustReschedule() {
+                return true;
+            }
+
+            @Override
+            protected void runInternal() {
+            }
+        };
+
+        assertFalse(task.isScheduled());
+        task.rescheduleIfNecessary();
+        assertTrue(task.isScheduled());
+        task.close();
+        assertTrue(task.isClosed());
+        assertFalse(task.isScheduled());
+    }
+
+    @Test
+    public void testChangeInterval() throws Exception {
+
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        AbstractAsyncTask task = new AbstractAsyncTask(logger, threadPool, TimeValue.timeValueHours(1), true) {
+
+            @Override
+            protected boolean mustReschedule() {
+                return latch.getCount() > 0;
+            }
+
+            @Override
+            protected void runInternal() {
+                latch.countDown();
+            }
+        };
+
+        assertFalse(task.isScheduled());
+        task.rescheduleIfNecessary();
+        assertTrue(task.isScheduled());
+        task.setInterval(TimeValue.timeValueMillis(1));
+        assertTrue(task.isScheduled());
+        // This should only take 2 milliseconds in ideal conditions, but allow 10 seconds in case of VM stalls
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertBusy(() -> assertFalse(task.isScheduled()));
+        task.close();
+        assertFalse(task.isScheduled());
+        assertTrue(task.isClosed());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -738,6 +738,14 @@ public abstract class EngineTestCase extends ESTestCase {
             tombstoneDocSupplier);
     }
 
+    protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath) {
+        return noOpConfig(indexSettings, store, translogPath, null);
+    }
+
+    protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath, LongSupplier globalCheckpointSupplier) {
+        return config(indexSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier);
+    }
+
     protected static final BytesReference B_1 = new BytesArray(new byte[]{1});
     protected static final BytesReference B_2 = new BytesArray(new byte[]{2});
     protected static final BytesReference B_3 = new BytesArray(new byte[]{3});

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.engine;
+
+import static org.elasticsearch.cluster.routing.ShardRoutingHelper.initWithSameId;
+
+import java.io.IOException;
+
+import org.elasticsearch.cluster.routing.RecoverySource.ExistingStoreRecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.junit.Test;
+
+public class NoOpEngineRecoveryTests extends IndexShardTestCase {
+
+    @Test
+    public void testRecoverFromNoOp() throws IOException {
+        final int nbDocs = scaledRandomIntBetween(1, 100);
+
+        final IndexShard indexShard = newStartedShard(true);
+        for (int i = 0; i < nbDocs; i++) {
+            indexDoc(indexShard, String.valueOf(i));
+        }
+        indexShard.close("test", true);
+
+        final ShardRouting shardRouting = indexShard.routingEntry();
+        IndexShard primary = reinitShard(indexShard, initWithSameId(shardRouting, ExistingStoreRecoverySource.INSTANCE), NoOpEngine::new);
+        recoverShardFromStore(primary);
+        assertEquals(primary.seqNoStats().getMaxSeqNo(), primary.getMaxSeqNoOfUpdatesOrDeletes());
+        assertEquals(nbDocs, primary.docStats().getCount());
+
+        IndexShard replica = newShard(false, Settings.EMPTY, NoOpEngine::new);
+        recoverReplica(replica, primary, true);
+        assertEquals(replica.seqNoStats().getMaxSeqNo(), replica.getMaxSeqNoOfUpdatesOrDeletes());
+        assertEquals(nbDocs, replica.docStats().getCount());
+        closeShards(primary, replica);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.LockObtainFailedException;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.seqno.ReplicationTracker;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.index.translog.TranslogDeletionPolicy;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.junit.Test;
+
+import io.crate.common.io.IOUtils;
+
+public class NoOpEngineTests extends EngineTestCase {
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
+
+    @Test
+    public void testNoopEngine() throws IOException {
+        engine.close();
+        final NoOpEngine engine = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir));
+        expectThrows(UnsupportedOperationException.class, () -> engine.syncFlush(null, null));
+        assertThat(engine.refreshNeeded(), equalTo(false));
+        assertThat(engine.shouldPeriodicallyFlush(), equalTo(false));
+        engine.close();
+    }
+
+    @Test
+    public void testTwoNoopEngines() throws IOException {
+        engine.close();
+        // Ensure that we can't open two noop engines for the same store
+        final EngineConfig engineConfig = noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir);
+        try (NoOpEngine ignored = new NoOpEngine(engineConfig)) {
+            UncheckedIOException e = expectThrows(UncheckedIOException.class, () -> new NoOpEngine(engineConfig));
+            assertThat(e.getCause(), instanceOf(LockObtainFailedException.class));
+        }
+    }
+
+    @Test
+    public void testNoopAfterRegularEngine() throws IOException {
+        int docs = randomIntBetween(1, 10);
+        ReplicationTracker tracker = (ReplicationTracker) engine.config().getGlobalCheckpointSupplier();
+        ShardRouting routing = TestShardRouting.newShardRouting("test", shardId.id(), "node",
+            null, true, ShardRoutingState.STARTED, allocationId);
+        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(shardId).addShard(routing).build();
+        tracker.updateFromMaster(1L, Collections.singleton(allocationId.getId()), table);
+        tracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
+        for (int i = 0; i < docs; i++) {
+            ParsedDocument doc = testParsedDocument("" + i, null, testDocumentWithTextField(), B_1, null);
+            engine.index(indexForDoc(doc));
+            tracker.updateLocalCheckpoint(allocationId.getId(), i);
+        }
+
+        flushAndTrimTranslog(engine);
+
+        long localCheckpoint = engine.getPersistedLocalCheckpoint();
+        long maxSeqNo = engine.getSeqNoStats(100L).getMaxSeqNo();
+        engine.close();
+
+        final NoOpEngine noOpEngine = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir, tracker));
+        assertThat(noOpEngine.getPersistedLocalCheckpoint(), equalTo(localCheckpoint));
+        assertThat(noOpEngine.getSeqNoStats(100L).getMaxSeqNo(), equalTo(maxSeqNo));
+        try (Engine.IndexCommitRef ref = noOpEngine.acquireLastIndexCommit(false)) {
+            try (IndexReader reader = DirectoryReader.open(ref.getIndexCommit())) {
+                assertThat(reader.numDocs(), equalTo(docs));
+            }
+        }
+        noOpEngine.close();
+    }
+
+    @Test
+    public void testNoOpEngineDocStats() throws Exception {
+        IOUtils.close(engine, store);
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            Path translogPath = createTempDir();
+            EngineConfig config = config(defaultSettings, store, translogPath, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            final int numDocs = scaledRandomIntBetween(10, 3000);
+            int deletions = 0;
+            try (InternalEngine engine = createEngine(config)) {
+                for (int i = 0; i < numDocs; i++) {
+                    engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+                    if (rarely()) {
+                        engine.flush();
+                    }
+                    engine.syncTranslog(); // advance persisted local checkpoint
+                    globalCheckpoint.set(engine.getPersistedLocalCheckpoint());
+                }
+
+                for (int i = 0; i < numDocs; i++) {
+                    if (randomBoolean()) {
+                        String delId = Integer.toString(i);
+                        Engine.DeleteResult result = engine.delete(new Engine.Delete(delId, newUid(delId), primaryTerm.get()));
+                        assertTrue(result.isFound());
+                        engine.syncTranslog(); // advance persisted local checkpoint
+                        globalCheckpoint.set(engine.getPersistedLocalCheckpoint());
+                        deletions += 1;
+                    }
+                }
+                engine.getLocalCheckpointTracker().waitForProcessedOpsToComplete(numDocs + deletions - 1);
+                flushAndTrimTranslog(engine);
+            }
+
+            final DocsStats expectedDocStats;
+            try (InternalEngine engine = createEngine(config)) {
+                expectedDocStats = engine.docStats();
+            }
+
+            try (NoOpEngine noOpEngine = new NoOpEngine(config)) {
+                assertEquals(expectedDocStats.getCount(), noOpEngine.docStats().getCount());
+                assertEquals(expectedDocStats.getDeleted(), noOpEngine.docStats().getDeleted());
+                assertEquals(expectedDocStats.getTotalSizeInBytes(), noOpEngine.docStats().getTotalSizeInBytes());
+                assertEquals(expectedDocStats.getAverageSizeInBytes(), noOpEngine.docStats().getAverageSizeInBytes());
+            } catch (AssertionError e) {
+                logger.error(config.getMergePolicy());
+                throw e;
+            }
+        }
+    }
+
+    private void flushAndTrimTranslog(final InternalEngine engine) {
+        engine.flush(true, true);
+        final TranslogDeletionPolicy deletionPolicy = engine.getTranslog().getDeletionPolicy();
+        deletionPolicy.setRetentionSizeInBytes(-1);
+        deletionPolicy.setRetentionAgeInMillis(-1);
+        deletionPolicy.setMinTranslogGenerationForRecovery(engine.getTranslog().getGeneration().translogFileGeneration);
+        engine.flush(true, true);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -505,6 +505,33 @@ public abstract class IndexShardTestCase extends ESTestCase {
             EMPTY_EVENT_LISTENER, listeners);
     }
 
+
+    /**
+     * Takes an existing shard, closes it and starts a new initialing shard at the same location
+     *
+     * @param routing       the shard routing to use for the newly created shard.
+     * @param listeners     new listerns to use for the newly created shard
+     * @param indexMetadata the index metadata to use for the newly created shard
+     * @param engineFactory the engine factory for the new shard
+     */
+    protected IndexShard reinitShard(IndexShard current,
+                                     ShardRouting routing,
+                                     EngineFactory engineFactory,
+                                     IndexingOperationListener... listeners) throws IOException {
+        closeShards(current);
+        return newShard(
+            routing,
+            current.shardPath(),
+            current.indexSettings().getIndexMetadata(),
+            null,
+            null,
+            engineFactory,
+            current.getGlobalCheckpointSyncer(),
+            EMPTY_EVENT_LISTENER,
+            listeners
+        );
+    }
+
     /**
      * Creates a new empty shard and starts it. The shard will randomly be a replica or a primary.
      */


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

Deferred this initially, but sub-sequent patches touch it and the
ReadOnlyEngine was already ported in earlier commits, so seemed like a good
time to port it over now.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)