### PR TITLE
Backport ES changes to make transport APIs async - part 2

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -61,6 +61,13 @@ public abstract class BytesReference implements Comparable<BytesReference>, ToXC
     public abstract byte get(int index);
 
     /**
+     * Returns the integer read from the 4 bytes (BE) starting at the given index.
+     */
+    public int getInt(int index) {
+        return (get(index) & 0xFF) << 24 | (get(index + 1) & 0xFF) << 16 | (get(index + 2) & 0xFF) << 8 | get(index + 3) & 0xFF;
+    }
+
+    /**
      * Finds the index of the first occurrence of the given marker between within the given bounds.
      * @param marker marker byte to search
      * @param from lower bound for the index to check (inclusive)

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -71,6 +71,12 @@ public final class CompositeBytesReference extends BytesReference {
     }
 
     @Override
+    public int getInt(int index) {
+        final int i = getOffsetIndex(index);
+        return references[i].getInt(index - offsets[i]);
+    }
+
+    @Override
     public int length() {
         return length;
     }

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -250,8 +250,8 @@ public class ThreadPool implements Scheduler, Closeable {
      * Warning: this {@linkplain ExecutorService} will not throw {@link RejectedExecutionException}
      * if you submit a task while it shutdown. It will instead silently queue it and not run it.
      */
