### PR TITLE
Port back elastic search testcases

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.block;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.EnumSet.copyOf;
+import static org.elasticsearch.test.VersionUtils.randomVersion;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
+
+public class ClusterBlockTests extends ESTestCase {
+
+    public void testSerialization() throws Exception {
+        int iterations = randomIntBetween(5, 20);
+        for (int i = 0; i < iterations; i++) {
+            Version version = randomVersion(random());
+            ClusterBlock clusterBlock = randomClusterBlock(version);
+
+            BytesStreamOutput out = new BytesStreamOutput();
+            out.setVersion(version);
+            clusterBlock.writeTo(out);
+
+            StreamInput in = out.bytes().streamInput();
+            in.setVersion(version);
+            ClusterBlock result = new ClusterBlock(in);
+
+            assertClusterBlockEquals(clusterBlock, result);
+        }
+    }
+
+    public void testToStringDanglingComma() {
+        final ClusterBlock clusterBlock = randomClusterBlock();
+        assertThat(clusterBlock.toString(), not(endsWith(",")));
+    }
+
+    public void testGlobalBlocksCheckedIfNoIndicesSpecified() {
+        ClusterBlock globalBlock = randomClusterBlock();
+        ClusterBlocks clusterBlocks = new ClusterBlocks(Collections.singleton(globalBlock), ImmutableOpenMap.of());
+        ClusterBlockException exception = clusterBlocks.indicesBlockedException(randomFrom(globalBlock.levels()), new String[0]);
+        assertNotNull(exception);
+        assertEquals(exception.blocks(), Collections.singleton(globalBlock));
+    }
+
+    public void testRemoveIndexBlockWithId() {
+        final ClusterBlocks.Builder builder = ClusterBlocks.builder();
+        builder.addIndexBlock("index-1",
+                              new ClusterBlock(1, "uuid", "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL)));
+        builder.addIndexBlock("index-1",
+                              new ClusterBlock(2, "uuid", "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL)));
+        builder.addIndexBlock("index-1",
+                              new ClusterBlock(3, "uuid", "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL)));
+        builder.addIndexBlock("index-1",
+                              new ClusterBlock(3, "other uuid", "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL)));
+
+        builder.addIndexBlock("index-2",
+                              new ClusterBlock(3, "uuid3", "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL)));
+
+        ClusterBlocks clusterBlocks = builder.build();
+        assertThat(clusterBlocks.indices().get("index-1").size(), equalTo(4));
+        assertThat(clusterBlocks.indices().get("index-2").size(), equalTo(1));
+
+        builder.removeIndexBlockWithId("index-1", 3);
+        clusterBlocks = builder.build();
+
+        assertThat(clusterBlocks.indices().get("index-1").size(), equalTo(2));
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-1", 1), is(true));
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-1", 2), is(true));
+        assertThat(clusterBlocks.indices().get("index-2").size(), equalTo(1));
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-2", 3), is(true));
+
+        builder.removeIndexBlockWithId("index-2", 3);
+        clusterBlocks = builder.build();
+
+        assertThat(clusterBlocks.indices().get("index-1").size(), equalTo(2));
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-1", 1), is(true));
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-1", 2), is(true));
+        assertThat(clusterBlocks.indices().get("index-2"), nullValue());
+        assertThat(clusterBlocks.hasIndexBlockWithId("index-2", 3), is(false));
+    }
+
+    public void testGetIndexBlockWithId() {
+        final int blockId = randomInt();
+        final ClusterBlock[] clusterBlocks = new ClusterBlock[randomIntBetween(1, 5)];
+
+        final ClusterBlocks.Builder builder = ClusterBlocks.builder();
+        for (int i = 0; i < clusterBlocks.length; i++) {
+            clusterBlocks[i] = new ClusterBlock(blockId, "uuid" + i, "", true, true, true, RestStatus.OK, copyOf(ClusterBlockLevel.ALL));
+            builder.addIndexBlock("index", clusterBlocks[i]);
+        }
+
+        assertThat(builder.build().indices().get("index").size(), equalTo(clusterBlocks.length));
+        assertThat(builder.build().getIndexBlockWithId("index", blockId), is(oneOf(clusterBlocks)));
+        assertThat(builder.build().getIndexBlockWithId("index", randomValueOtherThan(blockId, ESTestCase::randomInt)), nullValue());
+    }
+
+    private ClusterBlock randomClusterBlock() {
+        return randomClusterBlock(randomVersion(random()));
+    }
+
+    private ClusterBlock randomClusterBlock(final Version version) {
+        final String uuid = randomBoolean() ? UUIDs.randomBase64UUID() : null;
+        final List<ClusterBlockLevel> levels = Arrays.asList(ClusterBlockLevel.values());
+        return new ClusterBlock(randomInt(), uuid, "cluster block #" + randomInt(), randomBoolean(), randomBoolean(), randomBoolean(),
+                                randomFrom(RestStatus.values()), copyOf(randomSubsetOf(randomIntBetween(1, levels.size()), levels)));
+    }
+
+    private void assertClusterBlockEquals(final ClusterBlock expected, final ClusterBlock actual) {
+        assertEquals(expected, actual);
+        assertThat(actual.id(), equalTo(expected.id()));
+        assertThat(actual.uuid(), equalTo(expected.uuid()));
+        assertThat(actual.status(), equalTo(expected.status()));
+        assertThat(actual.description(), equalTo(expected.description()));
+        assertThat(actual.retryable(), equalTo(expected.retryable()));
+        assertThat(actual.disableStatePersistence(), equalTo(expected.disableStatePersistence()));
+        assertArrayEquals(actual.levels().toArray(), expected.levels().toArray());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import io.crate.common.io.IOUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.translog.SnapshotMatchers;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class LuceneChangesSnapshotTests extends EngineTestCase {
+    private MapperService mapperService;
+
+    @Before
+    public void createMapper() throws Exception {
+        mapperService = createMapperService("test");
+    }
+
+    @Override
+    protected Settings indexSettings() {
+        return Settings.builder().put(super.indexSettings())
+            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true) // always enable soft-deletes
+            .build();
+    }
+
+    public void testBasics() throws Exception {
+        long fromSeqNo = randomNonNegativeLong();
+        long toSeqNo = randomLongBetween(fromSeqNo, Long.MAX_VALUE);
+        // Empty engine
+        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapperService, fromSeqNo, toSeqNo, true)) {
+            IllegalStateException error = expectThrows(IllegalStateException.class, () -> drainAll(snapshot));
+            assertThat(error.getMessage(),
+                       containsString("Not all operations between from_seqno [" + fromSeqNo + "] and to_seqno [" + toSeqNo + "] found"));
+        }
+        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapperService, fromSeqNo, toSeqNo, false)) {
+            assertThat(snapshot, SnapshotMatchers.size(0));
+        }
+        int numOps = between(1, 100);
+        int refreshedSeqNo = -1;
+        for (int i = 0; i < numOps; i++) {
+            String id = Integer.toString(randomIntBetween(i, i + 5));
+            ParsedDocument doc = createParsedDoc(id, null, randomBoolean());
+            if (randomBoolean()) {
+                engine.index(indexForDoc(doc));
+            } else {
+                engine.delete(new Engine.Delete(doc.id(), newUid(doc.id()), primaryTerm.get()));
+            }
+            if (rarely()) {
+                if (randomBoolean()) {
+                    engine.flush();
+                } else {
+                    engine.refresh("test");
+                }
+                refreshedSeqNo = i;
+            }
+        }
+        if (refreshedSeqNo == -1) {
+            fromSeqNo = between(0, numOps);
+            toSeqNo = randomLongBetween(fromSeqNo, numOps * 2);
+
+            Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+            try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(
+                searcher, mapperService, between(1, LuceneChangesSnapshot.DEFAULT_BATCH_SIZE), fromSeqNo, toSeqNo, false)) {
+                searcher = null;
+                assertThat(snapshot, SnapshotMatchers.size(0));
+            } finally {
+                IOUtils.close(searcher);
+            }
+
+            searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+            try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(
+                searcher, mapperService, between(1, LuceneChangesSnapshot.DEFAULT_BATCH_SIZE), fromSeqNo, toSeqNo, true)) {
+                searcher = null;
+                IllegalStateException error = expectThrows(IllegalStateException.class, () -> drainAll(snapshot));
+                assertThat(error.getMessage(),
+                           containsString("Not all operations between from_seqno [" + fromSeqNo + "] and to_seqno [" + toSeqNo + "] found"));
+            }finally {
+                IOUtils.close(searcher);
+            }
+        } else {
+            fromSeqNo = randomLongBetween(0, refreshedSeqNo);
+            toSeqNo = randomLongBetween(refreshedSeqNo + 1, numOps * 2);
+            Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+            try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(
+                searcher, mapperService, between(1, LuceneChangesSnapshot.DEFAULT_BATCH_SIZE), fromSeqNo, toSeqNo, false)) {
+                searcher = null;
+                assertThat(snapshot, SnapshotMatchers.containsSeqNoRange(fromSeqNo, refreshedSeqNo));
+            } finally {
+                IOUtils.close(searcher);
+            }
+            searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+            try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(
+                searcher, mapperService, between(1, LuceneChangesSnapshot.DEFAULT_BATCH_SIZE), fromSeqNo, toSeqNo, true)) {
+                searcher = null;
+                IllegalStateException error = expectThrows(IllegalStateException.class, () -> drainAll(snapshot));
+                assertThat(error.getMessage(),
+                           containsString("Not all operations between from_seqno [" + fromSeqNo + "] and to_seqno [" + toSeqNo + "] found"));
+            }finally {
+                IOUtils.close(searcher);
+            }
+            toSeqNo = randomLongBetween(fromSeqNo, refreshedSeqNo);
+            searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+            try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(
+                searcher, mapperService, between(1, LuceneChangesSnapshot.DEFAULT_BATCH_SIZE), fromSeqNo, toSeqNo, true)) {
+                searcher = null;
+                assertThat(snapshot, SnapshotMatchers.containsSeqNoRange(fromSeqNo, toSeqNo));
+            } finally {
+                IOUtils.close(searcher);
+            }
+        }
+        // Get snapshot via engine will auto refresh
+        fromSeqNo = randomLongBetween(0, numOps - 1);
+        toSeqNo = randomLongBetween(fromSeqNo, numOps - 1);
+        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapperService, fromSeqNo, toSeqNo, randomBoolean())) {
+            assertThat(snapshot, SnapshotMatchers.containsSeqNoRange(fromSeqNo, toSeqNo));
+        }
+    }
+
+    /**
+     * A nested document is indexed into Lucene as multiple documents. While the root document has both sequence number and primary term,
+     * non-root documents don't have primary term but only sequence numbers. This test verifies that {@link LuceneChangesSnapshot}
+     * correctly skip non-root documents and returns at most one operation per sequence number.
+     */
+    public void testSkipNonRootOfNestedDocuments() throws Exception {
+        Map<Long, Long> seqNoToTerm = new HashMap<>();
+        List<Engine.Operation> operations = generateHistoryOnReplica(between(1, 100), randomBoolean(), randomBoolean());
+        for (Engine.Operation op : operations) {
+            if (engine.getLocalCheckpointTracker().hasProcessed(op.seqNo()) == false) {
+                seqNoToTerm.put(op.seqNo(), op.primaryTerm());
+            }
+            applyOperation(engine, op);
+            if (rarely()) {
+                engine.refresh("test");
+            }
+            if (rarely()) {
+                engine.rollTranslogGeneration();
+            }
+            if (rarely()) {
+                engine.flush();
+            }
+        }
+        long maxSeqNo = engine.getLocalCheckpointTracker().getMaxSeqNo();
+        engine.refresh("test");
+        Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+        try (Translog.Snapshot snapshot = new LuceneChangesSnapshot(searcher, mapperService, between(1, 100), 0, maxSeqNo, false)) {
+            assertThat(snapshot.totalOperations(), equalTo(seqNoToTerm.size()));
+            Translog.Operation op;
+            while ((op = snapshot.next()) != null) {
+                assertThat(op.toString(), op.primaryTerm(), equalTo(seqNoToTerm.get(op.seqNo())));
+            }
+            assertThat(snapshot.skippedOperations(), equalTo(0));
+        }
+    }
+
+    public void testUpdateAndReadChangesConcurrently() throws Exception {
+        Follower[] followers = new Follower[between(1, 3)];
+        CountDownLatch readyLatch = new CountDownLatch(followers.length + 1);
+        AtomicBoolean isDone = new AtomicBoolean();
+        for (int i = 0; i < followers.length; i++) {
+            followers[i] = new Follower(engine, isDone, readyLatch);
+            followers[i].start();
+        }
+        boolean onPrimary = randomBoolean();
+        List<Engine.Operation> operations = new ArrayList<>();
+        int numOps = scaledRandomIntBetween(1, 1000);
+        for (int i = 0; i < numOps; i++) {
+            String id = Integer.toString(randomIntBetween(1, 10));
+            ParsedDocument doc = createParsedDoc(id, randomAlphaOfLengthBetween(1, 5), randomBoolean());
+            final Engine.Operation op;
+            if (onPrimary) {
+                if (randomBoolean()) {
+                    op = new Engine.Index(newUid(doc), primaryTerm.get(), doc);
+                } else {
+                    op = new Engine.Delete(doc.id(), newUid(doc.id()), primaryTerm.get());
+                }
+            } else {
+                if (randomBoolean()) {
+                    op = replicaIndexForDoc(doc, randomNonNegativeLong(), i, randomBoolean());
+                } else {
+                    op = replicaDeleteForDoc(doc.id(), randomNonNegativeLong(), i, randomNonNegativeLong());
+                }
+            }
+            operations.add(op);
+        }
+        readyLatch.countDown();
+        readyLatch.await();
+        concurrentlyApplyOps(operations, engine);
+        assertThat(engine.getLocalCheckpointTracker().getProcessedCheckpoint(), equalTo(operations.size() - 1L));
+        isDone.set(true);
+        for (Follower follower : followers) {
+            follower.join();
+            IOUtils.close(follower.engine, follower.engine.store);
+        }
+    }
+
+    class Follower extends Thread {
+        private final InternalEngine leader;
+        private final InternalEngine engine;
+        private final TranslogHandler translogHandler;
+        private final AtomicBoolean isDone;
+        private final CountDownLatch readLatch;
+
+        Follower(InternalEngine leader, AtomicBoolean isDone, CountDownLatch readLatch) throws IOException {
+            this.leader = leader;
+            this.isDone = isDone;
+            this.readLatch = readLatch;
+            this.translogHandler = new TranslogHandler(xContentRegistry(), IndexSettingsModule.newIndexSettings(shardId.getIndexName(),
+                                                                                                                leader.engineConfig.getIndexSettings().getSettings()));
+            this.engine = createEngine(createStore(), createTempDir());
+        }
+
+        void pullOperations(InternalEngine follower) throws IOException {
+            long leaderCheckpoint = leader.getLocalCheckpointTracker().getProcessedCheckpoint();
+            long followerCheckpoint = follower.getLocalCheckpointTracker().getProcessedCheckpoint();
+            if (followerCheckpoint < leaderCheckpoint) {
+                long fromSeqNo = followerCheckpoint + 1;
+                long batchSize = randomLongBetween(0, 100);
+                long toSeqNo = Math.min(fromSeqNo + batchSize, leaderCheckpoint);
+                try (Translog.Snapshot snapshot = leader.newChangesSnapshot("test", mapperService, fromSeqNo, toSeqNo, true)) {
+                    translogHandler.run(follower, snapshot);
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                readLatch.countDown();
+                readLatch.await();
+                while (isDone.get() == false ||
+                       engine.getLocalCheckpointTracker().getProcessedCheckpoint() <
+                       leader.getLocalCheckpointTracker().getProcessedCheckpoint()) {
+                    pullOperations(engine);
+                }
+                assertConsistentHistoryBetweenTranslogAndLuceneIndex(engine, mapperService);
+                // have to verify without source since we are randomly testing without _source
+                List<DocIdSeqNoAndSource> docsWithoutSourceOnFollower = getDocIds(engine, true).stream()
+                    .map(d -> new DocIdSeqNoAndSource(d.getId(), null, d.getSeqNo(), d.getPrimaryTerm(), d.getVersion()))
+                    .collect(Collectors.toList());
+                List<DocIdSeqNoAndSource> docsWithoutSourceOnLeader = getDocIds(leader, true).stream()
+                    .map(d -> new DocIdSeqNoAndSource(d.getId(), null, d.getSeqNo(), d.getPrimaryTerm(), d.getVersion()))
+                    .collect(Collectors.toList());
+                assertThat(docsWithoutSourceOnFollower, equalTo(docsWithoutSourceOnLeader));
+            } catch (Exception ex) {
+                throw new AssertionError(ex);
+            }
+        }
+    }
+
+    private List<Translog.Operation> drainAll(Translog.Snapshot snapshot) throws IOException {
+        List<Translog.Operation> operations = new ArrayList<>();
+        Translog.Operation op;
+        while ((op = snapshot.next()) != null) {
+            final Translog.Operation newOp = op;
+            logger.error("Reading [{}]", op);
+            assert operations.stream().allMatch(o -> o.seqNo() < newOp.seqNo()) : "Operations [" + operations + "], op [" + op + "]";
+            operations.add(newOp);
+        }
+        return operations;
+    }
+
+    public void testOverFlow() throws Exception {
+        long fromSeqNo = randomLongBetween(0, 5);
+        long toSeqNo = randomLongBetween(Long.MAX_VALUE - 5, Long.MAX_VALUE);
+        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapperService, fromSeqNo, toSeqNo, true)) {
+            IllegalStateException error = expectThrows(IllegalStateException.class, () -> drainAll(snapshot));
+            assertThat(error.getMessage(),
+                       containsString("Not all operations between from_seqno [" + fromSeqNo + "] and to_seqno [" + toSeqNo + "] found"));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.engine;
+
+import io.crate.common.io.IOUtils;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.seqno.SeqNoStats;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.store.Store;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader.getElasticsearchDirectoryReader;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class ReadOnlyEngineTests extends EngineTestCase {
+
+    public void testReadOnlyEngine() throws Exception {
+        IOUtils.close(engine, store);
+        Engine readOnlyEngine = null;
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            int numDocs = scaledRandomIntBetween(10, 1000);
+            final SeqNoStats lastSeqNoStats;
+            final List<DocIdSeqNoAndSource> lastDocIds;
+            try (InternalEngine engine = createEngine(config)) {
+                Engine.Get get = null;
+                for (int i = 0; i < numDocs; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(new Engine.Index(newUid(doc), doc, i, primaryTerm.get(), 1, null, Engine.Operation.Origin.REPLICA,
+                                                  System.nanoTime(), -1, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0));
+                    if (get == null || rarely()) {
+                        get = newGet(doc);
+                    }
+                    if (rarely()) {
+                        engine.flush();
+                    }
+                    globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getPersistedLocalCheckpoint()));
+                }
+                engine.syncTranslog();
+                globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getPersistedLocalCheckpoint()));
+                engine.flush();
+                readOnlyEngine = new ReadOnlyEngine(engine.engineConfig, engine.getSeqNoStats(globalCheckpoint.get()),
+                                                    engine.getTranslogStats(), false, Function.identity());
+                lastSeqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
+                lastDocIds = getDocIds(engine, true);
+                assertThat(readOnlyEngine.getPersistedLocalCheckpoint(), equalTo(lastSeqNoStats.getLocalCheckpoint()));
+                assertThat(readOnlyEngine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo(), equalTo(lastSeqNoStats.getMaxSeqNo()));
+                assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
+                for (int i = 0; i < numDocs; i++) {
+                    if (randomBoolean()) {
+                        String delId = Integer.toString(i);
+                        engine.delete(new Engine.Delete(delId, newUid(delId), primaryTerm.get()));
+                    }
+                    if (rarely()) {
+                        engine.flush();
+                    }
+                }
+                Engine.Searcher external = readOnlyEngine.acquireSearcher("test", Engine.SearcherScope.EXTERNAL);
+                Engine.Searcher internal = readOnlyEngine.acquireSearcher("test", Engine.SearcherScope.INTERNAL);
+                assertSame(external.getIndexReader(), internal.getIndexReader());
+                assertThat(external.getIndexReader(), instanceOf(DirectoryReader.class));
+                DirectoryReader dirReader = external.getDirectoryReader();
+                ElasticsearchDirectoryReader esReader = getElasticsearchDirectoryReader(dirReader);
+                IndexReader.CacheHelper helper = esReader.getReaderCacheHelper();
+                assertNotNull(helper);
+                assertEquals(helper.getKey(), dirReader.getReaderCacheHelper().getKey());
+
+                IOUtils.close(external, internal);
+                // the locked down engine should still point to the previous commit
+                assertThat(readOnlyEngine.getPersistedLocalCheckpoint(), equalTo(lastSeqNoStats.getLocalCheckpoint()));
+                assertThat(readOnlyEngine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo(), equalTo(lastSeqNoStats.getMaxSeqNo()));
+                assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
+            }
+            // Close and reopen the main engine
+            try (InternalEngine recoveringEngine = new InternalEngine(config)) {
+                recoveringEngine.recoverFromTranslog(translogHandler, Long.MAX_VALUE);
+                // the locked down engine should still point to the previous commit
+                assertThat(readOnlyEngine.getPersistedLocalCheckpoint(), equalTo(lastSeqNoStats.getLocalCheckpoint()));
+                assertThat(readOnlyEngine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo(), equalTo(lastSeqNoStats.getMaxSeqNo()));
+                assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
+            }
+        } finally {
+            IOUtils.close(readOnlyEngine);
+        }
+    }
+
+    public void testEnsureMaxSeqNoIsEqualToGlobalCheckpoint() throws IOException {
+        IOUtils.close(engine, store);
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            final int numDocs = scaledRandomIntBetween(10, 100);
+            try (InternalEngine engine = createEngine(config)) {
+                long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
+                for (int i = 0; i < numDocs; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(new Engine.Index(newUid(doc), doc, i, primaryTerm.get(), 1, null, Engine.Operation.Origin.REPLICA,
+                                                  System.nanoTime(), -1, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0));
+                    maxSeqNo = engine.getProcessedLocalCheckpoint();
+                }
+                engine.syncTranslog();
+                globalCheckpoint.set(engine.getPersistedLocalCheckpoint() - 1);
+                engine.flushAndClose();
+
+                IllegalStateException exception = expectThrows(IllegalStateException.class,
+                                                               () -> new ReadOnlyEngine(config, null, null, true, Function.identity()) {
+                                                                   @Override
+                                                                   protected boolean assertMaxSeqNoEqualsToGlobalCheckpoint(final long maxSeqNo, final long globalCheckpoint) {
+                                                                       // we don't want the assertion to trip in this test
+                                                                       return true;
+                                                                   }
+                                                               });
+                assertThat(exception.getMessage(), equalTo("Maximum sequence number [" + maxSeqNo
+                                                           + "] from last commit does not match global checkpoint [" + globalCheckpoint.get() + "]"));
+            }
+        }
+    }
+
+    public void testTranslogStats() throws IOException {
+        IOUtils.close(engine, store);
+        try (Store store = createStore()) {
+            final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            final boolean softDeletesEnabled = config.getIndexSettings().isSoftDeleteEnabled();
+            final int numDocs = frequently() ? scaledRandomIntBetween(10, 200) : 0;
+            int uncommittedDocs = 0;
+
+            try (InternalEngine engine = createEngine(config)) {
+                for (int i = 0; i < numDocs; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(new Engine.Index(newUid(doc), doc, i, primaryTerm.get(), 1, null, Engine.Operation.Origin.REPLICA,
+                                                  System.nanoTime(), -1, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0));
+                    globalCheckpoint.set(i);
+                    if (rarely()) {
+                        engine.flush();
+                        uncommittedDocs = 0;
+                    } else {
+                        uncommittedDocs += 1;
+                    }
+                }
+
+                assertThat(engine.getTranslogStats().estimatedNumberOfOperations(),
+                           equalTo(softDeletesEnabled ? uncommittedDocs : numDocs));
+                assertThat(engine.getTranslogStats().getUncommittedOperations(), equalTo(uncommittedDocs));
+                assertThat(engine.getTranslogStats().getTranslogSizeInBytes(), greaterThan(0L));
+                assertThat(engine.getTranslogStats().getUncommittedSizeInBytes(), greaterThan(0L));
+
+                engine.flush(true, true);
+            }
+
+            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, Function.identity())) {
+                assertThat(readOnlyEngine.getTranslogStats().estimatedNumberOfOperations(), equalTo(softDeletesEnabled ? 0 : numDocs));
+                assertThat(readOnlyEngine.getTranslogStats().getUncommittedOperations(), equalTo(0));
+                assertThat(readOnlyEngine.getTranslogStats().getTranslogSizeInBytes(), greaterThan(0L));
+                assertThat(readOnlyEngine.getTranslogStats().getUncommittedSizeInBytes(), greaterThan(0L));
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.util.RamUsageTester;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.test.ESTestCase;
+
+public class VersionValueTests extends ESTestCase {
+
+    public void testIndexRamBytesUsed() {
+        Translog.Location translogLoc = null;
+        if (randomBoolean()) {
+            translogLoc = new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+        }
+        IndexVersionValue versionValue = new IndexVersionValue(translogLoc, randomLong(), randomLong(), randomLong());
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+    }
+
+    public void testDeleteRamBytesUsed() {
+        DeleteVersionValue versionValue = new DeleteVersionValue(randomLong(), randomLong(), randomLong(), randomLong());
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This ports back some elasticsearch testcases, which worked out of the box. It is taken from the state of elasticsearch `704317da71c`. See commits for details.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
