### PR TITLE
Migrate sql-parser tests to assertThrows.

### DIFF
--- a/libs/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
@@ -25,20 +25,14 @@ package io.crate.sql;
 
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntervalLiteral;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IntervalLiteralTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testYear() {
@@ -114,22 +108,22 @@ public class IntervalLiteralTest {
 
     @Test
     public void testSecondToHour() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Startfield must be less significant than Endfield");
-        SqlParser.createExpression("INTERVAL '1' SECOND TO HOUR");
+        assertThrows(IllegalArgumentException.class,
+                     () -> SqlParser.createExpression("INTERVAL '1' SECOND TO HOUR"),
+                     "Startfield must be less significant than Endfield");
     }
 
     @Test
     public void testSecondToYear() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Startfield must be less significant than Endfield");
-        SqlParser.createExpression("INTERVAL '1' SECOND TO YEAR");
+        assertThrows(IllegalArgumentException.class,
+                     () -> SqlParser.createExpression("INTERVAL '1' SECOND TO YEAR"),
+                     "Startfield must be less significant than Endfield");
     }
 
     @Test
     public void testDayToYear() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Startfield must be less significant than Endfield");
-        SqlParser.createExpression("INTERVAL '1' DAY TO YEAR");
+        assertThrows(IllegalArgumentException.class,
+                     () -> SqlParser.createExpression("INTERVAL '1' DAY TO YEAR"),
+                     "Startfield must be less significant than Endfield");
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -25,17 +25,13 @@ package io.crate.sql;
 
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntegerLiteral;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LiteralsTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testEscape() throws Exception {
@@ -235,16 +231,16 @@ public class LiteralsTest {
 
     @Test
     public void testThatInvalidLengthEscapedUnicode16SequenceThrowsException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
-        Literals.replaceEscapedChars("\\u006");
+        assertThrows(IllegalArgumentException.class,
+                     () -> Literals.replaceEscapedChars("\\u006"),
+                     Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
     public void testThatInvalidHexEscapedUnicode16SequenceThrowsException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
-        Literals.replaceEscapedChars("\\u006G");
+        assertThrows(IllegalArgumentException.class,
+                     () -> Literals.replaceEscapedChars("\\u006G"),
+                     Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
@@ -275,16 +271,16 @@ public class LiteralsTest {
 
     @Test
     public void testThatInvalidLengthEscapedUnicode32SequenceThrowsException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
-        Literals.replaceEscapedChars("\\U0061");
+        assertThrows(IllegalArgumentException.class,
+                     () -> Literals.replaceEscapedChars("\\U0061"),
+                     Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
     public void testThatInvalidHexEscapedUnicode32SequenceThrowsException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(Literals.ESCAPED_UNICODE_ERROR);
-        Literals.replaceEscapedChars("\\U0000006G");
+        assertThrows(IllegalArgumentException.class,
+                     () -> Literals.replaceEscapedChars("\\U0000006G"),
+                     Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -38,9 +38,7 @@ import io.crate.sql.tree.Query;
 import io.crate.sql.tree.QuerySpecification;
 import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Locale;
@@ -57,11 +55,9 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestSqlParser {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testComments() {
@@ -187,135 +183,135 @@ public class TestSqlParser {
 
     @Test
     public void testEmptyExpression() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:1: mismatched input '<EOF>'");
-        SqlParser.createExpression("");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createExpression(""),
+                     "line 1:1: mismatched input '<EOF>'");
     }
 
     @Test
     public void testEmptyStatement() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:1: mismatched input '<EOF>'");
-        SqlParser.createStatement("");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement(""),
+                     "line 1:1: mismatched input '<EOF>'");
     }
 
     @Test
     public void testExpressionWithTrailingJunk() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:7: extraneous input 'x' expecting");
-        SqlParser.createExpression("1 + 1 x");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("1 + 1 x"),
+                     "line 1:7: extraneous input 'x' expecting");
     }
 
     @Test
     public void testTokenizeErrorStartOfLine() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:1: extraneous input '@' expecting");
-        SqlParser.createStatement("@select");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("@select"),
+                     "line 1:1: extraneous input '@' expecting");
     }
 
     @Test
     public void testTokenizeErrorMiddleOfLine() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:25: no viable alternative at input 'select * from foo where @'");
-        SqlParser.createStatement("select * from foo where @what");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from foo where @what"),
+                     "line 1:25: no viable alternative at input 'select * from foo where @'");
     }
 
     @Test
     public void testTokenizeErrorIncompleteToken() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:15: no viable alternative at input 'select * from ''");