-    public Executor generic() {
-        return executor(Names.GENERIC);
+    public ExecutorService generic() {
+        return (ExecutorService) executor(Names.GENERIC);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/CompressibleBytesOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/transport/CompressibleBytesOutputStream.java
@@ -39,8 +39,8 @@ import java.util.zip.DeflaterOutputStream;
  * written to this stream. If compression is enabled, the proper EOS bytes will be written at that point.
  * The underlying {@link BytesReference} will be returned.
  *
- * {@link CompressibleBytesOutputStream#close()} should be called when the bytes are no longer needed and
- * can be safely released.
+ * {@link CompressibleBytesOutputStream#close()} will NOT close the underlying stream. The byte stream passed
+ * in the constructor must be closed individually.
  */
 final class CompressibleBytesOutputStream extends StreamOutput {
 
@@ -92,12 +92,9 @@ final class CompressibleBytesOutputStream extends StreamOutput {
 
     @Override
     public void close() throws IOException {
-        if (stream == bytesStreamOutput) {
-            assert shouldCompress == false : "If the streams are the same we should not be compressing";
-            IOUtils.close(stream);
-        } else {
+        if (stream != bytesStreamOutput) {
             assert shouldCompress : "If the streams are different we should be compressing";
-            IOUtils.close(stream, bytesStreamOutput);
+            IOUtils.close(stream);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.component.Lifecycle;
@@ -228,7 +229,18 @@ public class ConnectionManager implements Closeable {
     }
 
     private Transport.Connection internalOpenConnection(DiscoveryNode node, ConnectionProfile connectionProfile) {
-        Transport.Connection connection = transport.openConnection(node, connectionProfile);
+        PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
+        Releasable pendingConnection = transport.openConnection(node, connectionProfile, future);
+        Transport.Connection connection;
+        try {
+            connection = future.actionGet();
+        } catch (IllegalStateException e) {
+            // If the future was interrupted we must cancel the pending connection to avoid channels leaking
+            if (e.getCause() instanceof InterruptedException) {
+                pendingConnection.close();
+            }
+            throw e;
+        }
         try {
             connectionListener.onConnectionOpened(connection);
         } finally {

--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.Compressor;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.compress.NotCompressedException;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+
+import io.crate.common.io.IOUtils;
+
+public abstract class InboundMessage extends NetworkMessage implements Closeable {
+
+    private final StreamInput streamInput;
+
+    InboundMessage(Version version, byte status, long requestId, StreamInput streamInput) {
+        super(version, status, requestId);
+        this.streamInput = streamInput;
+    }
+
+    StreamInput getStreamInput() {
+        return streamInput;
+    }
+
+    static class Reader {
+
+        private final Version version;
+        private final NamedWriteableRegistry namedWriteableRegistry;
+
+        Reader(Version version, NamedWriteableRegistry namedWriteableRegistry) {
+            this.version = version;
+            this.namedWriteableRegistry = namedWriteableRegistry;
+        }
+
+        InboundMessage deserialize(BytesReference reference) throws IOException {
+            int messageLengthBytes = reference.length();
+            final int totalMessageSize = messageLengthBytes + TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
+            // we have additional bytes to read, outside of the header
+            boolean hasMessageBytesToRead = (totalMessageSize - TcpHeader.HEADER_SIZE) > 0;
+            StreamInput streamInput = reference.streamInput();
+            boolean success = false;
+            try {
+                long requestId = streamInput.readLong();
+                byte status = streamInput.readByte();
+                Version remoteVersion = Version.fromId(streamInput.readInt());
+                final boolean isHandshake = TransportStatus.isHandshake(status);
+                ensureVersionCompatibility(remoteVersion, version, isHandshake);
+                if (TransportStatus.isCompress(status) && hasMessageBytesToRead && streamInput.available() > 0) {
+                    Compressor compressor;
+                    try {
+                        final int bytesConsumed = TcpHeader.REQUEST_ID_SIZE + TcpHeader.STATUS_SIZE + TcpHeader.VERSION_ID_SIZE;
+                        compressor = CompressorFactory.compressor(reference.slice(bytesConsumed, reference.length() - bytesConsumed));
+                    } catch (NotCompressedException ex) {
+                        int maxToRead = Math.min(reference.length(), 10);
+                        StringBuilder sb = new StringBuilder("stream marked as compressed, but no compressor found, first [")
+                            .append(maxToRead).append("] content bytes out of [").append(reference.length())
+                            .append("] readable bytes with message size [").append(messageLengthBytes).append("] ").append("] are [");
+                        for (int i = 0; i < maxToRead; i++) {
+                            sb.append(reference.get(i)).append(",");
+                        }
+                        sb.append("]");
+                        throw new IllegalStateException(sb.toString());
+                    }
+                    streamInput = compressor.streamInput(streamInput);
+                }
+                streamInput = new NamedWriteableAwareStreamInput(streamInput, namedWriteableRegistry);
+                streamInput.setVersion(remoteVersion);
+
+                ThreadContext.bwcReadHeaders(streamInput);
+
+                InboundMessage message;
+                if (TransportStatus.isRequest(status)) {
+                    Set<String> features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
+                    String action = streamInput.readString();
+                    message = new RequestMessage(remoteVersion, status, requestId, action, features, streamInput);
+                } else {
+                    message = new ResponseMessage(remoteVersion, status, requestId, streamInput);
+                }
+                success = true;
+                return message;
+            } finally {
+                if (success == false) {
+                    IOUtils.closeWhileHandlingException(streamInput);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        streamInput.close();
+    }
+
+    private static void ensureVersionCompatibility(Version version, Version currentVersion, boolean isHandshake) {
+        // for handshakes we are compatible with N-2 since otherwise we can't figure out our initial version
+        // since we are compatible with N-1 and N+1 so we always send our minCompatVersion as the initial version in the
+        // handshake. This looks odd but it's required to establish the connection correctly we check for real compatibility
+        // once the connection is established
+        final Version compatibilityVersion = isHandshake ? currentVersion.minimumCompatibilityVersion() : currentVersion;
+        if (version.isCompatible(compatibilityVersion) == false) {
+            final Version minCompatibilityVersion = isHandshake ? compatibilityVersion : compatibilityVersion.minimumCompatibilityVersion();
+            String msg = "Received " + (isHandshake ? "handshake " : "") + "message from unsupported version: [";
+            throw new IllegalStateException(msg + version + "] minimal compatible version is: [" + minCompatibilityVersion + "]");
+        }
+    }
+
+    public static class RequestMessage extends InboundMessage {
+
+        private final String actionName;
+        private final Set<String> features;
+
+        RequestMessage(Version version,
+                       byte status,
+                       long requestId,
+                       String actionName,
+                       Set<String> features,
+                       StreamInput streamInput) {
+            super(version, status, requestId, streamInput);
+            this.actionName = actionName;
+            this.features = features;
+        }
+
+        String getActionName() {
+            return actionName;
+        }
+
+        Set<String> getFeatures() {
+            return features;
+        }
+    }
+
+    public static class ResponseMessage extends InboundMessage {
+
+        ResponseMessage(Version version, byte status, long requestId, StreamInput streamInput) {
+            super(version, status, requestId, streamInput);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/NetworkMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/NetworkMessage.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+
+/**
+ * Represents a transport message sent over the network. Subclasses implement serialization and
+ * deserialization.
+ */
+public abstract class NetworkMessage {
+
+    protected final Version version;
+    protected final long requestId;
+    protected final byte status;
+
+    NetworkMessage(Version version, byte status, long requestId) {
+        this.version = version;
+        this.requestId = requestId;
+        this.status = status;
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
+    public long getRequestId() {
+        return requestId;
+    }
+
+    boolean isCompress() {
+        return TransportStatus.isCompress(status);
+    }
+
+    boolean isResponse() {
+        return TransportStatus.isRequest(status) == false;
+    }
+
+    boolean isRequest() {
+        return TransportStatus.isRequest(status);
+    }
+
+    boolean isHandshake() {
+        return TransportStatus.isHandshake(status);
+    }
+
+    boolean isError() {
+        return TransportStatus.isError(status);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.NotifyOnceListener;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.network.CloseableChannel;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import io.crate.common.CheckedSupplier;
+import io.crate.common.io.IOUtils;
+
+final class OutboundHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger(OutboundHandler.class);
+
+    private final MeanMetric transmittedBytesMetric = new MeanMetric();
+    private final ThreadPool threadPool;
+    private final BigArrays bigArrays;
+
+    OutboundHandler(ThreadPool threadPool, BigArrays bigArrays) {
+        this.threadPool = threadPool;
+        this.bigArrays = bigArrays;
+    }
+
+    void sendBytes(TcpChannel channel, BytesReference bytes, ActionListener<Void> listener) {
+        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        SendContext sendContext = new SendContext(channel, () -> bytes, listener);
+        try {
+            internalSendMessage(channel, sendContext);
+        } catch (IOException e) {
+            // This should not happen as the bytes are already serialized
+            throw new AssertionError(e);
+        }
+    }
+
+    void sendMessage(TcpChannel channel, OutboundMessage networkMessage, ActionListener<Void> listener) throws IOException {
+        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        MessageSerializer serializer = new MessageSerializer(networkMessage, bigArrays);
+        SendContext sendContext = new SendContext(channel, serializer, listener, serializer);
+        internalSendMessage(channel, sendContext);
+    }
+
+    /**
+     * sends a message to the given channel, using the given callbacks.
+     */
+    private void internalSendMessage(TcpChannel channel, SendContext sendContext) throws IOException {
+        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
+        BytesReference reference = sendContext.get();
+        try {
+            channel.sendMessage(reference, sendContext);
+        } catch (RuntimeException ex) {
+            sendContext.onFailure(ex);
+            CloseableChannel.closeChannel(channel);
+            throw ex;
+        }
+
+    }
+
+    MeanMetric getTransmittedBytes() {
+        return transmittedBytesMetric;
+    }
+
+    private static class MessageSerializer implements CheckedSupplier<BytesReference, IOException>, Releasable {
+
+        private final OutboundMessage message;
+        private final BigArrays bigArrays;
+        private volatile ReleasableBytesStreamOutput bytesStreamOutput;
+
+        private MessageSerializer(OutboundMessage message, BigArrays bigArrays) {
+            this.message = message;
+            this.bigArrays = bigArrays;
+        }
+
+        @Override
+        public BytesReference get() throws IOException {
+            bytesStreamOutput = new ReleasableBytesStreamOutput(bigArrays);
+            return message.serialize(bytesStreamOutput);
+        }
+
+        @Override
+        public void close() {
+            IOUtils.closeWhileHandlingException(bytesStreamOutput);
+        }
+    }
+
+    private class SendContext extends NotifyOnceListener<Void> implements CheckedSupplier<BytesReference, IOException> {
+
+        private final TcpChannel channel;
+        private final CheckedSupplier<BytesReference, IOException> messageSupplier;
+        private final ActionListener<Void> listener;
+        private final Releasable optionalReleasable;
+        private long messageSize = -1;
+
+        private SendContext(TcpChannel channel,
+                            CheckedSupplier<BytesReference, IOException> messageSupplier,
+                            ActionListener<Void> listener) {
+            this(channel, messageSupplier, listener, null);
+        }
+
+        private SendContext(TcpChannel channel,
+                            CheckedSupplier<BytesReference, IOException> messageSupplier,
+                            ActionListener<Void> listener,
+                            Releasable optionalReleasable) {
+            this.channel = channel;
+            this.messageSupplier = messageSupplier;
+            this.listener = listener;
+            this.optionalReleasable = optionalReleasable;
+        }
+
+        public BytesReference get() throws IOException {
+            BytesReference message;
+            try {
+                message = messageSupplier.get();
+                messageSize = message.length();
+                return message;
+            } catch (Exception e) {
+                onFailure(e);
+                throw e;
+            }
+        }
+
+        @Override
+        protected void innerOnResponse(Void v) {
+            assert messageSize != -1 : "If onResponse is being called, the message should have been serialized";
+            transmittedBytesMetric.inc(messageSize);
+            closeAndCallback(() -> listener.onResponse(v));
+        }
+
+        @Override
+        protected void innerOnFailure(Exception e) {
+            LOGGER.warn(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
+            closeAndCallback(() -> listener.onFailure(e));
+        }
+
+        private void closeAndCallback(Runnable runnable) {
+            Releasables.close(optionalReleasable, runnable::run);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+
+import java.io.IOException;
+import java.util.Set;
+
+abstract class OutboundMessage extends NetworkMessage implements Writeable {
+
+    private final Writeable message;
+
+    OutboundMessage(Version version, byte status, long requestId, Writeable message) {
+        super(version, status, requestId);
+        this.message = message;
+    }
+
+    BytesReference serialize(BytesStreamOutput bytesStream) throws IOException {
+        bytesStream.setVersion(version);
+        bytesStream.skip(TcpHeader.HEADER_SIZE);
+
+        // The compressible bytes stream will not close the underlying bytes stream
+        BytesReference reference;
+        try (CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bytesStream, TransportStatus.isCompress(status))) {
+            stream.setVersion(version);
+            ThreadContext.bwcWriteHeaders(stream);
+            writeTo(stream);
+            reference = writeMessage(stream);
+        }
+        bytesStream.seek(0);
+        TcpHeader.writeHeader(bytesStream, requestId, status, version, reference.length() - TcpHeader.HEADER_SIZE);
+        return reference;
+    }
+
+    private BytesReference writeMessage(CompressibleBytesOutputStream stream) throws IOException {
+        final BytesReference zeroCopyBuffer;
+        if (message instanceof BytesTransportRequest) {
+            BytesTransportRequest bRequest = (BytesTransportRequest) message;
+            bRequest.writeThin(stream);
+            zeroCopyBuffer = bRequest.bytes;
+        } else if (message instanceof RemoteTransportException) {
+            stream.writeException((RemoteTransportException) message);
+            zeroCopyBuffer = BytesArray.EMPTY;
+        } else {
+            message.writeTo(stream);
+            zeroCopyBuffer = BytesArray.EMPTY;
+        }
+        // we have to call materializeBytes() here before accessing the bytes. A CompressibleBytesOutputStream
+        // might be implementing compression. And materializeBytes() ensures that some marker bytes (EOS marker)
+        // are written. Otherwise we barf on the decompressing end when we read past EOF on purpose in the
+        // #validateRequest method. this might be a problem in deflate after all but it's important to write
+        // the marker bytes.
+        final BytesReference message = stream.materializeBytes();
+        if (zeroCopyBuffer.length() == 0) {
+            return message;
+        } else {
+            return new CompositeBytesReference(message, zeroCopyBuffer);
+        }
+    }
+
+    static class Request extends OutboundMessage {
+
+        private final String[] features;
+        private final String action;
+
+        Request(String[] features,
+                Writeable message,
+                Version version,
+                String action,
+                long requestId,
+                boolean isHandshake,
+                boolean compress) {
+            super(version, setStatus(compress, isHandshake, message), requestId, message);
+            this.features = features;
+            this.action = action;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeStringArray(features);
+            out.writeString(action);
+        }
+
+        private static byte setStatus(boolean compress, boolean isHandshake, Writeable message) {
+            byte status = 0;
+            status = TransportStatus.setRequest(status);
+            if (compress && OutboundMessage.canCompress(message)) {
+                status = TransportStatus.setCompress(status);
+            }
+            if (isHandshake) {
+                status = TransportStatus.setHandshake(status);
+            }
+
+            return status;
+        }
+    }
+
+    static class Response extends OutboundMessage {
+
+        private final Set<String> features;
+
+        Response(Set<String> features,
+                 Writeable message,
+                 Version version,
+                 long requestId,
+                 boolean isHandshake,
+                 boolean compress) {
+            super(version, setStatus(compress, isHandshake, message), requestId, message);
+            this.features = features;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.setFeatures(features);
+        }
+
+        private static byte setStatus(boolean compress, boolean isHandshake, Writeable message) {
+            byte status = 0;
+            status = TransportStatus.setResponse(status);
+            if (message instanceof RemoteTransportException) {
+                status = TransportStatus.setError(status);
+            }
+            if (compress) {
+                status = TransportStatus.setCompress(status);
+            }
+            if (isHandshake) {
+                status = TransportStatus.setHandshake(status);
+            }
+
+            return status;
+        }
+    }
+
+    private static boolean canCompress(Writeable message) {
+        return message instanceof BytesTransportRequest == false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -921,11 +921,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 + Integer.toHexString(headerBuffer.get(2) & 0xFF) + ","
                 + Integer.toHexString(headerBuffer.get(3) & 0xFF) + ")");
         }
-        final int messageLength;
-        try (StreamInput input = headerBuffer.streamInput()) {
-            input.skip(TcpHeader.MARKER_BYTES_SIZE);
-            messageLength = input.readInt();
-        }
+        final int messageLength = headerBuffer.getInt(TcpHeader.MARKER_BYTES_SIZE);
         if (messageLength == TransportKeepAlive.PING_DATA_SIZE) {
             // This is a ping
             return 0;

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -159,7 +159,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final MeanMetric transmittedBytesMetric = new MeanMetric();
     private volatile Map<String, RequestHandlerRegistry> requestHandlers = Collections.emptyMap();
     private final ResponseHandlers responseHandlers = new ResponseHandlers();
-    private final TcpTransportHandshaker handshaker;
+    private final TransportHandshaker handshaker;
     private final TransportKeepAlive keepAlive;
 
     public TcpTransport(String transportName,
@@ -180,14 +180,14 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.compress = Transport.TRANSPORT_TCP_COMPRESS.get(settings);
         this.networkService = networkService;
         this.transportName = transportName;
-        this.handshaker = new TcpTransportHandshaker(
+        this.handshaker = new TransportHandshaker(
             version,
             threadPool,
             (node, channel, requestId, v) -> sendRequestToChannel(
                 node,
                 channel,
                 requestId,
-                TcpTransportHandshaker.HANDSHAKE_ACTION_NAME,
+                TransportHandshaker.HANDSHAKE_ACTION_NAME,
                 TransportRequest.Empty.INSTANCE,
                 TransportRequestOptions.EMPTY,
                 v,
@@ -199,7 +199,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 channel,
                 response,
                 requestId,
-                TcpTransportHandshaker.HANDSHAKE_ACTION_NAME,
+                TransportHandshaker.HANDSHAKE_ACTION_NAME,
                 TransportResponseOptions.EMPTY,
                 TransportStatus.setHandshake((byte) 0)
             )
@@ -1250,7 +1250,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         TransportChannel transportChannel = null;
         try {
             if (TransportStatus.isHandshake(status)) {
-                handshaker.handleHandshake(version, features, channel, requestId);
+                handshaker.handleHandshake(version, features, channel, requestId, stream);
             } else {
                 final RequestHandlerRegistry reg = getRequestHandler(action);
                 if (reg == null) {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -431,28 +431,28 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         PortsRange portsRange = new PortsRange(port);
         final AtomicReference<Exception> lastException = new AtomicReference<>();
         final AtomicReference<InetSocketAddress> boundSocket = new AtomicReference<>();
-        boolean success = portsRange.iterate(portNumber -> {
-            try {
-                TcpServerChannel channel = bind(name, new InetSocketAddress(hostAddress, portNumber));
-                synchronized (serverChannels) {
-                    List<TcpServerChannel> list = serverChannels.get(name);
-                    if (list == null) {
-                        list = new ArrayList<>();
-                        serverChannels.put(name, list);
-                    }
-                    list.add(channel);
-                    boundSocket.set(channel.getLocalAddress());
-                }
-            } catch (Exception e) {
-                lastException.set(e);
-                return false;
+        closeLock.writeLock().lock();
+        try {
+            if (lifecycle.initialized() == false && lifecycle.started() == false) {
+                throw new IllegalStateException("transport has been stopped");
             }
-            return true;
-        });
-        if (!success) {
-            throw new BindTransportException("Failed to bind to [" + port + "]", lastException.get());
+            boolean success = portsRange.iterate(portNumber -> {
+                try {
+                    TcpServerChannel channel = bind(name, new InetSocketAddress(hostAddress, portNumber));
+                    serverChannels.computeIfAbsent(name, k -> new ArrayList<>()).add(channel);
+                    boundSocket.set(channel.getLocalAddress());
+                } catch (Exception e) {
+                    lastException.set(e);
+                    return false;
+                }
+                return true;
+            });
+            if (!success) {
+                throw new BindTransportException("Failed to bind to [" + port + "]", lastException.get());
+            }
+        } finally {
+            closeLock.writeLock().unlock();
         }
-
         if (logger.isDebugEnabled()) {
             logger.debug("Bound profile [{}] to address {{}}", name, NetworkAddress.format(boundSocket.get()));
         }
@@ -601,6 +601,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     protected final void doStop() {
         final CountDownLatch latch = new CountDownLatch(1);
         // make sure we run it on another thread than a possible IO handler thread
+        assert threadPool.generic().isShutdown() == false : "Must stop transport before terminating underlying threadpool";
         threadPool.generic().execute(() -> {
             closeLock.writeLock().lock();
             try {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -24,10 +24,8 @@ import static org.elasticsearch.common.transport.NetworkExceptionHelper.isCloseC
 import static org.elasticsearch.common.transport.NetworkExceptionHelper.isConnectException;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.StreamCorruptedException;
-import java.io.UncheckedIOException;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -66,22 +64,14 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
-import org.elasticsearch.common.compress.Compressor;
-import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.compress.NotCompressedException;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.metrics.MeanMetric;
@@ -99,7 +89,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.Node;
@@ -108,7 +97,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.common.Booleans;
 import io.crate.common.collections.MapBuilder;
-import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 
 public abstract class TcpTransport extends AbstractLifecycleComponent implements Transport {
@@ -144,8 +132,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final Map<String, List<TcpServerChannel>> serverChannels = newConcurrentMap();
     private final Set<TcpChannel> acceptedChannels = ConcurrentCollections.newConcurrentSet();
 
-    private final NamedWriteableRegistry namedWriteableRegistry;
-
     // this lock is here to make sure we close this transport and disconnect all the client nodes
     // connections while no connect operations is going on
     private final ReadWriteLock closeLock = new ReentrantReadWriteLock();
@@ -156,11 +142,12 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final String transportName;
 
     private final MeanMetric readBytesMetric = new MeanMetric();
-    private final MeanMetric transmittedBytesMetric = new MeanMetric();
     private volatile Map<String, RequestHandlerRegistry> requestHandlers = Collections.emptyMap();
     private final ResponseHandlers responseHandlers = new ResponseHandlers();
     private final TransportHandshaker handshaker;
     private final TransportKeepAlive keepAlive;
+    private final InboundMessage.Reader reader;
+    private final OutboundHandler outboundHandler;
 
     public TcpTransport(String transportName,
                         Settings settings,
@@ -176,10 +163,10 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.threadPool = threadPool;
         this.bigArrays = bigArrays;
         this.circuitBreakerService = circuitBreakerService;
-        this.namedWriteableRegistry = namedWriteableRegistry;
         this.compress = Transport.TRANSPORT_TCP_COMPRESS.get(settings);
         this.networkService = networkService;
         this.transportName = transportName;
+        this.outboundHandler = new OutboundHandler(threadPool, bigArrays);
         this.handshaker = new TransportHandshaker(
             version,
             threadPool,
@@ -191,7 +178,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 TransportRequest.Empty.INSTANCE,
                 TransportRequestOptions.EMPTY,
                 v,
-                TransportStatus.setHandshake((byte) 0)
+                true
             ),
             (v, features, channel, response, requestId) -> sendResponse(
                 v,
@@ -201,10 +188,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 requestId,
                 TransportHandshaker.HANDSHAKE_ACTION_NAME,
                 TransportResponseOptions.EMPTY,
-                TransportStatus.setHandshake((byte) 0)
+                true
             )
         );
-        this.keepAlive = new TransportKeepAlive(threadPool, this::internalSendMessage);
+        this.keepAlive = new TransportKeepAlive(threadPool, this.outboundHandler::sendBytes);
+        this.reader = new InboundMessage.Reader(version, namedWriteableRegistry);
         this.nodeName = Node.NODE_NAME_SETTING.get(settings);
         final Settings defaultFeatures = DEFAULT_FEATURES_SETTING.get(settings);
         if (defaultFeatures == null) {
@@ -308,7 +296,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             TcpChannel channel = channel(options.type());
-            sendRequestToChannel(this.node, channel, requestId, action, request, options, getVersion(), (byte) 0);
+            sendRequestToChannel(this.node, channel, requestId, action, request, options, getVersion());
         }
 
         @Override
@@ -622,8 +610,10 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 for (Map.Entry<String, List<TcpServerChannel>> entry : serverChannels.entrySet()) {
                     String profile = entry.getKey();
                     List<TcpServerChannel> channels = entry.getValue();
-                    ActionListener<Void> closeFailLogger = ActionListener.wrap(c -> {},
-                        e -> logger.warn(() -> new ParameterizedMessage("Error closing serverChannel for profile [{}]", profile), e));
+                    ActionListener<Void> closeFailLogger = ActionListener.wrap(
+                        c -> {},
+                        e -> logger.warn(() -> new ParameterizedMessage("Error closing serverChannel for profile [{}]", profile), e)
+                    );
                     channels.forEach(c -> c.addCloseListener(closeFailLogger));
                     CloseableChannel.closeChannels(channels, true);
                 }
@@ -677,27 +667,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             // in case we are able to return data, serialize the exception content and sent it back to the client
             if (channel.isOpen()) {
                 BytesArray message = new BytesArray(e.getMessage().getBytes(StandardCharsets.UTF_8));
-                ActionListener<Void> listener = new ActionListener<Void>() {
-
-                    @Override
-                    public void onResponse(Void v) {
-                        CloseableChannel.closeChannel(channel, false);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        logger.debug("failed to send message to httpOnTransport channel", e);
-                        CloseableChannel.closeChannel(channel, false);
-                    }
-                };
-                // We do not call internalSendMessage because we are not sending a message that is an
-                // elasticsearch binary message. We are just serializing an exception here. Not formatting it
-                // as an elasticsearch transport message.
-                try {
-                    channel.sendMessage(message, new SendListener(channel, message.length(), listener));
-                } catch (Exception ex) {
-                    listener.onFailure(ex);
-                }
+                outboundHandler.sendBytes(channel, message, ActionListener.wrap(() -> CloseableChannel.closeChannel(channel)));
             }
         } else {
             logger.warn(() -> new ParameterizedMessage("exception caught on transport layer [{}], closing connection", channel), e);
@@ -741,65 +711,40 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      */
     protected abstract void stopInternal();
 
-    public boolean canCompress(TransportRequest request) {
-        return compress && (!(request instanceof BytesTransportRequest));
+    private void sendRequestToChannel(final DiscoveryNode node,
+                                      final TcpChannel channel,
+                                      final long requestId,
+                                      final String action,
+                                      final TransportRequest request,
+                                      TransportRequestOptions options,
+                                      Version channelVersion) throws IOException, TransportException {
+        sendRequestToChannel(node, channel, requestId, action, request, options, channelVersion, false);
     }
 
-    private void sendRequestToChannel(final DiscoveryNode node, final TcpChannel channel, final long requestId, final String action,
-                                      final TransportRequest request, TransportRequestOptions options, Version channelVersion,
-                                      byte status) throws IOException, TransportException {
-        if (compress) {
-            options = TransportRequestOptions.builder(options).withCompress(true).build();
-        }
-
-        // only compress if asked and the request is not bytes. Otherwise only
-        // the header part is compressed, and the "body" can't be extracted as compressed
-        final boolean compressMessage = options.compress() && canCompress(request);
-
-        status = TransportStatus.setRequest(status);
-        ReleasableBytesStreamOutput bStream = new ReleasableBytesStreamOutput(bigArrays);
-        final CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bStream, compressMessage);
-        boolean addedReleaseListener = false;
-        try {
-            if (compressMessage) {
-                status = TransportStatus.setCompress(status);
-            }
-
-            // we pick the smallest of the 2, to support both backward and forward compatibility
-            // note, this is the only place we need to do this, since from here on, we use the serialized version
-            // as the version to use also when the node receiving this request will send the response with
-            Version version = Version.min(this.version, channelVersion);
-
-            stream.setVersion(version);
-            ThreadContext.bwcWriteHeaders(stream);
-            stream.writeStringArray(features);
-            stream.writeString(action);
-            BytesReference message = buildMessage(requestId, status, node.getVersion(), request, stream);
-            final TransportRequestOptions finalOptions = options;
-            // this might be called in a different thread
-            ReleaseListener releaseListener = new ReleaseListener(stream,
-                () -> messageListener.onRequestSent(node, requestId, action, request, finalOptions));
-            internalSendMessage(channel, message, releaseListener);
-            addedReleaseListener = true;
-        } finally {
-            if (!addedReleaseListener) {
-                IOUtils.close(stream);
-            }
-        }
-    }
-
-    /**
-     * sends a message to the given channel, using the given callbacks.
-     */
-    private void internalSendMessage(TcpChannel channel, BytesReference message, ActionListener<Void> listener) {
-        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
-        try {
-            channel.sendMessage(message, new SendListener(channel, message.length(), listener));
-        } catch (Exception ex) {
-            // call listener to ensure that any resources are released
-            listener.onFailure(ex);
-            onException(channel, ex);
-        }
+    private void sendRequestToChannel(final DiscoveryNode node,
+                                      final TcpChannel channel,
+                                      final long requestId,
+                                      final String action,
+                                      final TransportRequest request,
+                                      TransportRequestOptions options,
+                                      Version channelVersion,
+                                      boolean isHandshake) throws IOException, TransportException {
+        Version version = Version.min(this.version, channelVersion);
+        OutboundMessage.Request message = new OutboundMessage.Request(
+            features,
+            request,
+            version,
+            action,
+            requestId,
+            isHandshake,
+            compress
+        );
+        TransportRequestOptions finalOptions = compress
+            ? TransportRequestOptions.builder(options).withCompress(true).build()
+            : options;
+        ActionListener<Void> listener = ActionListener.wrap(() ->
+            messageListener.onRequestSent(node, requestId, action, request, finalOptions));
+        outboundHandler.sendMessage(channel, message, listener);
     }
 
     /**
@@ -819,23 +764,20 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             final Exception error,
             final long requestId,
             final String action) throws IOException {
-        try (BytesStreamOutput stream = new BytesStreamOutput()) {
-            stream.setVersion(nodeVersion);
-            stream.setFeatures(features);
-            RemoteTransportException tx = new RemoteTransportException(
-                nodeName, new TransportAddress(channel.getLocalAddress()), action, error);
-            ThreadContext.bwcWriteHeaders(stream);
-            stream.writeException(tx);
-            byte status = 0;
-            status = TransportStatus.setResponse(status);
-            status = TransportStatus.setError(status);
-            final BytesReference bytes = stream.bytes();
-            final BytesReference header = buildHeader(requestId, status, nodeVersion, bytes.length());
-            CompositeBytesReference message = new CompositeBytesReference(header, bytes);
-            ReleaseListener releaseListener = new ReleaseListener(null,
-                () -> messageListener.onResponseSent(requestId, action, error));
-            internalSendMessage(channel, message, releaseListener);
-        }
+
+        Version version = Version.min(this.version, nodeVersion);
+        TransportAddress address = new TransportAddress(channel.getLocalAddress());
+        RemoteTransportException tx = new RemoteTransportException(nodeName, address, action, error);
+        OutboundMessage.Response message = new OutboundMessage.Response(
+            features,
+            tx,
+            version,
+            requestId,
+            false,
+            false
+        );
+        ActionListener<Void> listener = ActionListener.wrap(() -> messageListener.onResponseSent(requestId, action, error));
+        outboundHandler.sendMessage(channel, message, listener);
     }
 
     /**
@@ -851,7 +793,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             final long requestId,
             final String action,
             final TransportResponseOptions options) throws IOException {
-        sendResponse(nodeVersion, features, channel, response, requestId, action, options, (byte) 0);
+        sendResponse(nodeVersion, features, channel, response, requestId, action, options, false);
     }
 
     private void sendResponse(
@@ -862,85 +804,26 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             final long requestId,
             final String action,
             TransportResponseOptions options,
-            byte status) throws IOException {
-        if (compress) {
-            options = TransportResponseOptions.builder(options).withCompress(true).build();
-        }
-        status = TransportStatus.setResponse(status); // TODO share some code with sendRequest
-        ReleasableBytesStreamOutput bStream = new ReleasableBytesStreamOutput(bigArrays);
-        CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bStream, options.compress());
-        boolean addedReleaseListener = false;
-        try {
-            if (options.compress()) {
-                status = TransportStatus.setCompress(status);
-            }
-            ThreadContext.bwcWriteHeaders(stream);
-            stream.setVersion(nodeVersion);
-            stream.setFeatures(features);
-            BytesReference message = buildMessage(requestId, status, nodeVersion, response, stream);
-
-            final TransportResponseOptions finalOptions = options;
-            // this might be called in a different thread
-            ReleaseListener releaseListener = new ReleaseListener(stream,
-                () -> messageListener.onResponseSent(requestId, action, response, finalOptions));
-            internalSendMessage(channel, message, releaseListener);
-            addedReleaseListener = true;
-        } finally {
-            if (!addedReleaseListener) {
-                IOUtils.close(stream);
-            }
-        }
-    }
-
-    /**
-     * Writes the Tcp message header into a bytes reference.
-     *
-     * @param requestId       the request ID
-     * @param status          the request status
-     * @param protocolVersion the protocol version used to serialize the data in the message
-     * @param length          the payload length in bytes
-     * @see TcpHeader
-     */
-    final BytesReference buildHeader(long requestId, byte status, Version protocolVersion, int length) throws IOException {
-        try (BytesStreamOutput headerOutput = new BytesStreamOutput(TcpHeader.HEADER_SIZE)) {
-            headerOutput.setVersion(protocolVersion);
-            TcpHeader.writeHeader(headerOutput, requestId, status, protocolVersion, length);
-            final BytesReference bytes = headerOutput.bytes();
-            assert bytes.length() == TcpHeader.HEADER_SIZE : "header size mismatch expected: " + TcpHeader.HEADER_SIZE + " but was: "
-                + bytes.length();
-            return bytes;
-        }
-    }
-
-    /**
-     * Serializes the given message into a bytes representation
-     */
-    private BytesReference buildMessage(long requestId, byte status, Version nodeVersion, TransportMessage message,
-                                        CompressibleBytesOutputStream stream) throws IOException {
-        final BytesReference zeroCopyBuffer;
-        if (message instanceof BytesTransportRequest) { // what a shitty optimization - we should use a direct send method instead
-            BytesTransportRequest bRequest = (BytesTransportRequest) message;
-            assert nodeVersion.equals(bRequest.version());
-            bRequest.writeThin(stream);
-            zeroCopyBuffer = bRequest.bytes;
-        } else {
-            message.writeTo(stream);
-            zeroCopyBuffer = BytesArray.EMPTY;
-        }
-        // we have to call materializeBytes() here before accessing the bytes. A CompressibleBytesOutputStream
-        // might be implementing compression. And materializeBytes() ensures that some marker bytes (EOS marker)
-        // are written. Otherwise we barf on the decompressing end when we read past EOF on purpose in the
-        // #validateRequest method. this might be a problem in deflate after all but it's important to write
-        // the marker bytes.
-        final BytesReference messageBody = stream.materializeBytes();
-        final BytesReference header = buildHeader(requestId, status, stream.getVersion(), messageBody.length() + zeroCopyBuffer.length());
-        return new CompositeBytesReference(header, messageBody, zeroCopyBuffer);
+            boolean isHandshake) throws IOException {
+        Version version = Version.min(this.version, nodeVersion);
+        OutboundMessage.Response message = new OutboundMessage.Response(
+            features,
+            response,
+            version,
+            requestId,
+            isHandshake,
+            compress
+        );
+        ActionListener<Void> listener = ActionListener.wrap(
+            () -> messageListener.onResponseSent(requestId, action, response, TransportResponseOptions.EMPTY)
+        );
+        outboundHandler.sendMessage(channel, message, listener);
     }
 
     /**
      * Handles inbound message that has been decoded.
      *
-     * @param channel the channel the message if fomr
+     * @param channel the channel the message is from
      * @param message the message
      */
     public void inboundMessage(TcpChannel channel, BytesReference message) {
@@ -1102,51 +985,19 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      * This method handles the message receive part for both request and responses
      */
     public final void messageReceived(BytesReference reference, TcpChannel channel) throws IOException {
-        String profileName = channel.getProfile();
-        InetSocketAddress remoteAddress = channel.getRemoteAddress();
-        int messageLengthBytes = reference.length();
-        final int totalMessageSize = messageLengthBytes + TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
-        readBytesMetric.inc(totalMessageSize);
-        // we have additional bytes to read, outside of the header
-        boolean hasMessageBytesToRead = (totalMessageSize - TcpHeader.HEADER_SIZE) > 0;
-        StreamInput streamIn = reference.streamInput();
-        boolean success = false;
-        try {
-            long requestId = streamIn.readLong();
-            byte status = streamIn.readByte();
-            Version version = Version.fromId(streamIn.readInt());
-            if (TransportStatus.isCompress(status) && hasMessageBytesToRead && streamIn.available() > 0) {
-                Compressor compressor;
-                try {
-                    final int bytesConsumed = TcpHeader.REQUEST_ID_SIZE + TcpHeader.STATUS_SIZE + TcpHeader.VERSION_ID_SIZE;
-                    compressor = CompressorFactory.compressor(reference.slice(bytesConsumed, reference.length() - bytesConsumed));
-                } catch (NotCompressedException ex) {
-                    int maxToRead = Math.min(reference.length(), 10);
-                    StringBuilder sb = new StringBuilder("stream marked as compressed, but no compressor found, first [").append(maxToRead)
-                        .append("] content bytes out of [").append(reference.length())
-                        .append("] readable bytes with message size [").append(messageLengthBytes).append("] ").append("] are [");
-                    for (int i = 0; i < maxToRead; i++) {
-                        sb.append(reference.get(i)).append(",");
-                    }
-                    sb.append("]");
-                    throw new IllegalStateException(sb.toString());
-                }
-                streamIn = compressor.streamInput(streamIn);
-            }
-            final boolean isHandshake = TransportStatus.isHandshake(status);
-            ensureVersionCompatibility(version, this.version, isHandshake);
-            streamIn = new NamedWriteableAwareStreamInput(streamIn, namedWriteableRegistry);
-            streamIn.setVersion(version);
-            ThreadContext.bwcReadHeaders(streamIn);
-            if (TransportStatus.isRequest(status)) {
-                handleRequest(channel, profileName, streamIn, requestId, messageLengthBytes, version, remoteAddress, status);
+        readBytesMetric.inc(reference.length() + TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE);
+        try (InboundMessage message = reader.deserialize(reference)) {
+            if (message.isRequest()) {
+                handleRequest(channel, (InboundMessage.RequestMessage) message, reference.length());
             } else {
                 final TransportResponseHandler<?> handler;
-                if (isHandshake) {
+                long requestId = message.getRequestId();
+                if (message.isHandshake()) {
                     handler = handshaker.removeHandlerForHandshake(requestId);
                 } else {
-                    TransportResponseHandler<?> theHandler = responseHandlers.onResponseReceived(requestId, messageListener);
-                    if (theHandler == null && TransportStatus.isError(status)) {
+                    TransportResponseHandler<? extends TransportResponse> theHandler =
+                        responseHandlers.onResponseReceived(requestId, messageListener);
+                    if (theHandler == null && message.isError()) {
                         handler = handshaker.removeHandlerForHandshake(requestId);
                     } else {
                         handler = theHandler;
@@ -1154,40 +1005,20 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 }
                 // ignore if its null, the service logs it
                 if (handler != null) {
-                    if (TransportStatus.isError(status)) {
-                        handlerResponseError(streamIn, handler);
+                    if (message.isError()) {
+                        handlerResponseError(message.getStreamInput(), handler);
                     } else {
-                        handleResponse(streamIn, handler);
+                        handleResponse(message.getStreamInput(), handler);
                     }
                     // Check the entire message has been read
-                    final int nextByte = streamIn.read();
+                    final int nextByte = message.getStreamInput().read();
                     // calling read() is useful to make sure the message is fully read, even if there is an EOS marker
                     if (nextByte != -1) {
                         throw new IllegalStateException("Message not fully read (response) for requestId [" + requestId + "], handler ["
-                            + handler + "], error [" + TransportStatus.isError(status) + "]; resetting");
+                            + handler + "], error [" + message.isError() + "]; resetting");
                     }
                 }
             }
-            success = true;
-        } finally {
-            if (success) {
-                IOUtils.close(streamIn);
-            } else {
-                IOUtils.closeWhileHandlingException(streamIn);
-            }
-        }
-    }
-
-    static void ensureVersionCompatibility(Version version, Version currentVersion, boolean isHandshake) {
-        // for handshakes we are compatible with N-2 since otherwise we can't figure out our initial version
-        // since we are compatible with N-1 and N+1 so we always send our minCompatVersion as the initial version in the
-        // handshake. This looks odd but it's required to establish the connection correctly we check for real compatibility
-        // once the connection is established
-        final Version compatibilityVersion = isHandshake ? currentVersion.minimumCompatibilityVersion() : currentVersion;
-        if (version.isCompatible(compatibilityVersion) == false) {
-            final Version minCompatibilityVersion = isHandshake ? compatibilityVersion : compatibilityVersion.minimumCompatibilityVersion();
-            String msg = "Received " + (isHandshake ? "handshake " : "") + "message from unsupported version: [";
-            throw new IllegalStateException(msg + version + "] minimal compatible version is: [" + minCompatibilityVersion + "]");
         }
     }
 
@@ -1211,7 +1042,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 handler.handleResponse(response);
             }
         });
-
     }
 
     /**
@@ -1241,15 +1071,18 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         });
     }
 
-    protected String handleRequest(TcpChannel channel, String profileName, final StreamInput stream, long requestId,
-                                   int messageLengthBytes, Version version, InetSocketAddress remoteAddress, byte status)
-        throws IOException {
-        final Set<String> features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(stream.readStringArray())));
-        final String action = stream.readString();
+
+    protected void handleRequest(TcpChannel channel, InboundMessage.RequestMessage message, int messageLengthBytes) throws IOException {
+        final Set<String> features = message.getFeatures();
+        final String profileName = channel.getProfile();
+        final String action = message.getActionName();
+        final long requestId = message.getRequestId();
+        final StreamInput stream = message.getStreamInput();
+        final Version version = message.getVersion();
         messageListener.onRequestReceived(requestId, action);
         TransportChannel transportChannel = null;
         try {
-            if (TransportStatus.isHandshake(status)) {
+            if (message.isHandshake()) {
                 handshaker.handleHandshake(version, features, channel, requestId, stream);
             } else {
                 final RequestHandlerRegistry reg = getRequestHandler(action);
@@ -1261,8 +1094,17 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 } else {
                     getInFlightRequestBreaker().addWithoutBreaking(messageLengthBytes);
                 }
-                transportChannel = new TcpTransportChannel(this, channel, transportName, action, requestId, version, features, profileName,
-                    messageLengthBytes);
+                transportChannel = new TcpTransportChannel(
+                    this,
+                    channel,
+                    transportName,
+                    action,
+                    requestId,
+                    version,
+                    features,
+                    profileName,
+                    messageLengthBytes
+                );
                 final TransportRequest request = reg.newRequest(stream);
                 // in case we throw an exception, i.e. when the limit is hit, we don't want to verify
                 validateRequest(stream, requestId, action);
@@ -1281,7 +1123,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 logger.warn(() -> new ParameterizedMessage("Failed to send error message back to client for action [{}]", action), inner);
             }
         }
-        return action;
     }
 
     // This template method is needed to inject custom error checking logic in tests.
@@ -1361,70 +1202,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
     }
 
-    /**
-     * This listener increments the transmitted bytes metric on success.
-     */
-    private class SendListener extends NotifyOnceListener<Void> {
-
-        private final TcpChannel channel;
-        private final long messageSize;
-        private final ActionListener<Void> delegateListener;
-
-        private SendListener(TcpChannel channel, long messageSize, ActionListener<Void> delegateListener) {
-            this.channel = channel;
-            this.messageSize = messageSize;
-            this.delegateListener = delegateListener;
-        }
-
-        @Override
-        protected void innerOnResponse(Void v) {
-            transmittedBytesMetric.inc(messageSize);
-            delegateListener.onResponse(v);
-        }
-
-        @Override
-        protected void innerOnFailure(Exception e) {
-            logger.warn(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
-            delegateListener.onFailure(e);
-        }
-    }
-
-    private class ReleaseListener implements ActionListener<Void> {
-
-        private final Closeable optionalCloseable;
-        private final Runnable transportAdaptorCallback;
-
-        private ReleaseListener(Closeable optionalCloseable, Runnable transportAdaptorCallback) {
-            this.optionalCloseable = optionalCloseable;
-            this.transportAdaptorCallback = transportAdaptorCallback;
-        }
-
-        @Override
-        public void onResponse(Void aVoid) {
-            closeAndCallback(null);
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            closeAndCallback(e);
-        }
-
-        private void closeAndCallback(final Exception e) {
-            try {
-                IOUtils.close(optionalCloseable, transportAdaptorCallback::run);
-            } catch (final IOException inner) {
-                if (e != null) {
-                    inner.addSuppressed(e);
-                }
-                throw new UncheckedIOException(inner);
-            }
-        }
-    }
-
     @Override
     public final TransportStats getStats() {
-        return new TransportStats(acceptedChannels.size(), readBytesMetric.count(), readBytesMetric.sum(), transmittedBytesMetric.count(),
-            transmittedBytesMetric.sum());
+        MeanMetric transmittedBytes = outboundHandler.getTransmittedBytes();
+        return new TransportStats(acceptedChannels.size(), readBytesMetric.count(), readBytesMetric.sum(), transmittedBytes.count(),
+            transmittedBytes.sum());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -67,7 +67,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NotifyOnceListener;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -84,6 +83,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.network.NetworkAddress;
@@ -329,28 +329,17 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     }
 
     @Override
-    public NodeChannels openConnection(DiscoveryNode node, ConnectionProfile connectionProfile) {
-        Objects.requireNonNull(connectionProfile, "connection profile cannot be null");
+    public Releasable openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Transport.Connection> listener) {
+        Objects.requireNonNull(profile, "connection profile cannot be null");
         if (node == null) {
             throw new ConnectTransportException(null, "can't open connection to a null node");
         }
-        connectionProfile = maybeOverrideConnectionProfile(connectionProfile);
+        ConnectionProfile finalProfile = maybeOverrideConnectionProfile(profile);
         closeLock.readLock().lock(); // ensure we don't open connections while we are closing
         try {
             ensureOpen();
-
-            PlainActionFuture<NodeChannels> connectionFuture = PlainActionFuture.newFuture();
-            List<TcpChannel> pendingChannels = initiateConnection(node, connectionProfile, connectionFuture);
-
-            try {
-                return connectionFuture.actionGet();
-            } catch (IllegalStateException e) {
-                // If the future was interrupted we can close the channels to improve the shutdown of the MockTcpTransport
-                if (e.getCause() instanceof InterruptedException) {
-                    CloseableChannel.closeChannels(pendingChannels, false);
-                }
-                throw e;
-            }
+            List<TcpChannel> pendingChannels = initiateConnection(node, finalProfile, listener);
+            return () -> CloseableChannel.closeChannels(pendingChannels, false);
         } finally {
             closeLock.readLock().unlock();
         }
@@ -358,7 +347,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     private List<TcpChannel> initiateConnection(DiscoveryNode node,
                                                 ConnectionProfile connectionProfile,
-                                                ActionListener<NodeChannels> listener) {
+                                                ActionListener<Transport.Connection> listener) {
         int numConnections = connectionProfile.getNumConnections();
         assert numConnections > 0 : "A connection profile must be configured with at least one connection";
 
@@ -1550,13 +1539,13 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         private final DiscoveryNode node;
         private final ConnectionProfile connectionProfile;
         private final List<TcpChannel> channels;
-        private final ActionListener<NodeChannels> listener;
+        private final ActionListener<Transport.Connection> listener;
         private final CountDown countDown;
 
         private ChannelsConnectedListener(DiscoveryNode node,
                                           ConnectionProfile connectionProfile,
                                           List<TcpChannel> channels,
-                                          ActionListener<NodeChannels> listener) {
+                                          ActionListener<Transport.Connection> listener) {
             this.node = node;
             this.connectionProfile = connectionProfile;
             this.channels = channels;

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -139,7 +139,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     protected final Settings settings;
     private final String nodeName;
     private volatile BoundTransportAddress boundAddress;
-    private final String transportName;
 
     private final MeanMetric readBytesMetric = new MeanMetric();
     private volatile Map<String, RequestHandlerRegistry> requestHandlers = Collections.emptyMap();
@@ -149,8 +148,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final InboundMessage.Reader reader;
     private final OutboundHandler outboundHandler;
 
-    public TcpTransport(String transportName,
-                        Settings settings,
+    public TcpTransport(Settings settings,
                         Version version,
                         ThreadPool threadPool,
                         BigArrays bigArrays,
@@ -165,7 +163,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.circuitBreakerService = circuitBreakerService;
         this.compress = Transport.TRANSPORT_TCP_COMPRESS.get(settings);
         this.networkService = networkService;
-        this.transportName = transportName;
         this.outboundHandler = new OutboundHandler(threadPool, bigArrays);
         this.handshaker = new TransportHandshaker(
             version,
@@ -1094,7 +1091,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 transportChannel = new TcpTransportChannel(
                     this,
                     channel,
-                    transportName,
                     action,
                     requestId,
                     version,
@@ -1111,7 +1107,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             // the circuit breaker tripped
             if (transportChannel == null) {
                 transportChannel =
-                        new TcpTransportChannel(this, channel, transportName, action, requestId, version, features, profileName, 0);
+                        new TcpTransportChannel(this, channel, action, requestId, version, features, profileName, 0);
             }
             try {
                 transportChannel.sendResponse(e);

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -34,11 +34,16 @@ public final class TcpTransportChannel implements TransportChannel {
     private final String profileName;
     private final long reservedBytes;
     private final AtomicBoolean released = new AtomicBoolean();
-    private final String channelType;
     private final TcpChannel channel;
 
-    TcpTransportChannel(TcpTransport transport, TcpChannel channel, String channelType, String action, long requestId, Version version,
-                        Set<String> features, String profileName, long reservedBytes) {
+    TcpTransportChannel(TcpTransport transport,
+                        TcpChannel channel,
+                        String action,
+                        long requestId,
+                        Version version,
+                        Set<String> features,
+                        String profileName,
+                        long reservedBytes) {
         this.version = version;
         this.features = features;
         this.channel = channel;
@@ -47,7 +52,6 @@ public final class TcpTransportChannel implements TransportChannel {
         this.requestId = requestId;
         this.profileName = profileName;
         this.reservedBytes = reservedBytes;
-        this.channelType = channelType;
     }
 
     @Override
@@ -92,7 +96,7 @@ public final class TcpTransportChannel implements TransportChannel {
 
     @Override
     public String getChannelType() {
-        return channelType;
+        return "transport";
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.transport.BoundTransportAddress;
@@ -86,10 +87,12 @@ public interface Transport extends LifecycleComponent {
     }
 
     /**
-     * Opens a new connection to the given node and returns it. The returned connection is not managed by
-     * the transport implementation. This connection must be closed once it's not needed anymore.
+     * Opens a new connection to the given node. When the connection is fully connected, the listener is
+     * called. A {@link Releasable} is returned representing the pending connection. If the caller of this
+     * method decides to move on before the listener is called with the completed connection, they should
+     * release the pending connection to prevent hanging connections.
      */
-    Connection openConnection(DiscoveryNode node, ConnectionProfile profile);
+    Releasable openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Transport.Connection> listener);
 
     TransportStats getStats();
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.metrics.CounterMetric;
@@ -39,7 +42,7 @@ import io.crate.common.unit.TimeValue;
  * Sends and receives transport-level connection handshakes. This class will send the initial handshake,
  * manage state/timeouts while the handshake is in transit, and handle the eventual response.
  */
-final class TcpTransportHandshaker {
+final class TransportHandshaker {
 
     static final String HANDSHAKE_ACTION_NAME = "internal:tcp/handshake";
     private final ConcurrentMap<Long, HandshakeResponseHandler> pendingHandshakes = new ConcurrentHashMap<>();
@@ -50,8 +53,8 @@ final class TcpTransportHandshaker {
     private final HandshakeRequestSender handshakeRequestSender;
     private final HandshakeResponseSender handshakeResponseSender;
 
-    TcpTransportHandshaker(Version version, ThreadPool threadPool, HandshakeRequestSender handshakeRequestSender,
-                           HandshakeResponseSender handshakeResponseSender) {
+    TransportHandshaker(Version version, ThreadPool threadPool, HandshakeRequestSender handshakeRequestSender,
+                        HandshakeResponseSender handshakeResponseSender) {
         this.version = version;
         this.threadPool = threadPool;
         this.handshakeRequestSender = handshakeRequestSender;
@@ -88,11 +91,19 @@ final class TcpTransportHandshaker {
         }
     }
 
-    void handleHandshake(Version version, Set<String> features, TcpChannel channel, long requestId) throws IOException {
-        handshakeResponseSender.sendResponse(version, features, channel, new VersionHandshakeResponse(this.version), requestId);
+    void handleHandshake(Version version, Set<String> features, TcpChannel channel, long requestId, StreamInput stream) throws IOException {
+        // Must read the handshake request to exhaust the stream
+        HandshakeRequest handshakeRequest = new HandshakeRequest(stream);
+        final int nextByte = stream.read();
+        if (nextByte != -1) {
+            throw new IllegalStateException("Handshake request not fully read for requestId [" + requestId + "], action ["
+                + TransportHandshaker.HANDSHAKE_ACTION_NAME + "], available [" + stream.available() + "]; resetting");
+        }
+        HandshakeResponse response = new HandshakeResponse(this.version);
+        handshakeResponseSender.sendResponse(version, features, channel, response, requestId);
     }
 
-    TransportResponseHandler<VersionHandshakeResponse> removeHandlerForHandshake(long requestId) {
+    TransportResponseHandler<HandshakeResponse> removeHandlerForHandshake(long requestId) {
         return pendingHandshakes.remove(requestId);
     }
 
@@ -104,7 +115,7 @@ final class TcpTransportHandshaker {
         return numHandshakes.count();
     }
 
-    private class HandshakeResponseHandler implements TransportResponseHandler<VersionHandshakeResponse> {
+    private class HandshakeResponseHandler implements TransportResponseHandler<HandshakeResponse> {
 
         private final long requestId;
         private final Version currentVersion;
@@ -118,14 +129,14 @@ final class TcpTransportHandshaker {
         }
 
         @Override
-        public VersionHandshakeResponse read(StreamInput in) throws IOException {
-            return new VersionHandshakeResponse(in);
+        public HandshakeResponse read(StreamInput in) throws IOException {
+            return new HandshakeResponse(in);
         }
 
         @Override
-        public void handleResponse(VersionHandshakeResponse response) {
+        public void handleResponse(HandshakeResponse response) {
             if (isDone.compareAndSet(false, true)) {
-                Version version = response.version;
+                Version version = response.responseVersion;
                 if (currentVersion.isCompatible(version) == false) {
                     listener.onFailure(new IllegalStateException("Received message from unsupported version: [" + version
                         + "] minimal compatible version is: [" + currentVersion.minimumCompatibilityVersion() + "]"));
@@ -154,22 +165,64 @@ final class TcpTransportHandshaker {
         }
     }
 
-    static final class VersionHandshakeResponse extends TransportResponse {
+
+    static final class HandshakeRequest extends TransportRequest {
 
         private final Version version;
 
-        VersionHandshakeResponse(Version version) {
+        HandshakeRequest(Version version) {
             this.version = version;
         }
 
-        private VersionHandshakeResponse(StreamInput in) throws IOException {
-            version = Version.readVersion(in);
+        HandshakeRequest(StreamInput streamInput) throws IOException {
+            super(streamInput);
+            BytesReference remainingMessage;
+            try {
+                remainingMessage = streamInput.readBytesReference();
+            } catch (EOFException e) {
+                remainingMessage = null;
+            }
+            if (remainingMessage == null) {
+                version = null;
+            } else {
+                try (StreamInput messageStreamInput = remainingMessage.streamInput()) {
+                    this.version = Version.readVersion(messageStreamInput);
+                }
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput streamOutput) throws IOException {
+            super.writeTo(streamOutput);
+            assert version != null;
+            try (BytesStreamOutput messageStreamOutput = new BytesStreamOutput(4)) {
+                Version.writeVersion(version, messageStreamOutput);
+                BytesReference reference = messageStreamOutput.bytes();
+                streamOutput.writeBytesReference(reference);
+            }
+        }
+    }
+
+    static final class HandshakeResponse extends TransportResponse {
+
+        private final Version responseVersion;
+
+        HandshakeResponse(Version version) {
+            this.responseVersion = version;
+        }
+
+        private HandshakeResponse(StreamInput in) throws IOException {
+            responseVersion = Version.readVersion(in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            assert version != null;
-            Version.writeVersion(version, out);
+            assert responseVersion != null;
+            Version.writeVersion(responseVersion, out);
+        }
+
+        Version getResponseVersion() {
+            return responseVersion;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportStatus.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStatus.java
@@ -66,6 +66,4 @@ public final class TransportStatus {
         value |= STATUS_HANDSHAKE;
         return value;
     }
-
-
 }

--- a/server/src/main/java/org/elasticsearch/transport/netty4/ByteBufBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/ByteBufBytesReference.java
@@ -47,6 +47,17 @@ final class ByteBufBytesReference extends BytesReference {
     }
 
     @Override
+    public int getInt(int index) {
+        return buffer.getInt(offset + index);
+    }
+
+    @Override
+    public int indexOf(byte marker, int from) {
+        final int start = offset + from;
+        return buffer.forEachByte(start, length - start, value -> value != marker);
+    }
+
+    @Override
     public int length() {
         return length;
     }

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -117,7 +117,7 @@ public class Netty4Transport extends TcpTransport {
                            BigArrays bigArrays,
                            NamedWriteableRegistry namedWriteableRegistry,
                            CircuitBreakerService circuitBreakerService) {
-        super("netty", settings, version, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
+        super(settings, version, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
         Netty4Utils.setAvailableProcessors(EsExecutors.PROCESSORS_SETTING.get(settings));
         this.workerCount = WORKER_COUNT.get(settings);
 

--- a/server/src/test/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/server/src/test/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.ConnectionProfile;
@@ -130,17 +131,28 @@ public final class StubbableTransport implements Transport {
     }
 
     @Override
-    public Connection openConnection(DiscoveryNode node, ConnectionProfile profile) {
+    public Releasable openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Connection> listener) {
         TransportAddress address = node.getAddress();
         OpenConnectionBehavior behavior = connectBehaviors.getOrDefault(address, defaultConnectBehavior);
-        Connection connection;
-        if (behavior == null) {
-            connection = delegate.openConnection(node, profile);
-        } else {
-            connection = behavior.openConnection(delegate, node, profile);
-        }
 
-        return new WrappedConnection(connection);
+        ActionListener<Connection> wrappedListener = new ActionListener<Connection>() {
+
+            @Override
+            public void onResponse(Connection connection) {
+                listener.onResponse(new WrappedConnection(connection));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        };
+
+        if (behavior == null) {
+            return delegate.openConnection(node, profile, wrappedListener);
+        } else {
+            return behavior.openConnection(delegate, node, profile, wrappedListener);
+        }
     }
 
     @Override
@@ -251,7 +263,10 @@ public final class StubbableTransport implements Transport {
 
     @FunctionalInterface
     public interface OpenConnectionBehavior {
-        Connection openConnection(Transport transport, DiscoveryNode discoveryNode, ConnectionProfile profile);
+        Releasable openConnection(Transport transport,
+                                  DiscoveryNode discoveryNode,
+                                  ConnectionProfile profile,
+                                  ActionListener<Connection> listener);
 
         default void clearCallback() {}
     }

--- a/server/src/test/java/org/elasticsearch/transport/FakeTcpChannel.java
+++ b/server/src/test/java/org/elasticsearch/transport/FakeTcpChannel.java
@@ -30,9 +30,10 @@ public class FakeTcpChannel implements TcpChannel {
 
     private final boolean isServer;
     private final String profile;
-    private final AtomicReference<BytesReference> messageCaptor;
     private final ChannelStats stats = new ChannelStats();
     private final CompletableContext<Void> closeContext = new CompletableContext<>();
+    private final AtomicReference<BytesReference> messageCaptor;
+    private final AtomicReference<ActionListener<Void>> listenerCaptor;
 
     public FakeTcpChannel() {
         this(false, "profile", new AtomicReference<>());
@@ -51,6 +52,7 @@ public class FakeTcpChannel implements TcpChannel {
         this.isServer = isServer;
         this.profile = profile;
         this.messageCaptor = messageCaptor;
+        this.listenerCaptor = new AtomicReference<>();
     }
 
     @Override
@@ -76,6 +78,7 @@ public class FakeTcpChannel implements TcpChannel {
     @Override
     public void sendMessage(BytesReference reference, ActionListener<Void> listener) {
         messageCaptor.set(reference);
+        listenerCaptor.set(listener);
     }
 
     @Override
@@ -101,5 +104,13 @@ public class FakeTcpChannel implements TcpChannel {
     @Override
     public ChannelStats getChannelStats() {
         return stats;
+    }
+
+    public AtomicReference<BytesReference> getMessageCaptor() {
+        return messageCaptor;
+    }
+
+    public AtomicReference<ActionListener<Void>> getListenerCaptor() {
+        return listenerCaptor;
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/InboundMessageTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundMessageTests.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+public class InboundMessageTests extends ESTestCase {
+
+    private final NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
+
+    @Test
+    public void testReadRequest() throws IOException {
+        String[] features = {"feature1", "feature2"};
+        String value = randomAlphaOfLength(10);
+        Message message = new Message(value);
+        String action = randomAlphaOfLength(10);
+        long requestId = randomLong();
+        boolean isHandshake = randomBoolean();
+        boolean compress = randomBoolean();
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        OutboundMessage.Request request = new OutboundMessage.Request(features, message, version, action, requestId,
+            isHandshake, compress);
+        BytesReference reference;
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            reference = request.serialize(streamOutput);
+        }
+
+        InboundMessage.Reader reader = new InboundMessage.Reader(version, registry);
+        BytesReference sliced = reference.slice(6, reference.length() - 6);
+        InboundMessage.RequestMessage inboundMessage = (InboundMessage.RequestMessage) reader.deserialize(sliced);
+
+        assertEquals(isHandshake, inboundMessage.isHandshake());
+        assertEquals(compress, inboundMessage.isCompress());
+        assertEquals(version, inboundMessage.getVersion());
+        assertEquals(action, inboundMessage.getActionName());
+        assertEquals(new HashSet<>(Arrays.asList(features)), inboundMessage.getFeatures());
+        assertTrue(inboundMessage.isRequest());
+        assertFalse(inboundMessage.isResponse());
+        assertFalse(inboundMessage.isError());
+        assertEquals(value, new Message(inboundMessage.getStreamInput()).value);
+    }
+
+    @Test
+    public void testReadResponse() throws IOException {
+        HashSet<String> features = new HashSet<>(Arrays.asList("feature1", "feature2"));
+        String value = randomAlphaOfLength(10);
+        Message message = new Message(value);
+        long requestId = randomLong();
+        boolean isHandshake = randomBoolean();
+        boolean compress = randomBoolean();
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        OutboundMessage.Response request = new OutboundMessage.Response(
+            features, message, version, requestId, isHandshake, compress);
+        BytesReference reference;
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            reference = request.serialize(streamOutput);
+        }
+
+        InboundMessage.Reader reader = new InboundMessage.Reader(version, registry);
+        BytesReference sliced = reference.slice(6, reference.length() - 6);
+        InboundMessage.ResponseMessage inboundMessage = (InboundMessage.ResponseMessage) reader.deserialize(sliced);
+        assertEquals(isHandshake, inboundMessage.isHandshake());
+        assertEquals(compress, inboundMessage.isCompress());
+        assertEquals(version, inboundMessage.getVersion());
+        assertTrue(inboundMessage.isResponse());
+        assertFalse(inboundMessage.isRequest());
+        assertFalse(inboundMessage.isError());
+        assertEquals(value, new Message(inboundMessage.getStreamInput()).value);
+    }
+
+    @Test
+    public void testReadErrorResponse() throws IOException {
+        HashSet<String> features = new HashSet<>(Arrays.asList("feature1", "feature2"));
+        RemoteTransportException exception = new RemoteTransportException("error", new IOException());
+        long requestId = randomLong();
+        boolean isHandshake = randomBoolean();
+        boolean compress = randomBoolean();
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        OutboundMessage.Response request = new OutboundMessage.Response(
+            features, exception, version, requestId, isHandshake, compress);
+        BytesReference reference;
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            reference = request.serialize(streamOutput);
+        }
+
+        InboundMessage.Reader reader = new InboundMessage.Reader(version, registry);
+        BytesReference sliced = reference.slice(6, reference.length() - 6);
+        InboundMessage.ResponseMessage inboundMessage = (InboundMessage.ResponseMessage) reader.deserialize(sliced);
+        assertEquals(isHandshake, inboundMessage.isHandshake());
+        assertEquals(compress, inboundMessage.isCompress());
+        assertEquals(version, inboundMessage.getVersion());
+        assertTrue(inboundMessage.isResponse());
+        assertFalse(inboundMessage.isRequest());
+        assertTrue(inboundMessage.isError());
+        assertEquals("[error]", inboundMessage.getStreamInput().readException().getMessage());
+    }
+
+    private void testVersionIncompatibility(Version version, Version currentVersion, boolean isHandshake) throws IOException {
+        String[] features = {};
+        String value = randomAlphaOfLength(10);
+        Message message = new Message(value);
+        String action = randomAlphaOfLength(10);
+        long requestId = randomLong();
+        boolean compress = randomBoolean();
+        OutboundMessage.Request request = new OutboundMessage.Request(features, message, version, action, requestId, isHandshake, compress);
+        BytesReference reference;
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            reference = request.serialize(streamOutput);
+        }
+
+        BytesReference sliced = reference.slice(6, reference.length() - 6);
+        InboundMessage.Reader reader = new InboundMessage.Reader(currentVersion, registry);
+        reader.deserialize(sliced);
+    }
+
+    private static final class Message extends TransportMessage {
+
+        public String value;
+
+        private Message() {
+        }
+
+        private Message(StreamInput in) throws IOException {
+            value = in.readString();
+        }
+
+        private Message(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(value);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -102,8 +102,7 @@ public class MockTcpTransport extends TcpTransport {
     public MockTcpTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
                             NetworkService networkService, Version mockVersion) {
-        super("mock-tcp-transport",
-              settings,
+        super(settings,
               mockVersion,
               threadPool,
               bigArrays,

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class OutboundHandlerTests extends ESTestCase {
+
+    private final TestThreadPool threadPool = new TestThreadPool(getClass().getName());
+    private final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
+    private OutboundHandler handler;
+    private FakeTcpChannel fakeTcpChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        fakeTcpChannel = new FakeTcpChannel(randomBoolean());
+        handler = new OutboundHandler(threadPool, BigArrays.NON_RECYCLING_INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        super.tearDown();
+    }
+
+    public void testSendRawBytes() {
+        BytesArray bytesArray = new BytesArray("message".getBytes(StandardCharsets.UTF_8));
+
+        AtomicBoolean isSuccess = new AtomicBoolean(false);
+        AtomicReference<Exception> exception = new AtomicReference<>();
+        ActionListener<Void> listener = ActionListener.wrap((v) -> isSuccess.set(true), exception::set);
+        handler.sendBytes(fakeTcpChannel, bytesArray, listener);
+
+        BytesReference reference = fakeTcpChannel.getMessageCaptor().get();
+        ActionListener<Void> sendListener  = fakeTcpChannel.getListenerCaptor().get();
+        if (randomBoolean()) {
+            sendListener.onResponse(null);
+            assertTrue(isSuccess.get());
+            assertNull(exception.get());
+        } else {
+            IOException e = new IOException("failed");
+            sendListener.onFailure(e);
+            assertFalse(isSuccess.get());
+            assertSame(e, exception.get());
+        }
+
+        assertEquals(bytesArray, reference);
+    }
+
+    public void testSendMessage() throws IOException {
+        OutboundMessage message;
+        Version version = Version.CURRENT;
+        String actionName = "handshake";
+        long requestId = randomLongBetween(0, 300);
+        boolean isHandshake = randomBoolean();
+        boolean compress = randomBoolean();
+        String value = "message";
+        Writeable writeable = new Message(value);
+
+        boolean isRequest = randomBoolean();
+        if (isRequest) {
+            message = new OutboundMessage.Request(new String[0], writeable, version, actionName, requestId, isHandshake, compress);
+        } else {
+            message = new OutboundMessage.Response(new HashSet<>(), writeable, version, requestId, isHandshake, compress);
+        }
+
+        AtomicBoolean isSuccess = new AtomicBoolean(false);
+        AtomicReference<Exception> exception = new AtomicReference<>();
+        ActionListener<Void> listener = ActionListener.wrap((v) -> isSuccess.set(true), exception::set);
+        handler.sendMessage(fakeTcpChannel, message, listener);
+
+        BytesReference reference = fakeTcpChannel.getMessageCaptor().get();
+        ActionListener<Void> sendListener  = fakeTcpChannel.getListenerCaptor().get();
+        if (randomBoolean()) {
+            sendListener.onResponse(null);
+            assertTrue(isSuccess.get());
+            assertNull(exception.get());
+        } else {
+            IOException e = new IOException("failed");
+            sendListener.onFailure(e);
+            assertFalse(isSuccess.get());
+            assertSame(e, exception.get());
+        }
+
+        InboundMessage.Reader reader = new InboundMessage.Reader(Version.CURRENT, namedWriteableRegistry);
+        try (InboundMessage inboundMessage = reader.deserialize(reference.slice(6, reference.length() - 6))) {
+            assertEquals(version, inboundMessage.getVersion());
+            assertEquals(requestId, inboundMessage.getRequestId());
+            if (isRequest) {
+                assertTrue(inboundMessage.isRequest());
+                assertFalse(inboundMessage.isResponse());
+            } else {
+                assertTrue(inboundMessage.isResponse());
+                assertFalse(inboundMessage.isRequest());
+            }
+            if (isHandshake) {
+                assertTrue(inboundMessage.isHandshake());
+            } else {
+                assertFalse(inboundMessage.isHandshake());
+            }
+            if (compress) {
+                assertTrue(inboundMessage.isCompress());
+            } else {
+                assertFalse(inboundMessage.isCompress());
+            }
+            Message readMessage = new Message(inboundMessage.getStreamInput());
+            assertEquals(value, readMessage.value);
+        }
+    }
+
+    private static final class Message extends TransportMessage {
+
+        public String value;
+
+        private Message(String value) {
+            this.value = value;
+        }
+
+        public Message(StreamInput in) throws IOException {
+            value = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(value);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTest.java
@@ -145,8 +145,7 @@ public class TcpTransportTest extends ESTestCase {
     private void testDefaultSeedAddresses(final Settings settings, Matcher<Iterable<? extends String>> seedAddressesMatcher) {
         final TestThreadPool testThreadPool = new TestThreadPool("test");
         try {
-            final TcpTransport tcpTransport = new TcpTransport("test",
-                                                               settings,
+            final TcpTransport tcpTransport = new TcpTransport(settings,
                                                                Version.CURRENT,
                                                                testThreadPool,
                                                                BigArrays.NON_RECYCLING_INSTANCE,

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -32,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.junit.Test;
@@ -41,24 +44,24 @@ import io.crate.common.unit.TimeValue;
 
 public class TransportHandshakerTests extends ESTestCase {
 
-    private TcpTransportHandshaker handshaker;
+    private TransportHandshaker handshaker;
     private DiscoveryNode node;
     private TcpChannel channel;
     private TestThreadPool threadPool;
-    private TcpTransportHandshaker.HandshakeRequestSender requestSender;
-    private TcpTransportHandshaker.HandshakeResponseSender responseSender;
+    private TransportHandshaker.HandshakeRequestSender requestSender;
+    private TransportHandshaker.HandshakeResponseSender responseSender;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         String nodeId = "node-id";
         channel = mock(TcpChannel.class);
-        requestSender = mock(TcpTransportHandshaker.HandshakeRequestSender.class);
-        responseSender = mock(TcpTransportHandshaker.HandshakeResponseSender.class);
+        requestSender = mock(TransportHandshaker.HandshakeRequestSender.class);
+        responseSender = mock(TransportHandshaker.HandshakeResponseSender.class);
         node = new DiscoveryNode(nodeId, nodeId, nodeId, "host", "host_address", buildNewFakeTransportAddress(), Collections.emptyMap(),
             Collections.emptySet(), Version.CURRENT);
         threadPool = new TestThreadPool("thread-poll");
-        handshaker = new TcpTransportHandshaker(Version.CURRENT, threadPool, requestSender, responseSender);
+        handshaker = new TransportHandshaker(Version.CURRENT, threadPool, requestSender, responseSender);
     }
 
     @Override
@@ -78,18 +81,62 @@ public class TransportHandshakerTests extends ESTestCase {
         assertFalse(versionFuture.isDone());
 
         TcpChannel mockChannel = mock(TcpChannel.class);
-        handshaker.handleHandshake(Version.CURRENT, Collections.emptySet(), mockChannel, reqId);
+        TransportHandshaker.HandshakeRequest handshakeRequest = new TransportHandshaker.HandshakeRequest(Version.CURRENT);
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        handshakeRequest.writeTo(bytesStreamOutput);
+        StreamInput input = bytesStreamOutput.bytes().streamInput();
+        handshaker.handleHandshake(Version.CURRENT, Collections.emptySet(), mockChannel, reqId, input);
 
 
         ArgumentCaptor<TransportResponse> responseCaptor = ArgumentCaptor.forClass(TransportResponse.class);
         verify(responseSender).sendResponse(eq(Version.CURRENT), eq(Collections.emptySet()), eq(mockChannel), responseCaptor.capture(),
             eq(reqId));
 
-        TransportResponseHandler<TcpTransportHandshaker.VersionHandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
-        handler.handleResponse((TcpTransportHandshaker.VersionHandshakeResponse) responseCaptor.getValue());
+        TransportResponseHandler<TransportHandshaker.HandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
+        handler.handleResponse((TransportHandshaker.HandshakeResponse) responseCaptor.getValue());
 
         assertTrue(versionFuture.isDone());
         assertEquals(Version.CURRENT, versionFuture.actionGet());
+    }
+
+    @Test
+    public void testHandshakeRequestFutureVersionsCompatibility() throws IOException {
+        long reqId = randomLongBetween(1, 10);
+        handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), PlainActionFuture.newFuture());
+
+        verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
+
+        TcpChannel mockChannel = mock(TcpChannel.class);
+        TransportHandshaker.HandshakeRequest handshakeRequest = new TransportHandshaker.HandshakeRequest(Version.CURRENT);
+        BytesStreamOutput currentHandshakeBytes = new BytesStreamOutput();
+        handshakeRequest.writeTo(currentHandshakeBytes);
+
+        BytesStreamOutput lengthCheckingHandshake = new BytesStreamOutput();
+        BytesStreamOutput futureHandshake = new BytesStreamOutput();
+        TaskId.EMPTY_TASK_ID.writeTo(lengthCheckingHandshake);
+        TaskId.EMPTY_TASK_ID.writeTo(futureHandshake);
+        try (BytesStreamOutput internalMessage = new BytesStreamOutput()) {
+            Version.writeVersion(Version.CURRENT, internalMessage);
+            lengthCheckingHandshake.writeBytesReference(internalMessage.bytes());
+            internalMessage.write(new byte[1024]);
+            futureHandshake.writeBytesReference(internalMessage.bytes());
+        }
+        StreamInput futureHandshakeStream = futureHandshake.bytes().streamInput();
+        // We check that the handshake we serialize for this test equals the actual request.
+        // Otherwise, we need to update the test.
+        assertEquals(currentHandshakeBytes.bytes().length(), lengthCheckingHandshake.bytes().length());
+        assertEquals(1031, futureHandshakeStream.available());
+        handshaker.handleHandshake(Version.CURRENT, Collections.emptySet(), mockChannel, reqId, futureHandshakeStream);
+        assertEquals(0, futureHandshakeStream.available());
+
+
+        ArgumentCaptor<TransportResponse> responseCaptor = ArgumentCaptor.forClass(TransportResponse.class);
+        verify(responseSender).sendResponse(eq(Version.CURRENT), eq(Collections.emptySet()), eq(mockChannel), responseCaptor.capture(),
+            eq(reqId));
+
+        TransportHandshaker.HandshakeResponse response = (TransportHandshaker.HandshakeResponse) responseCaptor.getValue();
+
+        assertEquals(Version.CURRENT, response.getResponseVersion());
     }
 
     @Test
@@ -102,7 +149,7 @@ public class TransportHandshakerTests extends ESTestCase {
 
         assertFalse(versionFuture.isDone());
 
-        TransportResponseHandler<TcpTransportHandshaker.VersionHandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
+        TransportResponseHandler<TransportHandshaker.HandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
         handler.handleException(new TransportException("failed"));
 
         assertTrue(versionFuture.isDone());
@@ -118,7 +165,6 @@ public class TransportHandshakerTests extends ESTestCase {
         doThrow(new IOException("boom")).when(requestSender).sendRequest(node, channel, reqId, compatibilityVersion);
 
         handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
-
 
         assertTrue(versionFuture.isDone());
         ConnectTransportException cte = expectThrows(ConnectTransportException.class, versionFuture::actionGet);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


Relates to https://github.com/crate/crate/pull/10489

See commits


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)