### PR TITLE
Make close table use 3 steps instead of 1

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.index.Index;
+
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
+/**
+ * Structure for the 3 different cases:
+ *
+ *  - ALTER TABLE tbl       -- On a normal table
+ *  - ALTER TABLE tbl       -- On a partitioned table
+ *  - ALTER TABLE tbl PARTITION (pcol = ?)
+ */
+public final class AlterTableTarget {
+
+    public static AlterTableTarget resolve(IndexNameExpressionResolver indexNameResolver,
+                                           ClusterState state,
+                                           RelationName table,
+                                           @Nullable String partition) {
+        if (partition == null) {
+            Index[] indices = indexNameResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), table.indexNameOrAlias());
+            String templateName = PartitionName.templateName(table.schema(), table.name());
+            IndexTemplateMetadata indexTemplateMetadata = state.metadata().getTemplates().get(templateName);
+            return new AlterTableTarget(indices, indexTemplateMetadata);
+        } else {
+            Index[] indices = indexNameResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), partition);
+            return new AlterTableTarget(indices);
+        }
+    }
+
+    private final Index[] indices;
+
+    @Nullable
+    private final IndexTemplateMetadata indexTemplateMetadata;
+
+    public AlterTableTarget(Index[] indices, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
+        this.indices = indices;
+        this.indexTemplateMetadata = indexTemplateMetadata;
+    }
+
+    public AlterTableTarget(Index[] indices) {
+        this(indices, null);
+    }
+
+    public boolean isEmpty() {
+        return indices.length == 0 && indexTemplateMetadata == null;
+    }
+
+    public Index[] indices() {
+        return indices;
+    }
+
+    @Nullable
+    public IndexTemplateMetadata templateMetadata() {
+        return indexTemplateMetadata;
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/CloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CloseTable.java
@@ -1,0 +1,5 @@
+package io.crate.execution.ddl.tables;
+
+public final class CloseTable {
+
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -23,32 +23,65 @@
 package io.crate.execution.ddl.tables;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import com.carrotsearch.hppc.cursors.IntObjectCursor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.AckedClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotsService;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.execution.ddl.tables.close.IndexResult;
+import io.crate.execution.ddl.tables.close.ShardResult;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.cluster.CloseTableClusterStateTaskExecutor;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
@@ -56,6 +89,7 @@ import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
 @Singleton
 public class TransportOpenCloseTableOrPartitionAction extends TransportMasterNodeAction<OpenCloseTableOrPartitionRequest, AcknowledgedResponse> {
 
+    private static final Logger LOGGER = LogManager.getLogger(TransportOpenCloseTableOrPartitionAction.class);
     private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
     private static final String ACTION_NAME = "internal:crate:sql/table_or_partition/open_close";
 
@@ -125,38 +159,277 @@ public class TransportOpenCloseTableOrPartitionAction extends TransportMasterNod
     private void closeTable(OpenCloseTableOrPartitionRequest request,
                             ClusterState state,
                             ActionListener<AcknowledgedResponse> listener) throws Exception {
+        if (state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_3_0)) {
+            do3PhaseClose(request, state, listener);
+        } else {
+            clusterService.submitStateUpdateTask(
+                "close-table-or-partition",
+                request,
+                ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
+                closeExecutor,
+                new AckedClusterStateTaskListener() {
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        listener.onFailure(e);
+                    }
+
+                    @Override
+                    public boolean mustAck(DiscoveryNode discoveryNode) {
+                        return true;
+                    }
+
+                    @Override
+                    public void onAllNodesAcked(@Nullable Exception e) {
+                        listener.onResponse(new AcknowledgedResponse(true));
+                    }
+
+                    @Override
+                    public void onAckTimeout() {
+                        listener.onResponse(new AcknowledgedResponse(false));
+                    }
+
+                    @Override
+                    public TimeValue ackTimeout() {
+                        return request.ackTimeout();
+                    }
+                }
+            );
+        }
+    }
+
+    private void do3PhaseClose(OpenCloseTableOrPartitionRequest request,
+                               ClusterState state,
+                               ActionListener<AcknowledgedResponse> listener) {
+        assert !request.isOpenTable() : "Must close table";
+        assert state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_3_0) : "All nodes must support close verification action";
+
         clusterService.submitStateUpdateTask(
-            "close-table-or-partition",
-            request,
-            ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
-            closeExecutor,
-            new AckedClusterStateTaskListener() {
+            "add-block-table-to-close",
+            new ClusterStateUpdateTask(Priority.HIGH) {
+
+                private final Set<Index> blockedIndices = new HashSet<>();
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    // TODO: At which point should we change the template?
+                    RelationName table = request.tableIdent();
+                    String partition = request.partitionIndexName();
+                    Index[] indices = indexNameExpressionResolver.concreteIndices(
+                        currentState,
+                        IndicesOptions.lenientExpandOpen(),
+                        partition == null ? table.indexNameOrAlias() : partition
+                    );
+                    if (indices.length == 0) {
+                        return currentState;
+                    }
+                    return addCloseBlocks(currentState, indices, blockedIndices::add);
+                }
+
                 @Override
                 public void onFailure(String source, Exception e) {
                     listener.onFailure(e);
                 }
 
                 @Override
-                public boolean mustAck(DiscoveryNode discoveryNode) {
-                    return true;
-                }
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    if (oldState == newState) {
+                        assert blockedIndices.isEmpty() : "List of blocked indices is not empty but cluster state wasn't changed";
+                        listener.onResponse(new AcknowledgedResponse(true));
+                        return;
+                    }
 
-                @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
-                    listener.onResponse(new AcknowledgedResponse(true));
-                }
+                    assert blockedIndices.isEmpty() == false : "List of blocked indices is empty but cluster state was changed";
+                    threadPool.executor(ThreadPool.Names.MANAGEMENT)
+                        .execute(new WaitForClosedBlocksApplied(
+                            blockedIndices,
+                            ActionListener.wrap(
+                                closedBlocksResults -> clusterService.submitStateUpdateTask(
+                                    "close-indices",
+                                    new ClusterStateUpdateTask(Priority.URGENT) {
 
-                @Override
-                public void onAckTimeout() {
-                    listener.onResponse(new AcknowledgedResponse(false));
-                }
+                                        @Override
+                                        public ClusterState execute(final ClusterState currentState) throws Exception {
+                                            final ClusterState updatedState = closeRoutingTable(currentState, closedBlocksResults);
+                                            return allocationService.reroute(updatedState, "indices closed");
+                                        }
 
-                @Override
-                public TimeValue ackTimeout() {
-                    return request.ackTimeout();
+                                        @Override
+                                        public void onFailure(final String source, final Exception e) {
+                                            listener.onFailure(e);
+                                        }
+
+                                        @Override
+                                        public void clusterStateProcessed(final String source,
+                                                                          final ClusterState oldState, final ClusterState newState) {
+                                            boolean acknowledged = closedBlocksResults.values().stream()
+                                                .allMatch(AcknowledgedResponse::isAcknowledged);
+                                            listener.onResponse(new AcknowledgedResponse(acknowledged));
+                                        }
+                                    }
+                                ),
+                                listener::onFailure
+                            )
+                        ));
                 }
             }
         );
