### PR TITLE
Use doc values aggregators in the group by iterator.

### DIFF
--- a/server/src/main/java/io/crate/breaker/MultiSizeEstimator.java
+++ b/server/src/main/java/io/crate/breaker/MultiSizeEstimator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import io.crate.types.DataType;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiSizeEstimator extends SizeEstimator<List<Object>> {
+
+    private final List<SizeEstimator<Object>> subEstimators;
+
+    public MultiSizeEstimator(List<? extends DataType> keyTypes) {
+        subEstimators = new ArrayList<>(keyTypes.size());
+        for (DataType<?> keyType : keyTypes) {
+            subEstimators.add(SizeEstimatorFactory.create(keyType));
+        }
+    }
+
+    @Override
+    public long estimateSize(@Nullable List<Object> value) {
+        assert value != null && value.size() == subEstimators.size()
+            : "value must have the same number of items as there are keyTypes/sizeEstimators";
+
+        long size = 0;
+        for (int i = 0; i < value.size(); i++) {
+            size += subEstimators.get(i).estimateSize(value.get(i));
+        }
+        return size;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -23,8 +23,8 @@
 package io.crate.execution.engine.aggregation;
 
 import com.google.common.collect.Iterables;
+import io.crate.breaker.MultiSizeEstimator;
 import io.crate.breaker.RamAccounting;
-import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -295,30 +295,5 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                 return row;
             }
         });
