### PR TITLE
Fix primary key lookup with parameter placeholders requiring casts

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -93,6 +93,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2.3 that prevented primary key lookups
+  with parameter placeholders from working in some cases.
+
 - Fixed an issue resulting wrongly in a `RED` ``sys.health.health`` state for
   healthy partitions with less shards configured than the actual partitioned
   table.

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -21,9 +21,14 @@
 
 package io.crate.integrationtests;
 
+import io.crate.common.collections.Lists2;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.testing.DataTypeTesting;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -43,7 +48,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
@@ -1814,5 +1826,95 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is(
             "1\n"
         ));
+    }
+
+    @Test
+    public void test_primary_key_lookup_with_param_that_requires_cast_to_column_type() throws Exception {
+        execute("create table tbl (ts timestamp with time zone primary key, path text primary key)");
+        execute("INSERT INTO tbl (ts, path) VALUES ('2017-06-21T00:00:00.000000Z', 'c1')");
+
+        execute("select _id, path from tbl where ts = '2017-06-21' and path = 'c1'");
+        assertThat(printedTable(response.rows()), is(
+            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1\n"
+        ));
+        execute("select _id, path from tbl where ts = ? and path = ?", new Object[] { "2017-06-21", "c1" });
+        assertThat(printedTable(response.rows()), is(
+            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1\n"
+        ));
+    }
+
+    @Test
+    public void test_primary_key_lookups_returns_inserted_records() throws Exception {
+        int numKeys = randomIntBetween(1, 3);
+        Random random = RandomizedContext.current().getRandom();
+        StringBuilder createTable = new StringBuilder("CREATE TABLE tbl (");
+        ArrayList<DataType<?>> types = new ArrayList<>();
+        List<DataType<?>> typeCandidates = DataTypes.PRIMITIVE_TYPES.stream()
+            .filter(x -> !DataTypes.STORAGE_UNSUPPORTED.contains(x))
+            .collect(Collectors.toList());
+        for (int i = 0; i < numKeys; i++) {
+            var type = RandomPicks.randomFrom(random, typeCandidates);
+            types.add(type);
+            createTable.append("col");
+            createTable.append(i);
+            createTable.append(' ');
+            createTable.append(type.getName());
+            createTable.append(" PRIMARY KEY");
+            if (i + 1 < numKeys) {
+                createTable.append(", ");
+            }
+        }
+        createTable.append(")");
+        execute(createTable.toString());
+
+        String insert = "INSERT INTO tbl VALUES ("
+            + String.join(", ", Lists2.map(types, ignored -> "?"))
+            + ")";
+        Object[] args = new Object[types.size()];
+        for (int i = 0; i < types.size(); i++) {
+            var type = types.get(i);
+            args[i] = DataTypeTesting.getDataGenerator(type).get();
+        }
+        execute(insert, args);
+
+        StringBuilder selectInlineValues = new StringBuilder("SELECT 1 FROM tbl WHERE ");
+        StringBuilder selectParams = new StringBuilder("SELECT 1 FROM tbl WHERE ");
+        for (int i = 0; i < args.length; i++) {
+            var arg = args[i];
+            selectInlineValues.append("col");
+            selectParams.append("col");
+
+            selectInlineValues.append(i);
+            selectParams.append(i);
+
+            selectInlineValues.append(" = ");
+            if (arg instanceof String) {
+                selectInlineValues.append("'");
+                selectInlineValues.append(arg);
+                selectInlineValues.append("'");
+            } else {
+                selectInlineValues.append(arg);
+            }
+            selectParams.append(" = ?");
+
+            if (i + 1 < args.length) {
+                selectInlineValues.append(" AND ");
+                selectParams.append(" AND ");
+            }
+        }
+
+        execute(selectParams.toString(), args);
+        assertThat(
+            selectParams.toString() + " with values " + Arrays.toString(args) + " must return a record",
+            response.rowCount(),
+            is(1L)
+        );
+
+        execute(selectInlineValues.toString());
+        assertThat(
+            selectInlineValues.toString() + " must return a record",
+            response.rowCount(),
+            is(1L)
+        );
     }
 }

--- a/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -22,6 +22,19 @@
 
 package io.crate.planner.node.ddl;
 
+import static io.crate.planner.node.ddl.UpdateSettingsPlan.buildSettingsFrom;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.common.collections.MapBuilder;
 import io.crate.data.Row;
@@ -35,19 +48,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Assignment;
-import org.elasticsearch.test.ESTestCase;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.settings.Settings;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
-import static io.crate.planner.node.ddl.UpdateSettingsPlan.buildSettingsFrom;
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import io.crate.types.ObjectType;
 
 public class UpdateSettingsPlanTest extends ESTestCase {
 
@@ -92,7 +94,7 @@ public class UpdateSettingsPlanTest extends ESTestCase {
     @Test
     public void testUpdateObjectWithParameter() throws Exception {
         List<Assignment<Symbol>> settings = List.of(
-            new Assignment<>(Literal.of("stats"), List.of(new ParameterSymbol(0, DataTypes.LONG))));
+            new Assignment<>(Literal.of("stats"), List.of(new ParameterSymbol(0, ObjectType.UNTYPED))));
 
         Map<String, Object> param = MapBuilder.<String, Object>newMapBuilder()
             .put("enabled", true)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/commit/23dedb0e45f7726e3e23bf662bd17f8fc84fe843
fixed a case with the boolean type, but broke the handling when using
parameter symbols that require a cast.

A query like `ts = ?` where the user provides `2017-06-21` for `?`
used `2017-06-21` as literal value for the `_id` computation instead
of converting `2017-06-21` to a timestamp first.

Fixes https://github.com/crate/crate/issues/10470


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)