### PR TITLE
Account for memory used and adapt size in insert-from-query operations

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -42,6 +42,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nullable;
@@ -56,12 +57,14 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
                                       ClusterService clusterService,
                                       Schemas schemas,
                                       NodeJobsCounter nodeJobsCounter,
+                                      CircuitBreakerService circuitBreakerService,
                                       NodeContext nodeCtx,
                                       ThreadPool threadPool,
                                       Settings settings,
                                       TransportActionProvider transportActionProvider) {
         super(
             clusterService,
+            circuitBreakerService,
             schemas,
             nodeJobsCounter,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.data.BatchIterator;
@@ -80,6 +81,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                                         LuceneQueryBuilder luceneQueryBuilder,
                                         ClusterService clusterService,
                                         NodeJobsCounter nodeJobsCounter,
+                                        CircuitBreakerService circuitBreakerService,
                                         NodeContext nodeCtx,
                                         ThreadPool threadPool,
                                         Settings settings,
@@ -88,6 +90,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                                         BigArrays bigArrays) {
         super(
             clusterService,
+            circuitBreakerService,
             schemas,
             nodeJobsCounter,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -30,6 +30,7 @@ import io.crate.metadata.NodeContext;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.analyze.WhereClause;
@@ -61,6 +62,7 @@ public abstract class ShardCollectorProvider {
     final EvaluatingNormalizer shardNormalizer;
 
     ShardCollectorProvider(ClusterService clusterService,
+                           CircuitBreakerService circuitBreakerService,
                            Schemas schemas,
                            NodeJobsCounter nodeJobsCounter,
                            NodeContext nodeCtx,
@@ -80,6 +82,7 @@ public abstract class ShardCollectorProvider {
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService,
             nodeCtx,
             threadPool,
             settings,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
@@ -53,6 +53,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -74,6 +75,7 @@ public class CollectSourceResolver {
     @Inject
     public CollectSourceResolver(ClusterService clusterService,
                                  NodeJobsCounter nodeJobsCounter,
+                                 CircuitBreakerService circuitBreakerService,
                                  NodeContext nodeCtx,
                                  Settings settings,
                                  ThreadPool threadPool,
@@ -92,6 +94,7 @@ public class CollectSourceResolver {
         ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService,
             nodeCtx,
             threadPool,
             settings,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -188,6 +188,7 @@ public class ShardCollectSource implements CollectSource {
         BigArrays bigArrays = new BigArrays(pageCacheRecycler, circuitBreakerService, HierarchyCircuitBreakerService.QUERY, true);
         this.shardCollectorProviderFactory = new ShardCollectorProviderFactory(
             clusterService,
+            circuitBreakerService,
             settings,
             schemas,
             threadPool,
@@ -206,6 +207,7 @@ public class ShardCollectSource implements CollectSource {
         sharedProjectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService,
             nodeCtx,
             threadPool,
             settings,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import static io.crate.blob.v2.BlobIndex.isBlobIndex;
@@ -53,8 +54,10 @@ public class ShardCollectorProviderFactory {
     private final NodeJobsCounter nodeJobsCounter;
     private final BigArrays bigArrays;
     private final Settings settings;
+    private final CircuitBreakerService circuitBreakerService;
 
     ShardCollectorProviderFactory(ClusterService clusterService,
+                                  CircuitBreakerService circuitBreakerService,
                                   Settings settings,
                                   Schemas schemas,
                                   ThreadPool threadPool,
@@ -65,6 +68,7 @@ public class ShardCollectorProviderFactory {
                                   NodeJobsCounter nodeJobsCounter,
                                   BigArrays bigArrays) {
         this.settings = settings;
+        this.circuitBreakerService = circuitBreakerService;
         this.schemas = schemas;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
@@ -84,6 +88,7 @@ public class ShardCollectorProviderFactory {
                 clusterService,
                 schemas,
                 nodeJobsCounter,
+                circuitBreakerService,
                 nodeCtx,
                 threadPool,
                 settings,
@@ -95,6 +100,7 @@ public class ShardCollectorProviderFactory {
                 luceneQueryBuilder,
                 clusterService,
                 nodeJobsCounter,
+                circuitBreakerService,
                 nodeCtx,
                 threadPool,
                 settings,

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -41,6 +41,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -58,6 +59,7 @@ public class ColumnIndexWriterProjector implements Projector {
 
     public ColumnIndexWriterProjector(ClusterService clusterService,
                                       NodeJobsCounter nodeJobsCounter,
+                                      CircuitBreaker queryCircuitBreaker,
                                       ScheduledExecutorService scheduler,
                                       Executor executor,
                                       TransactionContext txnCtx,
@@ -123,6 +125,7 @@ public class ColumnIndexWriterProjector implements Projector {
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
             nodeJobsCounter,
+            queryCircuitBreaker,
             scheduler,
             executor,
             bulkActions,

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -66,6 +67,7 @@ public class IndexWriterProjector implements Projector {
 
     public IndexWriterProjector(ClusterService clusterService,
                                 NodeJobsCounter nodeJobsCounter,
+                                CircuitBreaker queryCircuitBreaker,
                                 ScheduledExecutorService scheduler,
                                 Executor executor,
                                 TransactionContext txnCtx,
@@ -117,6 +119,7 @@ public class IndexWriterProjector implements Projector {
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
             nodeJobsCounter,
+            queryCircuitBreaker,
             scheduler,
             executor,
             bulkActions,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -107,6 +107,8 @@ import org.elasticsearch.common.settings.Settings;
 import io.crate.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nullable;
@@ -148,13 +150,16 @@ public class ProjectionToProjectorVisitor
     private final EvaluatingNormalizer normalizer;
     private final Function<RelationName, SysRowUpdater<?>> sysUpdaterGetter;
     private final Function<RelationName, StaticTableDefinition<?>> staticTableDefinitionGetter;
+    private final CircuitBreakerService circuitBreakerService;
     private final Version indexVersionCreated;
     @Nullable
     private final ShardId shardId;
     private final int numProcessors;
 
+
     public ProjectionToProjectorVisitor(ClusterService clusterService,
                                         NodeJobsCounter nodeJobsCounter,
+                                        CircuitBreakerService circuitBreakerService,
                                         NodeContext nodeCtx,
                                         ThreadPool threadPool,
                                         Settings settings,
@@ -167,6 +172,7 @@ public class ProjectionToProjectorVisitor
                                         @Nullable ShardId shardId) {
         this.clusterService = clusterService;
         this.nodeJobsCounter = nodeJobsCounter;
+        this.circuitBreakerService = circuitBreakerService;
         this.nodeCtx = nodeCtx;
         this.threadPool = threadPool;
         this.settings = settings;
@@ -182,6 +188,7 @@ public class ProjectionToProjectorVisitor
 
     public ProjectionToProjectorVisitor(ClusterService clusterService,
                                         NodeJobsCounter nodeJobsCounter,
+                                        CircuitBreakerService circuitBreakerService,
                                         NodeContext nodeCtx,
                                         ThreadPool threadPool,
                                         Settings settings,
@@ -192,7 +199,8 @@ public class ProjectionToProjectorVisitor
                                         Function<RelationName, StaticTableDefinition<?>> staticTableDefinitionGetter) {
         this(clusterService,
             nodeJobsCounter,
-             nodeCtx,
+            circuitBreakerService,
+            nodeCtx,
             threadPool,
             settings,
             transportActionProvider,
@@ -419,6 +427,7 @@ public class ProjectionToProjectorVisitor
         return new IndexWriterProjector(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             context.txnCtx,
@@ -467,6 +476,7 @@ public class ProjectionToProjectorVisitor
         return new ColumnIndexWriterProjector(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             context.txnCtx,

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -177,6 +177,7 @@ public class JobSetup {
         this.projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             nodeJobsCounter,
+            circuitBreakerService,
             nodeCtx,
             threadPool,
             settings,

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -88,6 +88,15 @@ public interface CircuitBreaker {
     double addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException;
 
     /**
+     * Similar to {@link #addEstimateBytesAndMaybeBreak}, but is more lenient and
+     * doesn't break if `wantedBytes` is not available, but will instead account for
+     * a lower value as long as that value is above `minAcceptableBytes`.
+     *
+     * @return the number of bytes actually accounted for.
+     */
+    long addBytesRangeAndMaybeBreak(long minAcceptableBytes, long wantedBytes, String label);
+
+    /**
      * Adjust the circuit breaker without tripping
      */
     long addWithoutBreaking(long bytes);

--- a/server/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
@@ -24,7 +24,7 @@ package org.elasticsearch.common.breaker;
  * basically noops
  */
 public class NoopCircuitBreaker implements CircuitBreaker {
-    public static final int LIMIT = -1;
+    public static final int LIMIT = Integer.MAX_VALUE;
 
     private final String name;
 
@@ -35,6 +35,11 @@ public class NoopCircuitBreaker implements CircuitBreaker {
     @Override
     public double addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
         return 0;
+    }
+
+    @Override
+    public long addBytesRangeAndMaybeBreak(long minAcceptableBytes, long wantedBytes, String label) {
+        return wantedBytes;
     }
 
     @Override

--- a/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -107,7 +108,17 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
                 BlobShard blobShard = blobIndicesService.blobShard(new ShardId(".blob_b1", indexUUID, 0));
                 Schemas schemas = new Schemas(Collections.emptyMap(), clusterService, null);
                 assertNotNull(blobShard);
-                collectorProvider = new BlobShardCollectorProvider(blobShard, clusterService, schemas, null, null, null, Settings.EMPTY, null);
+                collectorProvider = new BlobShardCollectorProvider(
+                    blobShard,
+                    clusterService,
+                    schemas,
+                    null,
+                    new NoneCircuitBreakerService(),
+                    null,
+                    null,
+                    Settings.EMPTY,
+                    null
+                );
                 assertNotNull(collectorProvider);
             } catch (Exception e) {
                 fail("Exception shouldn't be thrown: " + e.getMessage());

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -50,6 +50,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
@@ -85,6 +86,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
         IndexWriterProjector writerProjector = new IndexWriterProjector(
             clusterService(),
             new NodeJobsCounter(),
+            new NoopCircuitBreaker("dummy"),
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             CoordinatorTxnCtx.systemTransactionContext(),

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -43,6 +43,7 @@ import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.After;
 import org.junit.Before;
@@ -98,6 +99,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
         IndexWriterProjector indexWriter = new IndexWriterProjector(
             clusterService,
             new NodeJobsCounter(),
+            new NoopCircuitBreaker("dummy"),
             scheduler,
             executor,
             CoordinatorTxnCtx.systemTransactionContext(),

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -53,6 +53,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -85,6 +86,7 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             new NodeJobsCounter(),
+            new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,
             Settings.EMPTY,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -63,6 +63,7 @@ import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -99,6 +100,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         visitor = new ProjectionToProjectorVisitor(
             clusterService,
             new NodeJobsCounter(),
+            new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,
             Settings.EMPTY,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -41,6 +41,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -68,6 +69,7 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
             new NodeJobsCounter(),
+            new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,
             Settings.EMPTY,

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.breaker;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.indices.breaker.BreakerSettings;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class ChildMemoryCircuitBreakerTest {
+
+    @Test
+    public void test_add_bytes_and_range_returns_lower_bytes_than_wanted_if_free_is_below_wanted() throws Exception {
+        var breaker = new ChildMemoryCircuitBreaker(
+            new BreakerSettings(
+                "dummy",
+                500L,
+                1.0d,
+                CircuitBreaker.Type.MEMORY
+            ),
+            LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
+            new NoneCircuitBreakerService(),
+            "dummy"
+        );
+        breaker.addEstimateBytesAndMaybeBreak(400L, "reserve 400");
+        long reserved = breaker.addBytesRangeAndMaybeBreak(50L, 300L, "reserve another 300");
+        assertThat(reserved, is(100L));
+    }
+
+    @Test
+    public void test_add_bytes_and_range_returns_trips_if_free_is_below_min_acceptable_bytes() throws Exception {
+        var breaker = new ChildMemoryCircuitBreaker(
+            new BreakerSettings(
+                "dummy",
+                500L,
+                1.0d,
+                CircuitBreaker.Type.MEMORY
+            ),
+            LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
+            new NoneCircuitBreakerService(),
+            "dummy"
+        );
+        breaker.addEstimateBytesAndMaybeBreak(400L, "reserve 400");
+        Assertions.assertThrows(
+            CircuitBreakingException.class,
+            () -> breaker.addBytesRangeAndMaybeBreak(200L, 300L, "reserve another 300")
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
@@ -143,6 +143,11 @@ public class MemoryCircuitBreaker implements CircuitBreaker {
         return newUsed;
     }
 
+    @Override
+    public long addBytesRangeAndMaybeBreak(long minAcceptableBytes, long wantedBytes, String label) {
+        throw new UnsupportedOperationException("This class is only used in tests and no test uses this function");
+    }
+
     /**
      * Add an <b>exact</b> number of bytes, not checking for tripping the
      * circuit breaker. This bypasses the overheadConstant multiplication.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/commit/9aae2a0534c7e89b6e7de5d81c6455cddb1938dd

This changes the insert-from-query logic to take the free memory of the
query circuit breaker into consideration when computing the
bytes-per-bulk-requests size.

It also accounts for the max-bytes up-front before it starts reading the
data into memory. That should protect against cases where many
concurrent insert-from-query operations would try to load data into
memory that cannot possibly fit - leading to high GC pressure and maybe
even an OOM error.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)