### PR TITLE
Remove obsolete Ignore annotation for subscript on object literal

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -740,11 +740,10 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(printedTable(response.rows()), is("1| 2\n"));
     }
 
-    @Ignore("We haven't added inner types for object literals, so this test is expected to fail")
     @Test
     public void testSubscriptOnSubSelectFromUnnestWithObjectLiteral() {
         execute("select col1['b'] from (select * from unnest([{b=1}])) t1");
-        assertThat(printedTable(response.rows()), is(""));
+        assertThat(printedTable(response.rows()), is("1\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We enabled this case a while ago

    select col1['b'] from (select * from unnest([{b=1}])) t1

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)