-        SqlParser.createStatement("select * from 'oops");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from 'oops"),
+                     "line 1:15: no viable alternative at input 'select * from ''");
     }
 
     @Test
     public void testParseErrorStartOfLine() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 3:1: extraneous input 'from' expecting");
-        SqlParser.createStatement("select *\nfrom x\nfrom");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select *\nfrom x\nfrom"),
+                     "line 3:1: extraneous input 'from' expecting");
     }
 
     @Test
     public void testParseErrorMiddleOfLine() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
-        SqlParser.createStatement("select *\nfrom x\nwhere from");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select *\nfrom x\nwhere from"),
+                     "line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
     }
 
     @Test
     public void testParseErrorEndOfInput() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:14: no viable alternative at input 'select * from'");
-        SqlParser.createStatement("select * from");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from"),
+                     "line 1:14: no viable alternative at input 'select * from'");
     }
 
     @Test
     public void testParseErrorEndOfInputWhitespace() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:16: no viable alternative at input 'select * from  '");
-        SqlParser.createStatement("select * from  ");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from  "),
+                     "line 1:16: no viable alternative at input 'select * from  '");
     }
 
     @Test
     public void testParseErrorBackquotes() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:15: backquoted identifiers are not supported; use double quotes to quote identifiers");
-        SqlParser.createStatement("select * from `foo`");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from `foo`"),
+                     "line 1:15: backquoted identifiers are not supported; use double quotes to quote identifiers");
     }
 
     @Test
     public void testParseErrorBackquotesEndOfInput() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:19: backquoted identifiers are not supported; use double quotes to quote identifiers");
-        SqlParser.createStatement("select * from foo `bar`");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from foo `bar`"),
+                     "line 1:19: backquoted identifiers are not supported; use double quotes to quote identifiers");
     }
 
     @Test
     public void testParseErrorDigitIdentifiers() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:8: identifiers must not start with a digit; surround the identifier with double quotes");
-        SqlParser.createStatement("select 1x from dual");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select 1x from dual"),
+                     "line 1:8: identifiers must not start with a digit; surround the identifier with double quotes");
     }
 
     @Test
     public void testIdentifierWithColon() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:15: identifiers must not contain ':'");
-        SqlParser.createStatement("select * from foo:bar");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select * from foo:bar"),
+                     "line 1:15: identifiers must not contain ':'");
     }
 
     @Test
     public void testParseErrorDualOrderBy() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:35: mismatched input 'order'");
-        SqlParser.createStatement("select fuu from dual order by fuu order by fuu");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select fuu from dual order by fuu order by fuu"),
+                     "line 1:35: mismatched input 'order'");
     }
 
     @Test
     public void testParseErrorReverseOrderByLimit() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:31: mismatched input 'order' expecting {<EOF>, ';'}");
-        SqlParser.createStatement("select fuu from dual limit 10 order by fuu");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select fuu from dual limit 10 order by fuu"),
+                     "line 1:31: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseOrderByLimitOffset() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:41: mismatched input 'order' expecting {<EOF>, ';'}");
-        SqlParser.createStatement("select fuu from dual limit 10 offset 20 order by fuu");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select fuu from dual limit 10 offset 20 order by fuu"),
+                     "line 1:41: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseOrderByOffset() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:32: mismatched input 'order' expecting {<EOF>, ';'}");
-        SqlParser.createStatement("select fuu from dual offset 20 order by fuu");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select fuu from dual offset 20 order by fuu"),
+                     "line 1:32: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseLimitOffset() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:32: mismatched input 'limit' expecting {<EOF>, ';'}");
-        SqlParser.createStatement("select fuu from dual offset 20 limit 10");
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("select fuu from dual offset 20 order by fuu"),
+                     "line 1:32: mismatched input 'limit' expecting {<EOF>, ';'}");
     }
 
     @Test
@@ -396,9 +392,9 @@ public class TestSqlParser {
 
     @Test
     public void testTrimFunctionMissingFromWhenCharsToTrimIsPresentThrowsException() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:10: no viable alternative at input 'TRIM(' ' chars'");
-        assertInstanceOf("TRIM(' ' chars)", FunctionCall.class);
+        assertThrows(ParsingException.class,
+                     () -> assertInstanceOf("TRIM(' ' chars)", FunctionCall.class),
+                     "line 1:10: no viable alternative at input 'TRIM(' ' chars'");
     }
 
     private void assertInstanceOf(String expr, Class<? extends Node> cls) {
@@ -408,16 +404,16 @@ public class TestSqlParser {
 
     @Test
     public void testStackOverflowExpression() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:1: expression is too large (stack overflow while parsing)");
-        SqlParser.createExpression(Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x));
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createExpression(Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
+                     "line 1:1: expression is too large (stack overflow while parsing)");
     }
 
     @Test
     public void testStackOverflowStatement() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:1: statement is too large (stack overflow while parsing)");
