### PR TITLE
Also pause insert-from-query on high memory usage

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,10 @@ Changes
 Fixes
 =====
 
+- Improved the throttling behavior of ``INSERT INTO .. <query>``, it is now
+  more aggressive to reduce the amount of memory used by a ``INSERT INTO``
+  operation.
+
 - Fixed an issue which resulted in an error when a parameter symbol
   (placeholder) is used inside an aggregation.
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.LogManager;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -66,6 +67,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
     private static final BackoffPolicy BACKOFF_POLICY = LimitedExponentialBackoff.limitedExponential(1000);
     public static final int DEFAULT_BULK_SIZE = 10_000;
 
+    private final UUID jobId;
     private final int bulkSize;
     private final ScheduledExecutorService scheduler;
     private final Executor executor;
@@ -78,7 +80,8 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
     private final Collector<ShardResponse, TAcc, TResult> collector;
     private int numItems = -1;
 
-    public ShardDMLExecutor(int bulkSize,
+    public ShardDMLExecutor(UUID jobId,
+                            int bulkSize,
                             ScheduledExecutorService scheduler,
                             Executor executor,
                             CollectExpression<Row, ?> uidExpression,
@@ -89,6 +92,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
                             BiConsumer<TReq, ActionListener<ShardResponse>> transportAction,
                             Collector<ShardResponse, TAcc, TResult> collector
                             ) {
+        this.jobId = jobId;
         this.bulkSize = bulkSize;
         this.scheduler = scheduler;
         this.executor = executor;
@@ -142,6 +146,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
         }
 
         return new BatchIteratorBackpressureExecutor<>(
+            jobId,
             scheduler,
             executor,
             reqBatchIterator,

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
@@ -23,6 +23,8 @@
 package io.crate.execution.engine.indexing;
 
 import io.crate.execution.dml.ShardRequest;
+
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.ArrayList;
@@ -31,7 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item> {
+public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
+    extends ShardRequest.Item>
+    implements Accountable {
 
     final Map<String, List<ItemAndRoutingAndSourceInfo<TItem>>> itemsByMissingIndex = new HashMap<>();
     final Map<String, List<ReadFailureAndLineNumber>> itemsWithFailureBySourceUri = new HashMap<>();
@@ -83,7 +87,8 @@ public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
         sourceUrisWithFailure.put(sourceUri, uriReadFailure);
     }
 
-    long usedMemoryEstimate() {
+    @Override
+    public long ramBytesUsed() {
         return usedMemoryEstimate;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -22,34 +22,8 @@
 
 package io.crate.execution.engine.indexing;
 
-import io.crate.action.FutureActionListener;
-import io.crate.action.LimitedExponentialBackoff;
-import io.crate.breaker.TypeGuessEstimateRowSize;
-import io.crate.data.BatchIterator;
-import io.crate.data.BatchIterators;
-import io.crate.data.Row;
-import io.crate.execution.dml.ShardResponse;
-import io.crate.execution.dml.upsert.ShardUpsertRequest;
-import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.RowShardResolver;
-import io.crate.execution.jobs.NodeJobsCounter;
-import io.crate.execution.support.RetryListener;
-import io.crate.settings.CrateSetting;
-import io.crate.types.DataTypes;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
-import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
-import org.elasticsearch.action.bulk.BackoffPolicy;
-import org.elasticsearch.action.bulk.BulkRequestExecutor;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Setting;
-import io.crate.common.unit.TimeValue;
-import org.elasticsearch.index.shard.ShardId;
+import static io.crate.execution.jobs.NodeJobsCounter.MAX_NODE_CONCURRENT_OPERATIONS;
 
-import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +39,36 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 
-import static io.crate.execution.jobs.NodeJobsCounter.MAX_NODE_CONCURRENT_OPERATIONS;
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkRequestExecutor;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.index.shard.ShardId;
+
+import io.crate.action.FutureActionListener;
+import io.crate.action.LimitedExponentialBackoff;
+import io.crate.breaker.TypeGuessEstimateRowSize;
+import io.crate.common.unit.TimeValue;
+import io.crate.data.BatchIterator;
+import io.crate.data.BatchIterators;
+import io.crate.data.Row;
+import io.crate.execution.dml.ShardResponse;
+import io.crate.execution.dml.upsert.ShardUpsertRequest;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.RowShardResolver;
+import io.crate.execution.jobs.NodeJobsCounter;
+import io.crate.execution.support.RetryListener;
+import io.crate.settings.CrateSetting;
+import io.crate.types.DataTypes;
 
 public class ShardingUpsertExecutor
     implements Function<BatchIterator<Row>, CompletableFuture<? extends Iterable<? extends Row>>> {
@@ -263,11 +266,14 @@ public class ShardingUpsertExecutor
         Predicate<ShardedRequests<ShardUpsertRequest, ShardUpsertRequest.Item>> shouldPause =
             this::shouldPauseOnPartitionCreation;
         if (batchIterator.hasLazyResultSet()) {
-            shouldPause = shouldPause.or(this::shouldPauseOnTargetNodeJobsCounter);
+            shouldPause = shouldPause
+                .or(this::shouldPauseOnTargetNodeJobsCounter)
+                .or(isUsedBytesOverThreshold);
         }
 
         BatchIteratorBackpressureExecutor<ShardedRequests<ShardUpsertRequest, ShardUpsertRequest.Item>, UpsertResults> executor =
             new BatchIteratorBackpressureExecutor<>(
+                jobId,
                 scheduler,
                 this.executor,
                 reqBatchIterator,
@@ -340,7 +346,8 @@ public class ShardingUpsertExecutor
 
     private static class IsUsedBytesOverThreshold implements Predicate<ShardedRequests<?, ?>> {
 
-        private static final double HEAP_PERCENTAGE = 0.30d;
+        private static final double HEAP_PERCENTAGE = 0.20d;
+        private static final long MAX_MEMORY_PER_REQUEST_IN_BYTES = ByteSizeUnit.MB.toBytes(100);
 
         private final long maxBytesUsableByShardedRequests;
 
@@ -351,7 +358,18 @@ public class ShardingUpsertExecutor
 
         @Override
         public final boolean test(ShardedRequests<?, ?> shardedRequests) {
-            return shardedRequests.usedMemoryEstimate() > maxBytesUsableByShardedRequests;
+            long usedMemoryEstimate = shardedRequests.ramBytesUsed();
+            boolean requestsTooBig = usedMemoryEstimate > maxBytesUsableByShardedRequests
+                || usedMemoryEstimate > MAX_MEMORY_PER_REQUEST_IN_BYTES;
+            if (requestsTooBig && LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                    "Creating smaller bulk requests because shardedRequests is using too much memory. "
+                        + "ramBytesUsed={} itemsByShard={} itemSize={}",
+                    shardedRequests.ramBytesUsed(),
+                    shardedRequests.itemsByShard().size(),
+                    shardedRequests.ramBytesUsed() / shardedRequests.itemsByShard().size());
+            }
+            return requestsTooBig;
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -527,6 +527,7 @@ public class ProjectionToProjectorVisitor
         );
 
         return new ShardDMLExecutor<>(
+            context.jobId,
             ShardDMLExecutor.DEFAULT_BULK_SIZE,
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
@@ -550,6 +551,7 @@ public class ProjectionToProjectorVisitor
         TimeValue reqTimeout = ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings);
 
         ShardDMLExecutor<?, ?, ?, ?> shardDMLExecutor = new ShardDMLExecutor<>(
+            context.jobId,
             ShardDMLExecutor.DEFAULT_BULK_SIZE,
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),

--- a/server/src/test/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutorTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,6 +76,7 @@ public class BatchIteratorBackpressureExecutorTest extends ESTestCase {
             return false;
         };
         BatchIteratorBackpressureExecutor<Integer, Integer> executor = new BatchIteratorBackpressureExecutor<>(
+            UUID.randomUUID(),
             scheduler,
             this.executor,
             it,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We added a byte-threshold to the partitioning, which leads to smaller
individual bulk requests, but it still allowed concurrent execution
which can lead to many smaller bulk requests being held in memory for a
long time.

This adds the byte-threshold rule also to the pause check, to pause
reading more data if a lot of memory is occupied.

This is based on some heap dumps from nodes which crashed due to OOM
where a large chunk of memory was used up by response handlers.

This also lowers the allowed heap percentage that the bulk requests may
take (from 30% to 20%) and adds a second static max size (100MB)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)