### PR TITLE
Fix subscript col ident exposure in some system tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,10 @@ Fixes
   that didn't fully match the given arguments, leading to a subsequent runtime
   failure when trying to access tables.
 
+- Fixed exposure of the full qualified name of a sub-script column in
+  `information_schema.tables.partitioned_by` and
+  `pg_catalog.pg_attribute.attname` to use the CrateDB SQL compatible identifier.
+
 - Fixed an issue that led to a ``Message not fully read`` error when trying to
   decommission a node using ``ALTER CLUSTER DECOMMISSION``.
 

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -313,6 +313,10 @@ public class ColumnIdent implements Comparable<ColumnIdent> {
         return name;
     }
 
+    /**
+     * This is the internal representation of a column identifier and may not supported by the SQL syntax.
+     * For external exposure use {@link #sqlFqn()}.
+     */
     public String fqn() {
         if (isTopLevel()) {
             return name;

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -105,7 +105,7 @@ public class InformationTablesTableInfo {
                         if (partitionedBy == null || partitionedBy.isEmpty()) {
                             return null;
                         }
-                        return Lists2.map(partitionedBy, ColumnIdent::fqn);
+                        return Lists2.map(partitionedBy, ColumnIdent::sqlFqn);
                     }
                     return null;
                 })

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -44,7 +44,7 @@ public class PgAttributeTable {
     public static SystemTable<ColumnContext> create() {
         return SystemTable.<ColumnContext>builder(IDENT)
             .add("attrelid", INTEGER, c -> relationOid(c.tableInfo))
-            .add("attname", STRING, c -> c.info.column().fqn())
+            .add("attname", STRING, c -> c.info.column().sqlFqn())
             .add("atttypid", INTEGER, c -> PGTypes.get(c.info.valueType()).oid())
             .add("attstattarget", INTEGER, c -> 0)
             .add("attlen", SHORT, c -> PGTypes.get(c.info.valueType()).typeLen())

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -322,8 +322,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testSelectPartitionedTablesFromInformationSchemaTable() {
-        execute("create table test (id int primary key, name string) partitioned by (id)");
-        execute("insert into test (id, name) values (1, 'Youri'), (2, 'Ruben')");
+        execute("create table test (id int, name string, o object as (i int), primary key (id, o['i']))" +
+                " partitioned by (o['i'])");
+        execute("insert into test (id, name, o) values (1, 'Youri', {i=10}), (2, 'Ruben', {i=20})");
         ensureGreen();
 
         execute("select table_name, number_of_shards, number_of_replicas, " +
@@ -333,8 +334,8 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals("test", response.rows()[0][0]);
         assertEquals(4, response.rows()[0][1]);
         assertEquals("0-1", response.rows()[0][2]);
-        assertEquals("id", response.rows()[0][3]);
-        assertThat((List<Object>) response.rows()[0][4], Matchers.contains("id"));
+        assertEquals("_id", response.rows()[0][3]);
+        assertThat((List<Object>) response.rows()[0][4], Matchers.contains("o['i']"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -41,7 +41,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
 
     @Before
     public void createRelations() {
-        execute("create table doc.t1 (id int primary key, s string)");
+        execute("create table doc.t1 (id int primary key, s string, o object as (a int))");
         execute("create view doc.v1 as select id from doc.t1");
     }
 
@@ -55,7 +55,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select * from pg_catalog.pg_class where relname in ('t1', 'v1', 'tables', 'nodes') order by relname");
         assertThat(printedTable(response.rows()), is(
             "-1420189195| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| nodes| -458336339| 17| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
-            "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 2| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
+            "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 3| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
             "-1689918046| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| tables| 204690627| 16| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
             "845171032| NULL| 0| 0| 0| 0| false| 0| false| false| false| false| false| false| false| true| false| v| 0| v1| -2048275947| 1| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n"));
     }
@@ -76,7 +76,9 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select a.* from pg_catalog.pg_attribute as a join pg_catalog.pg_class as c on a.attrelid = c.oid where c.relname = 't1' order by a.attnum");
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| 4| id| 0| false| 1| NULL| 728874843| 0| NULL| 23| -1\n" +
-            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1\n"));
+            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1\n" +
+            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| o| 0| false| 3| NULL| 728874843| 0| NULL| 114| -1\n" +
+            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| 4| o['a']| 0| false| NULL| NULL| 728874843| 0| NULL| 23| -1\n"));
     }
 
     @Test
@@ -147,7 +149,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select ct.oid, ct.relkind, ct.relname, ct.relnamespace, ct.relnatts, ct.relpersistence, ct.relreplident, ct.reltuples" +
                 " from pg_class ct, (select * from pg_index i, pg_class c where c.relname = 't1' and c.oid = i.indrelid) i" +
                 " where ct.oid = i.indexrelid;");
-        assertThat(printedTable(response.rows()), is("-649073482| i| t1_pkey| -2048275947| 2| p| p| 0.0\n"));
+        assertThat(printedTable(response.rows()), is("-649073482| i| t1_pkey| -2048275947| 3| p| p| 0.0\n"));
     }
 
     @Test


### PR DESCRIPTION
When exposing a full-qualified name, we always must use the
`ColumnIdent.sqlFqn()` because the `ColumnIdent.fqn()`, which uses a
dot-notation, is not supported by our SQL syntax.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
