### PR TITLE
Fix flaky tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -54,7 +55,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.crate.common.collections.Tuple;
@@ -503,7 +503,6 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
     }
 
     @Test
-    @Ignore("https://github.com/crate/crate/issues/10331")
     public void testReplicaIgnoresOlderRetentionLeasesVersion() {
         final AllocationId allocationId = AllocationId.newInitializing();
         final ReplicationTracker replicationTracker = new ReplicationTracker(
@@ -536,8 +535,8 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                     randomNonNegativeLong(),
                     randomAlphaOfLength(8)
                 ));
-                version++;
             }
+            version++;
             if (rarely()) {
                 primaryTerm++;
             }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -80,7 +80,6 @@ import org.elasticsearch.test.store.MockFSDirectoryFactory;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.crate.common.collections.Tuple;
@@ -196,7 +195,6 @@ public class IndexShardTests extends IndexShardTestCase {
 
 
     @Test
-    @Ignore("https://github.com/crate/crate/issues/10351")
     public void testAcquirePrimaryAllOperationsPermits() throws Exception {
         final IndexShard indexShard = newStartedShard(true);
         assertEquals(0, indexShard.getActiveOperationsCount());
@@ -245,7 +243,6 @@ public class IndexShardTests extends IndexShardTestCase {
                 } else {
                     indexShard.acquireAllPrimaryOperationsPermits(future, TimeValue.timeValueHours(1L));
                 }
-                assertEquals(0, indexShard.getActiveOperationsCount());
             });
             threads[threadId].start();
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

---

Fix flaky testAddOrRenewRetentionLease

Closes https://github.com/crate/crate/issues/10328

See https://github.com/elastic/elasticsearch/commit/d2cc1459a35594f9d55d6c8dc42729c9c688b2eb

We also have to enable soft deletes to make sure index is used for peer
recovery. (For the test changes introduced in
https://github.com/elastic/elasticsearch/commit/01287eacb2f2d2673bc25078fb0b76d81beaad9b)

---

Fix flaky testAcquirePrimaryAllOperationsPermits

See https://github.com/elastic/elasticsearch/commit/9bdbba23f8ca907efc1114cbd390e6263493ca92

Closes https://github.com/crate/crate/issues/10351

---

Fix testReplicaIgnoresOlderRetentionLeasesVersion

See https://github.com/elastic/elasticsearch/commit/1ec04dff43576f05e395e020705320b41b3c4a2e

Closes https://github.com/crate/crate/issues/10331


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)