### PR TITLE
Make JobKilledException serializable to fix flaky KillIntegrationTest

### DIFF
--- a/server/src/main/java/io/crate/exceptions/JobKilledException.java
+++ b/server/src/main/java/io/crate/exceptions/JobKilledException.java
@@ -21,14 +21,22 @@
 
 package io.crate.exceptions;
 
-import javax.annotation.Nullable;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
 
-public class JobKilledException extends RuntimeException implements UnscopedException {
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class JobKilledException extends ElasticsearchException implements UnscopedException {
 
     public static final String MESSAGE = "Job killed";
 
     public static JobKilledException of(@Nullable String reason) {
         return reason == null ? new JobKilledException() : new JobKilledException(reason);
+    }
+
+    public JobKilledException(final StreamInput in) throws IOException {
+        super(in);
     }
 
     private JobKilledException(String reason) {

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -993,7 +993,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 org.elasticsearch.index.shard.ShardNotInPrimaryModeException.class,
                 org.elasticsearch.index.shard.ShardNotInPrimaryModeException::new,
                 155,
-                Version.V_4_3_0);
+                Version.V_4_3_0),
+        JOB_KILLED_EXCEPTION(
+            io.crate.exceptions.JobKilledException.class,
+            io.crate.exceptions.JobKilledException::new,
+                156,
+            Version.V_4_3_0);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This makes `JobKilledException` extending `ElasticsearchException` to make it fully
serializable and streamable across nodes, to make sure it will never be wrapped
in a `NotSerializableExceptionWrapper` to fix the flaky `KillIntegrationTest`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
