### PR TITLE
Do not close index searchers outside of the CollectTask.

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -100,42 +100,37 @@ public class DocValuesAggregates {
         ShardId shardId = indexShard.shardId();
         SharedShardContext shardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Searcher searcher = shardContext.acquireSearcher(LuceneShardCollectorProvider.formatSource(phase));
-        try {
-            QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
-            collectTask.addSearcher(shardContext.readerId(), searcher);
-            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-                phase.where(),
-                collectTask.txnCtx(),
-                indexShard.mapperService(),
-                indexShard.shardId().getIndexName(),
-                queryShardContext,
-                table,
-                shardContext.indexService().cache()
-            );
+        QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
+        collectTask.addSearcher(shardContext.readerId(), searcher);
+        LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+            phase.where(),
+            collectTask.txnCtx(),
+            indexShard.mapperService(),
+            indexShard.shardId().getIndexName(),
+            queryShardContext,
+            table,
+            shardContext.indexService().cache()
+        );
 
-            AtomicReference<Throwable> killed = new AtomicReference<>();
-            return CollectingBatchIterator.newInstance(
-                () -> killed.set(BatchIterator.CLOSED),
-                killed::set,
-                () -> {
-                    try {
-                        return CompletableFuture.completedFuture(getRow(
-                            collectTask.getRamAccounting(),
-                            killed,
-                            searcher,
-                            queryContext.query(),
-                            aggregators
-                        ));
-                    } catch (Throwable t) {
-                        return CompletableFuture.failedFuture(t);
-                    }
-                },
-                true
-            );
-        } catch (Throwable t) {
-            searcher.close();
-            throw t;
-        }
+        AtomicReference<Throwable> killed = new AtomicReference<>();
+        return CollectingBatchIterator.newInstance(
+            () -> killed.set(BatchIterator.CLOSED),
+            killed::set,
+            () -> {
+                try {
+                    return CompletableFuture.completedFuture(getRow(
+                        collectTask.getRamAccounting(),
+                        killed,
+                        searcher,
+                        queryContext.query(),
+                        aggregators
+                    ));
+                } catch (Throwable t) {
+                    return CompletableFuture.failedFuture(t);
+                }
+            },
+            true
+        );
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -132,50 +132,45 @@ final class DocValuesGroupByOptimizedIterator {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
-        try {
-            QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+        QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
+        collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
-            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
-                = docInputFactory.getCtx(collectTask.txnCtx());
-            docCtx.add(columnKeyRefs);
-            List<? extends LuceneCollectorExpression<?>> keyExpressions = docCtx.expressions();
+        InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
+            = docInputFactory.getCtx(collectTask.txnCtx());
+        docCtx.add(columnKeyRefs);
+        List<? extends LuceneCollectorExpression<?>> keyExpressions = docCtx.expressions();
 
-            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-                collectPhase.where(),
-                collectTask.txnCtx(),
-                indexShard.mapperService(),
-                indexShard.shardId().getIndexName(),
-                queryShardContext,
-                table,
-                sharedShardContext.indexService().cache()
+        LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+            collectPhase.where(),
+            collectTask.txnCtx(),
+            indexShard.mapperService(),
+            indexShard.shardId().getIndexName(),
+            queryShardContext,
+            table,
+            sharedShardContext.indexService().cache()
+        );
+
+        var ramAccounting = collectTask.getRamAccounting();
+        if (columnKeyRefs.size() == 1) {
+            return GroupByIterator.forSingleKey(
+                aggregators,
+                searcher,
+                columnKeyRefs.get(0),
+                keyExpressions,
+                ramAccounting,
+                queryContext.query(),
+                new CollectorContext(sharedShardContext.readerId())
             );
-
-            var ramAccounting = collectTask.getRamAccounting();
-            if (columnKeyRefs.size() == 1) {
-                return GroupByIterator.forSingleKey(
-                    aggregators,
-                    searcher,
-                    columnKeyRefs.get(0),
-                    keyExpressions,
-                    ramAccounting,
-                    queryContext.query(),
-                    new CollectorContext(sharedShardContext.readerId())
-                );
-            } else {
-                return GroupByIterator.forManyKeys(
-                    aggregators,
-                    searcher,
-                    columnKeyRefs,
-                    keyExpressions,
-                    ramAccounting,
-                    queryContext.query(),
-                    new CollectorContext(sharedShardContext.readerId())
-                );
-            }
-        } catch (Throwable t) {
-            searcher.close();
-            throw t;
+        } else {
+            return GroupByIterator.forManyKeys(
+                aggregators,
+                searcher,
+                columnKeyRefs,
+                keyExpressions,
+                ramAccounting,
+                queryContext.query(),
+                new CollectorContext(sharedShardContext.readerId())
+            );
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

In the doc values group by and aggregation optimizations
(`GroupByOptimizedIterator`, `DocValuesGroupByOptimizedIterator`,
`DocValuesAggregates`) index searchers are added explicitly to the
collect task and their closing, in case of failure, is managed as
well by the above-mentioned classes. That is redundant. The collect
task manages closing of the added index searcher itself. See
`CollectTask#innerKill` or `CollectTask#close/innerClose`.

CollectTask index searchers closing [test case](https://github.com/crate/crate/blob/master/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java#L99-L110).

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
