### PR TITLE
Avoid create partitions requests if there are no partitions to create

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -78,4 +78,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a performance regression that caused unnecessary traffic and load to
+  the active master node when processing ``INSERT`` statements.

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -700,8 +700,7 @@ public class InsertFromValues implements LogicalPlan {
         return throwable instanceof IndexNotFoundException && IndexParts.isPartitioned(index);
     }
 
-    private static CompletableFuture<AcknowledgedResponse> createIndices(TransportCreatePartitionsAction
-                                                                             createPartitionsAction,
+    private static CompletableFuture<AcknowledgedResponse> createIndices(TransportCreatePartitionsAction createPartitionsAction,
                                                                          Set<String> indices,
                                                                          ClusterService clusterService,
                                                                          UUID jobId) {
@@ -712,7 +711,9 @@ public class InsertFromValues implements LogicalPlan {
                 indicesToCreate.add(index);
             }
         }
-
+        if (indicesToCreate.isEmpty()) {
+            return CompletableFuture.completedFuture(new AcknowledgedResponse(true));
+        }
         FutureActionListener<AcknowledgedResponse, AcknowledgedResponse> listener = new FutureActionListener<>(r -> r);
         createPartitionsAction.execute(new CreatePartitionsRequest(indicesToCreate, jobId), listener);
         return listener;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`createIndices` is always called, even for non-partitioned tables and it
always made a request to the master node, even if there were no
partitions to create.

The `TransportCreatePartitionsAction` has a fast-path for the
empty-indices case, but only on the "request-is-already-received" end.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)