### PR TITLE
Update Lucene to 8.6.2

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -23,7 +23,7 @@ jacksonasl=1.9.13
 crate_admin_ui = 1.16.0
 jdbc=42.2.14
 
-lucene=8.6.0
+lucene=8.6.2
 
 # ES Azure
 azure_storage=8.6.0

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -129,7 +129,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_4_2_3 = new Version(ES_V_7_2_3_ID, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
     public static final Version V_4_2_4 = new Version(ES_V_7_2_4_ID, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
 
-    public static final Version V_4_3_0 = new Version(ES_V_7_3_0_ID, true, org.apache.lucene.util.Version.LUCENE_8_6_0);
+    public static final Version V_4_3_0 = new Version(ES_V_7_3_0_ID, true, org.apache.lucene.util.Version.LUCENE_8_6_2);
 
     public static final Version CURRENT = V_4_3_0;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Release page for 8.6.2 is not up yet, but it fixes a memory leak:

https://issues.apache.org/jira/browse/LUCENE-9478

And changes for 8.6.1:

https://lucene.apache.org/core/8_6_1/changes/Changes.html


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)