-    }
-
-
-    private static class MultiSizeEstimator extends SizeEstimator<List<Object>> {
-
-        private final List<SizeEstimator<Object>> subEstimators;
-
-        MultiSizeEstimator(List<? extends DataType> keyTypes) {
-            subEstimators = new ArrayList<>(keyTypes.size());
-            for (DataType keyType : keyTypes) {
-                subEstimators.add(SizeEstimatorFactory.create(keyType));
-            }
-        }
-
-        @Override
-        public long estimateSize(@Nullable List<Object> value) {
-            assert value != null && value.size() == subEstimators.size()
-                : "value must have the same number of items as there are keyTypes/sizeEstimators";
-
-            long size = 0;
-            for (int i = 0; i < value.size(); i++) {
-                size += subEstimators.get(i).estimateSize(value.get(i));
-            }
-            return size;
-        }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import io.crate.breaker.MultiSizeEstimator;
+import io.crate.breaker.RamAccounting;
+import io.crate.breaker.SizeEstimatorFactory;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.collections.Lists2;
+import io.crate.data.BatchIterator;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.exceptions.Exceptions;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.GroupProjection;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.GroupByMaps;
+import io.crate.execution.jobs.SharedShardContext;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.metadata.DocReferences;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static io.crate.execution.dsl.projection.Projections.shardProjections;
+import static io.crate.execution.engine.collect.LuceneShardCollectorProvider.formatSource;
+
+final class DocValuesGroupByOptimizedIterator {
+
+    @Nullable
+    static BatchIterator<Row> tryOptimize(Functions functions,
+                                          IndexShard indexShard,
+                                          DocTableInfo table,
+                                          LuceneQueryBuilder luceneQueryBuilder,
+                                          FieldTypeLookup fieldTypeLookup,
+                                          DocInputFactory docInputFactory,
+                                          RoutedCollectPhase collectPhase,
+                                          CollectTask collectTask) {
+        if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE)
+            || Symbols.containsColumn(collectPhase.where(), DocSysColumns.SCORE)) {
+            return null;
+        }
+
+        Collection<? extends Projection> shardProjections = shardProjections(collectPhase.projections());
+        GroupProjection groupProjection = getSinglePartialGroupProjection(shardProjections);
+        if (groupProjection == null) {
+            return null;
+        }
+
+        ArrayList<Reference> columnKeyRefs = new ArrayList<>(groupProjection.keys().size());
+        for (var key : groupProjection.keys()) {
+            var docKeyRef = getKeyRef(collectPhase.toCollect(), key);
+            if (docKeyRef == null) {
+                return null; // group by on non-reference
+            }
+            var columnKeyRef = (Reference) DocReferences.inverseSourceLookup(docKeyRef);
+            var keyFieldType = fieldTypeLookup.get(columnKeyRef.column().fqn());
+            if (keyFieldType == null || !keyFieldType.hasDocValues()) {
+                return null;
+            } else {
+                columnKeyRefs.add(columnKeyRef);
+            }
+        }
+
+        //noinspection rawtypes
+        List<DocValueAggregator> aggregators = DocValuesAggregates.createAggregators(
+            functions,
+            groupProjection.values(),
+            fieldTypeLookup,
+            collectPhase.toCollect(),
+            collectTask.txnCtx().sessionSettings().searchPath()
+        );
+        if (aggregators == null) {
+            return null;
+        }
+
+        ShardId shardId = indexShard.shardId();
+        SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        try {
+            QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
+            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+
+            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
+                = docInputFactory.getCtx(collectTask.txnCtx());
+            docCtx.add(columnKeyRefs);
+            List<? extends LuceneCollectorExpression<?>> keyExpressions = docCtx.expressions();
+
+            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+                collectPhase.where(),
+                collectTask.txnCtx(),
+                indexShard.mapperService(),
+                indexShard.shardId().getIndexName(),
+                queryShardContext,
+                table,
+                sharedShardContext.indexService().cache()
+            );
+
+            var ramAccounting = collectTask.getRamAccounting();
+            if (columnKeyRefs.size() == 1) {
+                return GroupByIterator.forSingleKey(
+                    aggregators,
+                    searcher,
+                    columnKeyRefs.get(0),
+                    keyExpressions,
+                    ramAccounting,
+                    queryContext.query(),
+                    new CollectorContext(sharedShardContext.readerId())
+                );
+            } else {
+                return GroupByIterator.forManyKeys(
+                    aggregators,
+                    searcher,
+                    columnKeyRefs,
+                    keyExpressions,
+                    ramAccounting,
+                    queryContext.query(),
+                    new CollectorContext(sharedShardContext.readerId())
+                );
+            }
+        } catch (Throwable t) {
+            searcher.close();
+            throw t;
+        }
+    }
+
+    static class GroupByIterator {
+
+        @VisibleForTesting
+        static BatchIterator<Row> forSingleKey(List<DocValueAggregator> aggregators,
+                                               IndexSearcher indexSearcher,
+                                               Reference keyReference,
+                                               List<? extends LuceneCollectorExpression<?>> keyExpressions,
+                                               RamAccounting ramAccounting,
+                                               Query query,
+                                               CollectorContext collectorContext) {
+            return GroupByIterator.getIterator(
+                aggregators,
+                indexSearcher,
+                keyExpressions,
+                ramAccounting,
+                GroupByMaps.accountForNewEntry(
+                    ramAccounting,
+                    SizeEstimatorFactory.create(keyReference.valueType()),
+                    null
+                ),
+                (expressions) -> expressions.get(0).value(),
+                (key, cells) -> cells[0] = key,
+                query,
+                new CollectorContext(collectorContext.readerId())
+            );
+        }
+
+        @VisibleForTesting
+        static <K> BatchIterator<Row> forManyKeys(List<DocValueAggregator> aggregators,
+                                                  IndexSearcher indexSearcher,
+                                                  List<Reference> keyColumnRefs,
+                                                  List<? extends LuceneCollectorExpression<?>> keyExpressions,
+                                                  RamAccounting ramAccounting,
+                                                  Query query,
+                                                  CollectorContext collectorContext) {
+            return GroupByIterator.getIterator(
+                aggregators,
+                indexSearcher,
+                keyExpressions,
+                ramAccounting,
+                GroupByMaps.accountForNewEntry(
+                    ramAccounting,
+                    new MultiSizeEstimator(
+                        Lists2.map(keyColumnRefs, Reference::valueType)
+                    ),
+                    null
+                ),
+                (expressions) -> {
+                    ArrayList<Object> key = new ArrayList<>(keyColumnRefs.size());
+                    for (int i = 0; i < expressions.size(); i++) {
+                        key.add(expressions.get(i).value());
+                    }
+                    return key;
+                },
+                (List<Object> keys, Object[] cells) -> {
+                    for (int i = 0; i < keys.size(); i++) {
+                        cells[i] = keys.get(i);
+                    }
+                },
+                query,
+                new CollectorContext(collectorContext.readerId())
+            );
+        }
+
+        @VisibleForTesting
+        static <K> BatchIterator<Row> getIterator(List<DocValueAggregator> aggregators,
+                                                  IndexSearcher indexSearcher,
+                                                  List<? extends LuceneCollectorExpression<?>> keyExpressions,
+                                                  RamAccounting ramAccounting,
+                                                  BiConsumer<Map<K, Object[]>, K> accountForNewKeyEntry,
+                                                  Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
+                                                  BiConsumer<K, Object[]> applyKeyToCells,
+                                                  Query query,
+                                                  CollectorContext collectorContext) {
+            for (int i = 0; i < keyExpressions.size(); i++) {
+                keyExpressions.get(i).startCollect(collectorContext);
+            }
+
+            AtomicReference<Throwable> killed = new AtomicReference<>();
+            return CollectingBatchIterator.newInstance(
+                () -> killed.set(BatchIterator.CLOSED),
+                killed::set,
+                () -> {
+                    try {
+                        return CompletableFuture.completedFuture(
+                            getRows(
+                                applyAggregatesGroupedByKey(
+                                    aggregators,
+                                    indexSearcher,
+                                    keyExpressions,
+                                    accountForNewKeyEntry,
+                                    keyExtractor,
+                                    ramAccounting,
+                                    query,
+                                    killed
+                                ),
+                                keyExpressions.size(),
+                                applyKeyToCells,
+                                aggregators,
+                                ramAccounting
+                            )
+                        );
+                    } catch (Throwable t) {
+                        return CompletableFuture.failedFuture(t);
+                    }
+                },
+                true
+            );
+        }
+
+        private static <K> Iterable<Row> getRows(Map<K, Object[]> groupedStates,
+                                                 int numberOfKeys,
+                                                 BiConsumer<K, Object[]> applyKeyToCells,
+                                                 List<DocValueAggregator> aggregators,
+                                                 RamAccounting ramAccounting) {
+            return () -> groupedStates.entrySet().stream()
+                .map(new Function<Map.Entry<K, Object[]>, Row>() {
+
+                    Object[] cells = new Object[numberOfKeys + aggregators.size()];
+                    RowN row = new RowN(cells);
+
+                    @Override
+                    public Row apply(Map.Entry<K, Object[]> entry) {
+                        K key = entry.getKey();
+                        applyKeyToCells.accept(key, cells);
+
+                        Object[] states = entry.getValue();
+                        int c = numberOfKeys;
+                        for (int i = 0; i < states.length; i++) {
+                            //noinspection unchecked
+                            cells[c] = aggregators.get(i).partialResult(ramAccounting, states[i]);
+                            c++;
+                        }
+                        return row;
+                    }
+                }).iterator();
+        }
+
+        private static <K> Map<K, Object[]> applyAggregatesGroupedByKey(
+            List<DocValueAggregator> aggregators,
+            IndexSearcher indexSearcher,
+            List<? extends LuceneCollectorExpression<?>> keyExpressions,
+            BiConsumer<Map<K, Object[]>, K> accountForNewKeyEntry,
+            Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
+            RamAccounting ramAccounting,
+            Query query,
+            AtomicReference<Throwable> killed
+        ) throws IOException {
+
+            HashMap<K, Object[]> statesByKey = new HashMap<>();
+            Weight weight = indexSearcher.createWeight(
+                indexSearcher.rewrite(query),
+                ScoreMode.COMPLETE_NO_SCORES,
+                1f
+            );
+            List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+            for (var leaf : leaves) {
+                raiseIfClosedOrKilled(killed);
+                Scorer scorer = weight.scorer(leaf);
+                if (scorer == null) {
+                    continue;
+                }
+                for (int i = 0; i < keyExpressions.size(); i++) {
+                    keyExpressions.get(i).setNextReader(leaf);
+                }
+                for (int i = 0; i < aggregators.size(); i++) {
+                    aggregators.get(i).loadDocValues(leaf.reader());
+                }
+
+                DocIdSetIterator docs = scorer.iterator();
+                Bits liveDocs = leaf.reader().getLiveDocs();
+                for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                    raiseIfClosedOrKilled(killed);
+                    if (docDeleted(liveDocs, doc)) {
+                        continue;
+                    }
+
+                    for (int i = 0; i < keyExpressions.size(); i++) {
+                        keyExpressions.get(i).setNextDocId(doc);
+                    }
+                    K key = keyExtractor.apply(keyExpressions);
+
+                    Object[] states = statesByKey.get(key);
+                    if (states == null) {
+                        states = new Object[aggregators.size()];
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            var aggregator = aggregators.get(i);
+                            states[i] = aggregator.initialState(ramAccounting);
+                            //noinspection unchecked
+                            aggregator.apply(ramAccounting, doc, states[i]);
+                        }
+                        accountForNewKeyEntry.accept(statesByKey, key);
+                        statesByKey.put(key, states);
+                    } else {
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            //noinspection unchecked
+                            aggregators.get(i).apply(ramAccounting, doc, states[i]);
+                        }
+                    }
+                }
+            }
+            return statesByKey;
+        }
+
+        private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {
+            return liveDocs != null && !liveDocs.get(doc);
+        }
+
+        private static void raiseIfClosedOrKilled(AtomicReference<Throwable> killed) {
+            Throwable killedException = killed.get();
+            if (killedException != null) {
+                Exceptions.rethrowUnchecked(killedException);
+            }
+        }
+    }
+
+    @Nullable
+    private static Reference getKeyRef(List<Symbol> toCollect, Symbol key) {
+        if (key instanceof InputColumn) {
+            Symbol keyRef = toCollect.get(((InputColumn) key).index());
+            if (keyRef instanceof Reference) {
+                return ((Reference) keyRef);
+            }
+        }
+        return null;
+    }
+
+    private static GroupProjection getSinglePartialGroupProjection(Collection<? extends Projection> shardProjections) {
+        if (shardProjections.size() != 1) {
+            return null;
+        }
+        Projection shardProjection = shardProjections.iterator().next();
+        if (!(shardProjection instanceof GroupProjection) ||
+            ((GroupProjection) shardProjection).mode() == AggregateMode.ITER_FINAL) {
+            return null;
+        }
+        return (GroupProjection) shardProjection;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -175,8 +175,21 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         if (it != null) {
             return it;
         }
+        it = DocValuesGroupByOptimizedIterator.tryOptimize(
+            nodeCtx.functions(),
+            indexShard,
+            table,
+            luceneQueryBuilder,
+            fieldTypeLookup,
+            docInputFactory,
+            normalizedPhase,
+            collectTask
+        );
+        if (it != null) {
+            return it;
+        }
         return DocValuesAggregates.tryOptimize(
-            nodeCtx,
+            nodeCtx.functions(),
             indexShard,
             table,
             luceneQueryBuilder,

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import io.crate.breaker.RamAccounting;
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.execution.engine.aggregation.impl.SumAggregation;
+import io.crate.expression.reference.doc.lucene.BytesRefColumnReference;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LongColumnReference;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.functions.Signature;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.TestingRowConsumer;
+import io.crate.types.DataTypes;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTest {
+
+    private Functions functions;
+    private IndexSearcher indexSearcher;
+
+    private List<Object[]> rows = List.of(
+        new Object[]{"1", 1L, 1L},
+        new Object[]{"0", 0L, 2L},
+        new Object[]{"1", 1L, 3L},
+        new Object[]{"0", 0L, 4L}
+    );
+
+    @Before
+    public void setup() throws IOException {
+        var nodeContext = createNodeContext();
+        functions = nodeContext.functions();
+
+        var indexWriter = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig());
+        for (var row : rows) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("x", BytesRefs.toBytesRef(row[0])));
+            doc.add(new NumericDocValuesField("y", (Long) row[1]));
+            doc.add(new NumericDocValuesField("z", (Long) row[2]));
+            indexWriter.addDocument(doc);
+        }
+        indexWriter.commit();
+        indexSearcher = new IndexSearcher(DirectoryReader.open(indexWriter));
+    }
+
+    @Test
+    public void test_group_by_doc_values_optimized_iterator_for_single_numeric_key() throws Exception {
+        SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
+            Signature.aggregate(
+                SumAggregation.NAME,
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature()
+            ),
+            List.of(DataTypes.LONG),
+            DataTypes.LONG
+        );
+
+        var aggregationField = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
+        aggregationField.setName("z");
+        var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
+            List.of(DataTypes.LONG),
+            List.of(aggregationField)
+        );
+
+        var keyExpressions = List.of(new LongColumnReference("y"));
+        var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forSingleKey(
+            List.of(sumDocValuesAggregator),
+            indexSearcher,
+            new Reference(
+                new ReferenceIdent(RelationName.fromIndexName("test"), "y"),
+                RowGranularity.DOC,
+                DataTypes.LONG,
+                null,
+                null
+            ),
+            keyExpressions,
+            RamAccounting.NO_ACCOUNTING,
+            new MatchAllDocsQuery(),
+            new CollectorContext()
+        );
+
+        var rowConsumer = new TestingRowConsumer();
+        rowConsumer.accept(it, null);
+        assertThat(
+            rowConsumer.getResult(),
+            containsInAnyOrder(new Object[]{0L, 6L}, new Object[]{1L, 4L}));
+    }
+
+    @Test
+    public void test_group_by_doc_values_optimized_iterator_for_many_keys() throws Exception {
+        SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
+            Signature.aggregate(
+                SumAggregation.NAME,
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature()
+            ),
+            List.of(DataTypes.LONG),
+            DataTypes.LONG
+        );
+
+        var aggregationField = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
+        aggregationField.setName("z");
+        var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
+            List.of(DataTypes.LONG),
+            List.of(aggregationField)
+        );
+        var keyExpressions = List.of(new BytesRefColumnReference("x"), new LongColumnReference("y"));
+        var keyRefs = List.of(
+            new Reference(
+                new ReferenceIdent(RelationName.fromIndexName("test"), "x"),
+                RowGranularity.DOC,
+                DataTypes.STRING,
+                null,
+                null
+            ),
+            new Reference(
+                new ReferenceIdent(RelationName.fromIndexName("test"), "y"),
+                RowGranularity.DOC,
+                DataTypes.LONG,
+                null,
+                null
+            )
+        );
+
+        var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forManyKeys(
+            List.of(sumDocValuesAggregator),
+            indexSearcher,
+            keyRefs,
+            keyExpressions,
+            RamAccounting.NO_ACCOUNTING,
+            new MatchAllDocsQuery(),
+            new CollectorContext()
+        );
+
+        var rowConsumer = new TestingRowConsumer();
+        rowConsumer.accept(it, null);
+
+        assertThat(
+            rowConsumer.getResult(),
+            containsInAnyOrder(new Object[]{"0", 0L, 6L}, new Object[]{"1", 1L, 4L})
+        );
+    }
+
+    @Test
+    public void test_optimized_iterator_stop_processing_on_kill() throws Exception {
+        Throwable expectedException = stopOnInterrupting(it -> it.kill(new InterruptedException("killed")));
+        assertThat(expectedException, instanceOf(InterruptedException.class));
+    }
+
+    @Test
+    public void test_optimized_iterator_stop_processing_on_close() throws Exception {
+        Throwable expectedException = stopOnInterrupting(BatchIterator::close);
+        assertThat(expectedException, instanceOf(IllegalStateException.class));
+    }
+
+    private Throwable stopOnInterrupting(Consumer<BatchIterator<Row>> interrupt) throws Exception {
+        CountDownLatch waitForLoadNextBatch = new CountDownLatch(1);
+        CountDownLatch pauseOnDocumentCollecting = new CountDownLatch(1);
+        CountDownLatch batchLoadingCompleted = new CountDownLatch(1);
+
+        BatchIterator<Row> it = createBatchIterator(() -> {
+            waitForLoadNextBatch.countDown();
+            try {
+                pauseOnDocumentCollecting.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                it.loadNextBatch().whenComplete((r, e) -> {
+                    if (e != null) {
+                        exception.set(e.getCause());
+                    }
+                    batchLoadingCompleted.countDown();
+                });
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        });
+        t.start();
+        waitForLoadNextBatch.await(5, TimeUnit.SECONDS);
+        interrupt.accept(it);
+        pauseOnDocumentCollecting.countDown();
+        batchLoadingCompleted.await(5, TimeUnit.SECONDS);
+        return exception.get();
+    }
+
+    private BatchIterator<Row> createBatchIterator(Runnable onNextReader) {
+        return DocValuesGroupByOptimizedIterator.GroupByIterator.getIterator(
+            List.of(),
+            indexSearcher,
+            List.of(new LuceneCollectorExpression<>() {
+
+                @Override
+                public void setNextReader(LeafReaderContext context) {
+                    onNextReader.run();
+                }
+
+                @Override
+                public Object value() {
+                    return null;
+                }
+            }),
+            RamAccounting.NO_ACCOUNTING,
+            (states, key) -> {
+            },
+            (expressions) -> expressions.get(0).value(),
+            (key, cells) -> cells[0] = key,
+            new MatchAllDocsQuery(),
+            new CollectorContext()
+        );
+    }
+}

