### PR TITLE
Add new close table transport using 3 step close

### DIFF
--- a/server/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/server/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -22,12 +22,15 @@
 
 package io.crate.execution;
 
+import org.elasticsearch.action.admin.indices.close.TransportVerifyShardBeforeCloseAction;
+import org.elasticsearch.common.inject.AbstractModule;
+
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
-import io.crate.statistics.TransportAnalyzeAction;
 import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.index.TransportSwapAndDropIndexNameAction;
 import io.crate.execution.ddl.tables.TransportAlterTableAction;
+import io.crate.execution.ddl.tables.TransportCloseTable;
 import io.crate.execution.ddl.tables.TransportCreateTableAction;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.tables.TransportOpenCloseTableOrPartitionAction;
@@ -47,7 +50,7 @@ import io.crate.execution.jobs.transport.TransportJobAction;
 import io.crate.expression.udf.TransportCreateUserDefinedFunctionAction;
 import io.crate.expression.udf.TransportDropUserDefinedFunctionAction;
 import io.crate.lucene.LuceneQueryBuilder;
-import org.elasticsearch.common.inject.AbstractModule;
+import io.crate.statistics.TransportAnalyzeAction;
 
 public class TransportExecutorModule extends AbstractModule {
 
@@ -71,6 +74,8 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportRenameTableAction.class).asEagerSingleton();
         bind(TransportSwapAndDropIndexNameAction.class).asEagerSingleton();
         bind(TransportOpenCloseTableOrPartitionAction.class).asEagerSingleton();
