### PR TITLE
Move error mapping for clients closer to the border

### DIFF
--- a/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
@@ -37,10 +37,14 @@ public final class Exceptions {
     }
 
     public static <T> T rethrowRuntimeException(Throwable t) {
+        throw toRuntimeException(t);
+    }
+
+    public static RuntimeException toRuntimeException(Throwable t) {
         if (t instanceof RuntimeException) {
-            throw (RuntimeException) t;
+            return (RuntimeException) t;
         } else {
-            throw new RuntimeException(t);
+            return new RuntimeException(t);
         }
     }
 

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -268,7 +268,7 @@ public class Session implements AutoCloseable {
                 statement = EMPTY_STMT;
             } else {
                 jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.user());
-                throw SQLExceptions.prepareForClientTransmission(t, accessControl::ensureMaySee);
+                throw t;
             }
         }
 

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -22,7 +22,9 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.auth.user.AccessControl;
 import io.crate.data.Row;
+import io.crate.exceptions.SQLExceptions;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.protocols.postgres.types.PGType;
@@ -179,8 +181,8 @@ public class Messages {
                           METHOD_NAME_CLIENT_AUTH, errorCode);
     }
 
-    static ChannelFuture sendErrorResponse(Channel channel, Throwable throwable) {
-        var error = PGError.fromThrowable(throwable);
+    static ChannelFuture sendErrorResponse(Channel channel, AccessControl accessControl, Throwable throwable) {
+        var error = PGError.fromThrowable(SQLExceptions.prepareForClientTransmission(accessControl, throwable));
         byte[] msg = error.message().getBytes(StandardCharsets.UTF_8);
         byte[] errorCode = error.status().code().getBytes(StandardCharsets.UTF_8);
         byte[] lineNumber = null;

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols;
 
+import io.crate.auth.user.AccessControl;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.metadata.ColumnIdent;
@@ -55,7 +56,7 @@ public class ErrorMappingTest {
                          PGErrorStatus pgErrorStatus,
                          HttpResponseStatus httpResponseStatus,
                          int errorCode) {
-        var throwable = SQLExceptions.prepareForClientTransmission(t, null);
+        var throwable = SQLExceptions.prepareForClientTransmission(AccessControl.DISABLED, t);
 
         var pgError = PGError.fromThrowable(throwable);
         assertThat(pgError.status(), is(pgErrorStatus));

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -509,7 +509,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
 
         if (failure != null) {
             when(session.sync()).thenAnswer(invocationOnMock -> {
-                Messages.sendErrorResponse(channel, failure);
+                Messages.sendErrorResponse(channel, AccessControl.DISABLED, failure);
                 return CompletableFuture.failedFuture(failure);
             });
         } else {

--- a/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.auth.user.AccessControl;
 import io.crate.data.Row1;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.DataTypes;
@@ -44,7 +45,7 @@ public class ResultSetReceiverTest {
             "select * from t",
             channel,
             TransactionState.IDLE,
-            RuntimeException::new,
+            AccessControl.DISABLED,
             Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
             null
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Reduces the number of places where we pre-process a exception before it
is send to a client.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)