### PR TITLE
Improve error handling when group by with an undefined type

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ Breaking Changes
 Changes
 =======
 
+- Added detailed information on the error when a column with an undefined type
+  is used to ``GROUP BY``.
+
 - Added detailed information to possible errors on ``repository`` creation to
   give better insights on the root cause of the error.
 

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -33,14 +33,9 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
-import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
-import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 
@@ -671,11 +666,11 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testGroupByUnknownGroupByColumn() throws Exception {
+    public void test_group_by_undefined_column_casted() throws Exception {
         this.setup.groupBySetup();
-        Assertions.assertThrows(Exception.class,
-                                () -> execute("select max(birthdate) from characters group by details_ignored['lol']",
-                                              "Cannot GROUP BY type: undefined"));
+        execute("select max(age) from characters group by details_ignored['lol']::String");
+        assertEquals(1, response.rowCount());
+        assertEquals(112, response.rows()[0][0]);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added more detailed information on the error message when a unknown column of the type object ignored is used in a ``GROUP BY``. See https://github.com/crate/crate/pull/10359#discussion_r469299729 for discussion on this.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
