### PR TITLE
Clarify indexing/tokenization schemes with dynamic object columns

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -917,9 +917,9 @@ Note that adding new columns to an object with a ``dynamic`` policy will affect
 the schema of the table. Once a column is added, it shows up in the
 ``information_schema.columns`` table and its type and attributes are fixed.
 They will have the type that was guessed by their inserted/updated value and
-they will always be ``not_indexed`` which means they are analyzed with the
-:ref:`plain <plain-analyzer>`, which means as-is.
-
+they will always be analyzed as-is with the :ref:`plain <plain-analyzer>`,
+which means the column will be indexed but not tokenized in the case of
+``text`` columns.
 
 If a new column ``a`` was added with type ``integer``, adding strings to this
 column will result in an error.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Originally, the documentation of dynamic object columns is that when added via insert/update, they were unindexed. However, the documentation also stated that they were analyzed with the plain fulltext analyzer, which *does* index columns but does not tokenize them. Similarly, the added column behaves as an indexed one in that you are able to search on it - searching on unindexed columns returns a ``java.lang.IllegalArgumentException: Cannot search on field [f] since it is not indexed.`` exception.

Is this correct? Or is there something more complex/nuanced with indexing going on with dynamically added object subcolumns @mkleen ?