### PR TITLE
Mute JdkDownloadPluginFunctionalTest.

### DIFF
--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
@@ -24,6 +24,7 @@ package io.crate.gradle.plugins.jdk;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -52,21 +53,25 @@ public class JdkDownloadPluginFunctionalTest {
     public static final String VERSION = "13.0.2+8";
 
     @Test
+    @Ignore
     public void testAarch64LinuxJDKExtraction() {
         assertExtraction("getAarch64LinuxJdk", "bin/java", VENDOR, VERSION);
     }
 
     @Test
+    @Ignore
     public void testX64LinuxJDKExtraction() {
         assertExtraction("getX64LinuxJdk", "bin/java", VENDOR, VERSION);
     }
 
     @Test
+    @Ignore
     public void testMacJDKExtraction() {
         assertExtraction("getMacJdk", "Contents/Home/bin/java", VENDOR, VERSION);
     }
 
     @Test
+    @Ignore
     public void testWindowsJDKExtraction() {
         assertExtraction("getWindowsJdk", "bin/java.exe", VENDOR, VERSION);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Tests are fetching real JDK artifacts instead of using the fake once.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
