### PR TITLE
Fix aggregation plan building when inputs contain params

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which resulted in an error when a parameter symbol
+  (placeholder) is used inside an aggregation.
+
 - Fixed an issue that could lead to the incorrect result of joining more than
   two tables even if the join condition is satisfied. Only the hash join
   implementation was affected by the issue.

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -32,10 +32,11 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.MatchPredicate;
+import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
@@ -305,7 +306,6 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         List<String> path = column.path();
 
         List<Symbol> arguments = mapTail(rootIC, path, Literal::of);
-        List<DataType<?>> argumentTypes = Symbols.typeView(arguments);
 
         return new Function(
             SubscriptObjectFunction.SIGNATURE,
@@ -330,5 +330,15 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
     public Symbol visitAggregation(Aggregation symbol, SourceSymbols sourceSymbols) {
         throw new AssertionError("Aggregation Symbols must not be visited with " +
                                  getClass().getCanonicalName());
+    }
+
+    @Override
+    public Symbol visitParameterSymbol(ParameterSymbol parameterSymbol, SourceSymbols sourceSymbols) {
+        return parameterSymbol;
+    }
+
+    @Override
+    public Symbol visitSelectSymbol(SelectSymbol selectSymbol, SourceSymbols sourceSymbols) {
+        return selectSymbol;
     }
 }

--- a/server/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/server/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -185,4 +185,25 @@ public class SymbolMatchers {
         return both(Matchers.<Symbol>instanceOf(Aggregation.class))
             .and(withFeature(s -> ((Aggregation) s).signature().getName().name(), "name", equalTo(name)));
     }
+
+    @SafeVarargs
+    public static Matcher<Symbol> isAggregation(final String name, Matcher<? super Symbol>... argMatchers) {
+        return both(isAggregation(name))
+            .and(withFeature(s -> ((Aggregation) s).inputs(), "args", contains(argMatchers)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Matcher<Symbol> isAggregation(final String name, @Nullable final List<DataType<?>> argumentTypes) {
+        if (argumentTypes == null) {
+            return isAggregation(name);
+        }
+        Matcher[] argMatchers = new Matcher[argumentTypes.size()];
+        ListIterator<DataType<?>> it = argumentTypes.listIterator();
+        while (it.hasNext()) {
+            int i = it.nextIndex();
+            DataType<?> type = it.next();
+            argMatchers[i] = hasDataType(type);
+        }
+        return isAggregation(name, argMatchers);
+    }
 }


### PR DESCRIPTION
Aggregation inputs must be compared against the outputs of a source
logical plan before any parameter or sub-query result binding happen
because all logical plan outputs are always unbound.

Fixes #10494.