--- a/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/server/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -311,7 +311,7 @@ public abstract class AggregationTest extends ESTestCase {
             4096);
 
         var batchIterator = DocValuesAggregates.tryOptimize(
-            nodeCtx,
+            nodeCtx.functions(),
             shard,
             mock(DocTableInfo.class),
             new LuceneQueryBuilder(nodeCtx),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`DocValuesGroupByOptimizedIterator` is kicked in when the group by keys and
aggregate functions fields utilize doc values. This optimization won't replace
the group by a single string key optimization. The optimization uses the
`DocValuesAggregator` implementations, if any exists for the used aggregation
functions signatures, to perform the required aggregations.

Follow up:
- probably consider the group by key cardinality-ratio to decide whether to use the `DocValuesGroupByOptimizedIterator`
- check a potential double-close searcher issue, see https://github.com/crate/crate/pull/10481#discussion_r484446354


Benchmarks. See the first 3 queries, the current optimization targets them.

Fork 1:
```
# Results (server side duration in ms)
V1: 4.3.0-91eab4079418606c6800b03f9b438adabb1cb7f4 (master)
V2: 4.3.0-7a781f2ce9e0508a1fbbe8f8aca4316b497ee684

Q: select avg("adRevenue"), sum("adRevenue"), min("adRevenue") from uservisits group by "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      638.100 ±  325.566 |    211.815 |    482.160 |    932.585 |   3125.512 |
|   V2    |      373.246 ±  196.211 |    124.022 |    277.423 |    549.255 |   1615.749 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  52.38%                           -  53.91%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 52.38%
The test has statistical significance

Q: select avg("adRevenue") from uservisits group by "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      452.103 ±  218.103 |    151.666 |    345.346 |    667.845 |   1006.138 |
|   V2    |      185.711 ±   85.982 |     53.151 |    145.821 |    266.296 |    450.111 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  83.53%                           -  81.25%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 83.53%
The test has statistical significance

Q: select avg("adRevenue") from uservisits group by "cCode", "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2103.870 ± 1050.969 |    497.677 |   1709.958 |   3193.367 |   4763.876 |
|   V2    |     1859.424 ±  942.139 |    414.991 |   1486.976 |   2866.043 |   3878.281 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  12.34%                           -  13.95%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 12.34%
The test has statistical significance

Q: select "cCode", avg("adRevenue") from uservisits group by "cCode"
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      381.050 ±  208.475 |    104.771 |    396.171 |    480.988 |   1456.100 |
|   V2    |      416.578 ±  230.937 |    111.100 |    421.884 |    525.586 |   1559.578 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   8.91%                           +   6.29%   
There is a 98.92% probability that the observed difference is not random, and the best estimate of that difference is 8.91%
The test has statistical significance

Q: select "cCode", count(*) from uservisits group by "cCode"
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      436.798 ±  612.384 |     54.301 |    187.792 |    264.789 |   2168.169 |
|   V2    |      394.126 ±  455.784 |     47.463 |    236.423 |    321.290 |   1533.854 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  10.27%                           +  22.93%   
There is a 42.32% probability that the observed difference is not random, and the best estimate of that difference is 10.27%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  218     2.60     1.91 |    0     0.00     0.00 |     2147      123 |  2092.40     278781
 V2 |  262     2.60     1.76 |    0     0.00     0.00 |     2147       52 |  2113.17     336127
    
V1 top allocation frames
  BytesRef.utf8ToString():89196875640
  StringUTF16.compress(...):55279245409
  GroupingCollector.evalKeyInputs(List):46236358862
  Float.valueOf(float):43693361381
  ArrayList.<init>(int):43296970152
V2 top allocation frames
  BytesRef.utf8ToString():121696878465
  DocValuesGroupByOptimizedIterator$GroupByIterator.lambda$forManyKeys$2(List, List):60725497291
  StringUTF16.compress(...):60709561912
  ArrayList.<init>(int):60696946969
  Float.valueOf(float):30925578229
```

Fork 2:
```
# Results (server side duration in ms)
V1: 4.3.0-91eab4079418606c6800b03f9b438adabb1cb7f4
V2: 4.3.0-7a781f2ce9e0508a1fbbe8f8aca4316b497ee684

Q: select avg("adRevenue"), sum("adRevenue"), min("adRevenue") from uservisits group by "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      627.276 ±  323.706 |    203.951 |    487.295 |    903.655 |   2906.228 |
|   V2    |      388.223 ±  197.518 |    116.546 |    301.322 |    558.523 |   1762.430 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  47.08%                           -  47.16%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 47.08%
The test has statistical significance

Q: select avg("adRevenue") from uservisits group by "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      451.690 ±  221.454 |    125.472 |    348.700 |    662.175 |   1000.080 |
|   V2    |      192.836 ±   88.972 |     64.655 |    149.921 |    274.790 |    442.393 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  80.32%                           -  79.73%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 80.32%
The test has statistical significance

Q: select avg("adRevenue") from uservisits group by "cCode", "duration"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2079.348 ± 1044.993 |    495.792 |   1676.263 |   3131.831 |   4460.352 |
|   V2    |     1704.987 ±  867.730 |    524.969 |   1371.779 |   2606.440 |   3615.633 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  19.78%                           -  19.98%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 19.78%
The test has statistical significance

Q: select "cCode", avg("adRevenue") from uservisits group by "cCode"
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      378.446 ±  214.287 |     93.080 |    381.851 |    479.441 |   1599.552 |
|   V2    |      400.246 ±  221.596 |     94.236 |    414.554 |    502.667 |   1517.380 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   5.60%                           +   8.21%   
There is a 88.59% probability that the observed difference is not random, and the best estimate of that difference is 5.60%
The test has no statistical significance

Q: select "cCode", count(*) from uservisits group by "cCode"
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      393.347 ±  541.522 |     57.325 |    180.287 |    264.866 |   1774.064 |
|   V2    |      387.077 ±  445.272 |     72.646 |    223.795 |    308.072 |   1514.709 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.61%                           +  21.53%   
There is a 7.12% probability that the observed difference is not random, and the best estimate of that difference is 1.61%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  222     2.58     1.78 |    0     0.00     0.00 |     2147      142 |  2086.78     285677
 V2 |  267     2.65     1.86 |    0     0.00     0.00 |     2147      119 |  2265.55     341691
    
V1 top allocation frames
  BytesRef.utf8ToString():91912280845
  StringUTF16.compress(...):56726976288
  GroupingCollector.evalKeyInputs(List):47236453620
  ArrayList.<init>(int):44709349392
  Float.valueOf(float):44008357601
V2 top allocation frames
  BytesRef.utf8ToString():123668417096
  DocValuesGroupByOptimizedIterator$GroupByIterator.lambda$forManyKeys$2(List, List):62053305301
  ArrayList.<init>(int):61975513304
  StringUTF16.compress(...):61710976368
  Float.valueOf(float):30948726637
```
## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
