### PR TITLE
Backport ES changes to make transport APIs async - part 1

### DIFF
--- a/libs/shared/src/main/java/io/crate/concurrent/CompletableContext.java
+++ b/libs/shared/src/main/java/io/crate/concurrent/CompletableContext.java
@@ -52,6 +52,10 @@ public class CompletableContext<T> {
         return completableFuture.isDone();
     }
 
+    public boolean completeExceptionally(Exception ex) {
+        return completableFuture.completeExceptionally(ex);
+    }
+
     public boolean complete(T value) {
         return completableFuture.complete(value);
     }

--- a/server/src/main/java/org/elasticsearch/common/AsyncBiFunction.java
+++ b/server/src/main/java/org/elasticsearch/common/AsyncBiFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.action.ActionListener;
+
+/**
+ * A {@link java.util.function.BiFunction}-like interface designed to be used with asynchronous executions.
+ */
+public interface AsyncBiFunction<T,U,C> {
+
+    void apply(T t, U u, ActionListener<C> listener);
+}

--- a/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
+++ b/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
@@ -27,7 +27,6 @@ import io.crate.common.io.IOUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +90,7 @@ public interface CloseableChannel extends Closeable {
             IOUtils.close(channels);
         } catch (IOException e) {
             // The CloseableChannel#close method does not throw IOException, so this should not occur.
-            throw new UncheckedIOException(e);
+            throw new AssertionError(e);
         }
         if (blocking) {
             ArrayList<ActionFuture<Void>> futures = new ArrayList<>(channels.size());

--- a/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
+++ b/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.network;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+
+import io.crate.common.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public interface CloseableChannel extends Closeable {
+
+    /**
+     * Closes the channel. For most implementations, this will be be an asynchronous process. For this
+     * reason, this method does not throw {@link java.io.IOException} There is no guarantee that the channel
+     * will be closed when this method returns. Use the {@link #addCloseListener(ActionListener)} method
+     * to implement logic that depends on knowing when the channel is closed.
+     */
+    @Override
+    void close();
+
+    /**
+     * Adds a listener that will be executed when the channel is closed. If the channel is still open when
+     * this listener is added, the listener will be executed by the thread that eventually closes the
+     * channel. If the channel is already closed when the listener is added the listener will immediately be
+     * executed by the thread that is attempting to add the listener.
+     *
+     * @param listener to be executed
+     */
+    void addCloseListener(ActionListener<Void> listener);
+
+    /**
+     * Indicates whether a channel is currently open
+     *
+     * @return boolean indicating if channel is open
+     */
+    boolean isOpen();
+
+    /**
+     * Closes the channel without blocking.
+     *
+     * @param channel to close
+     */
+    static <C extends CloseableChannel> void closeChannel(C channel) {
+        closeChannel(channel, false);
+    }
+
+    /**
+     * Closes the channel.
+     *
+     * @param channel  to close
+     * @param blocking indicates if we should block on channel close
+     */
+    static <C extends CloseableChannel> void closeChannel(C channel, boolean blocking) {
+        closeChannels(Collections.singletonList(channel), blocking);
+    }
+
+    /**
+     * Closes the channels.
+     *
+     * @param channels to close
+     * @param blocking indicates if we should block on channel close
+     */
+    static <C extends CloseableChannel> void closeChannels(List<C> channels, boolean blocking) {
+        try {
+            IOUtils.close(channels);
+        } catch (IOException e) {
+            // The CloseableChannel#close method does not throw IOException, so this should not occur.
+            throw new UncheckedIOException(e);
+        }
+        if (blocking) {
+            ArrayList<ActionFuture<Void>> futures = new ArrayList<>(channels.size());
+            for (final C channel : channels) {
+                PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
+                channel.addCloseListener(closeFuture);
+                futures.add(closeFuture);
+            }
+            blockOnFutures(futures);
+        }
+    }
+
+    static void blockOnFutures(List<ActionFuture<Void>> futures) {
+        for (ActionFuture<Void> future : futures) {
+            try {
+                future.get();
+            } catch (ExecutionException e) {
+                // Ignore as we are only interested in waiting for the close process to complete. Logging
+                // close exceptions happens elsewhere.
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/http/HttpServerChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpServerChannel.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http;
+
+import org.elasticsearch.common.network.CloseableChannel;
+
+import java.net.InetSocketAddress;
+
+public interface HttpServerChannel extends CloseableChannel {
+
+    /**
+     * Returns the local address for this channel.
+     *
+     * @return the local address of this channel.
+     */
+    InetSocketAddress getLocalAddress();
+}

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -32,9 +32,9 @@ public class HttpStats implements Writeable, ToXContentFragment {
     private final long serverOpen;
     private final long totalOpen;
 
-    public HttpStats(long serverOpen, long totalOpen) {
+    public HttpStats(long serverOpen, long totalOpened) {
         this.serverOpen = serverOpen;
-        this.totalOpen = totalOpen;
+        this.totalOpen = totalOpened;
     }
 
     public HttpStats(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -19,6 +19,14 @@
 
 package org.elasticsearch.transport;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -43,13 +51,6 @@ import org.elasticsearch.transport.netty4.Netty4Transport;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
 import io.crate.plugin.PipelineRegistry;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
 
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
 
@@ -115,6 +116,7 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
             NETTY_TRANSPORT_NAME,
             () -> new Netty4Transport(
                 settings,
+                Version.CURRENT,
                 threadPool,
                 networkService,
                 bigArrays,

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -25,6 +25,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.network.CloseableChannel;
 
+import io.crate.common.unit.TimeValue;
+
 
 /**
  * This is a tcp channel representing a single channel connection to another node. It is the base channel
@@ -32,6 +34,11 @@ import org.elasticsearch.common.network.CloseableChannel;
  * implementations must return channels that adhere to the required method contracts.
  */
 public interface TcpChannel extends CloseableChannel {
+
+    /**
+     * Indicates if the channel is an inbound server channel.
+     */
+    boolean isServerChannel();
 
     /**
      * This returns the profile for this channel.
@@ -70,4 +77,26 @@ public interface TcpChannel extends CloseableChannel {
      * @param listener to be executed
      */
     void addConnectListener(ActionListener<Void> listener);
+
+    /**
+     * Returns stats about this channel
+     */
+    ChannelStats getChannelStats();
+
+    class ChannelStats {
+
+        private volatile long lastAccessedTime;
+
+        public ChannelStats() {
+            lastAccessedTime = TimeValue.nsecToMSec(System.nanoTime());
+        }
+
+        void markAccessed(long relativeMillisTime) {
+            lastAccessedTime = relativeMillisTime;
+        }
+
+        long lastAccessedTime() {
+            return lastAccessedTime;
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -19,23 +19,20 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
-import io.crate.common.unit.TimeValue;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.network.CloseableChannel;
+
+import io.crate.common.unit.TimeValue;
 
 
 /**
@@ -43,25 +40,7 @@ import java.util.concurrent.TimeoutException;
  * abstraction used by the {@link TcpTransport} and {@link TransportService}. All tcp transport
  * implementations must return channels that adhere to the required method contracts.
  */
-public interface TcpChannel extends Releasable {
-
-    /**
-     * Closes the channel. This might be an asynchronous process. There is notguarantee that the channel
-     * will be closed when this method returns. Use the {@link #addCloseListener(ActionListener)} method
-     * to implement logic that depends on knowing when the channel is closed.
-     */
-    void close();
-
-    /**
-     * Adds a listener that will be executed when the channel is closed. If the channel is still open when
-     * this listener is added, the listener will be executed by the thread that eventually closes the
-     * channel. If the channel is already closed when the listener is added the listener will immediately be
-     * executed by the thread that is attempting to add the listener.
-     *
-     * @param listener to be executed
-     */
-    void addCloseListener(ActionListener<Void> listener);
-
+public interface TcpChannel extends CloseableChannel {
 
     /**
      * This sets the low level socket option {@link java.net.StandardSocketOptions} SO_LINGER on a channel.
@@ -71,13 +50,6 @@ public interface TcpChannel extends Releasable {
      */
     void setSoLinger(int value) throws IOException;
 
-
-    /**
-     * Indicates whether a channel is currently open
-     *
-     * @return boolean indicating if channel is open
-     */
-    boolean isOpen();
 
     /**
      * Returns the local address for this channel.
@@ -94,39 +66,6 @@ public interface TcpChannel extends Releasable {
      * @param listener to execute upon send completion
      */
     void sendMessage(BytesReference reference, ActionListener<Void> listener);
-
-    /**
-     * Closes the channel.
-     *
-     * @param channel to close
-     * @param blocking indicates if we should block on channel close
-     */
-    static <C extends TcpChannel> void closeChannel(C channel, boolean blocking) {
-        closeChannels(Collections.singletonList(channel), blocking);
-    }
-
-    /**
-     * Closes the channels.
-     *
-     * @param channels to close
-     * @param blocking indicates if we should block on channel close
-     */
-    static <C extends TcpChannel> void closeChannels(List<C> channels, boolean blocking) {
-        if (blocking) {
-            ArrayList<ActionFuture<Void>> futures = new ArrayList<>(channels.size());
-            for (final C channel : channels) {
-                if (channel.isOpen()) {
-                    PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
-                    channel.addCloseListener(closeFuture);
-                    channel.close();
-                    futures.add(closeFuture);
-                }
-            }
-            blockOnFutures(futures);
-        } else {
-            Releasables.close(channels);
-        }
-    }
 
     /**
      * Awaits for all of the pending connections to complete. Will throw an exception if at least one of the
@@ -167,17 +106,4 @@ public interface TcpChannel extends Releasable {
         }
     }
 
-    static void blockOnFutures(List<ActionFuture<Void>> futures) {
-        for (ActionFuture<Void> future : futures) {
-            try {
-                future.get();
-            } catch (ExecutionException e) {
-                // Ignore as we are only interested in waiting for the close process to complete. Logging
-                // close exceptions happens elsewhere.
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException("Future got interrupted", e);
-            }
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -42,11 +42,23 @@ import io.crate.common.unit.TimeValue;
 public interface TcpChannel extends CloseableChannel {
 
     /**
+     * This returns the profile for this channel.
+     */
+    String getProfile();
+
+    /**
      * Returns the local address for this channel.
      *
      * @return the local address of this channel.
      */
     InetSocketAddress getLocalAddress();
+
+    /**
+     * Returns the remote address for this channel. Can be null if channel does not have a remote address.
+     *
+     * @return the remote address of this channel.
+     */
+    InetSocketAddress getRemoteAddress();
 
     /**
      * Sends a tcp message to the channel. The listener will be executed once the send process has been

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -20,18 +20,10 @@
 package org.elasticsearch.transport;
 
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.network.CloseableChannel;
-
-import io.crate.common.unit.TimeValue;
 
 
 /**
@@ -70,42 +62,12 @@ public interface TcpChannel extends CloseableChannel {
     void sendMessage(BytesReference reference, ActionListener<Void> listener);
 
     /**
-     * Awaits for all of the pending connections to complete. Will throw an exception if at least one of the
-     * connections fails.
+     * Adds a listener that will be executed when the channel is connected. If the channel is still
+     * unconnected when this listener is added, the listener will be executed by the thread that eventually
+     * finishes the channel connection. If the channel is already connected when the listener is added the
+     * listener will immediately be executed by the thread that is attempting to add the listener.
      *
-     * @param discoveryNode the node for the pending connections
-     * @param connectionFutures representing the pending connections
-     * @param connectTimeout to wait for a connection
-     * @throws ConnectTransportException if one of the connections fails
+     * @param listener to be executed
      */
-    static void awaitConnected(DiscoveryNode discoveryNode, List<ActionFuture<Void>> connectionFutures, TimeValue connectTimeout)
-        throws ConnectTransportException {
-        Exception connectionException = null;
-        boolean allConnected = true;
-
-        for (ActionFuture<Void> connectionFuture : connectionFutures) {
-            try {
-                connectionFuture.get(connectTimeout.getMillis(), TimeUnit.MILLISECONDS);
-            } catch (TimeoutException e) {
-                allConnected = false;
-                break;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(e);
-            } catch (ExecutionException e) {
-                allConnected = false;
-                connectionException = (Exception) e.getCause();
-                break;
-            }
-        }
-
-        if (allConnected == false) {
-            if (connectionException == null) {
-                throw new ConnectTransportException(discoveryNode, "connect_timeout[" + connectTimeout + "]");
-            } else {
-                throw new ConnectTransportException(discoveryNode, "connect_exception", connectionException);
-            }
-        }
-    }
-
+    void addConnectListener(ActionListener<Void> listener);
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.transport;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -41,15 +40,6 @@ import io.crate.common.unit.TimeValue;
  * implementations must return channels that adhere to the required method contracts.
  */
 public interface TcpChannel extends CloseableChannel {
-
-    /**
-     * This sets the low level socket option {@link java.net.StandardSocketOptions} SO_LINGER on a channel.
-     *
-     * @param value to set for SO_LINGER
-     * @throws IOException that can be throw by the low level socket implementation
-     */
-    void setSoLinger(int value) throws IOException;
-
 
     /**
      * Returns the local address for this channel.

--- a/server/src/main/java/org/elasticsearch/transport/TcpServerChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpServerChannel.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.common.network.CloseableChannel;
+
+import java.net.InetSocketAddress;
+
+
+/**
+ * This is a tcp channel representing a server channel listening for new connections. It is the server
+ * channel abstraction used by the {@link TcpTransport} and {@link TransportService}. All tcp transport
+ * implementations must return server channels that adhere to the required method contracts.
+ */
+public interface TcpServerChannel extends CloseableChannel {
+
+    /**
+     * This returns the profile for this channel.
+     */
+    String getProfile();
+
+    /**
+     * Returns the local address for this channel.
+     *
+     * @return the local address of this channel.
+     */
+    InetSocketAddress getLocalAddress();
+
+}

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,7 +54,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -68,7 +66,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -88,7 +85,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.network.CloseableChannel;
@@ -103,6 +99,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -137,6 +134,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final String[] features;
 
     private final CircuitBreakerService circuitBreakerService;
+    private final Version version;
     protected final ThreadPool threadPool;
     protected final BigArrays bigArrays;
     protected final NetworkService networkService;
@@ -161,21 +159,24 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private volatile BoundTransportAddress boundAddress;
     private final String transportName;
 
-    private final ConcurrentMap<Long, HandshakeResponseHandler> pendingHandshakes = new ConcurrentHashMap<>();
-    private final CounterMetric numHandshakes = new CounterMetric();
-    private static final String HANDSHAKE_ACTION_NAME = "internal:tcp/handshake";
-
     private final MeanMetric readBytesMetric = new MeanMetric();
     private final MeanMetric transmittedBytesMetric = new MeanMetric();
     private volatile Map<String, RequestHandlerRegistry> requestHandlers = Collections.emptyMap();
     private final ResponseHandlers responseHandlers = new ResponseHandlers();
+    private final TcpTransportHandshaker handshaker;
     private final BytesReference pingMessage;
 
-    public TcpTransport(String transportName, Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                        CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+    public TcpTransport(String transportName,
+                        Settings settings,
+                        Version version,
+                        ThreadPool threadPool,
+                        BigArrays bigArrays,
+                        CircuitBreakerService circuitBreakerService,
+                        NamedWriteableRegistry namedWriteableRegistry,
                         NetworkService networkService) {
         this.settings = settings;
         this.profileSettings = getProfileSettings(settings);
+        this.version = version;
         this.threadPool = threadPool;
         this.bigArrays = bigArrays;
         this.circuitBreakerService = circuitBreakerService;
@@ -183,6 +184,30 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.compress = Transport.TRANSPORT_TCP_COMPRESS.get(settings);
         this.networkService = networkService;
         this.transportName = transportName;
+        this.handshaker = new TcpTransportHandshaker(
+            version,
+            threadPool,
+            (node, channel, requestId, v) -> sendRequestToChannel(
+                node,
+                channel,
+                requestId,
+                TcpTransportHandshaker.HANDSHAKE_ACTION_NAME,
+                TransportRequest.Empty.INSTANCE,
+                TransportRequestOptions.EMPTY,
+                v,
+                TransportStatus.setHandshake((byte) 0)
+            ),
+            (v, features, channel, response, requestId) -> sendResponse(
+                v,
+                features,
+                channel,
+                response,
+                requestId,
+                TcpTransportHandshaker.HANDSHAKE_ACTION_NAME,
+                TransportResponseOptions.EMPTY,
+                TransportStatus.setHandshake((byte) 0)
+            )
+        );
         this.nodeName = Node.NODE_NAME_SETTING.get(settings);
         final Settings defaultFeatures = DEFAULT_FEATURES_SETTING.get(settings);
         if (defaultFeatures == null) {
@@ -231,41 +256,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             throw new IllegalArgumentException("transport handlers for action " + reg.getAction() + " is already registered");
         }
         requestHandlers = MapBuilder.newMapBuilder(requestHandlers).put(reg.getAction(), reg).immutableMap();
-    }
-
-    private static class HandshakeResponseHandler implements TransportResponseHandler<VersionHandshakeResponse> {
-        final AtomicReference<Version> versionRef = new AtomicReference<>();
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
-        final TcpChannel channel;
-
-        HandshakeResponseHandler(TcpChannel channel) {
-            this.channel = channel;
-        }
-
-        @Override
-        public VersionHandshakeResponse read(StreamInput in) throws IOException {
-            return new VersionHandshakeResponse(in);
-        }
-
-        @Override
-        public void handleResponse(VersionHandshakeResponse response) {
-            final boolean success = versionRef.compareAndSet(null, response.version);
-            latch.countDown();
-            assert success;
-        }
-
-        @Override
-        public void handleException(TransportException exp) {
-            final boolean success = exceptionRef.compareAndSet(null, exp);
-            latch.countDown();
-            assert success;
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
     }
 
     public final class NodeChannels extends CloseableConnection {
@@ -381,84 +371,61 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         if (node == null) {
             throw new ConnectTransportException(null, "can't open connection to a null node");
         }
-        boolean success = false;
-        NodeChannels nodeChannels = null;
         connectionProfile = maybeOverrideConnectionProfile(connectionProfile);
         closeLock.readLock().lock(); // ensure we don't open connections while we are closing
         try {
             ensureOpen();
+
+            PlainActionFuture<NodeChannels> connectionFuture = PlainActionFuture.newFuture();
+            List<TcpChannel> pendingChannels = initiateConnection(node, connectionProfile, connectionFuture);
+
             try {
-                int numConnections = connectionProfile.getNumConnections();
-                assert numConnections > 0 : "A connection profile must be configured with at least one connection";
-                List<TcpChannel> channels = new ArrayList<>(numConnections);
-                List<ActionFuture<Void>> connectionFutures = new ArrayList<>(numConnections);
-                for (int i = 0; i < numConnections; ++i) {
-                    try {
-                        PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
-                        connectionFutures.add(connectFuture);
-                        TcpChannel channel = initiateChannel(node, connectFuture);
-                        logger.trace(() -> new ParameterizedMessage("Tcp transport client channel opened: {}", channel));
-                        channels.add(channel);
-                    } catch (Exception e) {
-                        // If there was an exception when attempting to instantiate the raw channels, we close all of the channels
-                        CloseableChannel.closeChannels(channels, false);
-                        throw e;
-                    }
+                return connectionFuture.actionGet();
+            } catch (IllegalStateException e) {
+                // If the future was interrupted we can close the channels to improve the shutdown of the MockTcpTransport
+                if (e.getCause() instanceof InterruptedException) {
+                    CloseableChannel.closeChannels(pendingChannels, false);
                 }
-
-                // If we make it past the block above, we successfully instantiated all of the channels
-                try {
-                    TcpChannel.awaitConnected(node, connectionFutures, connectionProfile.getConnectTimeout());
-                } catch (Exception ex) {
-                    CloseableChannel.closeChannels(channels, false);
-                    throw ex;
-                }
-
-                // If we make it past the block above, we have successfully established connections for all of the channels
-                final TcpChannel handshakeChannel = channels.get(0); // one channel is guaranteed by the connection profile
-                handshakeChannel.addCloseListener(ActionListener.wrap(() -> cancelHandshakeForChannel(handshakeChannel)));
-                Version version;
-                try {
-                    version = executeHandshake(node, handshakeChannel, connectionProfile.getHandshakeTimeout());
-                } catch (Exception ex) {
-                    CloseableChannel.closeChannels(channels, false);
-                    throw ex;
-                }
-
-                // If we make it past the block above, we have successfully completed the handshake and the connection is now open.
-                // At this point we should construct the connection, notify the transport service, and attach close listeners to the
-                // underlying channels.
-                nodeChannels = new NodeChannels(node, channels, connectionProfile, version);
-                final NodeChannels finalNodeChannels = nodeChannels;
-
-                Consumer<TcpChannel> onClose = c -> {
-                    assert c.isOpen() == false : "channel is still open when onClose is called";
-                    finalNodeChannels.close();
-                };
-
-                nodeChannels.channels.forEach(ch -> ch.addCloseListener(ActionListener.wrap(() -> onClose.accept(ch))));
-                success = true;
-                return nodeChannels;
-            } catch (ConnectTransportException e) {
                 throw e;
-            } catch (Exception e) {
-                // ConnectTransportExceptions are handled specifically on the caller end - we wrap the actual exception to ensure
-                // only relevant exceptions are logged on the caller end.. this is the same as in connectToNode
-                throw new ConnectTransportException(node, "general node connection failure", e);
-            } finally {
-                if (success == false) {
-                    IOUtils.closeWhileHandlingException(nodeChannels);
-                }
             }
         } finally {
             closeLock.readLock().unlock();
         }
     }
 
-    protected Version getCurrentVersion() {
-        // this is just for tests to mock stuff like the nodes version - tests can override this internally
-        return Version.CURRENT;
+    private List<TcpChannel> initiateConnection(DiscoveryNode node,
+                                                ConnectionProfile connectionProfile,
+                                                ActionListener<NodeChannels> listener) {
+        int numConnections = connectionProfile.getNumConnections();
+        assert numConnections > 0 : "A connection profile must be configured with at least one connection";
+
+        final List<TcpChannel> channels = new ArrayList<>(numConnections);
+        for (int i = 0; i < numConnections; ++i) {
+            try {
+                TcpChannel channel = initiateChannel(node);
+                logger.trace(() -> new ParameterizedMessage("Tcp transport client channel opened: {}", channel));
+                channels.add(channel);
+            } catch (ConnectTransportException e) {
+                CloseableChannel.closeChannels(channels, false);
+                listener.onFailure(e);
+                return channels;
+            } catch (Exception e) {
+                CloseableChannel.closeChannels(channels, false);
+                listener.onFailure(new ConnectTransportException(node, "general node connection failure", e));
+                return channels;
+            }
+        }
+        ChannelsConnectedListener channelsConnectedListener = new ChannelsConnectedListener(node, connectionProfile, channels, listener);
+
+        for (TcpChannel channel : channels) {
+            channel.addConnectListener(channelsConnectedListener);
+        }
+
+        TimeValue connectTimeout = connectionProfile.getConnectTimeout();
+        threadPool.schedule(channelsConnectedListener::onTimeout, connectTimeout, ThreadPool.Names.GENERIC);
+        return channels;
     }
+
 
     @Override
     public BoundTransportAddress boundAddress() {
@@ -640,7 +607,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     // not perfect, but PortsRange should take care of any port range validation, not a regex
     private static final Pattern BRACKET_PATTERN = Pattern.compile("^\\[(.*:.*)\\](?::([\\d\\-]*))?$");
 
-    /** parse a hostname+port range spec into its equivalent addresses */
+    /**
+     * parse a hostname+port range spec into its equivalent addresses
+     */
     static TransportAddress[] parse(String hostPortString, int defaultPort) throws UnknownHostException {
         Objects.requireNonNull(hostPortString);
         String host;
@@ -805,11 +774,10 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      * Initiate a single tcp socket channel.
      *
      * @param node for the initiated connection
-     * @param connectListener listener to be called when connection complete
      * @return the pending connection
      * @throws IOException if an I/O exception occurs while opening the channel
      */
-    protected abstract TcpChannel initiateChannel(DiscoveryNode node, ActionListener<Void> connectListener) throws IOException;
+    protected abstract TcpChannel initiateChannel(DiscoveryNode node) throws IOException;
 
     /**
      * Called to tear down internal resources
@@ -843,7 +811,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             // we pick the smallest of the 2, to support both backward and forward compatibility
             // note, this is the only place we need to do this, since from here on, we use the serialized version
             // as the version to use also when the node receiving this request will send the response with
-            Version version = Version.min(getCurrentVersion(), channelVersion);
+            Version version = Version.min(this.version, channelVersion);
 
             stream.setVersion(version);
             ThreadContext.bwcWriteHeaders(stream);
@@ -1205,7 +1173,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 streamIn = compressor.streamInput(streamIn);
             }
             final boolean isHandshake = TransportStatus.isHandshake(status);
-            ensureVersionCompatibility(version, getCurrentVersion(), isHandshake);
+            ensureVersionCompatibility(version, this.version, isHandshake);
             streamIn = new NamedWriteableAwareStreamInput(streamIn, namedWriteableRegistry);
             streamIn.setVersion(version);
             ThreadContext.bwcReadHeaders(streamIn);
@@ -1214,11 +1182,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             } else {
                 final TransportResponseHandler<?> handler;
                 if (isHandshake) {
-                    handler = pendingHandshakes.remove(requestId);
+                    handler = handshaker.removeHandlerForHandshake(requestId);
                 } else {
                     TransportResponseHandler<?> theHandler = responseHandlers.onResponseReceived(requestId, messageListener);
                     if (theHandler == null && TransportStatus.isError(status)) {
-                        handler = pendingHandshakes.remove(requestId);
+                        handler = handshaker.removeHandlerForHandshake(requestId);
                     } else {
                         handler = theHandler;
                     }
@@ -1321,9 +1289,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         TransportChannel transportChannel = null;
         try {
             if (TransportStatus.isHandshake(status)) {
-                final VersionHandshakeResponse response = new VersionHandshakeResponse(getCurrentVersion());
-                sendResponse(version, features, channel, response, requestId, HANDSHAKE_ACTION_NAME, TransportResponseOptions.EMPTY,
-                    TransportStatus.setHandshake((byte) 0));
+                handshaker.handleHandshake(version, features, channel, requestId);
             } else {
                 final RequestHandlerRegistry reg = getRequestHandler(action);
                 if (reg == null) {
@@ -1404,92 +1370,19 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
     }
 
-    private static final class VersionHandshakeResponse extends TransportResponse {
-        private final Version version;
-
-        private VersionHandshakeResponse(Version version) {
-            this.version = version;
-        }
-
-        public VersionHandshakeResponse(StreamInput in) throws IOException {
-            version = Version.readVersion(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            assert version != null;
-            Version.writeVersion(version, out);
-        }
-    }
-
-    public Version executeHandshake(DiscoveryNode node, TcpChannel channel, TimeValue timeout)
-        throws IOException, InterruptedException {
-        numHandshakes.inc();
-        final long requestId = responseHandlers.newRequestId();
-        final HandshakeResponseHandler handler = new HandshakeResponseHandler(channel);
-        AtomicReference<Version> versionRef = handler.versionRef;
-        AtomicReference<Exception> exceptionRef = handler.exceptionRef;
-        pendingHandshakes.put(requestId, handler);
-        boolean success = false;
-        try {
-            if (channel.isOpen() == false) {
-                // we have to protect us here since sendRequestToChannel won't barf if the channel is closed.
-                // it's weird but to change it will cause a lot of impact on the exception handling code all over the codebase.
-                // yet, if we don't check the state here we might have registered a pending handshake handler but the close
-                // listener calling #onChannelClosed might have already run and we are waiting on the latch below unitl we time out.
-                throw new IllegalStateException("handshake failed, channel already closed");
-            }
-            // for the request we use the minCompatVersion since we don't know what's the version of the node we talk to
-            // we also have no payload on the request but the response will contain the actual version of the node we talk
-            // to as the payload.
-            final Version minCompatVersion = getCurrentVersion().minimumCompatibilityVersion();
-            sendRequestToChannel(node, channel, requestId, HANDSHAKE_ACTION_NAME, TransportRequest.Empty.INSTANCE,
-                TransportRequestOptions.EMPTY, minCompatVersion, TransportStatus.setHandshake((byte) 0));
-            if (handler.latch.await(timeout.millis(), TimeUnit.MILLISECONDS) == false) {
-                throw new ConnectTransportException(node, "handshake_timeout[" + timeout + "]");
-            }
-            success = true;
-            if (exceptionRef.get() != null) {
-                throw new IllegalStateException("handshake failed", exceptionRef.get());
-            } else {
-                Version version = versionRef.get();
-                if (getCurrentVersion().isCompatible(version) == false) {
-                    throw new IllegalStateException("Received message from unsupported version: [" + version
-                        + "] minimal compatible version is: [" + getCurrentVersion().minimumCompatibilityVersion() + "]");
-                }
-                return version;
-            }
-        } finally {
-            final TransportResponseHandler<?> removedHandler = pendingHandshakes.remove(requestId);
-            // in the case of a timeout or an exception on the send part the handshake has not been removed yet.
-            // but the timeout is tricky since it's basically a race condition so we only assert on the success case.
-            assert success && removedHandler == null || success == false : "handler for requestId [" + requestId + "] is not been removed";
-        }
+    public void executeHandshake(DiscoveryNode node,
+                                 TcpChannel channel,
+                                 TimeValue timeout,
+                                 ActionListener<Version> listener) {
+        handshaker.sendHandshake(responseHandlers.newRequestId(), node, channel, timeout, listener);
     }
 
     final int getNumPendingHandshakes() { // for testing
-        return pendingHandshakes.size();
+        return handshaker.getNumPendingHandshakes();
     }
 
     final long getNumHandshakes() {
-        return numHandshakes.count(); // for testing
-    }
-
-    /**
-     * Called once the channel is closed for instance due to a disconnect or a closed socket etc.
-     */
-    private void cancelHandshakeForChannel(TcpChannel channel) {
-        final Optional<Long> first = pendingHandshakes.entrySet().stream()
-            .filter((entry) -> entry.getValue().channel == channel).map(Map.Entry::getKey).findFirst();
-        if (first.isPresent()) {
-            final Long requestId = first.get();
-            final HandshakeResponseHandler handler = pendingHandshakes.remove(requestId);
-            if (handler != null) {
-                // there might be a race removing this or this method might be called twice concurrently depending on how
-                // the channel is closed ie. due to connection reset or broken pipes
-                handler.handleException(new TransportException("connection reset"));
-            }
-        }
+        return handshaker.getNumHandshakes();
     }
 
     /**
@@ -1668,5 +1561,72 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     @Override
     public final RequestHandlerRegistry getRequestHandler(String action) {
         return requestHandlers.get(action);
+    }
+
+    private final class ChannelsConnectedListener implements ActionListener<Void> {
+
+        private final DiscoveryNode node;
+        private final ConnectionProfile connectionProfile;
+        private final List<TcpChannel> channels;
+        private final ActionListener<NodeChannels> listener;
+        private final CountDown countDown;
+
+        private ChannelsConnectedListener(DiscoveryNode node,
+                                          ConnectionProfile connectionProfile,
+                                          List<TcpChannel> channels,
+                                          ActionListener<NodeChannels> listener) {
+            this.node = node;
+            this.connectionProfile = connectionProfile;
+            this.channels = channels;
+            this.listener = listener;
+            this.countDown = new CountDown(channels.size());
+        }
+
+        @Override
+        public void onResponse(Void v) {
+            // Returns true if all connections have completed successfully
+            if (countDown.countDown()) {
+                final TcpChannel handshakeChannel = channels.get(0);
+                try {
+                    executeHandshake(node, handshakeChannel, connectionProfile.getHandshakeTimeout(), new ActionListener<Version>() {
+                        @Override
+                        public void onResponse(Version version) {
+                            NodeChannels nodeChannels = new NodeChannels(node, channels, connectionProfile, version);
+                            nodeChannels.channels.forEach(ch -> ch.addCloseListener(ActionListener.wrap(nodeChannels::close)));
+                            listener.onResponse(nodeChannels);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            CloseableChannel.closeChannels(channels, false);
+
+                            if (e instanceof ConnectTransportException) {
+                                listener.onFailure(e);
+                            } else {
+                                listener.onFailure(new ConnectTransportException(node, "general node connection failure", e));
+                            }
+                        }
+                    });
+                } catch (Exception ex) {
+                    CloseableChannel.closeChannels(channels, false);
+                    listener.onFailure(ex);
+                }
+            }
+        }
+
+        @Override
+        public void onFailure(Exception ex) {
+            if (countDown.fastForward()) {
+                CloseableChannel.closeChannels(channels, false);
+                listener.onFailure(new ConnectTransportException(node, "connect_exception", ex));
+            }
+        }
+
+        public void onTimeout() {
+            if (countDown.fastForward()) {
+                CloseableChannel.closeChannels(channels, false);
+                listener.onFailure(new ConnectTransportException(node, "connect_timeout[" + connectionProfile.getConnectTimeout() + "]"));
+            }
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -115,9 +115,7 @@ import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.new
 
 public abstract class TcpTransport extends AbstractLifecycleComponent implements Transport {
 
-
-    public static final String TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX = "transport_server_worker";
-    public static final String TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX = "transport_client_boss";
+    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = "transport_worker";
 
     public static final int PING_DATA_SIZE = -1;
     protected final CounterMetric successfulPings = new CounterMetric();

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -331,24 +331,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         public void close() {
             if (isClosing.compareAndSet(false, true)) {
                 try {
-                    if (lifecycle.stopped()) {
-                        /* We set SO_LINGER timeout to 0 to ensure that when we shutdown the node we don't
-                         * have a gazillion connections sitting in TIME_WAIT to free up resources quickly.
-                         * This is really the only part where we close the connection from the server side
-                         * otherwise the client (node) initiates the TCP closing sequence which doesn't cause
-                         * these issues. Setting this by default from the beginning can have unexpected
-                         * side-effects an should be avoided, our protocol is designed in a way that clients
-                         * close connection which is how it should be*/
-
-                        channels.forEach(c -> {
-                            try {
-                                c.setSoLinger(0);
-                            } catch (IOException e) {
-                                logger.warn(new ParameterizedMessage("unexpected exception when setting SO_LINGER on channel {}", c), e);
-                            }
-                        });
-                    }
-
                     boolean block = lifecycle.stopped() && Transports.isTransportThread(Thread.currentThread()) == false;
                     CloseableChannel.closeChannels(channels, block);
                 } finally {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportHandshaker.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import io.crate.common.unit.TimeValue;
+
+/**
+ * Sends and receives transport-level connection handshakes. This class will send the initial handshake,
+ * manage state/timeouts while the handshake is in transit, and handle the eventual response.
+ */
+final class TcpTransportHandshaker {
+
+    static final String HANDSHAKE_ACTION_NAME = "internal:tcp/handshake";
+    private final ConcurrentMap<Long, HandshakeResponseHandler> pendingHandshakes = new ConcurrentHashMap<>();
+    private final CounterMetric numHandshakes = new CounterMetric();
+
+    private final Version version;
+    private final ThreadPool threadPool;
+    private final HandshakeRequestSender handshakeRequestSender;
+    private final HandshakeResponseSender handshakeResponseSender;
+
+    TcpTransportHandshaker(Version version, ThreadPool threadPool, HandshakeRequestSender handshakeRequestSender,
+                           HandshakeResponseSender handshakeResponseSender) {
+        this.version = version;
+        this.threadPool = threadPool;
+        this.handshakeRequestSender = handshakeRequestSender;
+        this.handshakeResponseSender = handshakeResponseSender;
+    }
+
+    void sendHandshake(long requestId, DiscoveryNode node, TcpChannel channel, TimeValue timeout, ActionListener<Version> listener) {
+        numHandshakes.inc();
+        final HandshakeResponseHandler handler = new HandshakeResponseHandler(requestId, version, listener);
+        pendingHandshakes.put(requestId, handler);
+        channel.addCloseListener(ActionListener.wrap(
+            () -> handler.handleLocalException(new TransportException("handshake failed because connection reset"))));
+        boolean success = false;
+        try {
+            // for the request we use the minCompatVersion since we don't know what's the version of the node we talk to
+            // we also have no payload on the request but the response will contain the actual version of the node we talk
+            // to as the payload.
+            final Version minCompatVersion = version.minimumCompatibilityVersion();
+            handshakeRequestSender.sendRequest(node, channel, requestId, minCompatVersion);
+
+            threadPool.schedule(
+                () -> handler.handleLocalException(new ConnectTransportException(node, "handshake_timeout[" + timeout + "]")),
+                timeout,
+                ThreadPool.Names.GENERIC
+            );
+            success = true;
+        } catch (Exception e) {
+            handler.handleLocalException(new ConnectTransportException(node, "failure to send " + HANDSHAKE_ACTION_NAME, e));
+        } finally {
+            if (success == false) {
+                TransportResponseHandler<?> removed = pendingHandshakes.remove(requestId);
+                assert removed == null : "Handshake should not be pending if exception was thrown";
+            }
+        }
+    }
+
+    void handleHandshake(Version version, Set<String> features, TcpChannel channel, long requestId) throws IOException {
+        handshakeResponseSender.sendResponse(version, features, channel, new VersionHandshakeResponse(this.version), requestId);
+    }
+
+    TransportResponseHandler<VersionHandshakeResponse> removeHandlerForHandshake(long requestId) {
+        return pendingHandshakes.remove(requestId);
+    }
+
+    int getNumPendingHandshakes() {
+        return pendingHandshakes.size();
+    }
+
+    long getNumHandshakes() {
+        return numHandshakes.count();
+    }
+
+    private class HandshakeResponseHandler implements TransportResponseHandler<VersionHandshakeResponse> {
+
+        private final long requestId;
+        private final Version currentVersion;
+        private final ActionListener<Version> listener;
+        private final AtomicBoolean isDone = new AtomicBoolean(false);
+
+        private HandshakeResponseHandler(long requestId, Version currentVersion, ActionListener<Version> listener) {
+            this.requestId = requestId;
+            this.currentVersion = currentVersion;
+            this.listener = listener;
+        }
+
+        @Override
+        public VersionHandshakeResponse read(StreamInput in) throws IOException {
+            return new VersionHandshakeResponse(in);
+        }
+
+        @Override
+        public void handleResponse(VersionHandshakeResponse response) {
+            if (isDone.compareAndSet(false, true)) {
+                Version version = response.version;
+                if (currentVersion.isCompatible(version) == false) {
+                    listener.onFailure(new IllegalStateException("Received message from unsupported version: [" + version
+                        + "] minimal compatible version is: [" + currentVersion.minimumCompatibilityVersion() + "]"));
+                } else {
+                    listener.onResponse(version);
+                }
+            }
+        }
+
+        @Override
+        public void handleException(TransportException e) {
+            if (isDone.compareAndSet(false, true)) {
+                listener.onFailure(new IllegalStateException("handshake failed", e));
+            }
+        }
+
+        void handleLocalException(TransportException e) {
+            if (removeHandlerForHandshake(requestId) != null && isDone.compareAndSet(false, true)) {
+                listener.onFailure(e);
+            }
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+    }
+
+    static final class VersionHandshakeResponse extends TransportResponse {
+
+        private final Version version;
+
+        VersionHandshakeResponse(Version version) {
+            this.version = version;
+        }
+
+        private VersionHandshakeResponse(StreamInput in) throws IOException {
+            version = Version.readVersion(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            assert version != null;
+            Version.writeVersion(version, out);
+        }
+    }
+
+    @FunctionalInterface
+    interface HandshakeRequestSender {
+
+        void sendRequest(DiscoveryNode node, TcpChannel channel, long requestId, Version version) throws IOException;
+    }
+
+    @FunctionalInterface
+    interface HandshakeResponseSender {
+
+        void sendResponse(Version version, Set<String> features, TcpChannel channel, TransportResponse response, long requestId)
+            throws IOException;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -115,10 +115,6 @@ public interface Transport extends LifecycleComponent {
         void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options) throws
             IOException, TransportException;
 
-        default boolean sendPing() {
-            return false;
-        }
-
         /**
          * The listener's {@link ActionListener#onResponse(Object)} method will be called when this
          * connection is closed. No implementations currently throw an exception during close, so

--- a/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.AsyncBiFunction;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.common.util.concurrent.AbstractLifecycleRunnable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import io.crate.common.unit.TimeValue;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Implements the scheduling and sending of keep alive pings. Client channels send keep alive pings to the
+ * server and server channels respond. Pings are only sent at the scheduled time if the channel did not send
+ * and receive a message since the last ping.
+ */
+final class TransportKeepAlive implements Closeable {
+
+    static final int PING_DATA_SIZE = -1;
+
+    private final Logger logger = LogManager.getLogger(TransportKeepAlive.class);
+    private final CounterMetric successfulPings = new CounterMetric();
+    private final CounterMetric failedPings = new CounterMetric();
+    private final ConcurrentMap<TimeValue, ScheduledPing> pingIntervals = ConcurrentCollections.newConcurrentMap();
+    private final Lifecycle lifecycle = new Lifecycle();
+    private final ThreadPool threadPool;
+    private final AsyncBiFunction<TcpChannel, BytesReference, Void> pingSender;
+    private final BytesReference pingMessage;
+
+    TransportKeepAlive(ThreadPool threadPool, AsyncBiFunction<TcpChannel, BytesReference, Void> pingSender) {
+        this.threadPool = threadPool;
+        this.pingSender = pingSender;
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeByte((byte) 'E');
+            out.writeByte((byte) 'S');
+            out.writeInt(PING_DATA_SIZE);
+            pingMessage = out.bytes();
+        } catch (IOException e) {
+            throw new AssertionError(e.getMessage(), e); // won't happen
+        }
+
+        this.lifecycle.moveToStarted();
+    }
+
+    void registerNodeConnection(List<TcpChannel> nodeChannels, ConnectionProfile connectionProfile) {
+        TimeValue pingInterval = connectionProfile.getPingInterval();
+        if (pingInterval.millis() < 0) {
+            return;
+        }
+
+        final ScheduledPing scheduledPing = pingIntervals.computeIfAbsent(pingInterval, ScheduledPing::new);
+        scheduledPing.ensureStarted();
+
+        for (TcpChannel channel : nodeChannels) {
+            scheduledPing.addChannel(channel);
+
+            channel.addCloseListener(ActionListener.wrap(() -> {
+                scheduledPing.removeChannel(channel);
+            }));
+        }
+    }
+
+    /**
+     * Called when a keep alive ping is received. If the channel that received the keep alive ping is a
+     * server channel, a ping is sent back. If the channel that received the keep alive is a client channel,
+     * this method does nothing as the client initiated the ping in the first place.
+     *
+     * @param channel that received the keep alive ping
+     */
+    void receiveKeepAlive(TcpChannel channel) {
+        // The client-side initiates pings and the server-side responds. So if this is a client channel, this
+        // method is a no-op.
+        if (channel.isServerChannel()) {
+            sendPing(channel);
+        }
+    }
+
+    long successfulPingCount() {
+        return successfulPings.count();
+    }
+
+    long failedPingCount() {
+        return failedPings.count();
+    }
+
+    private void sendPing(TcpChannel channel) {
+        pingSender.apply(channel, pingMessage, new ActionListener<Void>() {
+
+            @Override
+            public void onResponse(Void v) {
+                successfulPings.inc();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (channel.isOpen()) {
+                    logger.debug(() -> new ParameterizedMessage("[{}] failed to send transport ping", channel), e);
+                    failedPings.inc();
+                } else {
+                    logger.trace(() -> new ParameterizedMessage("[{}] failed to send transport ping (channel closed)", channel), e);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        lifecycle.moveToStopped();
+        lifecycle.moveToClosed();
+    }
+
+    private class ScheduledPing extends AbstractLifecycleRunnable {
+
+        private final TimeValue pingInterval;
+
+        private final Set<TcpChannel> channels = ConcurrentCollections.newConcurrentSet();
+
+        private final AtomicBoolean isStarted = new AtomicBoolean(false);
+        private volatile long lastPingRelativeMillis;
+
+        private ScheduledPing(TimeValue pingInterval) {
+            super(lifecycle, logger);
+            this.pingInterval = pingInterval;
+            this.lastPingRelativeMillis = threadPool.relativeTimeInMillis();
+        }
+
+        void ensureStarted() {
+            if (isStarted.get() == false && isStarted.compareAndSet(false, true)) {
+                threadPool.schedule(this, pingInterval, ThreadPool.Names.GENERIC);
+            }
+        }
+
+        void addChannel(TcpChannel channel) {
+            channels.add(channel);
+        }
+
+        void removeChannel(TcpChannel channel) {
+            channels.remove(channel);
+        }
+
+        @Override
+        protected void doRunInLifecycle() {
+            for (TcpChannel channel : channels) {
+                // In the future it is possible that we may want to kill a channel if we have not read from
+                // the channel since the last ping. However, this will need to be backwards compatible with
+                // pre-6.6 nodes that DO NOT respond to pings
+                if (needsKeepAlivePing(channel)) {
+                    sendPing(channel);
+                }
+            }
+            this.lastPingRelativeMillis = threadPool.relativeTimeInMillis();
+        }
+
+        @Override
+        protected void onAfterInLifecycle() {
+            try {
+                threadPool.schedule(this, pingInterval, ThreadPool.Names.GENERIC);
+            } catch (EsRejectedExecutionException ex) {
+                if (ex.isExecutorShutdown()) {
+                    logger.debug("couldn't schedule new ping execution, executor is shutting down", ex);
+                } else {
+                    throw ex;
+                }
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            logger.warn("failed to send ping transport message", e);
+        }
+
+        private boolean needsKeepAlivePing(TcpChannel channel) {
+            TcpChannel.ChannelStats stats = channel.getChannelStats();
+            long accessedDelta = stats.lastAccessedTime() - lastPingRelativeMillis;
+            return accessedDelta <= 0;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -41,8 +41,7 @@ public enum Transports {
         final String threadName = t.getName();
         for (String s : Arrays.asList(
                 HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
-                TcpTransport.TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX,
-                TcpTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX,
+                TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX,
                 TEST_MOCK_TRANSPORT_THREAD_PREFIX,
                 NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
                 NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -19,17 +19,16 @@
 
 package org.elasticsearch.transport.netty4;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.Attribute;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.transport.TcpHeader;
 import org.elasticsearch.transport.Transports;
 
-import java.net.InetSocketAddress;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
 
 /**
  * A handler (must be the last one!) that does size based frame decoding and forwards the actual message
@@ -38,11 +37,9 @@ import java.net.InetSocketAddress;
 final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
 
     private final Netty4Transport transport;
-    private final String profileName;
 
-    Netty4MessageChannelHandler(Netty4Transport transport, String profileName) {
+    Netty4MessageChannelHandler(Netty4Transport transport) {
         this.transport = transport;
-        this.profileName = profileName;
     }
 
     @Override
@@ -57,12 +54,11 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
         final int expectedReaderIndex = buffer.readerIndex() + remainingMessageSize;
         try {
             Channel channel = ctx.channel();
-            InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
             // netty always copies a buffer, either in NioWorker in its read handler, where it copies to a fresh
             // buffer, or in the cumulative buffer, which is cleaned each time so it could be bigger than the actual size
             BytesReference reference = Netty4Utils.toBytesReference(buffer, remainingMessageSize);
             Attribute<NettyTcpChannel> channelAttribute = channel.attr(Netty4Transport.CHANNEL_KEY);
-            transport.messageReceived(reference, channelAttribute.get(), profileName, remoteAddress, remainingMessageSize);
+            transport.messageReceived(reference, channelAttribute.get());
         } finally {
             // Set the expected position of the buffer, no matter what happened
             buffer.readerIndex(expectedReaderIndex);

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
@@ -19,16 +19,15 @@
 
 package org.elasticsearch.transport.netty4;
 
+import java.util.List;
+
+import org.elasticsearch.transport.TcpHeader;
+import org.elasticsearch.transport.TcpTransport;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.TooLongFrameException;
-
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.transport.TcpHeader;
-import org.elasticsearch.transport.TcpTransport;
-
-import java.util.List;
 
 final class Netty4SizeHeaderFrameDecoder extends ByteToMessageDecoder {
 
@@ -41,15 +40,21 @@ final class Netty4SizeHeaderFrameDecoder extends ByteToMessageDecoder {
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         try {
-            BytesReference networkBytes = Netty4Utils.toBytesReference(in);
-            int messageLength = TcpTransport.readMessageLength(networkBytes) + HEADER_SIZE;
-            // If the message length is -1, we have not read a complete header. If the message length is
-            // greater than the network bytes available, we have not read a complete frame.
-            if (messageLength != -1 && messageLength <= networkBytes.length()) {
-                final ByteBuf message = in.skipBytes(HEADER_SIZE);
-                // 6 bytes would mean it is a ping. And we should ignore.
-                if (messageLength != 6) {
-                    out.add(message);
+            boolean continueDecode = true;
+            while (continueDecode) {
+                int messageLength = TcpTransport.readMessageLength(Netty4Utils.toBytesReference(in));
+                if (messageLength == -1) {
+                    continueDecode = false;
+                } else {
+                    int messageLengthWithHeader = messageLength + HEADER_SIZE;
+                    // If the message length is greater than the network bytes available, we have not read a complete frame.
+                    if (messageLengthWithHeader > in.readableBytes()) {
+                        continueDecode = false;
+                    } else {
+                        final ByteBuf message = in.retainedSlice(in.readerIndex() + HEADER_SIZE, messageLength);
+                        out.add(message);
+                        in.readerIndex(in.readerIndex() + messageLengthWithHeader);
+                    }
                 }
             }
         } catch (IllegalArgumentException ex) {

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -38,12 +38,15 @@ import io.netty.channel.ChannelPromise;
 public class Netty4TcpChannel implements TcpChannel {
 
     private final Channel channel;
+    private final boolean isServer;
     private final String profile;
     private final CompletableContext<Void> connectContext;
     private final CompletableFuture<Void> closeContext = new CompletableFuture<>();
+    private final ChannelStats stats = new ChannelStats();
 
-    Netty4TcpChannel(Channel channel, String profile, @Nullable ChannelFuture connectFuture) {
+    Netty4TcpChannel(Channel channel, boolean isServer, String profile, @Nullable ChannelFuture connectFuture) {
         this.channel = channel;
+        this.isServer = isServer;
         this.profile = profile;
         this.connectContext = new CompletableContext<>();
         this.channel.closeFuture().addListener(f -> {
@@ -81,6 +84,11 @@ public class Netty4TcpChannel implements TcpChannel {
     }
 
     @Override
+    public boolean isServerChannel() {
+        return isServer;
+    }
+
+    @Override
     public String getProfile() {
         return profile;
     }
@@ -93,6 +101,11 @@ public class Netty4TcpChannel implements TcpChannel {
     @Override
     public void addConnectListener(ActionListener<Void> listener) {
         connectContext.addListener(ActionListener.toBiConsumer(listener));
+    }
+
+    @Override
+    public ChannelStats getChannelStats() {
+        return stats;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -30,13 +30,13 @@ import org.elasticsearch.transport.TransportException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
-public class NettyTcpChannel implements TcpChannel {
+public class Netty4TcpChannel implements TcpChannel {
 
     private final Channel channel;
     private final CompletableFuture<Void> closeContext = new CompletableFuture<>();
     private final String profile;
 
-    NettyTcpChannel(Channel channel, String profile) {
+    Netty4TcpChannel(Channel channel, String profile) {
         this.channel = channel;
         this.profile = profile;
         this.channel.closeFuture().addListener(f -> {
@@ -106,7 +106,7 @@ public class NettyTcpChannel implements TcpChannel {
 
     @Override
     public String toString() {
-        return "NettyTcpChannel{" +
+        return "Netty4TcpChannel{" +
             "localAddress=" + getLocalAddress() +
             ", remoteAddress=" + channel.remoteAddress() +
             '}';

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpServerChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpServerChannel.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport.netty4;
+
+import java.net.InetSocketAddress;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.transport.TcpServerChannel;
+
+import io.crate.concurrent.CompletableContext;
+import io.netty.channel.Channel;
+
+public class Netty4TcpServerChannel implements TcpServerChannel {
+
+    private final Channel channel;
+    private final String profile;
+    private final CompletableContext<Void> closeContext = new CompletableContext<>();
+
+    Netty4TcpServerChannel(Channel channel, String profile) {
+        this.channel = channel;
+        this.profile = profile;
+        this.channel.closeFuture().addListener(f -> {
+            if (f.isSuccess()) {
+                closeContext.complete(null);
+            } else {
+                Throwable cause = f.cause();
+                if (cause instanceof Error) {
+                    ExceptionsHelper.maybeDieOnAnotherThread(cause);
+                    closeContext.completeExceptionally(new Exception(cause));
+                } else {
+                    closeContext.completeExceptionally((Exception) cause);
+                }
+            }
+        });
+    }
+
+    @Override
+    public String getProfile() {
+        return profile;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return (InetSocketAddress) channel.localAddress();
+    }
+
+    @Override
+    public void close() {
+        channel.close();
+    }
+
+    @Override
+    public void addCloseListener(ActionListener<Void> listener) {
+        closeContext.addListener(ActionListener.toBiConsumer(listener));
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public String toString() {
+        return "Netty4TcpChannel{" +
+            "localAddress=" + getLocalAddress() +
+            '}';
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -248,7 +248,7 @@ public class Netty4Transport extends TcpTransport {
         }
         addClosedExceptionLogger(channel);
 
-        NettyTcpChannel nettyChannel = new NettyTcpChannel(channel);
+        NettyTcpChannel nettyChannel = new NettyTcpChannel(channel, "default");
         channel.attr(CHANNEL_KEY).set(nettyChannel);
 
         channelFuture.addListener(f -> {
@@ -271,7 +271,7 @@ public class Netty4Transport extends TcpTransport {
     @Override
     protected NettyTcpChannel bind(String name, InetSocketAddress address) {
         Channel channel = serverBootstraps.get(name).bind(address).syncUninterruptibly().channel();
-        NettyTcpChannel esChannel = new NettyTcpChannel(channel);
+        NettyTcpChannel esChannel = new NettyTcpChannel(channel, name);
         channel.attr(CHANNEL_KEY).set(esChannel);
         return esChannel;
     }
@@ -297,7 +297,7 @@ public class Netty4Transport extends TcpTransport {
             ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));
             ch.pipeline().addLast("size", new Netty4SizeHeaderFrameDecoder());
             // using a dot as a prefix means this cannot come from any settings parsed
-            ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(Netty4Transport.this, ".client"));
+            ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(Netty4Transport.this));
         }
 
         @Override
@@ -318,12 +318,12 @@ public class Netty4Transport extends TcpTransport {
         @Override
         protected void initChannel(Channel ch) throws Exception {
             addClosedExceptionLogger(ch);
-            NettyTcpChannel nettyTcpChannel = new NettyTcpChannel(ch);
+            NettyTcpChannel nettyTcpChannel = new NettyTcpChannel(ch, name);
             ch.attr(CHANNEL_KEY).set(nettyTcpChannel);
             serverAcceptedChannel(nettyTcpChannel);
             ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));
             ch.pipeline().addLast("size", new Netty4SizeHeaderFrameDecoder());
-            ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(Netty4Transport.this, name));
+            ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(Netty4Transport.this));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -57,6 +56,7 @@ import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
@@ -202,6 +202,7 @@ public class Netty4Transport extends TcpTransport {
         }
 
         serverBootstrap.childHandler(new ServerChannelInitializer(name));
+        serverBootstrap.handler(new ServerChannelExceptionHandler());
 
         serverBootstrap.childOption(ChannelOption.TCP_NODELAY, profileSettings.tcpNoDelay);
         serverBootstrap.childOption(ChannelOption.SO_KEEPALIVE, profileSettings.tcpKeepAlive);
@@ -224,17 +225,11 @@ public class Netty4Transport extends TcpTransport {
         serverBootstraps.put(name, serverBootstrap);
     }
 
-    static final AttributeKey<NettyTcpChannel> CHANNEL_KEY = AttributeKey.newInstance("es-channel");
-
-    protected final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        final Throwable unwrapped = ExceptionsHelper.unwrap(cause, ElasticsearchException.class);
-        final Throwable t = unwrapped != null ? unwrapped : cause;
-        Channel channel = ctx.channel();
-        onException(channel.attr(CHANNEL_KEY).get(), t instanceof Exception ? (Exception) t : new ElasticsearchException(t));
-    }
+    static final AttributeKey<Netty4TcpChannel> CHANNEL_KEY = AttributeKey.newInstance("es-channel");
+    static final AttributeKey<Netty4TcpServerChannel> SERVER_CHANNEL_KEY = AttributeKey.newInstance("es-server-channel");
 
     @Override
-    protected NettyTcpChannel initiateChannel(DiscoveryNode node, ActionListener<Void> listener) throws IOException {
+    protected Netty4TcpChannel initiateChannel(DiscoveryNode node, ActionListener<Void> listener) throws IOException {
         InetSocketAddress address = node.getAddress().address();
         Bootstrap bootstrapWithHandler = clientBootstrap.clone();
         bootstrapWithHandler.handler((ChannelHandler) new ClientChannelInitializer());
@@ -248,7 +243,7 @@ public class Netty4Transport extends TcpTransport {
         }
         addClosedExceptionLogger(channel);
 
-        NettyTcpChannel nettyChannel = new NettyTcpChannel(channel, "default");
+        Netty4TcpChannel nettyChannel = new Netty4TcpChannel(channel, "default");
         channel.attr(CHANNEL_KEY).set(nettyChannel);
 
         channelFuture.addListener(f -> {
@@ -269,10 +264,10 @@ public class Netty4Transport extends TcpTransport {
     }
 
     @Override
-    protected NettyTcpChannel bind(String name, InetSocketAddress address) {
+    protected Netty4TcpServerChannel bind(String name, InetSocketAddress address) {
         Channel channel = serverBootstraps.get(name).bind(address).syncUninterruptibly().channel();
-        NettyTcpChannel esChannel = new NettyTcpChannel(channel, name);
-        channel.attr(CHANNEL_KEY).set(esChannel);
+        Netty4TcpServerChannel esChannel = new Netty4TcpServerChannel(channel, name);
+        channel.attr(SERVER_CHANNEL_KEY).set(esChannel);
         return esChannel;
     }
 
@@ -318,7 +313,7 @@ public class Netty4Transport extends TcpTransport {
         @Override
         protected void initChannel(Channel ch) throws Exception {
             addClosedExceptionLogger(ch);
-            NettyTcpChannel nettyTcpChannel = new NettyTcpChannel(ch, name);
+            Netty4TcpChannel nettyTcpChannel = new Netty4TcpChannel(ch, name);
             ch.attr(CHANNEL_KEY).set(nettyTcpChannel);
             serverAcceptedChannel(nettyTcpChannel);
             ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));
@@ -339,5 +334,20 @@ public class Netty4Transport extends TcpTransport {
                 logger.debug(() -> new ParameterizedMessage("exception while closing channel: {}", channel), f.cause());
             }
         });
+    }
+
+    @ChannelHandler.Sharable
+    private class ServerChannelExceptionHandler extends ChannelHandlerAdapter {
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ExceptionsHelper.maybeDieOnAnotherThread(cause);
+            Netty4TcpServerChannel serverChannel = ctx.channel().attr(SERVER_CHANNEL_KEY).get();
+            if (cause instanceof Error) {
+                onServerException(serverChannel, new Exception(cause));
+            } else {
+                onServerException(serverChannel, (Exception) cause);
+            }
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -248,7 +248,7 @@ public class Netty4Transport extends TcpTransport {
         }
         addClosedExceptionLogger(channel);
 
-        Netty4TcpChannel nettyChannel = new Netty4TcpChannel(channel, "default", connectFuture);
+        Netty4TcpChannel nettyChannel = new Netty4TcpChannel(channel, false, "default", connectFuture);
         channel.attr(CHANNEL_KEY).set(nettyChannel);
 
         return nettyChannel;
@@ -304,7 +304,7 @@ public class Netty4Transport extends TcpTransport {
         @Override
         protected void initChannel(Channel ch) throws Exception {
             addClosedExceptionLogger(ch);
-            Netty4TcpChannel nettyTcpChannel = new Netty4TcpChannel(ch, name, ch.newSucceededFuture());
+            Netty4TcpChannel nettyTcpChannel = new Netty4TcpChannel(ch, true, name, ch.newSucceededFuture());
             ch.attr(CHANNEL_KEY).set(nettyTcpChannel);
             serverAcceptedChannel(nettyTcpChannel);
             ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));

--- a/server/src/main/java/org/elasticsearch/transport/netty4/NettyTcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/NettyTcpChannel.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.transport.netty4;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -61,11 +60,6 @@ public class NettyTcpChannel implements TcpChannel {
     @Override
     public void addCloseListener(ActionListener<Void> listener) {
         closeContext.whenComplete(ActionListener.toBiConsumer(listener));
-    }
-
-    @Override
-    public void setSoLinger(int value) {
-        channel.config().setOption(ChannelOption.SO_LINGER, value);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/netty4/NettyTcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/NettyTcpChannel.java
@@ -34,9 +34,11 @@ public class NettyTcpChannel implements TcpChannel {
 
     private final Channel channel;
     private final CompletableFuture<Void> closeContext = new CompletableFuture<>();
+    private final String profile;
 
-    NettyTcpChannel(Channel channel) {
+    NettyTcpChannel(Channel channel, String profile) {
         this.channel = channel;
+        this.profile = profile;
         this.channel.closeFuture().addListener(f -> {
             if (f.isSuccess()) {
                 closeContext.complete(null);
@@ -58,6 +60,11 @@ public class NettyTcpChannel implements TcpChannel {
     }
 
     @Override
+    public String getProfile() {
+        return profile;
+    }
+
+    @Override
     public void addCloseListener(ActionListener<Void> listener) {
         closeContext.whenComplete(ActionListener.toBiConsumer(listener));
     }
@@ -70,6 +77,11 @@ public class NettyTcpChannel implements TcpChannel {
     @Override
     public InetSocketAddress getLocalAddress() {
         return (InetSocketAddress) channel.localAddress();
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return (InetSocketAddress) channel.remoteAddress();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/server/src/test/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -214,11 +214,6 @@ public final class StubbableTransport implements Transport {
         }
 
         @Override
-        public boolean sendPing() {
-            return connection.sendPing();
-        }
-
-        @Override
         public void addCloseListener(ActionListener<Void> listener) {
             connection.addCloseListener(listener);
         }

--- a/server/src/test/java/org/elasticsearch/transport/FakeTcpChannel.java
+++ b/server/src/test/java/org/elasticsearch/transport/FakeTcpChannel.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesReference;
+
+import io.crate.concurrent.CompletableContext;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FakeTcpChannel implements TcpChannel {
+
+    private final boolean isServer;
+    private final String profile;
+    private final AtomicReference<BytesReference> messageCaptor;
+    private final ChannelStats stats = new ChannelStats();
+    private final CompletableContext<Void> closeContext = new CompletableContext<>();
+
+    public FakeTcpChannel() {
+        this(false, "profile", new AtomicReference<>());
+    }
+
+    public FakeTcpChannel(boolean isServer) {
+        this(isServer, "profile", new AtomicReference<>());
+    }
+
+    public FakeTcpChannel(boolean isServer, AtomicReference<BytesReference> messageCaptor) {
+        this(isServer, "profile", messageCaptor);
+    }
+
+
+    public FakeTcpChannel(boolean isServer, String profile, AtomicReference<BytesReference> messageCaptor) {
+        this.isServer = isServer;
+        this.profile = profile;
+        this.messageCaptor = messageCaptor;
+    }
+
+    @Override
+    public boolean isServerChannel() {
+        return isServer;
+    }
+
+    @Override
+    public String getProfile() {
+        return profile;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public void sendMessage(BytesReference reference, ActionListener<Void> listener) {
+        messageCaptor.set(reference);
+    }
+
+    @Override
+    public void addConnectListener(ActionListener<Void> listener) {
+
+    }
+
+    @Override
+    public void close() {
+        closeContext.complete(null);
+    }
+
+    @Override
+    public void addCloseListener(ActionListener<Void> listener) {
+        closeContext.addListener(ActionListener.toBiConsumer(listener));
+    }
+
+    @Override
+    public boolean isOpen() {
+        return closeContext.isDone() == false;
+    }
+
+    @Override
+    public ChannelStats getChannelStats() {
+        return stats;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -163,14 +163,7 @@ public class MockTcpTransport extends TcpTransport {
                 output.write(minimalHeader);
                 output.writeInt(msgSize);
                 output.write(buffer);
-                final BytesReference bytes = output.bytes();
-                if (TcpTransport.validateMessageHeader(bytes)) {
-                    InetSocketAddress remoteAddress = (InetSocketAddress) socket.getRemoteSocketAddress();
-                    messageReceived(bytes.slice(TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE, msgSize),
-                                    mockChannel, mockChannel.profile, remoteAddress, msgSize);
-                } else {
-                    // ping message - we just drop all stuff
-                }
+                consumeNetworkReads(mockChannel, output.bytes());
             }
         }
     }
@@ -394,6 +387,11 @@ public class MockTcpTransport extends TcpTransport {
         }
 
         @Override
+        public String getProfile() {
+            return profile;
+        }
+
+        @Override
         public void addCloseListener(ActionListener<Void> listener) {
             closeFuture.whenComplete(ActionListener.toBiConsumer(listener));
         }
@@ -421,6 +419,11 @@ public class MockTcpTransport extends TcpTransport {
                 listener.onFailure(e);
                 onException(this, e);
             }
+        }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() {
+            return (InetSocketAddress) activeChannel.getRemoteSocketAddress();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -235,7 +235,7 @@ public class MockTcpTransport extends TcpTransport {
         socket.setReuseAddress(TransportSettings.TCP_REUSE_ADDRESS.get(settings));
     }
 
-    public final class MockChannel implements Closeable, TcpChannel {
+    public final class MockChannel implements Closeable, TcpChannel, TcpServerChannel {
         private final AtomicBoolean isOpen = new AtomicBoolean(true);
         private final InetSocketAddress localAddress;
         private final ServerSocket serverSocket;

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -399,14 +399,6 @@ public class MockTcpTransport extends TcpTransport {
         }
 
         @Override
-        public void setSoLinger(int value) throws IOException {
-            if (activeChannel != null && activeChannel.isClosed() == false) {
-                activeChannel.setSoLinger(true, value);
-            }
-
-        }
-
-        @Override
         public boolean isOpen() {
             return isOpen.get();
         }

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -22,6 +22,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cli.SuppressForbidden;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
@@ -44,6 +45,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -147,22 +149,23 @@ public class MockTcpTransport extends TcpTransport {
 
     private void readMessage(MockChannel mockChannel, StreamInput input) throws IOException {
         Socket socket = mockChannel.activeChannel;
-        byte[] minimalHeader = new byte[TcpHeader.MARKER_BYTES_SIZE];
-        int firstByte = input.read();
-        if (firstByte == -1) {
+        byte[] minimalHeader = new byte[TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE];
+        try {
+            input.readFully(minimalHeader);
+        } catch (EOFException eof) {
             throw new IOException("Connection reset by peer");
         }
-        minimalHeader[0] = (byte) firstByte;
-        minimalHeader[1] = (byte) input.read();
-        int msgSize = input.readInt();
+
+        // Read message length will throw stream corrupted exception if the marker bytes incorrect
+        int msgSize = TcpTransport.readMessageLength(new BytesArray(minimalHeader));
         if (msgSize == -1) {
             socket.getOutputStream().flush();
         } else {
-            try (BytesStreamOutput output = new ReleasableBytesStreamOutput(msgSize, bigArrays)) {
-                final byte[] buffer = new byte[msgSize];
-                input.readFully(buffer);
+            final byte[] buffer = new byte[msgSize];
+            input.readFully(buffer);
+            int expectedSize = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE + msgSize;
+            try (BytesStreamOutput output = new ReleasableBytesStreamOutput(expectedSize, bigArrays)) {
                 output.write(minimalHeader);
-                output.writeInt(msgSize);
                 output.write(buffer);
                 consumeNetworkReads(mockChannel, output.bytes());
             }

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportHandshakerTests.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.crate.common.unit.TimeValue;
+
+public class TcpTransportHandshakerTests extends ESTestCase {
+
+    private TcpTransportHandshaker handshaker;
+    private DiscoveryNode node;
+    private TcpChannel channel;
+    private TestThreadPool threadPool;
+    private TcpTransportHandshaker.HandshakeRequestSender requestSender;
+    private TcpTransportHandshaker.HandshakeResponseSender responseSender;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        String nodeId = "node-id";
+        channel = mock(TcpChannel.class);
+        requestSender = mock(TcpTransportHandshaker.HandshakeRequestSender.class);
+        responseSender = mock(TcpTransportHandshaker.HandshakeResponseSender.class);
+        node = new DiscoveryNode(nodeId, nodeId, nodeId, "host", "host_address", buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.emptySet(), Version.CURRENT);
+        threadPool = new TestThreadPool("thread-poll");
+        handshaker = new TcpTransportHandshaker(Version.CURRENT, threadPool, requestSender, responseSender);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        threadPool.shutdown();
+        super.tearDown();
+    }
+
+    @Test
+    public void testHandshakeRequestAndResponse() throws IOException {
+        PlainActionFuture<Version> versionFuture = PlainActionFuture.newFuture();
+        long reqId = randomLongBetween(1, 10);
+        handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
+
+        verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
+
+        assertFalse(versionFuture.isDone());
+
+        TcpChannel mockChannel = mock(TcpChannel.class);
+        handshaker.handleHandshake(Version.CURRENT, Collections.emptySet(), mockChannel, reqId);
+
+
+        ArgumentCaptor<TransportResponse> responseCaptor = ArgumentCaptor.forClass(TransportResponse.class);
+        verify(responseSender).sendResponse(eq(Version.CURRENT), eq(Collections.emptySet()), eq(mockChannel), responseCaptor.capture(),
+            eq(reqId));
+
+        TransportResponseHandler<TcpTransportHandshaker.VersionHandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
+        handler.handleResponse((TcpTransportHandshaker.VersionHandshakeResponse) responseCaptor.getValue());
+
+        assertTrue(versionFuture.isDone());
+        assertEquals(Version.CURRENT, versionFuture.actionGet());
+    }
+
+    @Test
+    public void testHandshakeError() throws IOException {
+        PlainActionFuture<Version> versionFuture = PlainActionFuture.newFuture();
+        long reqId = randomLongBetween(1, 10);
+        handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
+
+        verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
+
+        assertFalse(versionFuture.isDone());
+
+        TransportResponseHandler<TcpTransportHandshaker.VersionHandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
+        handler.handleException(new TransportException("failed"));
+
+        assertTrue(versionFuture.isDone());
+        IllegalStateException ise = expectThrows(IllegalStateException.class, versionFuture::actionGet);
+        assertThat(ise.getMessage(), containsString("handshake failed"));
+    }
+
+    @Test
+    public void testSendRequestThrowsException() throws IOException {
+        PlainActionFuture<Version> versionFuture = PlainActionFuture.newFuture();
+        long reqId = randomLongBetween(1, 10);
+        Version compatibilityVersion = Version.CURRENT.minimumCompatibilityVersion();
+        doThrow(new IOException("boom")).when(requestSender).sendRequest(node, channel, reqId, compatibilityVersion);
+
+        handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
+
+
+        assertTrue(versionFuture.isDone());
+        ConnectTransportException cte = expectThrows(ConnectTransportException.class, versionFuture::actionGet);
+        assertThat(cte.getMessage(), containsString("failure to send internal:tcp/handshake"));
+        assertNull(handshaker.removeHandlerForHandshake(reqId));
+    }
+
+    @Test
+    public void testHandshakeTimeout() throws IOException {
+        PlainActionFuture<Version> versionFuture = PlainActionFuture.newFuture();
+        long reqId = randomLongBetween(1, 10);
+        handshaker.sendHandshake(reqId, node, channel, new TimeValue(100, TimeUnit.MILLISECONDS), versionFuture);
+
+        verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
+
+        ConnectTransportException cte = expectThrows(ConnectTransportException.class, versionFuture::actionGet);
+        assertThat(cte.getMessage(), containsString("handshake_timeout"));
+
+        assertNull(handshaker.removeHandlerForHandshake(reqId));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
@@ -153,7 +153,7 @@ public class TcpTransportTest extends ESTestCase {
                                                                new NetworkService(Collections.emptyList())) {
 
                 @Override
-                protected TcpChannel bind(String name, InetSocketAddress address) {
+                protected TcpServerChannel bind(String name, InetSocketAddress address) {
                     throw new UnsupportedOperationException();
                 }
 

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.network.NetworkService;
@@ -146,6 +147,7 @@ public class TcpTransportTest extends ESTestCase {
         try {
             final TcpTransport tcpTransport = new TcpTransport("test",
                                                                settings,
+                                                               Version.CURRENT,
                                                                testThreadPool,
                                                                BigArrays.NON_RECYCLING_INSTANCE,
                                                                new NoneCircuitBreakerService(),
@@ -158,8 +160,7 @@ public class TcpTransportTest extends ESTestCase {
                 }
 
                 @Override
-                protected TcpChannel initiateChannel(DiscoveryNode node,
-                                                     ActionListener<Void> connectListener) {
+                protected TcpChannel initiateChannel(DiscoveryNode node) {
                     throw new UnsupportedOperationException();
                 }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -39,7 +39,7 @@ import org.mockito.ArgumentCaptor;
 
 import io.crate.common.unit.TimeValue;
 
-public class TcpTransportHandshakerTests extends ESTestCase {
+public class TransportHandshakerTests extends ESTestCase {
 
     private TcpTransportHandshaker handshaker;
     private DiscoveryNode node;

--- a/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.concurrent.ScheduledFuture;
+
+import org.elasticsearch.common.AsyncBiFunction;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.junit.Test;
+
+import io.crate.common.collections.Tuple;
+import io.crate.common.unit.TimeValue;
+
+public class TransportKeepAliveTests extends ESTestCase {
+
+    private final ConnectionProfile defaultProfile = ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY);
+    private BytesReference expectedPingMessage;
+    private AsyncBiFunction<TcpChannel, BytesReference, Void> pingSender;
+    private TransportKeepAlive keepAlive;
+    private CapturingThreadPool threadPool;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        super.setUp();
+        pingSender = mock(AsyncBiFunction.class);
+        threadPool = new CapturingThreadPool();
+        keepAlive = new TransportKeepAlive(threadPool, pingSender);
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeByte((byte) 'E');
+            out.writeByte((byte) 'S');
+            out.writeInt(-1);
+            expectedPingMessage = out.bytes();
+        } catch (IOException e) {
+            throw new AssertionError(e.getMessage(), e); // won't happen
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        threadPool.shutdown();
+        super.tearDown();
+    }
+
+    @Test
+    public void testRegisterNodeConnectionSchedulesKeepAlive() {
+        TimeValue pingInterval = TimeValue.timeValueSeconds(randomLongBetween(1, 60));
+        ConnectionProfile connectionProfile = new ConnectionProfile.Builder(defaultProfile)
+            .setPingInterval(pingInterval)
+            .build();
+
+        assertEquals(0, threadPool.scheduledTasks.size());
+
+        TcpChannel channel1 = new FakeTcpChannel();
+        TcpChannel channel2 = new FakeTcpChannel();
+        channel1.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        channel2.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        keepAlive.registerNodeConnection(Arrays.asList(channel1, channel2), connectionProfile);
+
+        assertEquals(1, threadPool.scheduledTasks.size());
+        Tuple<TimeValue, Runnable> taskTuple = threadPool.scheduledTasks.poll();
+        assertEquals(pingInterval, taskTuple.v1());
+        Runnable keepAliveTask = taskTuple.v2();
+        assertEquals(0, threadPool.scheduledTasks.size());
+        keepAliveTask.run();
+
+        verify(pingSender, times(1)).apply(same(channel1), eq(expectedPingMessage), any());
+        verify(pingSender, times(1)).apply(same(channel2), eq(expectedPingMessage), any());
+
+        // Test that the task has rescheduled itself
+        assertEquals(1, threadPool.scheduledTasks.size());
+        Tuple<TimeValue, Runnable> rescheduledTask = threadPool.scheduledTasks.poll();
+        assertEquals(pingInterval, rescheduledTask.v1());
+    }
+
+    @Test
+    public void testRegisterMultipleKeepAliveIntervals() {
+        TimeValue pingInterval1 = TimeValue.timeValueSeconds(randomLongBetween(1, 30));
+        ConnectionProfile connectionProfile1 = new ConnectionProfile.Builder(defaultProfile)
+            .setPingInterval(pingInterval1)
+            .build();
+
+        TimeValue pingInterval2 = TimeValue.timeValueSeconds(randomLongBetween(31, 60));
+        ConnectionProfile connectionProfile2 = new ConnectionProfile.Builder(defaultProfile)
+            .setPingInterval(pingInterval2)
+            .build();
+
+        assertEquals(0, threadPool.scheduledTasks.size());
+
+        TcpChannel channel1 = new FakeTcpChannel();
+        TcpChannel channel2 = new FakeTcpChannel();
+        channel1.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        channel2.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        keepAlive.registerNodeConnection(Collections.singletonList(channel1), connectionProfile1);
+        keepAlive.registerNodeConnection(Collections.singletonList(channel2), connectionProfile2);
+
+        assertEquals(2, threadPool.scheduledTasks.size());
+        Tuple<TimeValue, Runnable> taskTuple1 = threadPool.scheduledTasks.poll();
+        Tuple<TimeValue, Runnable> taskTuple2 = threadPool.scheduledTasks.poll();
+        assertEquals(pingInterval1, taskTuple1.v1());
+        assertEquals(pingInterval2, taskTuple2.v1());
+        Runnable keepAliveTask1 = taskTuple1.v2();
+        Runnable keepAliveTask2 = taskTuple1.v2();
+
+        assertEquals(0, threadPool.scheduledTasks.size());
+        keepAliveTask1.run();
+        assertEquals(1, threadPool.scheduledTasks.size());
+        keepAliveTask2.run();
+        assertEquals(2, threadPool.scheduledTasks.size());
+    }
+
+    @Test
+    public void testClosingChannelUnregistersItFromKeepAlive() {
+        TimeValue pingInterval1 = TimeValue.timeValueSeconds(randomLongBetween(1, 30));
+        ConnectionProfile connectionProfile = new ConnectionProfile.Builder(defaultProfile)
+            .setPingInterval(pingInterval1)
+            .build();
+
+        TcpChannel channel1 = new FakeTcpChannel();
+        TcpChannel channel2 = new FakeTcpChannel();
+        channel1.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        channel2.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        keepAlive.registerNodeConnection(Collections.singletonList(channel1), connectionProfile);
+        keepAlive.registerNodeConnection(Collections.singletonList(channel2), connectionProfile);
+
+        channel1.close();
+
+        Runnable task = threadPool.scheduledTasks.poll().v2();
+        task.run();
+
+        verify(pingSender, times(0)).apply(same(channel1), eq(expectedPingMessage), any());
+        verify(pingSender, times(1)).apply(same(channel2), eq(expectedPingMessage), any());
+    }
+
+    @Test
+    public void testKeepAliveResponseIfServer() {
+        TcpChannel channel = new FakeTcpChannel(true);
+        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+
+        keepAlive.receiveKeepAlive(channel);
+
+        verify(pingSender, times(1)).apply(same(channel), eq(expectedPingMessage), any());
+    }
+
+    @Test
+    public void testNoKeepAliveResponseIfClient() {
+        TcpChannel channel = new FakeTcpChannel(false);
+        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+
+        keepAlive.receiveKeepAlive(channel);
+
+        verify(pingSender, times(0)).apply(same(channel), eq(expectedPingMessage), any());
+    }
+
+    @Test
+    public void testOnlySendPingIfWeHaveNotWrittenAndReadSinceLastPing() {
+        TimeValue pingInterval = TimeValue.timeValueSeconds(15);
+        ConnectionProfile connectionProfile = new ConnectionProfile.Builder(defaultProfile)
+            .setPingInterval(pingInterval)
+            .build();
+
+        TcpChannel channel1 = new FakeTcpChannel();
+        TcpChannel channel2 = new FakeTcpChannel();
+        channel1.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        channel2.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        keepAlive.registerNodeConnection(Arrays.asList(channel1, channel2), connectionProfile);
+
+        Tuple<TimeValue, Runnable> taskTuple = threadPool.scheduledTasks.poll();
+        taskTuple.v2().run();
+
+        TcpChannel.ChannelStats stats = channel1.getChannelStats();
+        stats.markAccessed(threadPool.relativeTimeInMillis() + (pingInterval.millis() / 2));
+
+        taskTuple = threadPool.scheduledTasks.poll();
+        taskTuple.v2().run();
+
+        verify(pingSender, times(1)).apply(same(channel1), eq(expectedPingMessage), any());
+        verify(pingSender, times(2)).apply(same(channel2), eq(expectedPingMessage), any());
+    }
+
+    private class CapturingThreadPool extends TestThreadPool {
+
+        private final Deque<Tuple<TimeValue, Runnable>> scheduledTasks = new ArrayDeque<>();
+
+        private CapturingThreadPool() {
+            super(getTestName());
+        }
+
+        @Override
+        public ScheduledCancellable schedule(Runnable task, TimeValue delay, String executor) {
+            scheduledTasks.add(new Tuple<>(delay, task));
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See individual commits.

These are older patches from between 6.5.1 and 7.0.0
The next patch mentioned in es-backports.rst is

  60247d31728 Remove Blocking Transport APIs 

But for that we need to do some catch-up and bring in changes that make more
methods of the transport async.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)