+        bind(TransportCloseTable.class).asEagerSingleton();
+        bind(TransportVerifyShardBeforeCloseAction.class).asEagerSingleton();
         bind(TransportDropTableAction.class).asEagerSingleton();
         bind(TransportCreateUserDefinedFunctionAction.class).asEagerSingleton();
         bind(TransportDropUserDefinedFunctionAction.class).asEagerSingleton();

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.index.Index;
+
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
+/**
+ * Structure for the 3 different cases:
+ *
+ *  - ALTER TABLE tbl       -- On a normal table
+ *  - ALTER TABLE tbl       -- On a partitioned table
+ *  - ALTER TABLE tbl PARTITION (pcol = ?)
+ */
+public final class AlterTableTarget {
+
+    public static AlterTableTarget resolve(IndexNameExpressionResolver indexNameResolver,
+                                           ClusterState state,
+                                           RelationName table,
+                                           @Nullable String partition) {
+        if (partition == null) {
+            Index[] indices = indexNameResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), table.indexNameOrAlias());
+            String templateName = PartitionName.templateName(table.schema(), table.name());
+            IndexTemplateMetadata indexTemplateMetadata = state.metadata().getTemplates().get(templateName);
+            return new AlterTableTarget(table, partition, indices, indexTemplateMetadata);
+        } else {
+            Index[] indices = indexNameResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), partition);
+            return new AlterTableTarget(table, partition, indices);
+        }
+    }
+
+    private final Index[] indices;
+
+    @Nullable
+    private final IndexTemplateMetadata indexTemplateMetadata;
+
+    private final RelationName table;
+    private final String partition;
+
+
+    public AlterTableTarget(RelationName table, @Nullable String partition, Index[] indices, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
+        this.table = table;
+        this.partition = partition;
+        this.indices = indices;
+        this.indexTemplateMetadata = indexTemplateMetadata;
+    }
+
+    public AlterTableTarget(RelationName table, @Nullable String partition, Index[] indices) {
+        this(table, partition, indices, null);
+    }
+
+    public boolean targetsIndividualPartition() {
+        return partition != null;
+    }
+
+    public RelationName table() {
+        return table;
+    }
+
+    @Nullable
+    public String partition() {
+        return partition;
+    }
+
+    public boolean isEmpty() {
+        return indices.length == 0 && indexTemplateMetadata == null;
+    }
+
+    public Index[] indices() {
+        return indices;
+    }
+
+    @Nullable
+    public IndexTemplateMetadata templateMetadata() {
+        return indexTemplateMetadata;
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+
+package io.crate.execution.ddl.tables;
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.metadata.RelationName;
+
+public final class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
+
+    private final RelationName table;
+    private final String partition;
+
+    public CloseTableRequest(RelationName table, @Nullable String partition) {
+        this.table = table;
+        this.partition = partition;
+    }
+
+    public CloseTableRequest(StreamInput in) throws IOException {
+        super(in);
+        this.table = new RelationName(in);
+        this.partition = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        table.writeTo(out);
+        out.writeOptionalString(partition);
+    }
+
+    public RelationName table() {
+        return table;
+    }
+
+    @Nullable
+    public String partition() {
+        return partition;
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.carrotsearch.hppc.cursors.IntObjectCursor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.NotifyOnceListener;
+import org.elasticsearch.action.admin.indices.close.TransportVerifyShardBeforeCloseAction;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.collect.ImmutableOpenIntMap;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotsService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.cluster.DDLClusterStateHelpers;
+import io.crate.metadata.cluster.DDLClusterStateService;
+
+public final class TransportCloseTable extends TransportMasterNodeAction<CloseTableRequest, AcknowledgedResponse> {
+
+    private static final Logger LOGGER = LogManager.getLogger(TransportCloseTable.class);
+    private static final String ACTION_NAME = "internal:crate:sql/table_or_partition/close";
+    private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
+    private final TransportVerifyShardBeforeCloseAction verifyShardBeforeClose;
+    private final AllocationService allocationService;
+    private final DDLClusterStateService ddlClusterStateService;
+
+    @Inject
+    public TransportCloseTable(String actionName,
+                               TransportService transportService,
+                               ClusterService clusterService,
+                               ThreadPool threadPool,
+                               IndexNameExpressionResolver indexNameExpressionResolver,
+                               AllocationService allocationService,
+                               DDLClusterStateService ddlClusterStateService,
+                               TransportVerifyShardBeforeCloseAction verifyShardBeforeClose) {
+        super(
+            ACTION_NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            CloseTableRequest::new,
+            indexNameExpressionResolver
+        );
+        this.allocationService = allocationService;
+        this.ddlClusterStateService = ddlClusterStateService;
+        this.verifyShardBeforeClose = verifyShardBeforeClose;
+    }
+
+    @Override
+    protected String executor() {
+        // goes async right away
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(CloseTableRequest request,
+                                   ClusterState state,
+                                   ActionListener<AcknowledgedResponse> listener) throws Exception {
+        assert state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_3_0)
+            : "All nodes must be on 4.3 to use the new dedicated close action";
+
+        clusterService.submitStateUpdateTask("add-block-close-table", new AddCloseBlocksTask(listener, request));
+    }
+
+    /**
+     * Step 3 - Move index states from OPEN to CLOSE in cluster state for indices that are ready for closing.
+     * @param target
+     */
+    static ClusterState closeRoutingTable(ClusterState currentState,
+                                          AlterTableTarget target,
+                                          DDLClusterStateService ddlClusterStateService,
+                                          Map<Index, AcknowledgedResponse> results) {
+        IndexTemplateMetadata templateMetadata = target.templateMetadata();
+        ClusterState updatedState;
+        if (templateMetadata == null) {
+            updatedState = currentState;
+        } else {
+            Metadata.Builder metadata = Metadata.builder(currentState.metadata());
+            metadata.put(closePartitionTemplate(templateMetadata));
+            updatedState = ClusterState.builder(currentState).metadata(metadata).build();
+        }
+
+        String partition = target.partition();
+        if (partition != null) {
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(partition);
+            updatedState = ddlClusterStateService.onCloseTablePartition(updatedState, partitionName);
+        } else {
+            updatedState = ddlClusterStateService.onCloseTable(updatedState, target.table());
+        }
+
+        final Metadata.Builder metadata = Metadata.builder(updatedState.metadata());
+        final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(updatedState.blocks());
+        final RoutingTable.Builder routingTable = RoutingTable.builder(updatedState.routingTable());
+        final Set<String> closedIndices = new HashSet<>();
+        for (Map.Entry<Index, AcknowledgedResponse> result : results.entrySet()) {
+            final Index index = result.getKey();
+            try {
+                final IndexMetadata indexMetadata = metadata.getSafe(index);
+                if (indexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                    if (result.getValue().isAcknowledged()) {
+                        LOGGER.debug("closing index {} succeed, removing index routing table", index);
+                        metadata.put(IndexMetadata.builder(indexMetadata).state(IndexMetadata.State.CLOSE));
+                        routingTable.remove(index.getName());
+                        closedIndices.add(index.getName());
+                    } else {
+                        LOGGER.debug("closing index {} failed, removing index block because: {}", index, result.getValue());
+                        blocks.removeIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK);
+                    }
+                } else {
+                    LOGGER.debug("index {} has been closed since it was blocked before closing, ignoring", index);
+                }
+            } catch (IndexNotFoundException e) {
+                LOGGER.debug("index {} has been deleted since it was blocked before closing, ignoring", index);
+            }
+        }
+        LOGGER.info("completed closing of indices {}", closedIndices);
+        return ClusterState.builder(currentState)
+            .blocks(blocks)
+            .metadata(metadata)
+            .routingTable(routingTable.build())
+            .build();
+    }
+
+    private static IndexTemplateMetadata closePartitionTemplate(IndexTemplateMetadata templateMetadata) {
+        Map<String, Object> metaMap = Collections.singletonMap("_meta", Collections.singletonMap("closed", true));
+        return DDLClusterStateHelpers.updateTemplate(
+            templateMetadata,
+            metaMap,
+            Collections.emptyMap(),
+            Settings.EMPTY,
+            (n, s) -> {},
+            s -> true
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(CloseTableRequest request, ClusterState state) {
+        String partition = request.partition();
+        String indexName = partition == null ? request.table().indexNameOrAlias() : partition;
+        return state.blocks().indicesBlockedException(
+            ClusterBlockLevel.METADATA_WRITE,
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, indexName)
+        );
+    }
+
+    private static ClusterState addCloseBlocks(ClusterState currentState, Index[] indices, Consumer<Index> blockedIndex) {
+        Metadata.Builder metadata = Metadata.builder(currentState.metadata());
+        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+
+        Set<IndexMetadata> indicesToClose = new HashSet<>();
+        for (Index index : indices) {
+            final IndexMetadata indexMetadata = metadata.getSafe(index);
+            if (indexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                indicesToClose.add(indexMetadata);
+            } else {
+                LOGGER.debug("index {} is already closed, ignoring", index);
+            }
+        }
+        if (indicesToClose.isEmpty()) {
+            return currentState;
+        }
+
+        RestoreService.checkIndexClosing(currentState, indicesToClose);
+        SnapshotsService.checkIndexClosing(currentState, indicesToClose);
+
+        for (var indexToClose : indicesToClose) {
+            final Index index = indexToClose.getIndex();
+            blockedIndex.accept(index);
+            if (currentState.blocks().hasIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK) == false) {
+                blocks.addIndexBlock(index.getName(), IndexMetadata.INDEX_CLOSED_BLOCK);
+            }
+        }
+
+        return ClusterState.builder(currentState)
+            .blocks(blocks)
+            .metadata(metadata)
+            .routingTable(currentState.routingTable())
+            .build();
+    }
+
+    private final class AddCloseBlocksTask extends ClusterStateUpdateTask {
+
+        private final ActionListener<AcknowledgedResponse> listener;
+        private final CloseTableRequest request;
+        private final Set<Index> blockedIndices = new HashSet<>();
+
+        private AddCloseBlocksTask(ActionListener<AcknowledgedResponse> listener,
+                                   CloseTableRequest request) {
+            this.listener = listener;
+            this.request = request;
+        }
+
+        @Override
+        public ClusterState execute(ClusterState currentState) throws Exception {
+            RelationName table = request.table();
+            String partition = request.partition();
+            Index[] indices = indexNameExpressionResolver.concreteIndices(currentState,
+                    IndicesOptions.lenientExpandOpen(), partition == null ? table.indexNameOrAlias() : partition);
+            if (indices.length == 0) {
+                return currentState;
+            }
+            return addCloseBlocks(currentState, indices, blockedIndices::add);
+        }
+
+        @Override
+        public void onFailure(String source, Exception e) {
+            listener.onFailure(e);
+        }
+
+        @Override
+        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            if (oldState == newState) {
+                assert blockedIndices.isEmpty()
+                        : "List of blocked indices is not empty but cluster state wasn't changed";
+                listener.onResponse(new AcknowledgedResponse(true));
+                return;
+            }
+            assert blockedIndices.isEmpty() == false : "List of blocked indices is empty but cluster state was changed";
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+                .execute(new WaitForClosedBlocksApplied(
+                    blockedIndices,
+                    ActionListener.wrap(
+                        closedBlocksResults -> clusterService.submitStateUpdateTask(
+                            "close-indices",
+                            new CloseRoutingTableTask(
+                                Priority.URGENT,
+                                closedBlocksResults,
+                                request,
+                                listener
+                            )
+                        ),
+                        listener::onFailure)
+                    )
+                );
+        }
+    }
+
+
+    private final class CloseRoutingTableTask extends ClusterStateUpdateTask {
+
+        private final Map<Index, AcknowledgedResponse> closedBlocksResults;
+        private final ActionListener<AcknowledgedResponse> listener;
+        private final CloseTableRequest request;
+
+        private CloseRoutingTableTask(Priority priority,
+                                      Map<Index, AcknowledgedResponse> closedBlocksResults,
+                                      CloseTableRequest request,
+                                      ActionListener<AcknowledgedResponse> listener) {
+            super(priority);
+            this.closedBlocksResults = closedBlocksResults;
+            this.listener = listener;
+            this.request = request;
+        }
+
+        @Override
+        public ClusterState execute(final ClusterState currentState) throws Exception {
+            AlterTableTarget target = AlterTableTarget.resolve(
+                indexNameExpressionResolver,
+                currentState,
+                request.table(),
+                request.partition()
+            );
+            final ClusterState updatedState = closeRoutingTable(currentState, target, ddlClusterStateService, closedBlocksResults);
+            return allocationService.reroute(updatedState, "indices closed");
+        }
+
+        @Override
+        public void onFailure(final String source, final Exception e) {
+            listener.onFailure(e);
+        }
+
+        @Override
+        public void clusterStateProcessed(final String source, final ClusterState oldState, final ClusterState newState) {
+            boolean acknowledged = closedBlocksResults.values().stream().allMatch(AcknowledgedResponse::isAcknowledged);
+            listener.onResponse(new AcknowledgedResponse(acknowledged));
+        }
+    }
+
+
+    /**
+     * Step 2 - Wait for indices to be ready for closing
+     * <p>
+     * This step iterates over the indices previously blocked and sends a {@link TransportVerifyShardBeforeCloseAction} to each shard. If
+     * this action succeed then the shard is considered to be ready for closing. When all shards of a given index are ready for closing,
+     * the index is considered ready to be closed.
+     */
+    class WaitForClosedBlocksApplied extends ActionRunnable<Map<Index, AcknowledgedResponse>> {
+
+        private final Set<Index> blockedIndices;
+
+        private WaitForClosedBlocksApplied(Set<Index> blockedIndices,
+                                           ActionListener<Map<Index, AcknowledgedResponse>> listener) {
+            super(listener);
+            if (blockedIndices == null || blockedIndices.isEmpty()) {
+                throw new IllegalArgumentException("Cannot wait for closed blocks to be applied, list of blocked indices is empty or null");
+            }
+            this.blockedIndices = blockedIndices;
+        }
+
+        @Override
+        protected void doRun() throws Exception {
+            final Map<Index, AcknowledgedResponse> results = ConcurrentCollections.newConcurrentMap();
+            final CountDown countDown = new CountDown(blockedIndices.size());
+            final ClusterState state = clusterService.state();
+            for (Index blockedIndex : blockedIndices) {
+                waitForShardsReadyForClosing(blockedIndex, state, response -> {
+                    results.put(blockedIndex, response);
+                    if (countDown.countDown()) {
+                        listener.onResponse(Collections.unmodifiableMap(results));
+                    }
+                });
+            }
+        }
+
+        private void waitForShardsReadyForClosing(final Index index,
+                                                  final ClusterState state,
+                                                  final Consumer<AcknowledgedResponse> onResponse) {
+            final IndexMetadata indexMetadata = state.metadata().index(index);
+            if (indexMetadata == null) {
+                logger.debug("index {} has been blocked before closing and is now deleted, ignoring", index);
+                onResponse.accept(new AcknowledgedResponse(true));
+                return;
+            }
+            final IndexRoutingTable indexRoutingTable = state.routingTable().index(index);
+            if (indexRoutingTable == null || indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+                logger.debug("index {} has been blocked before closing and is already closed, ignoring", index);
+                onResponse.accept(new AcknowledgedResponse(true));
+                return;
+            }
+
+            final ImmutableOpenIntMap<IndexShardRoutingTable> shards = indexRoutingTable.getShards();
+            final AtomicArray<AcknowledgedResponse> results = new AtomicArray<>(shards.size());
+            final CountDown countDown = new CountDown(shards.size());
+
+            for (IntObjectCursor<IndexShardRoutingTable> shard : shards) {
+                final IndexShardRoutingTable shardRoutingTable = shard.value;
+                final ShardId shardId = shardRoutingTable.shardId();
+                sendVerifyShardBeforeCloseRequest(shardRoutingTable, new NotifyOnceListener<ReplicationResponse>() {
+                    @Override
+                    public void innerOnResponse(final ReplicationResponse replicationResponse) {
+                        ReplicationResponse.ShardInfo shardInfo = replicationResponse.getShardInfo();
+                        results.setOnce(shardId.id(), new AcknowledgedResponse(shardInfo.getFailed() == 0));
+                        processIfFinished();
+                    }
+
+                    @Override
+                    public void innerOnFailure(final Exception e) {
+                        results.setOnce(shardId.id(), new AcknowledgedResponse(false));
+                        processIfFinished();
+                    }
+
+                    private void processIfFinished() {
+                        if (countDown.countDown()) {
+                            final boolean acknowledged = results.asList().stream().allMatch(AcknowledgedResponse::isAcknowledged);
+                            onResponse.accept(new AcknowledgedResponse(acknowledged));
+                        }
+                    }
+                });
+            }
+        }
+
+        private void sendVerifyShardBeforeCloseRequest(final IndexShardRoutingTable shardRoutingTable,
+                                                       final ActionListener<ReplicationResponse> listener) {
+            final ShardId shardId = shardRoutingTable.shardId();
+            if (shardRoutingTable.primaryShard().unassigned()) {
+                logger.debug("primary shard {} is unassigned, ignoring", shardId);
+                final ReplicationResponse response = new ReplicationResponse();
+                response.setShardInfo(new ReplicationResponse.ShardInfo(shardRoutingTable.size(), shardRoutingTable.size()));
+                listener.onResponse(response);
+                return;
+            }
+            TransportVerifyShardBeforeCloseAction.ShardRequest shardRequest =
+                new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId);
+
+            // TODO propagate a task id from the parent CloseIndexRequest to the ShardCloseRequests
+            verifyShardBeforeClose.execute(shardRequest, listener);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
@@ -51,14 +51,14 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
-class DDLClusterStateHelpers {
+public class DDLClusterStateHelpers {
 
-    static IndexTemplateMetadata updateTemplate(IndexTemplateMetadata indexTemplateMetadata,
-                                                Map<String, Object> newMappings,
-                                                Map<String, Object> mappingsToRemove,
-                                                Settings newSettings,
-                                                BiConsumer<String, Settings> settingsValidator,
-                                                Predicate<String> settingsFilter) {
+    public static IndexTemplateMetadata updateTemplate(IndexTemplateMetadata indexTemplateMetadata,
+                                                       Map<String, Object> newMappings,
+                                                       Map<String, Object> mappingsToRemove,
+                                                       Settings newSettings,
+                                                       BiConsumer<String, Settings> settingsValidator,
+                                                       Predicate<String> settingsFilter) {
 
         // merge mappings & remove mappings
         Map<String, Object> mapping = removeFromMapping(

--- a/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateService.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateService.java
@@ -45,12 +45,12 @@ public class DDLClusterStateService {
         clusterStateModifiers.add(modifier);
     }
 
-    ClusterState onCloseTable(ClusterState currentState, RelationName relationName) {
+    public ClusterState onCloseTable(ClusterState currentState, RelationName relationName) {
         return applyOnAllModifiers(currentState,
             (modifier, clusterState) -> modifier.onCloseTable(clusterState, relationName));
     }
 
-    ClusterState onCloseTablePartition(ClusterState currentState, PartitionName partitionName) {
+    public ClusterState onCloseTablePartition(ClusterState currentState, PartitionName partitionName) {
         return applyOnAllModifiers(currentState,
             (modifier, clusterState) -> modifier.onCloseTablePartition(clusterState, partitionName));
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.close;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_CLOSED_BLOCK;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.support.replication.ReplicationOperation.Replicas;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportVerifyShardBeforeCloseAction extends TransportReplicationAction<
+    TransportVerifyShardBeforeCloseAction.ShardRequest, TransportVerifyShardBeforeCloseAction.ShardRequest, ReplicationResponse> {
+
+    public static final String NAME = "indices:admin/close" + "[s]";
+    private static final Logger LOGGER = LogManager.getLogger(TransportVerifyShardBeforeCloseAction.class);
+
+    @Inject
+    public TransportVerifyShardBeforeCloseAction(final Settings settings,
+                                                 final TransportService transportService,
+                                                 final ClusterService clusterService,
+                                                 final IndicesService indicesService,
+                                                 final ThreadPool threadPool,
+                                                 final ShardStateAction stateAction,
+                                                 final IndexNameExpressionResolver resolver) {
+        super(
+            NAME,
+            transportService,
+            clusterService,
+            indicesService,
+            threadPool,
+            stateAction,
+            resolver,
+            ShardRequest::new,
+            ShardRequest::new,
+            ThreadPool.Names.MANAGEMENT
+        );
+    }
+
+    @Override
+    protected ReplicationResponse read(StreamInput in) throws IOException {
+        return new ReplicationResponse(in);
+    }
+
+    @Override
+    protected void acquirePrimaryOperationPermit(final IndexShard primary,
+                                                 final ShardRequest request,
+                                                 final ActionListener<Releasable> onAcquired) {
+        primary.acquireAllPrimaryOperationsPermits(onAcquired, request.timeout());
+    }
+
+    @Override
+    protected void acquireReplicaOperationPermit(final IndexShard replica,
+                                                 final ShardRequest request,
+                                                 final ActionListener<Releasable> onAcquired,
+                                                 final long primaryTerm,
+                                                 final long globalCheckpoint,
+                                                 final long maxSeqNoOfUpdateOrDeletes) {
+        replica.acquireAllReplicaOperationsPermits(primaryTerm, globalCheckpoint, maxSeqNoOfUpdateOrDeletes, onAcquired, request.timeout());
+    }
+
+    @Override
+    protected void shardOperationOnPrimary(final ShardRequest shardRequest, final IndexShard primary,
+            ActionListener<PrimaryResult<ShardRequest, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            executeShardOperation(shardRequest, primary);
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
+    }
+
+    @Override
+    protected ReplicaResult shardOperationOnReplica(final ShardRequest shardRequest, final IndexShard replica) throws IOException {
+        executeShardOperation(shardRequest, replica);
+        return new ReplicaResult();
+    }
+
+    private void executeShardOperation(final ShardRequest request, final IndexShard indexShard) throws IOException {
+        final ShardId shardId = indexShard.shardId();
+        if (indexShard.getActiveOperationsCount() != IndexShard.OPERATIONS_BLOCKED) {
+            throw new IllegalStateException("Index shard " + shardId + " is not blocking all operations during closing");
+        }
+
+        final ClusterBlocks clusterBlocks = clusterService.state().blocks();
+        if (clusterBlocks.hasIndexBlock(shardId.getIndexName(), INDEX_CLOSED_BLOCK) == false) {
+            throw new IllegalStateException("Index shard " + shardId + " must be blocked by " + INDEX_CLOSED_BLOCK + " before closing");
+        }
+
+        indexShard.verifyShardBeforeIndexClosing();
+        indexShard.flush(new FlushRequest().force(true));
+        LOGGER.debug("{} shard is ready for closing", shardId);
+    }
+
+    @Override
+    protected Replicas<ShardRequest> newReplicasProxy(long primaryTerm) {
+        return new VerifyShardBeforeCloseActionReplicasProxy(primaryTerm);
+    }
+
+    /**
+     * A {@link ReplicasProxy} that marks as stale the shards that are unavailable during the verification
+     * and the flush of the shard. This is done to ensure that such shards won't be later promoted as primary
+     * or reopened in an unverified state with potential non flushed translog operations.
+     */
+    class VerifyShardBeforeCloseActionReplicasProxy extends ReplicasProxy {
+
+        public VerifyShardBeforeCloseActionReplicasProxy(long primaryTerm) {
+            super(primaryTerm);
+        }
+
+        @Override
+        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+            shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
+        }
+    }
+
+    public static class ShardRequest extends ReplicationRequest<ShardRequest> {
+
+        ShardRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public ShardRequest(ShardId shardId) {
+            super(shardId);
+        }
+
+
+        @Override
+        public String toString() {
+            return "verify shard before close {" + shardId + "}";
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a new dedicated close transport that is used if all nodes in a
cluster are on 4.3. It uses multiple steps to close a table or
partition.

This is similar to the changes in

  https://github.com/elastic/elasticsearch/commit/8e5dd20efb667d272fac4b2a151f8c09f0284024

This in preparation for

  https://github.com/crate/crate/pull/10404 / https://github.com/elastic/elasticsearch/commit/309a3e4ccbcdfcd830621a92d6e67af929123605

This doesn't extend or modify the existing open/close transport because
close now diverges further from the open logic and sharing logic between
the two in a non-compositional way becomes less appealing.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)