### PR TITLE
Integrate generated partition column expansion into Collect operator

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -78,6 +78,11 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression that caused ``SELECT`` statements on tables
+  with generated partitioned columns and a predicate that uses a column used to
+  compute the partitioned column to hit all partitions instead of only a
+  subset.
+
 - Fixed an issue that could lead to a ``IndexOutOfBoundsException`` when using
   virtual tables and joins.
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -69,6 +69,7 @@ import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
+import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -114,6 +115,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(TableDefinitions.IGNORED_NESTED_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
+            .addPartitionedTable(
+                "create table doc.parted_by_generated (" +
+                "   ts timestamp without time zone, " +
+                "   p as date_trunc('month', ts) " +
+                ") partitioned by (p)",
+                new PartitionName(new RelationName("doc", "parted_by_generated"), singletonList("1577836800000")).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted_by_generated"), singletonList("1580515200000")).asIndexName()
+            )
             .addTable(
                 "create table doc.gc_table (" +
                 "   revenue integer," +
@@ -1051,5 +1060,26 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "      └ Rename[b] AS a2\n" +
             "        └ Collect[doc.t2 | [b] | true]";
         assertThat(plan, isPlan(expectedPlan));
+    }
+
+    @Test
+    public void test_collect_execution_plan_is_narrowed_to_matching_generated_partition_columns() throws Exception {
+        String stmt = "SELECT * FROM parted_by_generated WHERE ts >= '2020-02-01'";
+        LogicalPlan plan = e.logicalPlan(stmt);
+        String expectedPlan =
+            "Collect[doc.parted_by_generated | [ts, p AS date_trunc('month', ts)] | (ts >= 1580515200000::bigint)]";
+        assertThat(plan, isPlan(expectedPlan));
+
+        Collect collect = (Collect) ((Merge) e.plan(stmt)).subPlan();;
+        RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collect.collectPhase();
+        Symbol where = routedCollectPhase.where();
+        assertThat(where, TestingHelpers.isSQL("(doc.parted_by_generated.ts >= 1580515200000::bigint)"));
+        assertThat(routedCollectPhase.routing().locations().values().stream()
+            .flatMap(x -> x.keySet().stream())
+            .collect(Collectors.toSet()),
+            contains(
+                ".partitioned.parted_by_generated.04732d9o60qj2d9i60o30c1g"
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We at some point accidentally removed the logic to expand generated
columns used in partitioned by columns. That prevented the partition
narrowing optimization from kicking in for those cases.

Closes https://github.com/crate/crate/issues/10431

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)