### PR TITLE
Fix usage of quoted subscript expr as an alias

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -86,7 +86,15 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             }
             childColumnName = aliasToColumnMapping.get(column.getRoot());
             if (childColumnName == null) {
-                return null;
+                // The column ident maybe a quoted subscript which points to an alias of a sub relation.
+                // Aliases are always strings but due to the support for quoted subscript expressions,
+                // the select column ident may already be expanded to a subscript.
+                var maybeQuotedSubscriptColumnAlias = new ColumnIdent(column.sqlFqn());
+                childColumnName = aliasToColumnMapping.get(maybeQuotedSubscriptColumnAlias);
+                if (childColumnName == null) {
+                    return null;
+                }
+                column = maybeQuotedSubscriptColumnAlias;
             } else {
                 childColumnName = new ColumnIdent(childColumnName.name(), column.path());
             }


### PR DESCRIPTION
Due to the recently added support for quoted subscript expressions, column aliases containing a valid quoted subscript expressions are now also expanded. When used with sub-selects the expanded alias won’t match the column string alias output exposed by the sub-relation.

This commits adds a fallback to collapse already expanded column idents if no output on the sub-relation with an expanded column ident can be found.

Example query:

```
SELECT "_"."my_col['x']" from (
  SELECT "my_col['x']" AS "my_col['x']" FROM my_table
) AS _;
```

Follow up of e95045b2a64bfe6be51c426c65f5e13761227909.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
