### PR TITLE
Deprecate the overhead circuit breaker setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ Breaking Changes
 Deprecations
 ============
 
+- Deprecated the ``*.overhead`` setting for all circuit breakers. It now
+  defaults to 1.0 for all of them and changing it has no effect.
+
 - Deprecated the :ref:`indices.breaker.fielddata.limit
   <indices.breaker.fielddata.limit>` and
   :ref:`indices.breaker.fielddata.overhead

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -992,11 +992,13 @@ keeps working.
 .. _indices.breaker.query.overhead:
 
 **indices.breaker.query.overhead**
-  | *Default:*   ``1.09``
+  | *Default:*   ``1.00``
   | *Runtime:*   ``no``
 
-  A constant that all data estimations are multiplied with to determine a final
-  estimation.
+  .. CAUTION::
+  
+      This setting is deprecated and has no effect.
+
 
 Field data circuit breaker
 --------------------------
@@ -1039,8 +1041,9 @@ exception is raised.
   | *Default:*   ``1.0``
   | *Runtime:*  ``yes``
 
-  A constant that all request estimations are multiplied with to determine a
-  final estimation.
+  .. CAUTION::
+  
+      This setting is deprecated and has no effect.
 
 Accounting circuit breaker
 --------------------------
@@ -1062,8 +1065,9 @@ memory used by Lucene for segments.
   | *Default:*  ``1.0``
   | *Runtime:*  ``yes``
 
-  A constant that all accounting estimations are multiplied with to determine a
-  final estimation.
+  .. CAUTION::
+  
+      This setting is deprecated and has no effect.
 
 .. _stats.breaker.log:
 

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -48,11 +48,8 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
      * @param parent parent circuit breaker service to delegate tripped breakers to
      * @param name the name of the breaker
      */
-    public ChildMemoryCircuitBreaker(BreakerSettings settings,
-                                     Logger logger,
-                                     CircuitBreakerService parent,
-                                     String name) {
-        this(settings, null, logger, parent, name);
+    public ChildMemoryCircuitBreaker(BreakerSettings settings, Logger logger, CircuitBreakerService parent) {
+        this(settings, null, logger, parent);
     }
 
     /**
@@ -68,9 +65,8 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     public ChildMemoryCircuitBreaker(BreakerSettings settings,
                                      ChildMemoryCircuitBreaker oldBreaker,
                                      Logger logger,
-                                     CircuitBreakerService parent,
-                                     String name) {
-        this.name = name;
+                                     CircuitBreakerService parent) {
+        this.name = settings.getName();
         this.settings = settings;
         this.memoryBytesLimit = settings.getLimit();
         this.overheadConstant = settings.getOverhead();

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -112,11 +112,6 @@ public interface CircuitBreaker {
     long getLimit();
 
     /**
-     * @return overhead of circuit breaker
-     */
-    double getOverhead();
-
-    /**
      * @return the number of times the circuit breaker has been tripped
      */
     long getTrippedCount();

--- a/server/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
@@ -58,11 +58,6 @@ public class NoopCircuitBreaker implements CircuitBreaker {
     }
 
     @Override
-    public double getOverhead() {
-        return 0;
-    }
-
-    @Override
     public long getTrippedCount() {
         return 0;
     }

--- a/server/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
@@ -29,13 +29,11 @@ public class BreakerSettings {
 
     private final String name;
     private final long limitBytes;
-    private final double overhead;
     private final CircuitBreaker.Type type;
 
-    public BreakerSettings(String name, long limitBytes, double overhead, CircuitBreaker.Type type) {
+    public BreakerSettings(String name, long limitBytes, CircuitBreaker.Type type) {
         this.name = name;
         this.limitBytes = limitBytes;
-        this.overhead = overhead;
         this.type = type;
     }
 
@@ -47,10 +45,6 @@ public class BreakerSettings {
         return this.limitBytes;
     }
 
-    public double getOverhead() {
-        return this.overhead;
-    }
-
     public CircuitBreaker.Type getType() {
         return this.type;
     }
@@ -59,7 +53,6 @@ public class BreakerSettings {
     public String toString() {
         return "[" + this.name +
                 ",type=" + this.type.toString() +
-                ",limit=" + this.limitBytes + "/" + new ByteSizeValue(this.limitBytes) +
-                ",overhead=" + this.overhead + "]";
+                ",limit=" + this.limitBytes + "/" + new ByteSizeValue(this.limitBytes) + "]";
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
@@ -63,6 +63,12 @@ public class CircuitBreakerStats {
         return this.trippedCount;
     }
 
+    /**
+     * Kept around for BWC of JMX metrics
+     *
+     * Overhead cannot be set by the user anymore and must always be 1.0
+     **/
+    @Deprecated
     public double getOverhead() {
         return this.overhead;
     }

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -351,19 +351,22 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             breakers.put(breakerSettings.getName(), breaker);
         } else {
             CircuitBreaker oldBreaker;
-            CircuitBreaker breaker = new ChildMemoryCircuitBreaker(breakerSettings,
-                    LogManager.getLogger(CHILD_LOGGER_PREFIX + breakerSettings.getName()),
-                    this, breakerSettings.getName());
-
+            CircuitBreaker breaker = new ChildMemoryCircuitBreaker(
+                breakerSettings,
+                LogManager.getLogger(CHILD_LOGGER_PREFIX + breakerSettings.getName()),
+                this
+            );
             for (;;) {
                 oldBreaker = breakers.putIfAbsent(breakerSettings.getName(), breaker);
                 if (oldBreaker == null) {
                     return;
                 }
-                breaker = new ChildMemoryCircuitBreaker(breakerSettings,
-                        (ChildMemoryCircuitBreaker)oldBreaker,
-                        LogManager.getLogger(CHILD_LOGGER_PREFIX + breakerSettings.getName()),
-                        this, breakerSettings.getName());
+                breaker = new ChildMemoryCircuitBreaker(
+                    breakerSettings,
+                    (ChildMemoryCircuitBreaker) oldBreaker,
+                    LogManager.getLogger(CHILD_LOGGER_PREFIX + breakerSettings.getName()),
+                    this
+                );
 
                 if (breakers.replace(breakerSettings.getName(), oldBreaker, breaker)) {
                     return;

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -73,21 +73,21 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public static final Setting<ByteSizeValue> REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING =
         Setting.memorySizeSetting("indices.breaker.request.limit", "60%", Property.Dynamic, Property.NodeScope);
     public static final Setting<Double> REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING =
-        Setting.doubleSetting("indices.breaker.request.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope);
+        Setting.doubleSetting("indices.breaker.request.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope, Property.Deprecated);
     public static final Setting<CircuitBreaker.Type> REQUEST_CIRCUIT_BREAKER_TYPE_SETTING =
         new Setting<>("indices.breaker.request.type", "memory", CircuitBreaker.Type::parseValue, Property.NodeScope);
 
     public static final Setting<ByteSizeValue> ACCOUNTING_CIRCUIT_BREAKER_LIMIT_SETTING =
         Setting.memorySizeSetting("indices.breaker.accounting.limit", "100%", Property.Dynamic, Property.NodeScope);
     public static final Setting<Double> ACCOUNTING_CIRCUIT_BREAKER_OVERHEAD_SETTING =
-        Setting.doubleSetting("indices.breaker.accounting.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope);
+        Setting.doubleSetting("indices.breaker.accounting.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope, Property.Deprecated);
     public static final Setting<CircuitBreaker.Type> ACCOUNTING_CIRCUIT_BREAKER_TYPE_SETTING =
         new Setting<>("indices.breaker.accounting.type", "memory", CircuitBreaker.Type::parseValue, Property.NodeScope);
 
     public static final Setting<ByteSizeValue> IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING =
         Setting.memorySizeSetting("network.breaker.inflight_requests.limit", "100%", Property.Dynamic, Property.NodeScope);
     public static final Setting<Double> IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_OVERHEAD_SETTING =
-        Setting.doubleSetting("network.breaker.inflight_requests.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope);
+        Setting.doubleSetting("network.breaker.inflight_requests.overhead", 1.0d, 0.0d, Property.Dynamic, Property.NodeScope, Property.Deprecated);
     public static final Setting<CircuitBreaker.Type> IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_TYPE_SETTING =
         new Setting<>("network.breaker.inflight_requests.type", "memory", CircuitBreaker.Type::parseValue, Property.NodeScope);
 
@@ -96,19 +96,19 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public static final CrateSetting<ByteSizeValue> QUERY_CIRCUIT_BREAKER_LIMIT_SETTING = CrateSetting.of(Setting.memorySizeSetting(
         "indices.breaker.query.limit", "60%", Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
     public static final CrateSetting<Double> QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING = CrateSetting.of(Setting.doubleSetting(
-        "indices.breaker.query.overhead", 1.09d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope),DataTypes.DOUBLE);
+        "indices.breaker.query.overhead", 1.00d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Deprecated), DataTypes.DOUBLE);
 
     public static final String JOBS_LOG = "jobs_log";
     public static final CrateSetting<ByteSizeValue> JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = CrateSetting.of(Setting.memorySizeSetting(
         "stats.breaker.log.jobs.limit", "5%", Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
     public static final CrateSetting<Double> JOBS_LOG_CIRCUIT_BREAKER_OVERHEAD_SETTING = CrateSetting.of(Setting.doubleSetting(
-        "stats.breaker.log.jobs.overhead", 1.0d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.DOUBLE);
+        "stats.breaker.log.jobs.overhead", 1.0d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Deprecated), DataTypes.DOUBLE);
 
     public static final String OPERATIONS_LOG = "operations_log";
     public static final CrateSetting<ByteSizeValue> OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = CrateSetting.of(Setting.memorySizeSetting(
         "stats.breaker.log.operations.limit", "5%", Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.STRING);
     public static final CrateSetting<Double> OPERATIONS_LOG_CIRCUIT_BREAKER_OVERHEAD_SETTING = CrateSetting.of(Setting.doubleSetting(
-        "stats.breaker.log.operations.overhead", 1.0d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope), DataTypes.DOUBLE);
+        "stats.breaker.log.operations.overhead", 1.0d, 0.0d, Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Deprecated), DataTypes.DOUBLE);
 
     public static final String BREAKING_EXCEPTION_MESSAGE =
         "[query] Data too large, data for [%s] would be larger than limit of [%d/%s]";
@@ -126,42 +126,44 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     private final AtomicLong parentTripCount = new AtomicLong(0);
 
     public HierarchyCircuitBreakerService(Settings settings, ClusterSettings clusterSettings) {
-        this.inFlightRequestsSettings = new BreakerSettings(CircuitBreaker.IN_FLIGHT_REQUESTS,
-                IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
-                IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_OVERHEAD_SETTING.get(settings),
-                IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
+        this.inFlightRequestsSettings = new BreakerSettings(
+            CircuitBreaker.IN_FLIGHT_REQUESTS,
+            IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
+            IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
         );
 
-        this.requestSettings = new BreakerSettings(CircuitBreaker.REQUEST,
-                REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
-                REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.get(settings),
-                REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
+        this.requestSettings = new BreakerSettings(
+            CircuitBreaker.REQUEST,
+            REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
+            REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
         );
 
-        this.accountingSettings = new BreakerSettings(CircuitBreaker.ACCOUNTING,
-                ACCOUNTING_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
-                ACCOUNTING_CIRCUIT_BREAKER_OVERHEAD_SETTING.get(settings),
-                ACCOUNTING_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
+        this.accountingSettings = new BreakerSettings(
+            CircuitBreaker.ACCOUNTING,
+            ACCOUNTING_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
+            ACCOUNTING_CIRCUIT_BREAKER_TYPE_SETTING.get(settings)
         );
 
-        this.parentSettings = new BreakerSettings(CircuitBreaker.PARENT,
-                TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(), 1.0,
-                CircuitBreaker.Type.PARENT);
+        this.parentSettings = new BreakerSettings(
+            CircuitBreaker.PARENT,
+            TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),
+            CircuitBreaker.Type.PARENT
+        );
 
-        queryBreakerSettings = new BreakerSettings(QUERY,
+        queryBreakerSettings = new BreakerSettings(
+            QUERY,
             QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.setting().get(settings).getBytes(),
-            QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING.setting().get(settings),
             CircuitBreaker.Type.MEMORY
         );
 
-        logJobsBreakerSettings = new BreakerSettings(JOBS_LOG,
+        logJobsBreakerSettings = new BreakerSettings(
+            JOBS_LOG,
             JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting().get(settings).getBytes(),
-            JOBS_LOG_CIRCUIT_BREAKER_OVERHEAD_SETTING.setting().get(settings),
             CircuitBreaker.Type.MEMORY);
 
-        logOperationsBreakerSettings = new BreakerSettings(OPERATIONS_LOG,
+        logOperationsBreakerSettings = new BreakerSettings(
+            OPERATIONS_LOG,
             OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting().get(settings).getBytes(),
-            OPERATIONS_LOG_CIRCUIT_BREAKER_OVERHEAD_SETTING.setting().get(settings),
             CircuitBreaker.Type.MEMORY);
 
         if (LOGGER.isTraceEnabled()) {
@@ -175,19 +177,20 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         registerBreaker(this.logJobsBreakerSettings);
         registerBreaker(this.logOperationsBreakerSettings);
 
-        clusterSettings.addSettingsUpdateConsumer(TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING, this::setTotalCircuitBreakerLimit, this::validateTotalCircuitBreakerLimit);
-        clusterSettings.addSettingsUpdateConsumer(IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING, IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_OVERHEAD_SETTING, this::setInFlightRequestsBreakerLimit);
-        clusterSettings.addSettingsUpdateConsumer(REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING, this::setRequestBreakerLimit);
-        clusterSettings.addSettingsUpdateConsumer(ACCOUNTING_CIRCUIT_BREAKER_LIMIT_SETTING, ACCOUNTING_CIRCUIT_BREAKER_OVERHEAD_SETTING, this::setAccountingBreakerLimit);
-        clusterSettings.addSettingsUpdateConsumer(QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.setting(), QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING.setting(),
-            (newLimit, newOverhead) ->
-                setBreakerLimit(queryBreakerSettings, QUERY, s -> this.queryBreakerSettings = s, newLimit, newOverhead));
-        clusterSettings.addSettingsUpdateConsumer(JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting(),
+        clusterSettings.addSettingsUpdateConsumer(TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING, this::setTotalCircuitBreakerLimit);
+        clusterSettings.addSettingsUpdateConsumer(IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING, this::setInFlightRequestsBreakerLimit);
+        clusterSettings.addSettingsUpdateConsumer(REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, this::setRequestBreakerLimit);
+        clusterSettings.addSettingsUpdateConsumer(ACCOUNTING_CIRCUIT_BREAKER_LIMIT_SETTING, this::setAccountingBreakerLimit);
+        clusterSettings.addSettingsUpdateConsumer(
+            QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.setting(),
+            (newLimit) -> setBreakerLimit(queryBreakerSettings, QUERY, s -> this.queryBreakerSettings = s, newLimit));
+        clusterSettings.addSettingsUpdateConsumer(
+            JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting(),
+            (newLimit) -> setBreakerLimit(logJobsBreakerSettings, JOBS_LOG, s -> this.logJobsBreakerSettings = s, newLimit));
+        clusterSettings.addSettingsUpdateConsumer(
+            OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting(),
             (newLimit) ->
-                setBreakerLimit(logJobsBreakerSettings, JOBS_LOG, s -> this.logJobsBreakerSettings = s, newLimit, null));
-        clusterSettings.addSettingsUpdateConsumer(OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.setting(),
-            (newLimit) ->
-                setBreakerLimit(logOperationsBreakerSettings, OPERATIONS_LOG, s -> this.logOperationsBreakerSettings = s, newLimit, null));
+                setBreakerLimit(logOperationsBreakerSettings, OPERATIONS_LOG, s -> this.logOperationsBreakerSettings = s, newLimit));
     }
 
     public static String breakingExceptionMessage(String label, long limit) {
@@ -200,64 +203,50 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         );
     }
 
-    private void setRequestBreakerLimit(ByteSizeValue newRequestMax, Double newRequestOverhead) {
-        BreakerSettings newRequestSettings = new BreakerSettings(CircuitBreaker.REQUEST, newRequestMax.getBytes(), newRequestOverhead,
-                HierarchyCircuitBreakerService.this.requestSettings.getType());
+    private void setRequestBreakerLimit(ByteSizeValue newRequestMax) {
+        BreakerSettings newRequestSettings = new BreakerSettings(
+            CircuitBreaker.REQUEST,
+            newRequestMax.getBytes(),
+            HierarchyCircuitBreakerService.this.requestSettings.getType()
+        );
         registerBreaker(newRequestSettings);
         HierarchyCircuitBreakerService.this.requestSettings = newRequestSettings;
         LOGGER.info("Updated breaker settings request: {}", newRequestSettings);
     }
 
-    private void setInFlightRequestsBreakerLimit(ByteSizeValue newInFlightRequestsMax, Double newInFlightRequestsOverhead) {
-        BreakerSettings newInFlightRequestsSettings = new BreakerSettings(CircuitBreaker.IN_FLIGHT_REQUESTS, newInFlightRequestsMax.getBytes(),
-            newInFlightRequestsOverhead, HierarchyCircuitBreakerService.this.inFlightRequestsSettings.getType());
+    private void setInFlightRequestsBreakerLimit(ByteSizeValue newInFlightRequestsMax) {
+        BreakerSettings newInFlightRequestsSettings = new BreakerSettings(
+            CircuitBreaker.IN_FLIGHT_REQUESTS,
+            newInFlightRequestsMax.getBytes(),
+            HierarchyCircuitBreakerService.this.inFlightRequestsSettings.getType()
+        );
         registerBreaker(newInFlightRequestsSettings);
         HierarchyCircuitBreakerService.this.inFlightRequestsSettings = newInFlightRequestsSettings;
         LOGGER.info("Updated breaker settings for in-flight requests: {}", newInFlightRequestsSettings);
     }
 
-    private void setAccountingBreakerLimit(ByteSizeValue newAccountingMax, Double newAccountingOverhead) {
-        BreakerSettings newAccountingSettings = new BreakerSettings(CircuitBreaker.ACCOUNTING, newAccountingMax.getBytes(),
-            newAccountingOverhead, HierarchyCircuitBreakerService.this.inFlightRequestsSettings.getType());
+    private void setAccountingBreakerLimit(ByteSizeValue newAccountingMax) {
+        BreakerSettings newAccountingSettings = new BreakerSettings(
+            CircuitBreaker.ACCOUNTING,
+            newAccountingMax.getBytes(),
+            HierarchyCircuitBreakerService.this.inFlightRequestsSettings.getType()
+        );
         registerBreaker(newAccountingSettings);
         HierarchyCircuitBreakerService.this.accountingSettings = newAccountingSettings;
         LOGGER.info("Updated breaker settings for accounting requests: {}", newAccountingSettings);
     }
 
-    private boolean validateTotalCircuitBreakerLimit(ByteSizeValue byteSizeValue) {
-        BreakerSettings newParentSettings = new BreakerSettings(CircuitBreaker.PARENT, byteSizeValue.getBytes(), 1.0, CircuitBreaker.Type.PARENT);
-        validateSettings(new BreakerSettings[]{newParentSettings});
-        return true;
-    }
-
     private void setTotalCircuitBreakerLimit(ByteSizeValue byteSizeValue) {
-        BreakerSettings newParentSettings = new BreakerSettings(CircuitBreaker.PARENT, byteSizeValue.getBytes(), 1.0, CircuitBreaker.Type.PARENT);
+        BreakerSettings newParentSettings = new BreakerSettings(CircuitBreaker.PARENT, byteSizeValue.getBytes(), CircuitBreaker.Type.PARENT);
         this.parentSettings = newParentSettings;
-    }
-
-    /**
-     * Validate that child settings are valid
-     */
-    public static void validateSettings(BreakerSettings[] childrenSettings) throws IllegalStateException {
-        for (BreakerSettings childSettings : childrenSettings) {
-            // If the child is disabled, ignore it
-            if (childSettings.getLimit() == -1) {
-                continue;
-            }
-
-            if (childSettings.getOverhead() < 0) {
-                throw new IllegalStateException("Child breaker overhead " + childSettings + " must be non-negative");
-            }
-        }
     }
 
     private void setBreakerLimit(BreakerSettings oldSettings,
                                  String breakerName,
                                  Consumer<BreakerSettings> settingsConsumer,
-                                 ByteSizeValue newLimit, Double newOverhead) {
+                                 ByteSizeValue newLimit) {
         long newLimitBytes = newLimit == null ? oldSettings.getLimit() : newLimit.getBytes();
-        newOverhead = newOverhead == null ? oldSettings.getOverhead() : newOverhead;
-        BreakerSettings newSettings = new BreakerSettings(breakerName, newLimitBytes, newOverhead, oldSettings.getType());
+        BreakerSettings newSettings = new BreakerSettings(breakerName, newLimitBytes, oldSettings.getType());
         registerBreaker(newSettings);
         settingsConsumer.accept(newSettings);
         LOGGER.info("[{}] Updated breaker settings: {}", breakerName, newSettings);
@@ -275,7 +264,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 CircuitBreaker.PARENT,
                 parentSettings.getLimit(),
                 parentUsed(0L),
-                parentTripCount.get(), 1.0
+                parentTripCount.get(),
+                1.0d
             );
         }
         CircuitBreaker breaker = requireNonNull(this.breakers.get(name), "Unknown circuit breaker: " + name);
@@ -284,7 +274,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             breaker.getLimit(),
             breaker.getUsed(),
             breaker.getTrippedCount(),
-            breaker.getOverhead());
+            1.0d
+        );
     }
 
     private long parentUsed(long newBytesReserved) {
@@ -313,7 +304,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         long parentLimit = this.parentSettings.getLimit();
         if (totalUsed > parentLimit) {
             long breakersTotalUsed = breakers.values().stream()
-                .mapToLong(x -> (long) (x.getUsed() * x.getOverhead()))
+                .mapToLong(CircuitBreaker::getUsed)
                 .sum();
             // if the individual breakers hardly use any memory we assume that there is a lot of heap usage by objects which can be GCd.
             // We want to allow the query so that it triggers GCs
@@ -329,7 +320,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             message.append(", usages [");
             message.append(this.breakers.entrySet().stream().map(e -> {
                 final CircuitBreaker breaker = e.getValue();
-                final long breakerUsed = (long)(breaker.getUsed() * breaker.getOverhead());
+                final long breakerUsed = breaker.getUsed();
                 return e.getKey() + "=" + breakerUsed + "/" + new ByteSizeValue(breakerUsed);
             }).collect(Collectors.joining(", ")));
             message.append("]");
@@ -343,9 +334,6 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
      */
     @Override
     public void registerBreaker(BreakerSettings breakerSettings) {
-        // Validate the settings
-        validateSettings(new BreakerSettings[] {breakerSettings});
-
         if (breakerSettings.getType() == CircuitBreaker.Type.NOOP) {
             CircuitBreaker breaker = new NoopCircuitBreaker(breakerSettings.getName());
             breakers.put(breakerSettings.getName(), breaker);

--- a/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
+++ b/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
@@ -70,43 +70,22 @@ public class CrateCircuitBreakerServiceTest extends ESTestCase {
     }
 
     @Test
-    public void testQueryCircuitBreakerDynamicSettings() throws Exception {
-        CircuitBreakerService breakerService = new HierarchyCircuitBreakerService(
-            Settings.EMPTY, clusterSettings);
-
-        Settings newSettings = Settings.builder()
-            .put(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 2.0)
-            .build();
-
-        clusterSettings.applySettings(newSettings);
-
-        CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
-        assertThat(breaker, notNullValue());
-        assertThat(breaker, instanceOf(CircuitBreaker.class));
-        assertThat(breaker.getOverhead(), is(2.0));
-    }
-
-    @Test
     public void testQueryBreakerAssignment() throws Exception {
         Settings settings = Settings.builder()
             .put(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "10m")
-            .put(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 1.0)
             .build();
         HierarchyCircuitBreakerService breakerService = new HierarchyCircuitBreakerService(settings, clusterSettings);
 
         CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
         assertThat(breaker.getLimit(), is(10_485_760L));
-        assertThat(breaker.getOverhead(), is(1.0));
 
         Settings newSettings = Settings.builder()
             .put(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "100m")
-            .put(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 2.0)
             .build();
         clusterSettings.applySettings(newSettings);
 
         breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
         assertThat(breaker.getLimit(), is(104_857_600L));
-        assertThat(breaker.getOverhead(), is(2.0));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -69,7 +69,7 @@ public class CircuitBreakerIntegrationTest extends SQLTransportIntegrationTest {
         execute("set global \"indices.breaker.query.limit\"='100b'");
 
         assertThrows(() -> execute("select text from t1 group by text"),
-                     isSQLError(is("[query] Data too large, data for [collect: 0] would be [130/130b], which " +
+                     isSQLError(is("[query] Data too large, data for [collect: 0] would be [120/120b], which " +
                                    "is larger than the limit of [100/100b]"),
                        INTERNAL_ERROR,
                        INTERNAL_SERVER_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -43,10 +43,8 @@ public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
 
     @Test
     public void selectGroupByWithBreaking() throws Exception {
-        // query takes 252 bytes of memory
-        // 252b * 1.09 = 275b => should break with limit 256b
         assertThrows(() -> execute("select region, count(*) from sys.summits group by 1"),
-                     isSQLError(is("[query] Data too large, data for [collect: 0] would be [305/305b], " +
+                     isSQLError(is("[query] Data too large, data for [collect: 0] would be [280/280b], " +
                                    "which is larger than the limit of [256/256b]"),
                                 INTERNAL_ERROR,
                                 INTERNAL_SERVER_ERROR,

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
@@ -36,7 +36,6 @@ public class ChildMemoryCircuitBreakerTest {
             new BreakerSettings(
                 "dummy",
                 500L,
-                1.0d,
                 CircuitBreaker.Type.MEMORY
             ),
             LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
@@ -53,7 +52,6 @@ public class ChildMemoryCircuitBreakerTest {
             new BreakerSettings(
                 "dummy",
                 500L,
-                1.0d,
                 CircuitBreaker.Type.MEMORY
             ),
             LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
@@ -40,8 +40,7 @@ public class ChildMemoryCircuitBreakerTest {
                 CircuitBreaker.Type.MEMORY
             ),
             LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
-            new NoneCircuitBreakerService(),
-            "dummy"
+            new NoneCircuitBreakerService()
         );
         breaker.addEstimateBytesAndMaybeBreak(400L, "reserve 400");
         long reserved = breaker.addBytesRangeAndMaybeBreak(50L, 300L, "reserve another 300");
@@ -58,8 +57,7 @@ public class ChildMemoryCircuitBreakerTest {
                 CircuitBreaker.Type.MEMORY
             ),
             LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
-            new NoneCircuitBreakerService(),
-            "dummy"
+            new NoneCircuitBreakerService()
         );
         breaker.addEstimateBytesAndMaybeBreak(400L, "reserve 400");
         Assertions.assertThrows(

--- a/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
@@ -181,14 +181,6 @@ public class MemoryCircuitBreaker implements CircuitBreaker {
     }
 
     /**
-     * @return the constant multiplier the breaker uses for aggregations
-     */
-    @Override
-    public double getOverhead() {
-        return this.overheadConstant;
-    }
-
-    /**
      * @return the number of times the breaker has been tripped
      */
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This deprecated the settings and internally removes any usages. The only
circuit breaker where the default diverged from 1.0 was the query breaker
and the already unused fielddata breaker.

The usefulness of the setting was questionable. It provided another knob to
tune the circuit breaker behavior, but it is somewhat redundant because
tuning the limit had more or less the same outcome.

    newUsed * overheadConstant > memoryBytesLimit

    =

    newUsed > memoryBytesLimit / overheadConstant

It made the implementations more complicated and also made it harder to 
reason about how the memory accounting works. Acting a bit like a smoke 
bomb.

There were also inconsistencies in its use. In one place it was applied to
the *delta*, in other cases it was applied to the *total*.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)