### PR TITLE
Map AmbiguousColumnAliasException to PG 42P09 error code

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,6 +51,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed the error code for the psql protocol when a column alias is
+  ambiguous from `XX000` `internal_error` to `42P09` `ambiguous_alias`.
+
 - Changed the error code for the psql protocol when a schema name
   is invalid from `XX000` `internal_error` to `3F000` `invalid_schema_name`.
 

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.DuplicateKeyException;
@@ -89,6 +90,8 @@ public class PGError {
             status = PGErrorStatus.AMBIGUOUS_COLUMN;
         } else if (throwable instanceof InvalidSchemaNameException) {
             status = PGErrorStatus.INVALID_SCHEMA_NAME;
+        } else if (throwable instanceof AmbiguousColumnAliasException) {
+            status = PGErrorStatus.AMBIGUOUS_ALIAS;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -23,6 +23,7 @@
 package io.crate.protocols;
 
 import io.crate.auth.user.AccessControl;
+import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.SQLExceptions;
@@ -35,6 +36,9 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
+import java.util.List;
+
+import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_ALIAS;
 import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.INVALID_SCHEMA_NAME;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -60,6 +64,15 @@ public class ErrorMappingTest {
                 INVALID_SCHEMA_NAME,
                 BAD_REQUEST,
                 4002);
+    }
+
+    @Test
+    public void test_ambiguous_column_alias_exception_error_mapping() {
+        isError(new AmbiguousColumnAliasException("x", List.of(createReference("x", DataTypes.STRING))),
+                is("Column alias \"x\" is ambiguous"),
+                AMBIGUOUS_ALIAS,
+                BAD_REQUEST,
+                4006);
     }
 
     private void isError(Throwable t,


### PR DESCRIPTION
This changes the error code for the psql protocol when a column
alias is ambiguous from XX000 internal_error to 42P09
ambiguous_alias.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
