### PR TITLE
Map UserDefinedFunctionUnknownException to PG 42883 error

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -51,26 +51,16 @@ Breaking Changes
 Changes
 =======
 
-- Changed the error code for the psql protocol when a column alias is
-  ambiguous from `XX000` `internal_error` to `42P09` `ambiguous_alias`.
-
-- Changed the error code for the psql protocol when a schema name
-  is invalid from `XX000` `internal_error` to `3F000` `invalid_schema_name`.
-
-- Changed the error code for the psql protocol when a column reference
-  is ambiguous from `XX000` `internal_error` to `42702` `ambiguous_column`.
-
-- Changed the error code for the psql protocol when a relation exists
-  already from `XX000` `internal_error` to `42P07` `duplicate_table`.
-
-- Changed the error code for the psql protocol when a column does not exist
-  from `XX000` `internal_error` to `42703` `undefined_column`.
-
-- Changed the error code for the psql protocol when a relation does not exist
-  from `XX000` `internal_error` to `42P01` `undefined_table`.
-
-- Changed the error code for the psql protocol when a document exists
-  already from `XX000` `internal_error` to `23505` `unique_violation`.
+- Changed the error code for the psql protocol from ``XX000`` ``internal_error``
+  when:
+  - a user defined function is missing to ``42883`` ``undefined_function``
+  - a column alias is ambiguous to ``42P09`` ``ambiguous_alias``
+  - a schema name is invalid to ``3F000`` ``invalid_schema_name``
+  - a column reference is ambiguous to ``42702`` ``ambiguous_column``
+  - a relation exists already to ``42P07`` ``duplicate_table``
+  - a column does not exist to ``42703`` ``undefined_column``
+  - a relation does not exist to ``42P01`` ``undefined_table``
+  - a document exists already to ``23505`` ``unique_violation``
 
 - Added scalar function :ref:`pg_function_is_visible <pg_function_is_visible>`.
 

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -30,6 +30,8 @@ import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.exceptions.UserDefinedFunctionUnknownException;
+
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 
@@ -92,6 +94,8 @@ public class PGError {
             status = PGErrorStatus.INVALID_SCHEMA_NAME;
         } else if (throwable instanceof AmbiguousColumnAliasException) {
             status = PGErrorStatus.AMBIGUOUS_ALIAS;
+        } else if (throwable instanceof UserDefinedFunctionUnknownException) {
+            status = PGErrorStatus.UNDEFINED_FUNCTION;
         }
         return new PGError(status, SQLExceptions.messageOf(throwable), throwable);
     }

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.protocols.postgres.PGError;
 import io.crate.protocols.postgres.PGErrorStatus;
@@ -41,7 +42,9 @@ import java.util.List;
 import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_ALIAS;
 import static io.crate.protocols.postgres.PGErrorStatus.AMBIGUOUS_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.INVALID_SCHEMA_NAME;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_FUNCTION;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static io.crate.testing.TestingHelpers.createReference;
@@ -73,6 +76,15 @@ public class ErrorMappingTest {
                 AMBIGUOUS_ALIAS,
                 BAD_REQUEST,
                 4006);
+    }
+
+    @Test
+    public void test_user_defined_function_unknown_exception_error_mapping() {
+        isError(new UserDefinedFunctionUnknownException("schema", "foo", List.of(DataTypes.STRING)),
+                is("Cannot resolve user defined function: 'schema.foo(text)'"),
+                UNDEFINED_FUNCTION,
+                NOT_FOUND,
+                4049);
     }
 
     private void isError(Throwable t,


### PR DESCRIPTION
This changes the error code for the psql protocol from XX000 internal_error
when a user defined function is missing to 42883 undefined_function.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
