### PR TITLE
Map RelationUnknown to PG 42P01 undefined_table error code

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed the error code for the psql protocol when a relation does not exist
+  from `XX000` `internal_error` to `42P01` `undefined_table`.
+  
 - Changed the error code for the psql protocol when a document exists
   already from `XX000` `internal_error` to `23505` `unique_violation`.
 

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -23,6 +23,7 @@
 package io.crate.protocols.postgres;
 
 import io.crate.exceptions.DuplicateKeyException;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -74,6 +75,8 @@ public class PGError {
             status = PGErrorStatus.FEATURE_NOT_SUPPORTED;
         } else if (throwable instanceof DuplicateKeyException) {
             status = PGErrorStatus.UNIQUE_VIOLATION;
+        } else if (throwable instanceof RelationUnknown) {
+            status = PGErrorStatus.UNDEFINED_TABLE;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -684,7 +685,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testDropUnknownTable() throws Exception {
         assertThrows(() -> execute("drop table test"),
-                     isSQLError(is("Relation 'test' unknown"), INTERNAL_ERROR, NOT_FOUND, 4041));
+                     isSQLError(is("Relation 'test' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -62,6 +62,7 @@ import java.util.StringJoiner;
 import java.util.UUID;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.protocols.postgres.PostgresNetty.PSQL_PORT_SETTING;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isPGError;
@@ -726,7 +727,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
 
             conn.createStatement().execute("set session search_path to DEFAULT");
             assertThrows(() -> conn.createStatement().execute("select * from foo"),
-                         isPGError(is("Relation 'foo' unknown"), INTERNAL_ERROR));
+                         isPGError(is("Relation 'foo' unknown"), UNDEFINED_TABLE));
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
@@ -49,7 +50,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
     public void testSelectSysColumnsFromInformationSchema() throws Exception {
         assertThrows(() -> execute("select sys.nodes.id, table_name, number_of_replicas from information_schema.tables"),
                      isSQLError(is("Relation 'sys.nodes' unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_TABLE,
                                 NOT_FOUND,
                                 4041));
     }
@@ -209,7 +210,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
     public void testSelectUnknownTableFromInformationSchema() throws Exception {
         assertThrows(() -> execute("select * from information_schema.non_existent"),
                      isSQLError(is("Relation 'information_schema.non_existent' unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_TABLE,
                                 NOT_FOUND,
                                 4041));
     }

--- a/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
@@ -25,7 +25,7 @@ package io.crate.integrationtests;
 import org.junit.Test;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -59,7 +59,7 @@ public class SwapTableITest extends SQLTransportIntegrationTest {
 
         assertThrows(() ->  execute("select * from t1"),
                      isSQLError(containsString("Relation 't1' unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_TABLE,
                                 NOT_FOUND,
                                 4041));
     }

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.resolveCanonicalString;
@@ -318,7 +319,7 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
     public void testSelectShardIdFromSysNodes() throws Exception {
         assertThrows(() -> execute(
             "select sys.shards.id from sys.nodes"),
-                     isSQLError(is("Relation 'sys.shards' unknown"), INTERNAL_ERROR, NOT_FOUND, 4041));
+                     isSQLError(is("Relation 'sys.shards' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -89,7 +90,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     @Test
     public void testSelectNonExistentGlobalExpression() throws Exception {
         assertThrows(() -> execute("select count(race), suess.cluster.name from characters"),
-            isSQLError(is("Relation 'suess.cluster' unknown"), INTERNAL_ERROR, NOT_FOUND, 4041));
+            isSQLError(is("Relation 'suess.cluster' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
     @Test
@@ -196,7 +197,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     @Test
     public void selectMultiGetRequestFromNonExistentTable() throws Exception {
         assertThrows(() -> execute("SELECT * FROM \"non_existent\" WHERE \"_id\" in (?,?)", new Object[]{"1", "2"}),
-                     isSQLError(is("Relation 'non_existent' unknown"), INTERNAL_ERROR, NOT_FOUND, 4041));
+                     isSQLError(is("Relation 'non_existent' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -1526,7 +1527,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         String stmtStrWhere = "select ''" + uniqueId + "'' from foobar";
         assertThrows(() -> execute(stmtStr),
                      isSQLError(containsString("Relation 'foobar' unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_TABLE,
                                 NOT_FOUND,
                                 4041));
         execute("select stmt from sys.jobs where stmt='" + stmtStrWhere + "'");


### PR DESCRIPTION
This changes the error code for the psql protocol when a relation
does not exist from `XX000` `internal_error` to `42P01` `undefined_table`.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