+    }
+
+    private static ClusterState addCloseBlocks(ClusterState currentState, Index[] indices, Consumer<Index> blockedIndex) {
+        Metadata.Builder metadata = Metadata.builder(currentState.metadata());
+        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+
+        Set<IndexMetadata> indicesToClose = Set.of();
+        for (Index index : indices) {
+            final IndexMetadata indexMetadata = metadata.getSafe(index);
+            if (indexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                indicesToClose.add(indexMetadata);
+            } else {
+                LOGGER.debug("index {} is already closed, ignoring", index);
+            }
+        }
+        if (indicesToClose.isEmpty()) {
+            return currentState;
+        }
+
+        RestoreService.checkIndexClosing(currentState, indicesToClose);
+        SnapshotsService.checkIndexClosing(currentState, indicesToClose);
+
+        for (var indexToClose : indicesToClose) {
+            final Index index = indexToClose.getIndex();
+            blockedIndex.accept(index);
+            if (currentState.blocks().hasIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK) == false) {
+                blocks.addIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK);
+            }
+        }
+
+        return ClusterState.builder(currentState)
+            .blocks(blocks)
+            .metadata(metadata)
+            .routingTable(currentState.routingTable())
+            .build();
+    }
+
+    /**
+     * Step 2 - Wait for indices to be ready for closing
+     * <p>
+     * This step iterates over the indices previously blocked and sends a {@link TransportVerifyShardBeforeCloseAction} to each shard. If
+     * this action succeed then the shard is considered to be ready for closing. When all shards of a given index are ready for closing,
+     * the index is considered ready to be closed.
+     */
+    class WaitForClosedBlocksApplied extends ActionRunnable<Map<Index, IndexResult>> {
+
+        private final Map<Index, ClusterBlock> blockedIndices;
+
+        private WaitForClosedBlocksApplied(final Map<Index, ClusterBlock> blockedIndices,
+                                           final ActionListener<Map<Index, IndexResult>> listener) {
+            super(listener);
+            if (blockedIndices == null || blockedIndices.isEmpty()) {
+                throw new IllegalArgumentException("Cannot wait for closed blocks to be applied, list of blocked indices is empty or null");
+            }
+            this.blockedIndices = blockedIndices;
+        }
+
+        @Override
+        protected void doRun() throws Exception {
+            final Map<Index, IndexResult> results = ConcurrentCollections.newConcurrentMap();
+            final CountDown countDown = new CountDown(blockedIndices.size());
+            final ClusterState state = clusterService.state();
+            blockedIndices.forEach((index, block) -> {
+                waitForShardsReadyForClosing(index, block, state, response -> {
+                    results.put(index, response);
+                    if (countDown.countDown()) {
+                        listener.onResponse(Collections.unmodifiableMap(results));
+                    }
+                });
+            });
+        }
+
+        private void waitForShardsReadyForClosing(final Index index,
+                                                  final ClusterBlock closingBlock,
+                                                  final ClusterState state,
+                                                  final Consumer<IndexResult> onResponse) {
+            final IndexMetadata indexMetadata = state.metadata().index(index);
+            if (indexMetadata == null) {
+                logger.debug("index {} has been blocked before closing and is now deleted, ignoring", index);
+                onResponse.accept(new IndexResult(index));
+                return;
+            }
+            final IndexRoutingTable indexRoutingTable = state.routingTable().index(index);
+            if (indexRoutingTable == null || indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+                assert state.blocks().hasIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK);
+                LOGGER.debug("index {} has been blocked before closing and is already closed, ignoring", index);
+                onResponse.accept(new IndexResult(index));
+                return;
+            }
+
+            final ImmutableOpenIntMap<IndexShardRoutingTable> shards = indexRoutingTable.getShards();
+            final AtomicArray<ShardResult> results = new AtomicArray<>(shards.size());
+            final CountDown countDown = new CountDown(shards.size());
+
+            for (IntObjectCursor<IndexShardRoutingTable> shard : shards) {
+                final IndexShardRoutingTable shardRoutingTable = shard.value;
+                final int shardId = shardRoutingTable.shardId().id();
+                sendVerifyShardBeforeCloseRequest(shardRoutingTable, closingBlock, new NotifyOnceListener<ReplicationResponse>() {
+                    @Override
+                    public void innerOnResponse(final ReplicationResponse replicationResponse) {
+                        ShardResult.Failure[] failures = Arrays.stream(replicationResponse.getShardInfo().getFailures())
+                            .map(f -> new ShardResult.Failure(f.index(), f.shardId(), f.getCause(), f.nodeId()))
+                            .toArray(ShardResult.Failure[]::new);
+                        results.setOnce(shardId, new ShardResult(shardId, failures));
+                        processIfFinished();
+                    }
+
+                    @Override
+                    public void innerOnFailure(final Exception e) {
+                        ShardResult.Failure failure = new ShardResult.Failure(index.getName(), shardId, e);
+                        results.setOnce(shardId, new ShardResult(shardId, new ShardResult.Failure[]{failure}));
+                        processIfFinished();
+                    }
+
+                    private void processIfFinished() {
+                        if (countDown.countDown()) {
+                            onResponse.accept(new IndexResult(index, results.toArray(new ShardResult[results.length()])));
+                        }
+                    }
+                });
+            }
+        }
+
+        private void sendVerifyShardBeforeCloseRequest(final IndexShardRoutingTable shardRoutingTable,
+                                                       final ClusterBlock closingBlock,
+                                                       final ActionListener<ReplicationResponse> listener) {
+            final ShardId shardId = shardRoutingTable.shardId();
+            if (shardRoutingTable.primaryShard().unassigned()) {
+                logger.debug("primary shard {} is unassigned, ignoring", shardId);
+                final ReplicationResponse response = new ReplicationResponse();
+                response.setShardInfo(new ReplicationResponse.ShardInfo(shardRoutingTable.size(), shardRoutingTable.size()));
+                listener.onResponse(response);
+                return;
+            }
+            final TransportVerifyShardBeforeCloseAction.ShardRequest shardRequest =
+                new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId, closingBlock, true, parentTaskId);
+            // TODO:
+            // if (request.ackTimeout() != null) {
+            //     shardRequest.timeout(request.ackTimeout());
+            // }
+            client.executeLocally(TransportVerifyShardBeforeCloseAction.TYPE, shardRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(ReplicationResponse replicationResponse) {
+                    final TransportVerifyShardBeforeCloseAction.ShardRequest shardRequest =
+                        new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId, closingBlock, false, parentTaskId);
+                    if (request.ackTimeout() != null) {
+                        shardRequest.timeout(request.ackTimeout());
+                    }
+                    client.executeLocally(TransportVerifyShardBeforeCloseAction.TYPE, shardRequest, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }
     }
 
     private void openTable(OpenCloseTableOrPartitionRequest request,

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -22,28 +22,39 @@
 
 package io.crate.execution.ddl.tables;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.cluster.CloseTableClusterStateTaskExecutor;
-import io.crate.metadata.cluster.DDLClusterStateService;
-import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.AckedClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import io.crate.common.unit.TimeValue;
+import io.crate.metadata.cluster.CloseTableClusterStateTaskExecutor;
+import io.crate.metadata.cluster.DDLClusterStateService;
+import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
+
 @Singleton
-public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTransportAction<OpenCloseTableOrPartitionRequest, AcknowledgedResponse> {
+public class TransportOpenCloseTableOrPartitionAction extends TransportMasterNodeAction<OpenCloseTableOrPartitionRequest, AcknowledgedResponse> {
 
     private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
     private static final String ACTION_NAME = "internal:crate:sql/table_or_partition/open_close";
@@ -64,29 +75,124 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
             transportService,
             clusterService,
             threadPool,
-            indexNameExpressionResolver,
             OpenCloseTableOrPartitionRequest::new,
-            AcknowledgedResponse::new,
-            AcknowledgedResponse::new,
-            "open-table-or-partition");
-        openExecutor = new OpenTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
-            ddlClusterStateService, metadataIndexUpgradeService, indexServices);
-        closeExecutor = new CloseTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
-            ddlClusterStateService);
-    }
-
-    @Override
-    public ClusterStateTaskExecutor<OpenCloseTableOrPartitionRequest> clusterStateTaskExecutor(OpenCloseTableOrPartitionRequest request) {
-        if (request.isOpenTable()) {
-            return openExecutor;
-        } else {
-            return closeExecutor;
-        }
+            indexNameExpressionResolver
+        );
+        openExecutor = new OpenTableClusterStateTaskExecutor(
+            indexNameExpressionResolver,
+            allocationService,
+            ddlClusterStateService,
+            metadataIndexUpgradeService,
+            indexServices
+        );
+        closeExecutor = new CloseTableClusterStateTaskExecutor(
+            indexNameExpressionResolver,
+            allocationService,
+            ddlClusterStateService
+        );
     }
 
     @Override
     protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexNameOrAlias()));
