### PR TITLE
Map InvalidSchemaNameException to PG 3F000 error code

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed the error code for the psql protocol when a schema name
+  is invalid from `XX000` `internal_error` to `3F000` `invalid_schema_name`.
+
 - Changed the error code for the psql protocol when a column reference
   is ambiguous from `XX000` `internal_error` to `42702` `ambiguous_column`.
 

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -25,6 +25,7 @@ package io.crate.protocols.postgres;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.DuplicateKeyException;
+import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
@@ -86,6 +87,8 @@ public class PGError {
             status = PGErrorStatus.DUPLICATE_TABLE;
         } else if (throwable instanceof AmbiguousColumnException) {
             status = PGErrorStatus.AMBIGUOUS_COLUMN;
+        } else if (throwable instanceof InvalidSchemaNameException) {
+            status = PGErrorStatus.INVALID_SCHEMA_NAME;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -24,6 +24,7 @@ package io.crate.protocols;
 
 import io.crate.auth.user.AccessControl;
 import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.metadata.ColumnIdent;
 import io.crate.protocols.postgres.PGError;
@@ -35,6 +36,7 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_COLUMN;
+import static io.crate.protocols.postgres.PGErrorStatus.INVALID_SCHEMA_NAME;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -49,6 +51,15 @@ public class ErrorMappingTest {
                 AMBIGUOUS_COLUMN,
                 BAD_REQUEST,
                 4006);
+    }
+
+    @Test
+    public void test_invalid_schema_name_exception_error_mapping() {
+        isError(new InvalidSchemaNameException("invalid"),
+                is("schema name \"invalid\" is invalid."),
+                INVALID_SCHEMA_NAME,
+                BAD_REQUEST,
+                4002);
     }
 
     private void isError(Throwable t,


### PR DESCRIPTION
## 9701  Summary of the changes / Why this improves CrateDB

This changes the error code for the psql protocol when a schema name
is invalid from `XX000` `internal_error` to `3F000` `invalid_schema_name`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
