### PR TITLE
Fix testRestartNodeWhileIndexing

### DIFF
--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1240,7 +1240,7 @@ public final class InternalTestCluster extends TestCluster {
                     }
                 }
             }
-        });
+        }, 60, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See

- https://github.com/elastic/elasticsearch/commit/008430a9c23235ee5be1fa21dc8dcc4e9e9ba231
- https://github.com/elastic/elasticsearch/commit/0cfc9ff77594a64737078ce6ffd4630a1a4253d5

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)