### PR TITLE
Increase assertBusy timeout for testMappingNewFieldsTimeoutDoesntAffectCheckpoints

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -46,6 +46,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import static io.crate.metadata.IndexParts.toIndexName;
 import static org.hamcrest.Matchers.equalTo;
@@ -288,6 +291,6 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
                 assertThat(shardStats.getShardRouting().toString(),
                            shardStats.getSeqNoStats().getGlobalCheckpoint(), equalTo(shardStats.getSeqNoStats().getLocalCheckpoint()));
             }
-        });
+        }, 1, TimeUnit.MINUTES);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Seeing test failures on Jenkins where the global checkpoint is not
up2date.

This increase the timeout to see if it simply takes too long - if it
continues to fail it may point to a bug.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)