### PR TITLE
Add cluster + session setting `expose_object_columns`

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -156,6 +156,7 @@ applied cluster settings.
     | settings['discovery']                                                             | object           |
     | settings['discovery']['zen']                                                      | object           |
     | settings['discovery']['zen']['publish_timeout']                                   | text             |
+    | settings['expose_object_columns']                                                 | boolean          |
     | settings['gateway']                                                               | object           |
     | settings['gateway']['expected_nodes']                                             | integer          |
     | settings['gateway']['recover_after_nodes']                                        | integer          |

--- a/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -64,6 +64,7 @@ public final class CoordinatorTxnCtx implements TransactionContext {
         return new SessionSettings(sessionContext.user().name(),
                                    sessionContext.searchPath(),
                                    sessionContext.isHashJoinEnabled(),
+                                   sessionContext.exposeObjectColumns(),
                                    sessionContext.excludedOptimizerRules());
     }
 

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -88,7 +88,9 @@ public final class CrateSettings implements ClusterStateListener {
         UDCService.UDC_INITIAL_DELAY_SETTING,
         UDCService.UDC_INTERVAL_SETTING,
 
-        MemoryManagerFactory.MEMORY_ALLOCATION_TYPE
+        MemoryManagerFactory.MEMORY_ALLOCATION_TYPE,
+
+        MetadataSettings.EXPOSE_OBJECT_COLUMNS_SETTING
     );
 
     private static final List<CrateSetting<?>> EXPOSED_ES_SETTINGS = List.of(

--- a/server/src/main/java/io/crate/metadata/settings/MetadataSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/MetadataSettings.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.settings;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.metadata.settings.session.SessionSetting;
+import io.crate.metadata.settings.session.SessionSettingProvider;
+import io.crate.settings.CrateSetting;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+@Singleton
+public final class MetadataSettings implements SessionSettingProvider {
+
+    public static final String EXPOSE_OBJECT_COLUMNS = "expose_object_columns";
+
+    public static final CrateSetting<Boolean> EXPOSE_OBJECT_COLUMNS_SETTING = CrateSetting.of(
+        Setting.boolSetting(
+            EXPOSE_OBJECT_COLUMNS,
+            true,
+            Setting.Property.Dynamic,
+            Setting.Property.NodeScope
+        ),
+        DataTypes.BOOLEAN
+    );
+
+    private volatile boolean exposeObjectColumns = true;
+
+    @Inject
+    public MetadataSettings(Settings settings, ClusterSettings clusterSettings) {
+        exposeObjectColumns = EXPOSE_OBJECT_COLUMNS_SETTING.setting().get(settings);
+        clusterSettings.addSettingsUpdateConsumer(EXPOSE_OBJECT_COLUMNS_SETTING.setting(), newValue -> {
+            exposeObjectColumns = newValue;
+        });
+    }
+
+    public boolean exposeObjectColumns() {
+        return exposeObjectColumns;
+    }
+
+    @Override
+    public List<SessionSetting<?>> sessionSettings() {
+        return List.of(
+            new SessionSetting<>(
+                EXPOSE_OBJECT_COLUMNS,
+                objects -> {
+                    if (objects.length != 1) {
+                        throw new IllegalArgumentException(
+                            EXPOSE_OBJECT_COLUMNS + " should have only one argument.");
+                    }
+                },
+                objects -> DataTypes.BOOLEAN.implicitCast(objects[0]),
+                SessionContext::setExposeObjectColumns,
+                s -> Boolean.toString(s.exposeObjectColumns()),
+                () -> String.valueOf(exposeObjectColumns),
+                "Whether CrateDB should expose the schema of object data types at system tables.",
+                DataTypes.BOOLEAN
+            )
+        );
+    }
+}

--- a/server/src/main/java/io/crate/metadata/settings/SessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/SessionSettings.java
@@ -39,26 +39,33 @@ public final class SessionSettings implements Writeable {
     private final SearchPath searchPath;
     private final boolean hashJoinsEnabled;
     private final Set<Class<? extends Rule<?>>> excludedOptimizerRules;
+    private final boolean exposeObjectColumns;
 
     public SessionSettings(StreamInput in) throws IOException {
         this.userName = in.readString();
         this.searchPath = SearchPath.createSearchPathFrom(in);
         this.hashJoinsEnabled = in.readBoolean();
-        // excludedOptimizerRules are only used on the coordinator node
+        // excludedOptimizerRules and exposeObjectColumns are only used on the coordinator node
         // and never needed any other node and therefore are excluded from
         // serialization on purpose.
         this.excludedOptimizerRules = Set.of();
+        this.exposeObjectColumns = true;
     }
 
     @VisibleForTesting
     public SessionSettings(String userName, SearchPath searchPath) {
-        this(userName, searchPath, true, Set.of());
+        this(userName, searchPath, true, true, Set.of());
     }
 
-    public SessionSettings(String userName, SearchPath searchPath, boolean hashJoinsEnabled, Set<Class<? extends Rule<?>>> rules) {
+    public SessionSettings(String userName,
+                           SearchPath searchPath,
+                           boolean hashJoinsEnabled,
+                           boolean exposeObjectColumns,
+                           Set<Class<? extends Rule<?>>> rules) {
         this.userName = userName;
         this.searchPath = searchPath;
         this.hashJoinsEnabled = hashJoinsEnabled;
+        this.exposeObjectColumns = exposeObjectColumns;
         this.excludedOptimizerRules = rules;
     }
 
@@ -76,6 +83,10 @@ public final class SessionSettings implements Writeable {
 
     public boolean hashJoinsEnabled() {
         return hashJoinsEnabled;
+    }
+
+    public boolean exposeObjectColumns() {
+        return exposeObjectColumns;
     }
 
     public Set<Class<? extends Rule<?>>> excludedOptimizerRules() {

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingModule.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingModule.java
@@ -22,6 +22,7 @@
 
 package io.crate.metadata.settings.session;
 
+import io.crate.metadata.settings.MetadataSettings;
 import io.crate.planner.optimizer.LoadedRules;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
@@ -30,8 +31,9 @@ public class SessionSettingModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(SessionSettingRegistry.class).asEagerSingleton();
         var sessionSettingProviderBinder = Multibinder.newSetBinder(binder(), SessionSettingProvider.class);
         sessionSettingProviderBinder.addBinding().to(LoadedRules.class);
+        sessionSettingProviderBinder.addBinding().to(MetadataSettings.class);
+        bind(SessionSettingRegistry.class).asEagerSingleton();
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -521,7 +521,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(817, response.rowCount());
+        assertEquals(818, response.rowCount());
     }
 
     @Test
@@ -1246,5 +1246,19 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "WHERE table_name = 't'");
         assertThat(printedTable(response.rows()), is("col1| NULL\n" +
                                                      "col2| 1\n"));
+    }
+
+    @Test
+    public void test_object_columns_are_filtered_out_if_disabled_by_setting_in_columns_table() {
+        execute("create table t1 (id int, obj object as (i int))");
+
+        execute("SET GLOBAL TRANSIENT expose_object_columns = false");
+        execute("SELECT column_name " +
+                "FROM information_schema.columns " +
+                "WHERE table_name = 't1'");
+        assertThat(printedTable(response.rows()), is("id\n" +
+                                                     "obj\n"));
+
+        execute("RESET GLOBAL expose_object_columns");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -108,6 +108,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
         execute("select name, setting, short_desc, min_val, max_val from pg_catalog.pg_settings");
         assertThat(printedTable(response.rows()), is(
             "enable_hashjoin| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL\n" +
+            "expose_object_columns| true| Whether CrateDB should expose the schema of object data types at system tables.| NULL| NULL\n" +
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL\n" +

--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -453,7 +453,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         NodeContext nodeCtx = internalCluster().getInstance(NodeContext.class, nodeName);
 
         SessionContext sessionContext = new SessionContext(
-            Option.NONE, User.CRATE_USER, sqlExecutor.getCurrentSchema());
+            Option.NONE, User.CRATE_USER, () -> true, sqlExecutor.getCurrentSchema());
         CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionContext);
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         PlannerContext plannerContext = new PlannerContext(

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -399,6 +399,7 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
         execute("show all");
         assertThat(printedTable(response.rows()), is(
             "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n" +
+            "expose_object_columns| true| Whether CrateDB should expose the schema of object data types at system tables.\n" +
             "max_index_keys| 32| Shows the maximum number of index keys.\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.\n" +

--- a/server/src/test/java/io/crate/metadata/settings/SessionSettingsTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/SessionSettingsTest.java
@@ -37,7 +37,7 @@ public class SessionSettingsTest {
 
     @Test
     public void testSessionSettingsStreaming() throws IOException {
-        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, Set.of(
+        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, true, Set.of(
             MergeFilters.class));
         BytesStreamOutput out = new BytesStreamOutput();
         s1.writeTo(out);

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -66,6 +66,7 @@ public class OptimizerRuleSessionSettingProviderTest {
         var mergefilterSettings = new SessionSettings("user",
                                                       SearchPath.createSearchPathFrom("dummySchema"),
                                                       true,
+                                                      true,
                                                       Set.of(MergeFilters.class));
 
         assertThat(sessionSetting.getValue(mergefilterSettings), is("false"));

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
@@ -42,6 +42,7 @@ public class OptimizerTest {
         SessionSettings sessionSettings = new SessionSettings("User",
                                                               SearchPath.pathWithPGCatalogAndDoc(),
                                                               true,
+                                                              true,
                                                               Set.of(MergeFilters.class));
 
         List<Rule<?>> rules = Optimizer.removeExcludedRules(List.of(new MergeFilters()),

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -34,6 +34,7 @@ import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.metadata.settings.MetadataSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -95,7 +96,8 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             new JobsLogs(() -> true),
             Settings.EMPTY,
             clusterService,
-            USER_MANAGER_PROVIDER
+            USER_MANAGER_PROVIDER,
+            new MetadataSettings(clusterService.getSettings(), clusterService.getClusterSettings())
         ) {
             @Override
             public Session createSession(@Nullable String defaultSchema, @Nullable User user) {

--- a/server/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/test/java/io/crate/testing/TestingHelpers.java
@@ -42,12 +42,17 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.settings.session.SessionSettingModule;
+import io.crate.settings.CrateSetting;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -171,7 +176,12 @@ public class TestingHelpers {
     }
 
     public static NodeContext createNodeContext(AbstractModule... additionalModules) {
-        ModulesBuilder modulesBuilder = new ModulesBuilder()
+        Setting<?>[] crateSettings = CrateSettings.CRATE_CLUSTER_SETTINGS.stream()
+            .map(CrateSetting::setting)
+            .toArray(Setting[]::new);
+
+       ModulesBuilder modulesBuilder = new ModulesBuilder()
+            .add(new SettingsModule(Settings.EMPTY, crateSettings))
             .add(new SessionSettingModule())
             .add(new OperatorModule())
             .add(new AggregationImplModule())


### PR DESCRIPTION
This new settings dictates whether inner columns of object data types shall be exposed at `information_schema.columns` and`pg_catalog.pg_attribute`.

Some apps do not support correct quoting of subscript expressions, the whole subscript will be quoted instead of just the identifier part (e.g. "my_col['a']" instead of "my_col"['a']).
Thus these apps will break if they use column information based on the system tables. To support such apps, exposing of all object inner columns can be disabled by this new setting.

The setting is implemented as a runtime cluster setting and additionally as a session setting, which by default derived its value from the cluster setting. The later will override the former for each session.
Existing sessions won't be affected if the runtime setting is modified during the lifetime of a session.
