### PR TITLE
Map ColumnUnknownException to PG 42703 undefined_column error code

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed the error code for the psql protocol when a column does not exist
+  from `XX000` `internal_error` to `42703` `undefined_column`.
+
 - Changed the error code for the psql protocol when a relation does not exist
   from `XX000` `internal_error` to `42P01` `undefined_table`.
   

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.DuplicateKeyException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
@@ -77,6 +78,8 @@ public class PGError {
             status = PGErrorStatus.UNIQUE_VIOLATION;
         } else if (throwable instanceof RelationUnknown) {
             status = PGErrorStatus.UNDEFINED_TABLE;
+        } else if (throwable instanceof ColumnUnknownException) {
+            status = PGErrorStatus.UNDEFINED_COLUMN;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 
 import static io.crate.metadata.table.ColumnPolicies.decodeMappingValue;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -95,7 +96,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
 
         assertThrows(() -> execute("insert into strict_table (id, name, boo) values (2, 'Trillian', true)"),
                      isSQLError(is("Column boo unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_COLUMN,
                                 NOT_FOUND,
                                 4043));
     }
@@ -116,7 +117,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0], is(Matchers.<Object>arrayContaining(1, "Ford")));
 
         assertThrows(() -> execute("update strict_table set name='Trillian', boo=true where id=1"),
-                     isSQLError(is("Column boo unknown"), INTERNAL_ERROR, NOT_FOUND,4043));
+                     isSQLError(is("Column boo unknown"), UNDEFINED_COLUMN, NOT_FOUND,4043));
     }
 
     @Test
@@ -401,7 +402,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThrows(() -> execute("insert into numbers (num, odd, prime, perfect) values (?, ?, ?, ?)",
                                    new Object[]{28, true, false, true}),
                      isSQLError(is("Column perfect unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_COLUMN,
                                 NOT_FOUND,
                                 4043
                      ));
@@ -439,7 +440,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThrows(() -> execute("update numbers set num=?, perfect=? where num=6",
                                    new Object[]{28, true}),
                      isSQLError(is("Column perfect unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_COLUMN,
                                 NOT_FOUND,
                                 4043));
     }
@@ -502,7 +503,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("alter table dynamic_table set (column_policy = 'strict')");
         waitNoPendingTasksOnAll();
         assertThrows(() -> execute("insert into dynamic_table (id, score, new_col) values (1, 4656234.345, 'hello')"),
-                     isSQLError(is("Column new_col unknown"), INTERNAL_ERROR, NOT_FOUND,4043));
+                     isSQLError(is("Column new_col unknown"), UNDEFINED_COLUMN, NOT_FOUND,4043));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -25,8 +25,10 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.core.Is.is;
 
 public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
@@ -78,8 +80,8 @@ public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (\"name\" string) with (number_of_replicas=0)");
         assertThrows(() -> execute("select count(*) from test where non_existant = 'Some Value'"),
                      isSQLError(is("Column non_existant unknown"),
-                                INTERNAL_ERROR,
-                                HttpResponseStatus.NOT_FOUND,
+                                UNDEFINED_COLUMN,
+                                NOT_FOUND,
                                 4043));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -177,7 +178,7 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
             "update ot set author['name']['middle_name']='Noel' where author['name']['first_name']='Douglas' " +
             "and author['name']['last_name']='Adams'"),
                      isSQLError(is("Column author['name']['middle_name'] unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_COLUMN,
                                 NOT_FOUND,
                                 4043));
     }

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
@@ -284,27 +285,27 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
     @Test
     public void testGroupByUnknownResultColumn() throws Exception {
         assertThrows(() -> execute("select lol from sys.shards group by table_name"),
-                     isSQLError(is("Column lol unknown"), INTERNAL_ERROR, NOT_FOUND, 4043));
+                     isSQLError(is("Column lol unknown"), UNDEFINED_COLUMN, NOT_FOUND, 4043));
     }
 
     @Test
     public void testGroupByUnknownGroupByColumn() throws Exception {
         assertThrows(() -> execute("select max(num_docs) from sys.shards group by lol"),
-                     isSQLError(is("Column lol unknown"), INTERNAL_ERROR, NOT_FOUND, 4043));
+                     isSQLError(is("Column lol unknown"), UNDEFINED_COLUMN, NOT_FOUND, 4043));
     }
 
     @Test
     public void testGroupByUnknownOrderBy() throws Exception {
         assertThrows(() -> execute(
             "select sum(num_docs), table_name from sys.shards group by table_name order by lol"),
-                     isSQLError(is("Column lol unknown"), INTERNAL_ERROR, NOT_FOUND, 4043));
+                     isSQLError(is("Column lol unknown"), UNDEFINED_COLUMN, NOT_FOUND, 4043));
     }
 
     @Test
     public void testGroupByUnknownWhere() throws Exception {
         assertThrows(() -> execute(
             "select sum(num_docs), table_name from sys.shards where lol='funky' group by table_name"),
-                     isSQLError(is("Column lol unknown"), INTERNAL_ERROR, NOT_FOUND, 4043));
+                     isSQLError(is("Column lol unknown"), UNDEFINED_COLUMN, NOT_FOUND, 4043));
         ;
     }
 
@@ -312,7 +313,7 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
     public void testGlobalAggregateUnknownWhere() throws Exception {
         assertThrows(() -> execute(
             "select sum(num_docs) from sys.shards where lol='funky'"),
-                     isSQLError(is("Column lol unknown"), INTERNAL_ERROR, NOT_FOUND, 4043));
+                     isSQLError(is("Column lol unknown"), UNDEFINED_COLUMN, NOT_FOUND, 4043));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -181,7 +182,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
         assertThrows(() -> execute("select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables " +
             "where table_name = 'settings_table'"),
                      isSQLError(is("Column settings['routing']['allocation']['exclude']['foo'] unknown"),
-                                INTERNAL_ERROR,
+                                UNDEFINED_COLUMN,
                                 NOT_FOUND,
                                 4043));
     }


### PR DESCRIPTION
This changes the error code for the psql protocol when a column
does not exist from XX000 internal_error to 42703 undefined_column..

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
