### PR TITLE
Prevent column prune logic from duplicating outputs

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -76,6 +76,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``IndexOutOfBoundsException`` when using
+  virtual tables and joins.
+
 - Fixed an issue that declared the rule optimizer settings as global. The
   settings are now session local.
 

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -22,6 +22,20 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -49,18 +63,6 @@ import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.statistics.TableStats;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 public class HashJoin implements LogicalPlan {
 
@@ -237,8 +239,8 @@ public class HashJoin implements LogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
-        ArrayList<Symbol> lhsToKeep = new ArrayList<>();
-        ArrayList<Symbol> rhsToKeep = new ArrayList<>();
+        LinkedHashSet<Symbol> lhsToKeep = new LinkedHashSet<>();
+        LinkedHashSet<Symbol> rhsToKeep = new LinkedHashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, lhs.outputs(), lhsToKeep::add);
             SymbolVisitors.intersection(outputToKeep, rhs.outputs(), rhsToKeep::add);
@@ -261,8 +263,8 @@ public class HashJoin implements LogicalPlan {
     @Nullable
     @Override
     public FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
-        ArrayList<Symbol> usedFromLeft = new ArrayList<>();
-        ArrayList<Symbol> usedFromRight = new ArrayList<>();
+        LinkedHashSet<Symbol> usedFromLeft = new LinkedHashSet<>();
+        LinkedHashSet<Symbol> usedFromRight = new LinkedHashSet<>();
         for (Symbol usedColumn : usedColumns) {
             SymbolVisitors.intersection(usedColumn, lhs.outputs(), usedFromLeft::add);
             SymbolVisitors.intersection(usedColumn, rhs.outputs(), usedFromRight::add);

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -226,7 +226,9 @@ public class LogicalPlanner {
         );
         LogicalPlan logicalPlan = relation.accept(planBuilder, relation.outputs());
         LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
+        assert logicalPlan.outputs().equals(optimizedPlan.outputs()) : "Optimized plan must have the same outputs as original plan";
         LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(tableStats, relation.outputs());
+        assert logicalPlan.outputs().equals(optimizedPlan.outputs()) : "Pruned plan must have the same outputs as original plan";
         LogicalPlan fetchOptimized = fetchOptimizer.optimize(
             prunedPlan,
             tableStats,
@@ -235,6 +237,7 @@ public class LogicalPlanner {
         if (fetchOptimized != prunedPlan || hints.contains(PlanHint.AVOID_TOP_LEVEL_FETCH)) {
             return fetchOptimized;
         }
+        assert logicalPlan.outputs().equals(fetchOptimized.outputs()) : "Fetch optimized plan must have the same outputs as original plan";
         // Doing a second pass here to also rewrite additional plan patterns to "Fetch"
         // The `fetchOptimizer` operators on `Limit - X` fragments of a tree.
         // This here instead operators on a narrow selection of top-level patterns

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -22,6 +22,20 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.planner.operators.Limit.limitAndOffset;
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -48,19 +62,6 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.statistics.TableStats;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static io.crate.planner.operators.Limit.limitAndOffset;
-import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 public class NestedLoopJoin implements LogicalPlan {
 
@@ -260,8 +261,8 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
-        ArrayList<Symbol> lhsToKeep = new ArrayList<>();
-        ArrayList<Symbol> rhsToKeep = new ArrayList<>();
+        LinkedHashSet<Symbol> lhsToKeep = new LinkedHashSet<>();
+        LinkedHashSet<Symbol> rhsToKeep = new LinkedHashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, lhs.outputs(), lhsToKeep::add);
             SymbolVisitors.intersection(outputToKeep, rhs.outputs(), rhsToKeep::add);
@@ -290,8 +291,8 @@ public class NestedLoopJoin implements LogicalPlan {
     @Nullable
     @Override
     public FetchRewrite rewriteToFetch(TableStats tableStats, Collection<Symbol> usedColumns) {
-        ArrayList<Symbol> usedFromLeft = new ArrayList<>();
-        ArrayList<Symbol> usedFromRight = new ArrayList<>();
+        LinkedHashSet<Symbol> usedFromLeft = new LinkedHashSet<>();
+        LinkedHashSet<Symbol> usedFromRight = new LinkedHashSet<>();
         for (Symbol usedColumn : usedColumns) {
             SymbolVisitors.intersection(usedColumn, lhs.outputs(), usedFromLeft::add);
             SymbolVisitors.intersection(usedColumn, rhs.outputs(), usedFromRight::add);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The prune logic extended the outputs, which led to a plan that had more
outputs than expected.

Fixes https://github.com/crate/crate/issues/10411

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)