+        return state.blocks().indicesBlockedException(
+            ClusterBlockLevel.METADATA_WRITE,
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexNameOrAlias())
+        );
+    }
+
+    @Override
+    protected String executor() {
+        // no need to use a thread pool, we go async right away
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(OpenCloseTableOrPartitionRequest request,
+                                   ClusterState state,
+                                   ActionListener<AcknowledgedResponse> listener) throws Exception {
+        if (request.isOpenTable()) {
+            openTable(request, state, listener);
+        } else {
+            closeTable(request, state, listener);
+        }
+    }
+
+    private void closeTable(OpenCloseTableOrPartitionRequest request,
+                            ClusterState state,
+                            ActionListener<AcknowledgedResponse> listener) throws Exception {
+        clusterService.submitStateUpdateTask(
+            "close-table-or-partition",
+            request,
+            ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
+            closeExecutor,
+            new AckedClusterStateTaskListener() {
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public boolean mustAck(DiscoveryNode discoveryNode) {
+                    return true;
+                }
+
+                @Override
+                public void onAllNodesAcked(@Nullable Exception e) {
+                    listener.onResponse(new AcknowledgedResponse(true));
+                }
+
+                @Override
+                public void onAckTimeout() {
+                    listener.onResponse(new AcknowledgedResponse(false));
+                }
+
+                @Override
+                public TimeValue ackTimeout() {
+                    return request.ackTimeout();
+                }
+            }
+        );
+    }
+
+    private void openTable(OpenCloseTableOrPartitionRequest request,
+                           ClusterState state,
+                           ActionListener<AcknowledgedResponse> listener) {
+        clusterService.submitStateUpdateTask(
+            "open-table-or-partition",
+            request,
+            ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
+            openExecutor,
+            new AckedClusterStateTaskListener() {
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public boolean mustAck(DiscoveryNode discoveryNode) {
+                    return true;
+                }
+
+                @Override
+                public void onAllNodesAcked(@Nullable Exception e) {
+                    listener.onResponse(new AcknowledgedResponse(true));
+                }
+
+                @Override
+                public void onAckTimeout() {
+                    listener.onResponse(new AcknowledgedResponse(false));
+                }
+
+                @Override
+                public TimeValue ackTimeout() {
+                    return request.ackTimeout();
+                }
+            }
+        );
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/close/IndexResult.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/close/IndexResult.java
@@ -1,0 +1,77 @@
+package io.crate.execution.ddl.tables.close;
+
+
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.Index;
+
+public final class IndexResult implements Writeable {
+
+      private final Index index;
+      private final @Nullable Exception exception;
+      private final @Nullable ShardResult[] shards;
+
+      public IndexResult(final Index index) {
+          this(index, null, null);
+      }
+
+      public IndexResult(final Index index, final Exception failure) {
+          this(index, Objects.requireNonNull(failure), null);
+      }
+
+      public IndexResult(final Index index, final ShardResult[] shards) {
+          this(index, null, Objects.requireNonNull(shards));
+      }
+
+      private IndexResult(final Index index, @Nullable final Exception exception, @Nullable final ShardResult[] shards) {
+          this.index = Objects.requireNonNull(index);
+          this.exception = exception;
+          this.shards = shards;
+      }
+
+      IndexResult(final StreamInput in) throws IOException {
+          this.index = new Index(in);
+          this.exception = in.readException();
+          this.shards = in.readOptionalArray(ShardResult::new, ShardResult[]::new);
+      }
+
+      @Override
+      public void writeTo(final StreamOutput out) throws IOException {
+          index.writeTo(out);
+          out.writeException(exception);
+          out.writeOptionalArray(shards);
+      }
+
+      public Index getIndex() {
+          return index;
+      }
+
+      public Exception getException() {
+          return exception;
+      }
+
+      public ShardResult[] getShards() {
+          return shards;
+      }
+
+      public boolean hasFailures() {
+          if (exception != null) {
+              return true;
+          }
+          if (shards != null) {
+              for (ShardResult shard : shards) {
+                  if (shard.hasFailures()) {
+                      return true;
+                  }
+              }
+          }
+          return false;
+      }
+
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/close/ShardResult.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/close/ShardResult.java
@@ -1,0 +1,85 @@
+package io.crate.execution.ddl.tables.close;
+
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.CollectionUtils;
+
+public final class ShardResult implements Writeable {
+
+    private final int id;
+    private final Failure[] failures;
+
+    public ShardResult(final int id, final Failure[] failures) {
+        this.id = id;
+        this.failures = failures;
+    }
+
+    ShardResult(final StreamInput in) throws IOException {
+        this.id = in.readVInt();
+        this.failures = in.readOptionalArray(Failure::readFailure, Failure[]::new);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeVInt(id);
+        out.writeOptionalArray(failures);
+    }
+
+    public boolean hasFailures() {
+        return CollectionUtils.isEmpty(failures) == false;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public Failure[] getFailures() {
+        return failures;
+    }
+
+    public static class Failure extends DefaultShardOperationFailedException {
+
+        private @Nullable String nodeId;
+
+        private Failure(StreamInput in) throws IOException {
+            super(in);
+            nodeId = in.readOptionalString();
+        }
+
+        public Failure(final String index, final int shardId, final Throwable reason) {
+            this(index, shardId, reason, null);
+        }
+
+        public Failure(final String index, final int shardId, final Throwable reason, final String nodeId) {
+            super(index, shardId, reason);
+            this.nodeId = nodeId;
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(nodeId);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+
+        static Failure readFailure(final StreamInput in) throws IOException {
+            return new Failure(in);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.close;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.support.replication.ReplicationOperation.Replicas;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportVerifyShardBeforeCloseAction extends TransportReplicationAction<
+    TransportVerifyShardBeforeCloseAction.ShardRequest, TransportVerifyShardBeforeCloseAction.ShardRequest, ReplicationResponse> {
+
+    public static final String NAME = "indices:admin/close" + "[s]";
+    protected Logger logger = LogManager.getLogger(getClass());
+
+    @Inject
+    public TransportVerifyShardBeforeCloseAction(final Settings settings,
+                                                 final TransportService transportService,
+                                                 final ClusterService clusterService,
+                                                 final IndicesService indicesService,
+                                                 final ThreadPool threadPool,
+                                                 final ShardStateAction stateAction,
+                                                 final IndexNameExpressionResolver resolver) {
+        super(
+            NAME,
+            transportService,
+            clusterService,
+            indicesService,
+            threadPool,
+            stateAction,
+            resolver,
+            ShardRequest::new,
+            ShardRequest::new,
+            ThreadPool.Names.MANAGEMENT
+        );
+    }
+
+    @Override
+    protected ReplicationResponse read(StreamInput in) throws IOException {
+        return new ReplicationResponse(in);
+    }
+
+    @Override
+    protected void acquirePrimaryOperationPermit(final IndexShard primary,
+                                                 final ShardRequest request,
+                                                 final ActionListener<Releasable> onAcquired) {
+        primary.acquireAllPrimaryOperationsPermits(onAcquired, request.timeout());
+    }
+
+    @Override
+    protected void acquireReplicaOperationPermit(final IndexShard replica,
+                                                 final ShardRequest request,
+                                                 final ActionListener<Releasable> onAcquired,
+                                                 final long primaryTerm,
+                                                 final long globalCheckpoint,
+                                                 final long maxSeqNoOfUpdateOrDeletes) {
+        replica.acquireAllReplicaOperationsPermits(primaryTerm, globalCheckpoint, maxSeqNoOfUpdateOrDeletes, onAcquired, request.timeout());
+    }
+
+    @Override
+    protected void shardOperationOnPrimary(final ShardRequest shardRequest, final IndexShard primary,
+            ActionListener<PrimaryResult<ShardRequest, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            executeShardOperation(shardRequest, primary);
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
+    }
+
+    @Override
+    protected ReplicaResult shardOperationOnReplica(final ShardRequest shardRequest, final IndexShard replica) throws IOException {
+        executeShardOperation(shardRequest, replica);
+        return new ReplicaResult();
+    }
+
+    private void executeShardOperation(final ShardRequest request, final IndexShard indexShard) throws IOException {
+        final ShardId shardId = indexShard.shardId();
+        if (indexShard.getActiveOperationsCount() != IndexShard.OPERATIONS_BLOCKED) {
+            throw new IllegalStateException("Index shard " + shardId + " is not blocking all operations during closing");
+        }
+
+        final ClusterBlocks clusterBlocks = clusterService.state().blocks();
+        if (clusterBlocks.hasIndexBlock(shardId.getIndexName(), request.clusterBlock()) == false) {
+            throw new IllegalStateException("Index shard " + shardId + " must be blocked by " + request.clusterBlock() + " before closing");
+        }
+        if (request.isPhase1()) {
+            // in order to advance the global checkpoint to the maximum sequence number, the (persisted) local checkpoint needs to be
+            // advanced first, which, when using async translog syncing, does not automatically hold at the time where we have acquired
+            // all operation permits. Instead, this requires and explicit sync, which communicates the updated (persisted) local checkpoint
+            // to the primary (we call this phase1), and phase2 can then use the fact that the global checkpoint has moved to the maximum
+            // sequence number to pass the verifyShardBeforeIndexClosing check and create a safe commit where the maximum sequence number
+            // is equal to the global checkpoint.
+            indexShard.sync();
+        } else {
+            indexShard.verifyShardBeforeIndexClosing();
+            indexShard.flush(new FlushRequest().force(true).waitIfOngoing(true));
+            logger.trace("{} shard is ready for closing", shardId);
+        }
+    }
+
+    @Override
+    protected Replicas<ShardRequest> newReplicasProxy(long primaryTerm) {
+        return new VerifyShardBeforeCloseActionReplicasProxy(primaryTerm);
+    }
+
+    /**
+     * A {@link ReplicasProxy} that marks as stale the shards that are unavailable during the verification
+     * and the flush of the shard. This is done to ensure that such shards won't be later promoted as primary
+     * or reopened in an unverified state with potential non flushed translog operations.
+     */
+    class VerifyShardBeforeCloseActionReplicasProxy extends ReplicasProxy {
+
+        public VerifyShardBeforeCloseActionReplicasProxy(long primaryTerm) {
+            super(primaryTerm);
+        }
+
+        @Override
+        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+            shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
+        }
+    }
+
+    public static class ShardRequest extends ReplicationRequest<ShardRequest> {
+
+        private final ClusterBlock clusterBlock;
+
+        private final boolean phase1;
+
+        ShardRequest(StreamInput in) throws IOException {
+            super(in);
+            clusterBlock = new ClusterBlock(in);
+            phase1 = in.readBoolean();
+        }
+
+        public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, final boolean phase1, final TaskId parentTaskId) {
+            super(shardId);
+            this.clusterBlock = Objects.requireNonNull(clusterBlock);
+            this.phase1 = phase1;
+            setParentTask(parentTaskId);
+        }
+
+        @Override
+        public String toString() {
+            return "verify shard " + shardId + " before close with block " + clusterBlock;
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+            clusterBlock.writeTo(out);
+            out.writeBoolean(phase1);
+        }
+
+        public ClusterBlock clusterBlock() {
+            return clusterBlock;
+        }
+
+        public boolean isPhase1() {
+            return phase1;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Strings;
 import io.crate.common.collections.Tuple;
+import io.crate.metadata.RelationName;
+
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -40,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 public class IndexNameExpressionResolver {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

This is in preparation for 

  https://github.com/crate/crate/pull/10404 / https://github.com/elastic/elasticsearch/commit/309a3e4ccbcdfcd830621a92d6e67af929123605


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)