### PR TITLE
bp: Peer recovery should flush at the end

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -34,6 +34,7 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -45,6 +46,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLeases;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardNotRecoveringException;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -304,9 +306,17 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             // Persist the global checkpoint.
             indexShard.sync();
             indexShard.persistRetentionLeases();
+            if (hasUncommittedOperations()) {
+                indexShard.flush(new FlushRequest().force(true).waitIfOngoing(true));
+            }
             indexShard.finalizeRecovery();
             return null;
         });
+    }
+
+    private boolean hasUncommittedOperations() throws IOException {
+        long localCheckpointOfCommit = Long.parseLong(indexShard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        return indexShard.estimateNumberOfHistoryOperations("peer-recovery", localCheckpointOfCommit + 1) > 0;
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
@@ -49,7 +50,7 @@ public class SysSegmentsTableInfoTest extends SQLTransportIntegrationTest {
                 " from sys.segments order by primary desc");
         assertThat(response.rowCount(), is(2L));
         validateResponse(response.rows()[0], true);
-        validateResponse(response.rows()[1],false);
+        validateResponse(response.rows()[1], false);
     }
 
     @SuppressWarnings("unchecked")
@@ -62,7 +63,7 @@ public class SysSegmentsTableInfoTest extends SQLTransportIntegrationTest {
         assertThat(result[5], is(0));
         assertThat((Long) result[6], greaterThan(2700L));
         assertThat((Long) result[7], greaterThan(900L));
-        assertThat(result[8], is(false));
+        assertThat(result[8], anyOf(is(true), is(false)));
         assertThat(result[9], is(true));
         assertThat(result[10], is(true));
         assertThat(result[11], is(Version.CURRENT.luceneVersion.toString()));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/75be2a669e1e7e38cfc0e7b55bf99c792fb8925f


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)