### PR TITLE
Add custom robots.txt for docs

### DIFF
--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+
+Sitemap: https://crate.io/docs/crate/reference/en/master/sitemap.xml


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Tests were failing:

    Warning, treated as error:
    html_extra_path entry '[...]/docs/_extra' does not exist


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)