### PR TITLE
Make TaskMissing extends ElasticSearchException

### DIFF
--- a/server/src/main/java/io/crate/exceptions/TaskMissing.java
+++ b/server/src/main/java/io/crate/exceptions/TaskMissing.java
@@ -21,10 +21,14 @@
 
 package io.crate.exceptions;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 import java.util.Locale;
 import java.util.UUID;
 
-public final class TaskMissing extends UnhandledServerException {
+public final class TaskMissing extends ElasticsearchException implements UnscopedException {
 
     public enum Type {
         ROOT("RootTask"),
@@ -39,6 +43,10 @@ public final class TaskMissing extends UnhandledServerException {
         public String friendlyName() {
             return name;
         }
+    }
+
+    public TaskMissing(final StreamInput in) throws IOException {
+        super(in);
     }
 
     public TaskMissing(Type type, UUID jobId) {

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -998,7 +998,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             io.crate.exceptions.JobKilledException.class,
             io.crate.exceptions.JobKilledException::new,
                 156,
+            Version.V_4_3_0),
+        TASK_MISSING_EXCEPTION(
+            io.crate.exceptions.TaskMissing.class,
+            io.crate.exceptions.TaskMissing::new,
+                157,
             Version.V_4_3_0);
+
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;


### PR DESCRIPTION
Make TaskMissing extends ElasticSearchException to make it serializable
accross nodes to fix the flaky KillIntegrationTest.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
