### PR TITLE
Fix flaky testTrimUnreferencedTranslogFiles

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -171,9 +171,6 @@ public class NoOpEngineTests extends EngineTestCase {
         for (int i = 0; i < numDocs; i++) {
             engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
             tracker.updateLocalCheckpoint(allocationId.getId(), i);
-            if (rarely()) {
-                engine.flush();
-            }
         }
         engine.flush(true, true);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The assertion

    assertThat(noOpEngine.getTranslogStats().estimatedNumberOfOperations(), equalTo(softDeleteEnabled ? 0 : numDocs));

fails if multiple eninge flushes happen while indexing documents.
The only changes in ES we haven't applied in the area is

  https://github.com/elastic/elasticsearch/commit/ebc468147321cfdd56a9d011e0b40126677b9e78

which we shouldn't apply yet as there are many other outstanding patches
before that.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)