### PR TITLE
Fix sys.health.health state for partitions

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1785,8 +1785,8 @@ because there are not enough eligible nodes available.
     +--------+----------------+-----------------+----------+------------+--------------+------------------------+
     | health | missing_shards | partition_ident | severity | table_name | table_schema | underreplicated_shards |
     +--------+----------------+-----------------+----------+------------+--------------+------------------------+
-    | GREEN  |              0 |                 |        1 | locations  | doc          |                      0 |
-    | GREEN  |              0 |                 |        1 | quotes     | doc          |                      0 |
+    | GREEN  |              0 |            NULL |        1 | locations  | doc          |                      0 |
+    | GREEN  |              0 |            NULL |        1 | quotes     | doc          |                      0 |
     +--------+----------------+-----------------+----------+------------+--------------+------------------------+
     SELECT 2 rows in set (... sec)
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -84,5 +84,9 @@ Changes
 Fixes
 =====
 
+- Fixed the resulting value for ``sys.health.partition_ident`` for
+  non-partitioned tables. As documented, a `NULL` value should be returned
+  instead of an empty string.
+
 - Fixed a performance regression that caused unnecessary traffic and load to
   the active master node when processing ``INSERT`` statements.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -84,6 +84,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue resulting wrongly in a `RED` ``sys.health.health`` state for
+  healthy partitions with less shards configured than the actual partitioned
+  table.
+
 - Fixed the resulting value for ``sys.health.partition_ident`` for
   non-partitioned tables. As documented, a `NULL` value should be returned
   instead of an empty string.

--- a/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.Session;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -154,7 +155,7 @@ public class TableHealthService {
             .iterator();
     }
 
-
+    @Nullable
     private TableHealth tableHealthFromEntry(Map.Entry<TablePartitionIdent, ShardsInfo> entry) {
         TablePartitionIdent ident = entry.getKey();
         ShardsInfo shardsInfo = entry.getValue();
@@ -165,7 +166,21 @@ public class TableHealthService {
         } catch (RelationUnknown e) {
             return null;
         }
-        return calculateHealth(ident, shardsInfo, tableInfo.numberOfShards());
+        int shardsCount = tableInfo.numberOfShards();
+        if (ident.partitionIdent != null) {
+            var partitionIndexName = IndexParts.toIndexName(
+                ident.tableSchema,
+                ident.tableName,
+                ident.partitionIdent
+            );
+            var indexMetaData = clusterService.state().getMetadata().index(partitionIndexName);
+            if (indexMetaData == null) {
+                return null;
+            }
+            shardsCount = indexMetaData.getNumberOfShards();
+        }
+
+        return calculateHealth(ident, shardsInfo, shardsCount);
     }
 
     @VisibleForTesting

--- a/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -218,8 +218,9 @@ public class TableHealthService {
 
         @Override
         public void setNextRow(Row row) {
+            var partitionIdent = (String) row.get(2);
             TablePartitionIdent ident = new TablePartitionIdent(
-                (String) row.get(0), (String) row.get(1), (String) row.get(2));
+                (String) row.get(0), (String) row.get(1), partitionIdent.isEmpty() ? null : partitionIdent);
             ShardsInfo shardsInfo = tables.getOrDefault(ident, new ShardsInfo());
             String routingState = (String) row.get(3);
             boolean primary = (boolean) row.get(4);

--- a/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
@@ -44,8 +44,8 @@ public class SysHealthITest extends SQLTransportIntegrationTest {
         execute("create table doc.t3 (id int) with(number_of_replicas=0)");
 
         execute("select * from sys.health order by severity desc");
-        assertThat(printedTable(response.rows()), is("RED| 2| | 3| t1| doc| 0\n" +
-                                                     "YELLOW| 0| | 2| t2| doc| 4\n" +
-                                                     "GREEN| 0| | 1| t3| doc| 0\n"));
+        assertThat(printedTable(response.rows()), is("RED| 2| NULL| 3| t1| doc| 0\n" +
+                                                     "YELLOW| 0| NULL| 2| t2| doc| 4\n" +
+                                                     "GREEN| 0| NULL| 1| t3| doc| 0\n"));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
@@ -48,4 +48,22 @@ public class SysHealthITest extends SQLTransportIntegrationTest {
                                                      "YELLOW| 0| NULL| 2| t2| doc| 4\n" +
                                                      "GREEN| 0| NULL| 1| t3| doc| 0\n"));
     }
+
+    @Test
+    public void test_health_of_partitioned_table_with_different_number_of_shards_per_partition() {
+        execute("create table doc.p1 (id int, p int)" +
+                " clustered into 2 shards" +
+                " partitioned by (p) " +
+                " with (number_of_replicas=0)"
+        );
+        execute("insert into doc.p1 (id, p) values (1, 1)");
+        execute("alter table doc.p1 set (number_of_shards = 4)");
+        execute("insert into doc.p1 (id, p) values (2, 2)");
+        refresh();
+
+        execute("select * from sys.health order by severity, partition_ident desc");
+        assertThat(printedTable(response.rows()), is(
+            "GREEN| 0| 04134| 1| p1| doc| 0\n" +
+            "GREEN| 0| 04132| 1| p1| doc| 0\n"));
+    }
 }


### PR DESCRIPTION
Use the `number_of_shards` setting of a partition instead of the partitioned table.
They could differ through the possibility of changing only the shards for future partitions.
If the value for the table is greater then the value of the  partition itself, using the tables value will result in missing shards and thus a `RED` health.

The first commit will fix the returned value of  ``sys.health.partition_ident`` for non-partitioned tables. As document, it should be ``NULL`` and not an empty string.