### PR TITLE
Migrate all crate tests in server module to assertThrows

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -56,8 +56,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.hamcrest.Matcher;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -73,9 +71,6 @@ import static io.crate.execution.engine.sort.Comparators.createComparator;
 import static org.hamcrest.Matchers.instanceOf;
 
 public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServiceUnitTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private AbstractModule[] additionalModules;
     private SqlExpressions sqlExpressions;

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -30,9 +30,6 @@ import org.junit.rules.ExpectedException;
 
 public class CIDROperatorTest extends AbstractScalarFunctionsTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void test_ipv4_operands_in_wrong_order() {
         expectedException.expect(IllegalArgumentException.class);

--- a/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
@@ -56,9 +56,6 @@ public class IpColumnReferenceTest extends DocLevelExpressionsTest {
         super("create table t (i ip, ia array(ip))");
     }
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         addIPv4Values(writer);

--- a/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
@@ -37,9 +37,7 @@ import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -52,6 +50,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,8 +58,6 @@ public class NodeStatsContextFieldResolverTest {
 
     private NodeStatsContextFieldResolver resolver;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     private TransportAddress postgresAddress;
 
     @Before
@@ -184,9 +181,9 @@ public class NodeStatsContextFieldResolverTest {
 
     @Test
     public void testResolveForNonExistingColumnIdent() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Cannot resolve NodeStatsContext field for \"dummy\" column ident.");
-        resolver.forTopColumnIdents(ImmutableSet.of(SysNodesTableInfo.Columns.ID, new ColumnIdent("dummy")));
+        assertThrows(IllegalArgumentException.class,
+                     () -> resolver.forTopColumnIdents(ImmutableSet.of(SysNodesTableInfo.Columns.ID, new ColumnIdent("dummy"))),
+                     "Cannot resolve NodeStatsContext field for \"dummy\" column ident.");
     }
 
     private void assertDefaultDiscoveryContext(NodeStatsContext context) {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
@@ -30,9 +30,6 @@ import org.junit.rules.ExpectedException;
 
 public class ArithmeticOverflowTest extends AbstractScalarFunctionsTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void test_integer_overflow() {
         expectedException.expect(IllegalArgumentException.class);

--- a/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
@@ -30,9 +30,6 @@ import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 
 public class ChrFunctionTest extends AbstractScalarFunctionsTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void test_null_value_returns_null() throws Exception {
         assertEvaluate("chr(null)", null);

--- a/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
@@ -30,9 +30,6 @@ import org.junit.rules.ExpectedException;
 
 public class StringPaddingFunctionTest extends AbstractScalarFunctionsTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void test_lpad_parameter_len_too_big() throws Exception {
         expectedException.expect(IllegalArgumentException.class);

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -31,9 +31,6 @@ import org.junit.rules.ExpectedException;
 
 public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void testEvaluateInvalidZoneIsNull() {
         assertEvaluate("timezone(null, 257504400000)", null);

--- a/server/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
+++ b/server/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
@@ -23,21 +23,17 @@
 package io.crate.geo;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Map;
 
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -53,9 +49,6 @@ import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 import org.locationtech.spatial4j.shape.jts.JtsPoint;
 
 public class GeoJSONUtilsTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     static {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
@@ -144,14 +137,12 @@ public class GeoJSONUtilsTest {
 
     @Test
     public void testInvalidWKT() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(allOf(
-            startsWith("Cannot convert WKT \""),
-            endsWith("\" to shape")));
-        GeoJSONUtils.wkt2Map("multilinestring (((10.05  10.28  3.4  8.4, 20.95  20.89  4.5  9.5),\n" +
-                             " \n" +
-                             "( 20.95  20.89  4.5  9.5, 31.92  21.45  3.6  8.6)))");
-
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.wkt2Map(
+                         "multilinestring (((10.05  10.28  3.4  8.4, 20.95  20.89  4.5  9.5),\n" +
+                         " \n" +
+                         "( 20.95  20.89  4.5  9.5, 31.92  21.45  3.6  8.6)))"),
+                     "Cannot convert WKT \"multilinestring (((10.05  10.28  3.4  8.4, 20.95  20.89  4.5  9.5)");
     }
 
     @Test
@@ -167,90 +158,90 @@ public class GeoJSONUtilsTest {
 
     @Test
     public void testInvalidMap() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot convert Map \"{}\" to shape");
-        GeoJSONUtils.map2Shape(Map.<String, Object>of());
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.map2Shape(Map.<String, Object>of()),
+                     "Cannot convert Map \"{}\" to shape");
     }
 
     @Test
     public void testValidateMissingType() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: type field missing");
-        GeoJSONUtils.validateGeoJson(Map.of());
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(Map.of()),
+                     "Invalid GeoJSON: type field missing");
     }
 
     @Test
     public void testValidateWrongType() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: invalid type");
-        GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, "Foo"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, "Foo")),
+                     "Invalid GeoJSON: invalid type");
     }
 
     @Test
     public void testValidateMissingCoordinates() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: coordinates field missing");
-        GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.LINE_STRING));
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.LINE_STRING)),
+                     "Invalid GeoJSON: coordinates field missing");
     }
 
     @Test
     public void testValidateGeometriesMissing() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: geometries field missing");
-        GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.GEOMETRY_COLLECTION));
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(Map.of(GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.GEOMETRY_COLLECTION)),
+                     "Invalid GeoJSON: coordinates field missing");
     }
 
     @Test
     public void testInvalidGeometryCollection() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: invalid GeometryCollection");
