### PR TITLE
Deprecate fielddata circuit breaker setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,16 @@ Breaking Changes
   their position is after an ``object`` type column.
 
 
+Deprecations
+============
+
+- Deprecated the :ref:`indices.breaker.fielddata.limit
+  <indices.breaker.fielddata.limit>` and
+  :ref:`indices.breaker.fielddata.overhead
+  <indices.breaker.fielddata.overhead>` settings. These no longer have any
+  effect as there is no fielddata cache anymore.
+
+
 Changes
 =======
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1001,9 +1001,8 @@ keeps working.
 Field data circuit breaker
 --------------------------
 
-The field data circuit breaker allows estimation of needed heap memory required
-for loading field data into memory. If a certain limit is reached an exception
-is raised.
+These settings are deprecated and will be removed in CrateDB 5.0. They don't
+have any effect anymore.
 
 .. _indices.breaker.fielddata.limit:
 
@@ -1011,7 +1010,6 @@ is raised.
   | *Default:*   ``60%``
   | *Runtime:*  ``yes``
 
-  Specifies the JVM heap limit for the fielddata breaker.
 
 .. _indices.breaker.fielddata.overhead:
 
@@ -1019,8 +1017,6 @@ is raised.
   | *Default:*   ``1.03``
   | *Runtime:*  ``yes``
 
-  A constant that all field data estimations are multiplied with to determine a
-  final estimation.
 
 Request circuit breaker
 -----------------------

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/CircuitBreakers.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/CircuitBreakers.java
@@ -28,6 +28,7 @@ public class CircuitBreakers implements CircuitBreakersMXBean {
     public static final String NAME = "io.crate.monitoring:type=CircuitBreakers";
 
     private final CircuitBreakerService circuitBreakerService;
+    private final CircuitBreakerStats EMPTY_FIELDDATA_STATS = new CircuitBreakerStats("fielddata", -1, -1, 0, 0);
 
     public CircuitBreakers(CircuitBreakerService circuitBreakerService) {
         this.circuitBreakerService = circuitBreakerService;
@@ -40,7 +41,7 @@ public class CircuitBreakers implements CircuitBreakersMXBean {
 
     @Override
     public CircuitBreakerStats getFieldData() {
-        return circuitBreakerService.stats(CircuitBreaker.FIELDDATA);
+        return EMPTY_FIELDDATA_STATS;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -36,11 +36,7 @@ public interface CircuitBreaker {
      * from by itself.
      */
     String PARENT = "parent";
-    /**
-     * The fielddata breaker tracks data used for fielddata (on fields) as well
-     * as the id cached used for parent/child queries.
-     */
-    String FIELDDATA = "fielddata";
+
     /**
      * The request breaker tracks memory used for particular requests. This
      * includes allocations for things like the cardinality aggregation, and

--- a/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.breaker;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -195,6 +196,6 @@ public class MemoryCircuitBreaker implements CircuitBreaker {
      */
     @Override
     public String getName() {
-        return FIELDDATA;
+        return HierarchyCircuitBreakerService.QUERY;
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -61,8 +61,6 @@ public class MemorySizeSettingsTests extends ESTestCase {
         double defaultTotalPercentage = 0.95d;
         assertMemorySizeSetting(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING, "indices.breaker.total.limit",
                 new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage)));
-        assertMemorySizeSetting(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING, "indices.breaker.fielddata.limit",
-                                new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.6)));
         assertMemorySizeSetting(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, "indices.breaker.request.limit",
                 new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.6)));
         assertMemorySizeSetting(HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/test/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
  */
 public class NoneCircuitBreakerService extends CircuitBreakerService {
 
-    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.FIELDDATA);
+    private final CircuitBreaker breaker = new NoopCircuitBreaker(HierarchyCircuitBreakerService.QUERY);
 
     public NoneCircuitBreakerService() {
     }
@@ -40,7 +40,7 @@ public class NoneCircuitBreakerService extends CircuitBreakerService {
 
     @Override
     public CircuitBreakerStats stats(String name) {
-        return new CircuitBreakerStats(CircuitBreaker.FIELDDATA, -1, -1, 0, 0);
+        return new CircuitBreakerStats(HierarchyCircuitBreakerService.QUERY, -1, -1, 0, 0);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2186,8 +2186,6 @@ public final class InternalTestCluster extends TestCluster {
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 final String name = nodeAndClient.name;
                 final CircuitBreakerService breakerService = getInstanceFromNode(CircuitBreakerService.class, nodeAndClient.node);
-                CircuitBreaker fdBreaker = breakerService.getBreaker(CircuitBreaker.FIELDDATA);
-                assertThat("Fielddata breaker not reset to 0 on node: " + name, fdBreaker.getUsed(), equalTo(0L));
                 try {
                     assertBusy(() -> {
                         CircuitBreaker acctBreaker = breakerService.getBreaker(CircuitBreaker.ACCOUNTING);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The fielddata circuit breaker isn't used in production code anymore.
The only existing calls are from tests.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)