### PR TITLE
Map AmbiguousColumnException to PG 42702 ambiguous_column error code

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed the error code for the psql protocol when a column reference
+  is ambiguous from `XX000` `internal_error` to `42702` `ambiguous_column`.
+
 - Changed the error code for the psql protocol when a relation exists
   already from `XX000` `internal_error` to `42P07` `duplicate_table`.
 

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.DuplicateKeyException;
 import io.crate.exceptions.RelationAlreadyExists;
@@ -83,6 +84,8 @@ public class PGError {
             status = PGErrorStatus.UNDEFINED_COLUMN;
         } else if (throwable instanceof RelationAlreadyExists) {
             status = PGErrorStatus.DUPLICATE_TABLE;
+        } else if (throwable instanceof AmbiguousColumnException) {
+            status = PGErrorStatus.AMBIGUOUS_COLUMN;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -29,6 +29,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols;
+
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.SQLExceptions;
+import io.crate.metadata.ColumnIdent;
+import io.crate.protocols.postgres.PGError;
+import io.crate.protocols.postgres.PGErrorStatus;
+import io.crate.rest.action.HttpError;
+import io.crate.types.DataTypes;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_COLUMN;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static io.crate.testing.TestingHelpers.createReference;
+
+public class ErrorMappingTest {
+
+    @Test
+    public void test_ambiguous_column_exception_error_mapping() {
+        isError(new AmbiguousColumnException(new ColumnIdent("x"), createReference("x", DataTypes.STRING)),
+                is("Column \"x\" is ambiguous"),
+                AMBIGUOUS_COLUMN,
+                BAD_REQUEST,
+                4006);
+    }
+
+    private void isError(Throwable t,
+                         Matcher<String> msg,
+                         PGErrorStatus pgErrorStatus,
+                         HttpResponseStatus httpResponseStatus,
+                         int errorCode) {
+        var throwable = SQLExceptions.prepareForClientTransmission(t, null);
+
+        var pgError = PGError.fromThrowable(throwable);
+        assertThat(pgError.status(), is(pgErrorStatus));
+        assertThat(pgError.message(), msg);
+
+        var httpError = HttpError.fromThrowable(throwable);
+        assertThat(httpError.errorCode(), is(errorCode));
+        assertThat(httpError.httpResponseStatus(), is(httpResponseStatus));
+        assertThat(httpError.message(), msg);
+    }
+}


### PR DESCRIPTION
This changes the error code for the psql protocol when a column
 reference is ambiguous from `XX000` `internal_error` to `42702`
`ambiguous_column`.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