-        GeoJSONUtils.validateGeoJson(
-            Map.of(
-                GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.GEOMETRY_COLLECTION,
-                GeoJSONUtils.GEOMETRIES_FIELD, List.<Object>of("ABC")
-            )
-        );
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(
+                         Map.of(
+                             GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.GEOMETRY_COLLECTION,
+                             GeoJSONUtils.GEOMETRIES_FIELD, List.<Object>of("ABC")
+                         )
+                     ),
+                     "Invalid GeoJSON: invalid GeometryCollection");
     }
 
     @Test
     public void testValidateInvalidCoordinates() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: invalid coordinate");
-        GeoJSONUtils.validateGeoJson(
-            Map.of(
-                GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POINT,
-                GeoJSONUtils.COORDINATES_FIELD, "ABC"
-            )
-        );
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(
+                         Map.of(
+                             GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POINT,
+                             GeoJSONUtils.COORDINATES_FIELD, "ABC"
+                         )
+                     ),
+                     "Invalid GeoJSON: invalid GeometryCollection");
     }
 
     @Test
     public void testInvalidNestedCoordinates() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: invalid coordinate");
-        GeoJSONUtils.validateGeoJson(
-            Map.of(
-                GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POINT,
-                GeoJSONUtils.COORDINATES_FIELD, new double[][]{
-                    {0.0, 1.0},
-                    {1.0, 0.0}
-                }
-            )
-        );
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(
+                         Map.of(
+                             GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POINT,
+                             GeoJSONUtils.COORDINATES_FIELD, new double[][]{
+                                 {0.0, 1.0},
+                                 {1.0, 0.0}
+                             }
+                         )
+                     ),
+                     "Invalid GeoJSON: invalid coordinate");
     }
 
     @Test
     public void testInvalidDepthNestedCoordinates() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid GeoJSON: invalid coordinate");
-        GeoJSONUtils.validateGeoJson(
-            Map.of(
-                GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POLYGON,
-                GeoJSONUtils.COORDINATES_FIELD, new double[][]{
-                    {0.0, 1.0},
-                    {1.0, 0.0}
-                }
-            )
-        );
+        assertThrows(IllegalArgumentException.class,
+                     () -> GeoJSONUtils.validateGeoJson(
+                         Map.of(
+                             GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.POLYGON,
+                             GeoJSONUtils.COORDINATES_FIELD, new double[][]{
+                                 {0.0, 1.0},
+                                 {1.0, 0.0}
+                             }
+                         )
+                     ),
+                     "Invalid GeoJSON: invalid coordinate");
     }
 }

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -29,9 +29,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.LoadedRules;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,11 +41,10 @@ import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SessionSettingRegistryTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
     private SessionContext sessionContext = SessionContext.systemSessionContext();
     private NodeContext nodeCtx = createNodeContext();
     private Function<Symbol, Object> eval = s -> SymbolEvaluator.evaluateWithoutParams(
@@ -58,10 +55,10 @@ public class SessionSettingRegistryTest {
 
     @Test
     public void testMaxIndexKeysSessionSettingCannotBeChanged() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("\"max_index_keys\" cannot be changed.");
         SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.MAX_INDEX_KEYS);
-        setting.apply(sessionContext, generateInput("32"), eval);
+        assertThrows(UnsupportedOperationException.class,
+                     () -> setting.apply(sessionContext, generateInput("32"), eval),
+                     "\"max_index_keys\" cannot be changed.");
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/TimestampTypesTest.java
+++ b/server/src/test/java/io/crate/types/TimestampTypesTest.java
@@ -1,18 +1,14 @@
 package io.crate.types;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TimestampTypesTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testTimestampWithZoneParseWithOffset() {
@@ -81,58 +77,58 @@ public class TimestampTypesTest {
 
     @Test
     public void testTimestampWithZoneUsingDoubleSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestamp("1999-01-08  04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestamp("1999-01-08  04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingDoubleSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestampIgnoreTimeZone("1999-01-08  04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestampIgnoreTimeZone("1999-01-08  04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithZoneNothingBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestamp("1999-01-0804:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestamp("1999-01-0804:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithoutZoneNothingBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestampIgnoreTimeZone("1999-01-0804:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestampIgnoreTimeZone("1999-01-0804:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithZoneUsingSpaceAndTBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestamp("1999-01-08 T04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestamp("1999-01-08 T04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingSpaceAndTBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestampIgnoreTimeZone("1999-01-08 T04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestampIgnoreTimeZone("1999-01-08 T04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithZoneUsingTAndSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestamp("1999-01-08T 04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestamp("1999-01-08T 04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
     public void testTimestampWithoutZoneUsingTAndSpaceBetweenDateAndTimeDoesNotParse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("could not be parsed, unparsed text found at index 10");
-        TimestampType.parseTimestampIgnoreTimeZone("1999-01-08T 04:00:00");
+        assertThrows(IllegalArgumentException.class,
+                     () -> TimestampType.parseTimestampIgnoreTimeZone("1999-01-08T 04:00:00"),
+                     "could not be parsed, unparsed text found at index 10");
     }
 
     @Test
@@ -143,8 +139,8 @@ public class TimestampTypesTest {
 
     @Test
     public void test_cast_object_to_timestamptz_throws_exception() {
-        expectedException.expect(ClassCastException.class);
-        expectedException.expectMessage("Can't cast '{}' to timestamp with time zone");
-        TimestampType.INSTANCE_WITH_TZ.implicitCast(Map.of());
+        assertThrows(ClassCastException.class,
+                     () -> TimestampType.INSTANCE_WITH_TZ.implicitCast(Map.of()),
+                     "Can't cast '{}' to timestamp with time zone");
     }
 }


### PR DESCRIPTION
This migrates all crate related tests in the server module from
ExpectedException to assertThrows.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