-        SqlParser.createStatement("SELECT " + Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x));
+        assertThrows(ParsingException.class,
+                     () -> SqlParser.createStatement("SELECT " + Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
+                     "line 1:1: statement is too large (stack overflow while parsing)");
     }
 
     @Test
@@ -435,16 +431,16 @@ public class TestSqlParser {
 
     @Test
     public void testFromStringLiteralCastDoesNotSupportArrayType() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
-        SqlParser.createExpression("array(boolean) '[1,2,0]'");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> SqlParser.createExpression("array(boolean) '[1,2,0]'"),
+                     "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
     }
 
     @Test
     public void testFromStringLiteralCastDoesNotSupportObjectType() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
-        SqlParser.createExpression("object '{\"x\": 10}'");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> SqlParser.createExpression("object '{\"x\": 10}'"),
+                     "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
     }
 
     private static void assertStatement(String query, Statement expected) {

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedFollowingFrameBoundTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedFollowingFrameBoundTest.java
@@ -23,9 +23,7 @@
 package io.crate.sql.tree;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Comparator;
 import java.util.List;
@@ -34,11 +32,9 @@ import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnboundedFollowingFrameBoundTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private List<Integer> partition;
     private Comparator<Integer> intComparator;
@@ -68,9 +64,9 @@ public class UnboundedFollowingFrameBoundTest {
 
     @Test
     public void testUnboundeFollowingCannotBeTheStartOfTheFrame() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("UNBOUNDED FOLLOWING cannot be the start of a frame");
-        UNBOUNDED_FOLLOWING.getStart(RANGE, 0, 3, 1, null, null, intComparator, partition);
+        assertThrows(IllegalStateException.class,
+                     () ->  UNBOUNDED_FOLLOWING.getStart(RANGE, 0, 3, 1, null, null, intComparator, partition),
+                     "UNBOUNDED FOLLOWING cannot be the start of a frame");
     }
 
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedPrecedingFrameBoundTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedPrecedingFrameBoundTest.java
@@ -23,9 +23,7 @@
 package io.crate.sql.tree;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Comparator;
 import java.util.List;
@@ -34,11 +32,9 @@ import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnboundedPrecedingFrameBoundTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private List<Integer> partition;
     private Comparator<Integer> intComparator;
@@ -67,8 +63,8 @@ public class UnboundedPrecedingFrameBoundTest {
 
     @Test
     public void testUnboundePrecedingCannotBeTheEndOfTheFrame() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("UNBOUNDED PRECEDING cannot be the start of a frame");
-        UNBOUNDED_PRECEDING.getEnd(RANGE, 0, 3, 1, null, null, intComparator, partition);
+        assertThrows(IllegalStateException.class,
+                     () -> UNBOUNDED_PRECEDING.getEnd(RANGE, 0, 3, 1, null, null, intComparator, partition),
+                     "UNBOUNDED PRECEDING cannot be the start of a frame");
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
@@ -22,9 +22,7 @@
 
 package io.crate.sql.tree;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,11 +31,9 @@ import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WindowTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private final Window emptyWindow = new Window(null, List.of(), List.of(), Optional.empty());
 
@@ -81,9 +77,9 @@ public class WindowTest {
         var current = new Window("w", List.of(), orderBy, Optional.empty());
         var provided = new Window(null, List.of(), List.of(), Optional.of(frame));
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Cannot copy window w because it has a frame clause");
-        current.merge(provided);
+        assertThrows(IllegalArgumentException.class,
+                     () -> current.merge(provided),
+                     "Cannot copy window w because it has a frame clause");
     }
 
     @Test
@@ -91,17 +87,17 @@ public class WindowTest {
         Window current = new Window("w", List.of(), orderBy, Optional.empty());
         Window provided = new Window(null, List.of(), orderBy, Optional.empty());
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Cannot override ORDER BY clause of window w");
-        current.merge(provided);
+        assertThrows(IllegalArgumentException.class,
+                     () -> current.merge(provided),
+                     "Cannot override ORDER BY clause of window w");
     }
 
     @Test
     public void test_merge_current_window_cannot_specify_partition_by() {
         var current = new Window("w", partitionBy, List.of(), Optional.empty());
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Cannot override PARTITION BY clause of window w");
-        current.merge(emptyWindow);
+        assertThrows(IllegalArgumentException.class,
+                     () -> current.merge(emptyWindow),
+                     "Cannot override PARTITION BY clause of window w");
     }
 }


### PR DESCRIPTION
This migrates all tests in the sql-parser module from the soon to be deprecated
ExpectedException to assertThrows.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
