### PR TITLE
Fix the join condition hash symbols ordering in the HashJoin.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -101,6 +101,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to the incorrect result of joining more than
+  two tables even if the join condition is satisfied. Only the hash join
+  implementation was affected by the issue.
+
 - Fixed a regression introduced in 4.2.3 that prevented primary key lookups
   with parameter placeholders from working in some cases.
 

--- a/server/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractor.java
@@ -33,7 +33,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +76,7 @@ public final class HashJoinConditionSymbolsExtractor {
 
     private static class Context {
         boolean insideEqOperator = false;
-        Map<RelationName, List<Symbol>> symbolsPerRelation = new HashMap<>();
+        Map<RelationName, List<Symbol>> symbolsPerRelation = new LinkedHashMap<>();
     }
 
     private static class SymbolExtractor extends DefaultTraversalSymbolVisitor<Context, Void> {

--- a/server/src/test/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractorTest.java
@@ -93,4 +93,36 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
             isFunction(ArithmeticFunctions.Names.ADD, isLiteral(1), isReference("i"))));
         assertThat(symbolsPerRelation.get(tr2.relationName()), containsInAnyOrder(isReference("b"), isReference("i"), isReference("y")));
     }
+
+    @Test
+    public void test_extract_symbols_per_relation_maintains_visit_order() {
+        Symbol joinCondition = sqlExpressions.asSymbol("t1.i = t3.z AND t3.c = t2.b");
+        Map<RelationName, List<Symbol>> symbolsPerRelation =
+            HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        assertThat(
+            symbolsPerRelation.keySet(),
+            contains(
+                RelationName.fromIndexName("t1"),
+                RelationName.fromIndexName("t3"),
+                RelationName.fromIndexName("t2"))
+        );
+        assertThat(
+            symbolsPerRelation.get(RelationName.fromIndexName("t3")),
+            contains(isReference("z"), isReference("c"))
+        );
+    }
+
+    @Test
+    public void test_extract_symbols_per_relation_maintains_visit_order_when_removing_an_entry_from_result() {
+        Symbol joinCondition = sqlExpressions.asSymbol("t1.i = t3.z AND t3.c = t2.b");
+        Map<RelationName, List<Symbol>> symbolsPerRelation =
+            HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        symbolsPerRelation.remove(RelationName.fromIndexName("t3"));
+        assertThat(
+            symbolsPerRelation.keySet(),
+            contains(
+                RelationName.fromIndexName("t1"),
+                RelationName.fromIndexName("t2"))
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It could have happened that joining more than 2 tables using hash join
won't return the joined tuples despite that the join condition is satisfied.
That could happen due to the non-deterministic ordering of the join condition
symbols (hash join symbols) which would lead to the wrong calculation of the
hash code for the join condition values on either join side. This change fixes
the ordering of the join condition symbols.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
