### PR TITLE
Add support for `SET AND RESET SESSION AUTHORIZATION` statements.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -66,6 +66,9 @@ Deprecations
 Changes
 =======
 
+- Added support for :ref:`SET SESSION AUTHORIZATION
+  <ref-set-session-authorization>` SQL statements.
+
 - Added detailed information on the error when a column with an undefined type
   is used to ``GROUP BY``.
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -66,7 +66,7 @@ Deprecations
 Changes
 =======
 
-- Added support for :ref:`SET SESSION AUTHORIZATION
+- Added support for :ref:`SET AND RESET SESSION AUTHORIZATION
   <ref-set-session-authorization>` SQL statements.
 
 - Added detailed information on the error when a column with an undefined type

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -45,8 +45,9 @@ SQL Statements
     revoke
     select
     set
-    set-transaction
     set-license
+    set-session-authorization
+    set-transaction
     show-columns
     show-create-table
     show-schemas

--- a/docs/sql/statements/set-session-authorization.rst
+++ b/docs/sql/statements/set-session-authorization.rst
@@ -1,0 +1,50 @@
+.. highlight:: psql
+.. _ref-set-session-authorization:
+
+=============================
+``SET SESSION AUTHORIZATION``
+=============================
+
+Set the user of the current session.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+Synopsis
+========
+
+::
+
+    SET [ SESSION | LOCAL ] SESSION AUTHORIZATION username
+    SET [ SESSION | LOCAL ] SESSION AUTHORIZATION DEFAULT
+
+Description
+===========
+
+These statements set or reset the user of the session to the given or revert
+the user back to the original authenticated user.
+
+The session user can be changed only if the initial authenticated user had the
+superuser privileges. Otherwise, the statement is only accepted if the specified
+``username`` matches the originally authenticated user.
+
+Using this statement, a superuser can temporarily become an unprivileged user
+and later switch back to a superuser. The superuser would switch using
+``SET SESSION AUTHORIZATION '<impersonating_user>'`` to drop privileges and
+become ``impersonating_user``. Later the original privileges can be restored
+using ``SET SESSION AUTHORIZATION <real_username>`` or
+``SET SESSION AUTHORIZATION DEFAULT``.
+
+``SET LOCAL`` does not have any effect on session. All ``SET LOCAL`` statements
+will be ignored by CrateDB and logged with the ``INFO`` logging level.
+
+Parameters
+==========
+
+:username:
+  The user name represented as an identifier or a string literal.
+
+:DEFAULT:
+  Used for resetting the session user to initial session (authenticated) user.

--- a/docs/sql/statements/set-session-authorization.rst
+++ b/docs/sql/statements/set-session-authorization.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _ref-set-session-authorization:
 
-=============================
-``SET SESSION AUTHORIZATION``
-=============================
+=======================================
+``SET AND RESET SESSION AUTHORIZATION``
+=======================================
 
 Set the user of the current session.
 
@@ -19,6 +19,7 @@ Synopsis
 
     SET [ SESSION | LOCAL ] SESSION AUTHORIZATION username
     SET [ SESSION | LOCAL ] SESSION AUTHORIZATION DEFAULT
+    RESET SESSION AUTHORIZATION
 
 Description
 ===========
@@ -39,6 +40,9 @@ using ``SET SESSION AUTHORIZATION <real_username>`` or
 
 ``SET LOCAL`` does not have any effect on session. All ``SET LOCAL`` statements
 will be ignored by CrateDB and logged with the ``INFO`` logging level.
+
+The ``DEFAULT`` and ``RESET`` forms reset the session and current user to be
+the originally authenticated user.
 
 Parameters
 ==========

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -101,7 +101,7 @@ public final class AccessControlImpl implements AccessControl {
     public AccessControlImpl(UserLookup userLookup, SessionContext sessionContext) {
         this.userLookup = userLookup;
         this.sessionContext = sessionContext;
-        this.sessionUser = sessionContext.user();
+        this.sessionUser = sessionContext.sessionUser();
         this.authenticatedUser = sessionContext.authenticatedUser();
     }
 

--- a/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/AccessControlImpl.java
@@ -52,6 +52,7 @@ import io.crate.analyze.AnalyzedPrivileges;
 import io.crate.analyze.AnalyzedRefreshTable;
 import io.crate.analyze.AnalyzedResetStatement;
 import io.crate.analyze.AnalyzedRestoreSnapshot;
+import io.crate.analyze.AnalyzedSetSessionAuthorizationStatement;
 import io.crate.analyze.AnalyzedSetStatement;
 import io.crate.analyze.AnalyzedSetTransaction;
 import io.crate.analyze.AnalyzedShowCreateTable;
@@ -86,7 +87,8 @@ import java.util.Locale;
 
 public final class AccessControlImpl implements AccessControl {
 
-    private final User user;
+    private final User sessionUser;
+    private final User authenticatedUser;
     private final UserLookup userLookup;
     private final SessionContext sessionContext;
 
@@ -99,20 +101,28 @@ public final class AccessControlImpl implements AccessControl {
     public AccessControlImpl(UserLookup userLookup, SessionContext sessionContext) {
         this.userLookup = userLookup;
         this.sessionContext = sessionContext;
-        this.user = sessionContext.user();
+        this.sessionUser = sessionContext.user();
+        this.authenticatedUser = sessionContext.authenticatedUser();
     }
 
     @Override
     public void ensureMayExecute(AnalyzedStatement statement) {
-        if (!user.isSuperUser()) {
-            statement.accept(new StatementVisitor(userLookup, sessionContext.searchPath().currentSchema()), user);
+        if (!sessionUser.isSuperUser()) {
+            statement.accept(
+                new StatementVisitor(
+                    userLookup,
+                    sessionContext.searchPath().currentSchema(),
+                    authenticatedUser
+                ),
+                sessionUser
+            );
         }
     }
 
     @Override
     public void ensureMaySee(Throwable t) throws MissingPrivilegeException {
-        if (!user.isSuperUser() && t instanceof CrateException) {
-            ((CrateException) t).accept(MaskSensitiveExceptions.INSTANCE, user);
+        if (!sessionUser.isSuperUser() && t instanceof CrateException) {
+            ((CrateException) t).accept(MaskSensitiveExceptions.INSTANCE, sessionUser);
         }
     }
 
@@ -216,8 +226,10 @@ public final class AccessControlImpl implements AccessControl {
 
         private final RelationVisitor relationVisitor;
         private final String defaultSchema;
+        private final User authenticatedUser;
 
-        public StatementVisitor(UserLookup userLookup, String defaultSchema) {
+        public StatementVisitor(UserLookup userLookup, String defaultSchema, User authenticatedUser) {
+            this.authenticatedUser = authenticatedUser;
             this.relationVisitor = new RelationVisitor(userLookup, defaultSchema);
             this.defaultSchema = defaultSchema;
         }
@@ -430,6 +442,19 @@ public final class AccessControlImpl implements AccessControl {
                     user,
                     defaultSchema
                 );
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitSetSessionAuthorizationStatement(AnalyzedSetSessionAuthorizationStatement analysis,
+                                                          User sessionUser) {
+            if (analysis.user() != null && !authenticatedUser.name().equals(analysis.user())) {
+                throw new UnauthorizedException(String.format(
+                    Locale.ENGLISH,
+                    "User \"%s\" is not authorized to execute the statement. " +
+                    "Superuser permissions are required or you can set the session " +
+                    "authorization back to the authenticated user.", sessionUser.name()));
             }
             return null;
         }

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -541,4 +541,13 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             ParamTypeHints.EMPTY);
         assertThat(validationCallArguments.size(), is(0));
     }
+
+    @Test
+    public void test_reset_session_authorization_from_normal_user_succeeds() {
+        e.analyzer.analyze(
+            SqlParser.createStatement("RESET SESSION AUTHORIZATION"),
+            new SessionContext(superUser, user),
+            ParamTypeHints.EMPTY);
+        assertThat(validationCallArguments.size(), is(0));
+    }
 }

--- a/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/AccessControlMayExecuteTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.auth.user;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.ParamTypeHints;
@@ -44,6 +43,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import static io.crate.auth.user.User.CRATE_USER;
 import static java.util.Collections.singletonList;
@@ -76,14 +76,14 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);
 
-        user = new User("normal", ImmutableSet.of(), ImmutableSet.of(), null) {
+        user = new User("normal", Set.of(), Set.of(), null) {
             @Override
             public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
                 validationCallArguments.add(Lists.newArrayList(type, clazz, ident, user.name()));
                 return true;
             }
         };
-        superUser = new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of(), null) {
+        superUser = new User("crate", EnumSet.of(User.Role.SUPERUSER), Set.of(), null) {
             @Override
             public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident, String defaultSchema) {
                 validationCallArguments.add(Lists.newArrayList(type, clazz, ident, superUser.name()));
@@ -497,5 +497,48 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         analyze("SET TRANSACTION READ ONLY");
         assertThat(validationCallArguments.size(), is(0));
     }
-}
 
+    @Test
+    public void test_set_session_user_from_superuser_to_normal_user_succeeds() {
+        analyze("SET SESSION AUTHORIZATION " + user.name(), superUser);
+        assertThat(validationCallArguments.size(), is(0));
+    }
+
+    @Test
+    public void test_set_session_user_from_normal_user_fails() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(
+            "User \"normal\" is not authorized to execute the statement. " +
+            "Superuser permissions are required or you can set the session " +
+            "authorization back to the authenticated user.");
+        analyze("SET SESSION AUTHORIZATION 'someuser'", user);
+    }
+
+    @Test
+    public void test_set_session_user_from_normal_user_to_superuser_fails() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(
+            "User \"normal\" is not authorized to execute the statement. " +
+            "Superuser permissions are required or you can set the session " +
+            "authorization back to the authenticated user.");
+        analyze("SET SESSION AUTHORIZATION " + superUser.name(), user);
+    }
+
+    @Test
+    public void test_set_session_user_from_normal_to_originally_authenticated_user_succeeds() {
+        e.analyzer.analyze(
+            SqlParser.createStatement("SET SESSION AUTHORIZATION " + superUser.name()),
+            new SessionContext(superUser, user),
+            ParamTypeHints.EMPTY);
+        assertThat(validationCallArguments.size(), is(0));
+    }
+
+    @Test
+    public void test_set_session_user_from_normal_user_to_default_succeeds() {
+        e.analyzer.analyze(
+            SqlParser.createStatement("SET SESSION AUTHORIZATION DEFAULT"),
+            new SessionContext(superUser, user),
+            ParamTypeHints.EMPTY);
+        assertThat(validationCallArguments.size(), is(0));
+    }
+}

--- a/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -32,7 +32,7 @@ public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTe
     private Session superUserSession;
     private Session normalUserSession;
 
-    private Session createSuperUserSession() {
+    protected Session createSuperUserSession() {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class);
         return sqlOperations.createSession(null, User.CRATE_USER);
     }

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -64,7 +64,7 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
         execute("SELECT SESSION_USER", session);
         assertThat(response.rows()[0][0], is("test"));
 
-        execute("SET SESSION AUTHORIZATION DEFAULT", session);
+        execute("RESET SESSION AUTHORIZATION", session);
         execute("SELECT SESSION_USER", session);
         assertThat(response.rows()[0][0], is("crate"));
     }

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -52,6 +52,23 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
         assertThat(response.rows()[0][0], is("crate"));
     }
 
+    @Test
+    public void test_set_session_user_from_auth_superuser_to_unprivileged_user_round_trip() {
+        var session = createSuperUserSession();
+
+        execute("SELECT SESSION_USER", session);
+        assertThat(response.rows()[0][0], is("crate"));
+
+        execute("CREATE USER test", session);
+        execute("SET SESSION AUTHORIZATION test", session);
+        execute("SELECT SESSION_USER", session);
+        assertThat(response.rows()[0][0], is("test"));
+
+        execute("SET SESSION AUTHORIZATION DEFAULT", session);
+        execute("SELECT SESSION_USER", session);
+        assertThat(response.rows()[0][0], is("crate"));
+    }
+
     private String getNodeByEnterpriseNode(boolean enterpriseEnabled) {
         if (enterpriseEnabled) {
             return internalCluster().getNodeNames()[0];

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -68,6 +68,7 @@ statement
         transactionMode (',' transactionMode)*                                       #setTransaction
     | SET (SESSION | LOCAL)? SESSION AUTHORIZATION
         (DEFAULT | username=stringLiteralOrIdentifier)                               #setSessionAuthorization
+    | RESET SESSION AUTHORIZATION                                                    #resetSessionAuthorization
     | SET (SESSION | LOCAL)? qname
         (EQ | TO) (DEFAULT | setExpr (',' setExpr)*)                                 #set
     | SET GLOBAL (PERSISTENT | TRANSIENT)?

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -64,8 +64,10 @@ statement
     | ALTER CLUSTER GC DANGLING ARTIFACTS                                            #alterClusterGCDanglingArtifacts
     | ALTER USER name=ident SET '(' genericProperties ')'                            #alterUser
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
-    | SET SESSION CHARACTERISTICS AS TRANSACTION transactionMode (',' transactionMode)*  #setTransaction
-    | SET TRANSACTION transactionMode (',' transactionMode)*                             #setTransaction
+    | SET (SESSION CHARACTERISTICS AS)? TRANSACTION
+        transactionMode (',' transactionMode)*                                       #setTransaction
+    | SET (SESSION | LOCAL)? SESSION AUTHORIZATION
+        (DEFAULT | username=stringLiteralOrIdentifier)                               #setSessionAuthorization
     | SET (SESSION | LOCAL)? qname
         (EQ | TO) (DEFAULT | setExpr (',' setExpr)*)                                 #set
     | SET GLOBAL (PERSISTENT | TRANSIENT)?
@@ -661,7 +663,7 @@ isolationLevel
     ;
 
 nonReserved
-    : ALIAS | ANALYZE | ANALYZER | AT | BERNOULLI | BLOB | CATALOGS | CHAR_FILTERS | CHECK | CLUSTERED
+    : ALIAS | ANALYZE | ANALYZER | AT | AUTHORIZATION | BERNOULLI | BLOB | CATALOGS | CHAR_FILTERS | CHECK | CLUSTERED
     | COLUMNS | COPY | CURRENT |  DAY | DEALLOCATE | DISTRIBUTED | DUPLICATE | DYNAMIC | EXPLAIN
     | EXTENDS | FOLLOWING | FORMAT | FULLTEXT | FUNCTIONS | GEO_POINT | GEO_SHAPE | GLOBAL
     | GRAPHVIZ | HOUR | IGNORED | ILIKE | INTERVAL | KEY | KILL | LICENSE | LOGICAL | LOCAL
@@ -681,6 +683,7 @@ nonReserved
     | DISCARD | PLANS | SEQUENCES | TEMPORARY | TEMP
     ;
 
+AUTHORIZATION: 'AUTHORIZATION';
 SELECT: 'SELECT';
 FROM: 'FROM';
 TO: 'TO';

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -83,6 +83,7 @@ import io.crate.sql.tree.Relation;
 import io.crate.sql.tree.RevokePrivilege;
 import io.crate.sql.tree.Select;
 import io.crate.sql.tree.SelectItem;
+import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import io.crate.sql.tree.SingleColumn;
 import io.crate.sql.tree.SortItem;
 import io.crate.sql.tree.StringLiteral;
@@ -1069,6 +1070,18 @@ public final class SqlFormatter {
         @Override
         protected Void visitSortItem(SortItem node, Integer indent) {
             node.getSortKey().accept(this, indent);
+            return null;
+        }
+
+        @Override
+        public Void visitSetSessionAuthorizationStatement(SetSessionAuthorizationStatement node,
+                                                          Integer context) {
+            var user = node.user();
+            builder
+                .append("SET ")
+                .append(node.scope())
+                .append(" SESSION AUTHORIZATION ")
+                .append(user != null ? quoteIdentifierIfNeeded(user) : "DEFAULT");
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -752,6 +752,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
+    public Node visitResetSessionAuthorization(SqlBaseParser.ResetSessionAuthorizationContext ctx) {
+        return new SetSessionAuthorizationStatement(SetSessionAuthorizationStatement.Scope.SESSION);
+    }
+
+    @Override
     public Node visitKill(SqlBaseParser.KillContext context) {
         return new KillStatement<>(
             visitIfPresent(context.jobId, Expression.class).orElse(null));

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -695,7 +696,6 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitSetTransaction(SetTransactionContext ctx) {
-        List<TransactionModeContext> transactionModeCtx = ctx.transactionMode();
         List<TransactionMode> modes = Lists2.map(ctx.transactionMode(), AstBuilder::getTransactionMode);
         return new SetTransactionStatement(modes);
     }
@@ -728,6 +728,27 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitResetGlobal(SqlBaseParser.ResetGlobalContext context) {
         return new ResetStatement<>(visitCollection(context.primaryExpression(), Expression.class));
+    }
+
+    @Override
+    public Node visitSetSessionAuthorization(SqlBaseParser.SetSessionAuthorizationContext context) {
+        SetSessionAuthorizationStatement.Scope scope;
+        if (context.LOCAL() != null) {
+            scope = SetSessionAuthorizationStatement.Scope.LOCAL;
+        } else {
+            scope = SetSessionAuthorizationStatement.Scope.SESSION;
+        }
+
+        if (context.DEFAULT() != null) {
+            return new SetSessionAuthorizationStatement(scope);
+        } else {
+            var userNameLiteral = visit(context.username);
+            assert userNameLiteral instanceof StringLiteral
+                : "username must be a StringLiteral because " +
+                  "the parser grammar is restricted to string literals";
+            var userName = ((StringLiteral) userNameLiteral).getValue();
+            return new SetSessionAuthorizationStatement(userName, scope);
+        }
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -484,6 +484,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitSetSessionAuthorizationStatement(SetSessionAuthorizationStatement node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitResetStatement(ResetStatement<?> node, C context) {
         return visitStatement(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/SetSessionAuthorizationStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/SetSessionAuthorizationStatement.java
@@ -30,8 +30,8 @@ public class SetSessionAuthorizationStatement extends Statement {
         SESSION, LOCAL
     }
 
-    private final String user;
     @Nullable
+    private final String user;
     private final Scope scope;
 
     public SetSessionAuthorizationStatement(Scope scope) {
@@ -43,6 +43,13 @@ public class SetSessionAuthorizationStatement extends Statement {
         this.user = user;
     }
 
+    /**
+     * user is null for the following statements::
+     * <p>
+     * SET [ SESSION | LOCAL ] SESSION AUTHORIZATION DEFAULT
+     * and
+     * RESET SESSION AUTHORIZATION
+     */
     @Nullable
     public String user() {
         return user;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/SetSessionAuthorizationStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/SetSessionAuthorizationStatement.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class SetSessionAuthorizationStatement extends Statement {
+
+    public enum Scope {
+        SESSION, LOCAL
+    }
+
+    private final String user;
+    @Nullable
+    private final Scope scope;
+
+    public SetSessionAuthorizationStatement(Scope scope) {
+        this(null, scope);
+    }
+
+    public SetSessionAuthorizationStatement(@Nullable String user, Scope scope) {
+        this.scope = scope;
+        this.user = user;
+    }
+
+    @Nullable
+    public String user() {
+        return user;
+    }
+
+    public Scope scope() {
+        return scope;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SetSessionAuthorizationStatement that = (SetSessionAuthorizationStatement) o;
+        return Objects.equals(user, that.user) &&
+               scope == that.scope;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, scope);
+    }
+
+    @Override
+    public String toString() {
+        return "SetSessionAuthorizationStatement{" +
+               "user='" + user + '\'' +
+               ", scope=" + scope +
+               '}';
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSetSessionAuthorizationStatement(this, context);
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -60,6 +60,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.Query;
 import io.crate.sql.tree.RevokePrivilege;
+import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowCreateTable;
 import io.crate.sql.tree.Statement;
@@ -128,7 +129,6 @@ public class TestStatementBuilder {
         printStatement("DISCARD TEMPORARY");
         printStatement("DISCARD TEMP");
     }
-
 
     @Test
     public void testEmptyOverClauseAfterFunction() {
@@ -377,6 +377,21 @@ public class TestStatementBuilder {
         printStatement("set some_setting TO ON");
 
         printStatement("set session characteristics as transaction isolation level read uncommitted");
+    }
+
+    @Test
+    public void test_set_session_authorization_statement_with_user() {
+        printStatement("set session authorization 'test'");
+        printStatement("set session authorization test");
+        printStatement("set session session authorization test");
+        printStatement("set local session authorization 'test'");
+    }
+
+    @Test
+    public void test_set_session_authorization_statement_with_default_user() {
+        printStatement("set session authorization default");
+        printStatement("set session session authorization default");
+        printStatement("set local session authorization default");
     }
 
     @Test
@@ -1698,6 +1713,7 @@ public class TestStatementBuilder {
             statement instanceof DropSnapshot ||
             statement instanceof Update ||
             statement instanceof Insert ||
+            statement instanceof SetSessionAuthorizationStatement ||
             statement instanceof Window) {
                 println(SqlFormatter.formatSql(statement));
                 println("");

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -395,6 +395,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_reset_session_authorization_statement() {
+        printStatement("reset session authorization");
+    }
+
+    @Test
     public void testKillStmtBuilder() {
         printStatement("kill all");
         printStatement("kill '6a3d6fb6-1401-4333-933d-b38c9322fca7'");

--- a/server/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/server/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -96,12 +96,12 @@ public class SQLOperations {
         return createSession(SessionContext.systemSessionContext());
     }
 
-    public Session createSession(@Nullable String defaultSchema, User user) {
+    public Session createSession(@Nullable String defaultSchema, User authenticatedUser) {
         SessionContext sessionContext;
         if (defaultSchema == null) {
-            sessionContext = new SessionContext(user);
+            sessionContext = new SessionContext(authenticatedUser);
         } else {
-            sessionContext = new SessionContext(user, defaultSchema);
+            sessionContext = new SessionContext(authenticatedUser, defaultSchema);
         }
 
         return createSession(sessionContext);

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -192,12 +192,12 @@ public class Session implements AutoCloseable {
         try {
             plan = planner.plan(analyzedStatement, plannerContext);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, statement, SQLExceptions.messageOf(t), sessionContext.user());
+            jobsLogs.logPreExecutionFailure(jobId, statement, SQLExceptions.messageOf(t), sessionContext.sessionUser());
             throw t;
         }
 
         StatementClassifier.Classification classification = StatementClassifier.classify(plan);
-        jobsLogs.logExecutionStart(jobId, statement, sessionContext.user(), classification);
+        jobsLogs.logExecutionStart(jobId, statement, sessionContext.sessionUser(), classification);
         JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver(
@@ -267,7 +267,7 @@ public class Session implements AutoCloseable {
             if ("".equals(query)) {
                 statement = EMPTY_STMT;
             } else {
-                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.user());
+                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.sessionUser());
                 throw t;
             }
         }
@@ -284,7 +284,7 @@ public class Session implements AutoCloseable {
                 UUID.randomUUID(),
                 query,
                 SQLExceptions.messageOf(t),
-                sessionContext.user());
+                sessionContext.sessionUser());
             throw t;
         }
         preparedStatements.put(
@@ -303,7 +303,7 @@ public class Session implements AutoCloseable {
         try {
             preparedStmt = getSafeStmt(statementName);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUID.randomUUID(), null, SQLExceptions.messageOf(t), sessionContext.user());
+            jobsLogs.logPreExecutionFailure(UUID.randomUUID(), null, SQLExceptions.messageOf(t), sessionContext.sessionUser());
             throw t;
         }
 
@@ -509,13 +509,13 @@ public class Session implements AutoCloseable {
                 jobId,
                 firstPreparedStatement.rawStatement(),
                 SQLExceptions.messageOf(t),
-                sessionContext.user());
+                sessionContext.sessionUser());
             throw t;
         }
         jobsLogs.logExecutionStart(
             jobId,
             firstPreparedStatement.rawStatement(),
-            sessionContext.user(),
+            sessionContext.sessionUser(),
             StatementClassifier.classify(plan)
         );
 
@@ -578,14 +578,14 @@ public class Session implements AutoCloseable {
         String rawStatement = portal.preparedStmt().rawStatement();
         if (analyzedStmt == null) {
             String errorMsg = "Statement must have been analyzed: " + rawStatement;
-            jobsLogs.logPreExecutionFailure(jobId, rawStatement, errorMsg, sessionContext.user());
+            jobsLogs.logPreExecutionFailure(jobId, rawStatement, errorMsg, sessionContext.sessionUser());
             throw new IllegalStateException(errorMsg);
         }
         Plan plan;
         try {
             plan = planner.plan(analyzedStmt, plannerContext);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, rawStatement, SQLExceptions.messageOf(t), sessionContext.user());
+            jobsLogs.logPreExecutionFailure(jobId, rawStatement, SQLExceptions.messageOf(t), sessionContext.sessionUser());
             throw t;
         }
         if (!analyzedStmt.isWriteOperation()) {
@@ -610,7 +610,7 @@ public class Session implements AutoCloseable {
             );
         }
         jobsLogs.logExecutionStart(
-            jobId, rawStatement, sessionContext.user(), StatementClassifier.classify(plan));
+            jobId, rawStatement, sessionContext.sessionUser(), StatementClassifier.classify(plan));
         RowConsumerToResultReceiver consumer = new RowConsumerToResultReceiver(
             resultReceiver, maxRows, new JobsLogsUpdateListener(jobId, jobsLogs));
         portal.setActiveConsumer(consumer);

--- a/server/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/server/src/main/java/io/crate/action/sql/SessionContext.java
@@ -91,7 +91,7 @@ public class SessionContext {
         return authenticatedUser;
     }
 
-    public User user() {
+    public User sessionUser() {
         return sessionUser;
     }
 

--- a/server/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/server/src/main/java/io/crate/action/sql/SessionContext.java
@@ -35,7 +35,8 @@ import static java.util.Objects.requireNonNull;
 
 public class SessionContext {
 
-    private final User user;
+    private final User authenticatedUser;
+    private User sessionUser;
 
     private SearchPath searchPath;
     private boolean hashJoinEnabled = true;
@@ -45,11 +46,16 @@ public class SessionContext {
      * Creates a new SessionContext suitable to use as system SessionContext
      */
     public static SessionContext systemSessionContext() {
-        return new SessionContext(User.CRATE_USER);
+        return new SessionContext(User.CRATE_USER, User.CRATE_USER);
     }
 
-    public SessionContext(User user, String... searchPath) {
-        this.user = requireNonNull(user, "User is required");
+    public SessionContext(User authenticatedUser, String... searchPath) {
+        this(authenticatedUser, authenticatedUser, searchPath);
+    }
+
+    public SessionContext(User authenticatedUser, User sessionUser, String... searchPath) {
+        this.authenticatedUser = requireNonNull(authenticatedUser, "Authenticated user is required");
+        this.sessionUser = requireNonNull(sessionUser, "Session user is required");
         this.searchPath = createSearchPathFrom(searchPath);
         this.excludedOptimizerRules = new HashSet<>();
     }
@@ -81,8 +87,16 @@ public class SessionContext {
         this.hashJoinEnabled = hashJoinEnabled;
     }
 
+    public User authenticatedUser() {
+        return authenticatedUser;
+    }
+
     public User user() {
-        return user;
+        return sessionUser;
+    }
+
+    public void setSessionUser(User user) {
+        sessionUser = user;
     }
 
     public Set<Class<? extends Rule<?>>> excludedOptimizerRules() {

--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -71,7 +71,7 @@ class AlterTableAddColumnAnalyzer {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
             alterTable.table().getName(),
             Operation.ALTER,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
         TableReferenceResolver referenceResolver = new TableReferenceResolver(tableInfo.columns(), tableInfo.ident());
 

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -65,7 +65,7 @@ class AlterTableAnalyzer {
         DocTableInfo docTableInfo = (DocTableInfo) schemas.resolveTableInfo(
             alterTable.table().getName(),
             Operation.ALTER_BLOCKS,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
 
         return new AnalyzedAlterTable(docTableInfo, alterTable);

--- a/server/src/main/java/io/crate/analyze/AnalyzedSetSessionAuthorizationStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedSetSessionAuthorizationStatement.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.sql.tree.SetSessionAuthorizationStatement;
+
+import javax.annotation.Nullable;
+
+public class AnalyzedSetSessionAuthorizationStatement implements AnalyzedStatement {
+
+    @Nullable
+    private final String user;
+    private final SetSessionAuthorizationStatement.Scope scope;
+
+    AnalyzedSetSessionAuthorizationStatement(@Nullable String user,
+                                             SetSessionAuthorizationStatement.Scope scope) {
+        this.user = user;
+        this.scope = scope;
+    }
+
+    /**
+     * user is null for the following statements::
+     * <p>
+     * SET [ SESSION | LOCAL ] SESSION AUTHORIZATION DEFAULT
+     * and
+     * RESET SESSION AUTHORIZATION
+     */
+    @Nullable
+    public String user() {
+        return user;
+    }
+
+    public SetSessionAuthorizationStatement.Scope scope() {
+        return scope;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
+        return analyzedStatementVisitor.visitSetSessionAuthorizationStatement(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return false;
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -113,6 +113,11 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitAnalyzedStatement(analysis, context);
     }
 
+    public R visitSetSessionAuthorizationStatement(AnalyzedSetSessionAuthorizationStatement analysis,
+                                                   C context) {
+        return visitAnalyzedStatement(analysis, context);
+    }
+
     public R visitAnalyzedAlterTableOpenClose(AnalyzedAlterTableOpenClose analysis, C context) {
         return visitDDLStatement(analysis, context);
     }

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -404,7 +404,7 @@ public class Analyzer {
         public AnalyzedStatement visitDenyPrivilege(DenyPrivilege node, Analysis context) {
             return privilegesAnalyzer.analyzeDeny(
                 node,
-                context.sessionContext().user(),
+                context.sessionContext().sessionUser(),
                 context.sessionContext().searchPath());
         }
 
@@ -462,7 +462,7 @@ public class Analyzer {
         public AnalyzedStatement visitGrantPrivilege(GrantPrivilege node, Analysis context) {
             return privilegesAnalyzer.analyzeGrant(
                 node,
-                context.sessionContext().user(),
+                context.sessionContext().sessionUser(),
                 context.sessionContext().searchPath());
         }
 
@@ -527,7 +527,7 @@ public class Analyzer {
         public AnalyzedStatement visitRevokePrivilege(RevokePrivilege node, Analysis context) {
             return privilegesAnalyzer.analyzeRevoke(
                 node,
-                context.sessionContext().user(),
+                context.sessionContext().sessionUser(),
                 context.sessionContext().searchPath());
         }
 

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.metadata.NodeContext;
+import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -134,7 +135,6 @@ public class Analyzer {
     private final KillAnalyzer killAnalyzer;
     private final SetStatementAnalyzer setStatementAnalyzer;
     private final ResetStatementAnalyzer resetStatementAnalyzer;
-    private final NodeContext nodeCtx;
 
     /**
      * @param relationAnalyzer is injected because we also need to inject it in
@@ -151,7 +151,6 @@ public class Analyzer {
                     UserManager userManager,
                     SessionSettingRegistry sessionSettingRegistry
     ) {
-        this.nodeCtx = nodeCtx;
         this.relationAnalyzer = relationAnalyzer;
         this.dropTableAnalyzer = new DropTableAnalyzer(schemas);
         this.dropCheckConstraintAnalyzer = new DropCheckConstraintAnalyzer(schemas);
@@ -538,6 +537,12 @@ public class Analyzer {
                 (SetStatement<Expression>) node,
                 context.paramTypeHints(),
                 context.transactionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitSetSessionAuthorizationStatement(SetSessionAuthorizationStatement node,
+                                                                       Analysis context) {
+            return new AnalyzedSetSessionAuthorizationStatement(node.user(), node.scope());
         }
 
         @Override

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -59,7 +59,7 @@ class CopyAnalyzer {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
             node.table().getName(),
             Operation.INSERT,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
 
         var exprCtx = new ExpressionAnalysisContext();
@@ -105,7 +105,7 @@ class CopyAnalyzer {
         TableInfo tableInfo = schemas.resolveTableInfo(
             node.table().getName(),
             Operation.COPY_TO,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
         Operation.blockedRaiseException(tableInfo, Operation.READ);
         DocTableRelation tableRelation = new DocTableRelation((DocTableInfo) tableInfo);

--- a/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
@@ -45,7 +45,7 @@ class DropCheckConstraintAnalyzer {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
             table.getName(),
             Operation.ALTER,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
         List<CheckConstraint<Symbol>> checkConstraints = tableInfo.checkConstraints();
         for (var checkConstraint : checkConstraints) {

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -65,7 +65,7 @@ class DropTableAnalyzer {
         T tableInfo;
         try {
             //noinspection unchecked
-            tableInfo = (T) schemas.resolveTableInfo(name, Operation.DROP, sessionContext.user(), sessionContext.searchPath());
+            tableInfo = (T) schemas.resolveTableInfo(name, Operation.DROP, sessionContext.sessionUser(), sessionContext.searchPath());
         } catch (SchemaUnknownException | RelationUnknown e) {
             if (dropIfExists) {
                 tableInfo = null;

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -109,7 +109,7 @@ class InsertAnalyzer {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
             insert.table().getName(),
             Operation.INSERT,
-            txnCtx.sessionContext().user(),
+            txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath()
         );
         List<Reference> targetColumns =

--- a/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -62,7 +62,7 @@ public class OptimizeTableAnalyzer {
             TableInfo tableInfo = schemas.resolveTableInfo(
                 table.getName(),
                 Operation.OPTIMIZE,
-                txnCtx.sessionContext().user(),
+                txnCtx.sessionContext().sessionUser(),
                 txnCtx.sessionContext().searchPath()
             );
             analyzedOptimizeTables.put(table, tableInfo);

--- a/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -61,7 +61,7 @@ class RefreshTableAnalyzer {
             var tableInfo = (DocTableInfo) schemas.resolveTableInfo(
                 table.getName(),
                 Operation.REFRESH,
-                txnCtx.sessionContext().user(),
+                txnCtx.sessionContext().sessionUser(),
                 txnCtx.sessionContext().searchPath());
             analyzedTables.put(analyzedTable, tableInfo);
         }

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -68,7 +68,7 @@ public final class SwapTableAnalyzer {
             dropSource = exprAnalyzer.convert(dropSourceExpr, new ExpressionAnalysisContext());
         }
         SearchPath searchPath = txnCtx.sessionContext().searchPath();
-        User user = txnCtx.sessionContext().user();
+        User user = txnCtx.sessionContext().sessionUser();
         return new AnalyzedSwapTable(
             (DocTableInfo) schemas.resolveTableInfo(swapTable.source(), Operation.ALTER, user, searchPath),
             (DocTableInfo) schemas.resolveTableInfo(swapTable.target(), Operation.ALTER, user, searchPath),

--- a/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -85,7 +85,7 @@ public final class ViewAnalyzer {
             query,
             createView.query(),
             createView.replaceExisting(),
-            txnCtx.sessionContext().user()
+            txnCtx.sessionContext().sessionUser()
         );
     }
 

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -596,7 +596,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             tableInfo = schemas.resolveTableInfo(
                 tableQualifiedName,
                 context.currentOperation(),
-                context.sessionContext().user(),
+                context.sessionContext().sessionUser(),
                 searchPath
             );
             if (tableInfo instanceof DocTableInfo) {

--- a/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -61,7 +61,7 @@ public final class CoordinatorTxnCtx implements TransactionContext {
 
     @Override
     public SessionSettings sessionSettings() {
-        return new SessionSettings(sessionContext.user().name(),
+        return new SessionSettings(sessionContext.sessionUser().name(),
                                    sessionContext.searchPath(),
                                    sessionContext.isHashJoinEnabled(),
                                    sessionContext.excludedOptimizerRules());

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -228,7 +228,7 @@ public class SysShardsTableInfo {
         String[] concreteIndices = Arrays.stream(clusterState.metadata().getConcreteAllOpenIndices())
             .filter(index -> !IndexParts.isDangling(index))
             .toArray(String[]::new);
-        User user = sessionContext != null ? sessionContext.user() : null;
+        User user = sessionContext != null ? sessionContext.sessionUser() : null;
         if (user != null) {
             List<String> accessibleTables = new ArrayList<>(concreteIndices.length);
             for (String indexName : concreteIndices) {

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
@@ -156,7 +156,7 @@ public class CreateSnapshotPlan implements Plan {
                     docTableInfo = (DocTableInfo) schemas.resolveTableInfo(
                         table.getName(),
                         Operation.CREATE_SNAPSHOT,
-                        txnCtx.sessionContext().user(),
+                        txnCtx.sessionContext().sessionUser(),
                         txnCtx.sessionContext().searchPath());
                 } catch (ResourceUnknownException e) {
                     if (ignoreUnavailable) {

--- a/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.statement;
+
+import io.crate.analyze.AnalyzedSetSessionAuthorizationStatement;
+import io.crate.auth.user.User;
+import io.crate.auth.user.UserManager;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+
+import static io.crate.data.SentinelRow.SENTINEL;
+
+public class SetSessionAuthorizationPlan implements Plan {
+
+    private final AnalyzedSetSessionAuthorizationStatement setSessionAuthorization;
+    private final UserManager userManager;
+
+    public SetSessionAuthorizationPlan(AnalyzedSetSessionAuthorizationStatement setSessionAuthorization,
+                                       UserManager userManager) {
+        this.setSessionAuthorization = setSessionAuthorization;
+        this.userManager = userManager;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier executor,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+        var sessionContext = plannerContext.transactionContext().sessionContext();
+        String userName = setSessionAuthorization.user();
+        User user;
+        if (userName != null) {
+            user = userManager.findUser(userName);
+            if (user == null) {
+                throw new IllegalArgumentException("User '" + userName + "' does not exist.");
+            }
+        } else {
+            user = sessionContext.authenticatedUser();
+        }
+        sessionContext.setSessionUser(user);
+        consumer.accept(InMemoryBatchIterator.empty(SENTINEL), null);
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -435,9 +435,9 @@ public class PostgresWireProtocol {
     private void finishAuthentication(Channel channel) {
         assert authContext != null : "finishAuthentication() requires an authContext instance";
         try {
-            User user = authContext.authenticate();
+            User authenticatedUser = authContext.authenticate();
             String database = properties.getProperty("database");
-            session = sqlOperations.createSession(database, user);
+            session = sqlOperations.createSession(database, authenticatedUser);
             Messages.sendAuthenticationOK(channel)
                 .addListener(f -> sendParamsAndRdyForQuery(channel));
         } catch (Exception e) {

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -214,13 +214,13 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
 
     private Session ensureSession(FullHttpRequest request) {
         String defaultSchema = request.headers().get(REQUEST_HEADER_SCHEMA);
-        User user = userFromAuthHeader(request.headers().get(HttpHeaderNames.AUTHORIZATION));
+        User authenticatedUser = userFromAuthHeader(request.headers().get(HttpHeaderNames.AUTHORIZATION));
         Session session = this.session;
         if (session == null) {
-            session = sqlOperations.createSession(defaultSchema, user);
-        } else if (session.sessionContext().user().equals(user) == false) {
+            session = sqlOperations.createSession(defaultSchema, authenticatedUser);
+        } else if (session.sessionContext().authenticatedUser().equals(authenticatedUser) == false) {
             session.close();
-            session = sqlOperations.createSession(defaultSchema, user);
+            session = sqlOperations.createSession(defaultSchema, authenticatedUser);
         } else {
             // We don't want to keep "set session" settings across requests yet to not mess with clients doing
             // per request round-robin

--- a/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
@@ -42,7 +42,7 @@ public class PgGetKeywordsFunctionTest extends AbstractTableFunctionsTest {
             rows.add(new RowN(it.next().materialize()));
         }
         rows.sort(Comparator.comparing(x -> ((String) x.get(0))));
-        assertThat(rows.size(), is(243));
+        assertThat(rows.size(), is(244));
         Row row = rows.get(0);
 
         assertThat(row.get(0), is("add"));

--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -525,7 +525,20 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
      * This is useful to execute a query on a specific node or to test using
      * session options like default schema.
      *
-     * @param stmt the SQL Statement
+     * @param stmt    the SQL Statement
+     * @param session the Session to use
+     * @return the SQLResponse
+     */
+    public SQLResponse execute(String stmt, Session session) {
+        return execute(stmt, null, session);
+    }
+
+    /**
+     * Execute an SQL Statement using a specific {@link Session}
+     * This is useful to execute a query on a specific node or to test using
+     * session options like default schema.
+     *
+     * @param stmt    the SQL Statement
      * @param session the Session to use
      * @return the SQLResponse
      */

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -150,7 +150,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName fqn = QualifiedName.of("schema", "t");
         SessionContext sessionContext = sqlExecutor.getSessionContext();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(fqn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
+            .resolveTableInfo(fqn, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));
@@ -171,7 +171,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SessionContext sessionContext = sqlExecutor.getSessionContext();
         expectedException.expect(SchemaUnknownException.class);
         expectedException.expectMessage("Schema 'bogus_schema' unknown");
-        sqlExecutor.schemas().resolveTableInfo(invalidFqn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
+        sqlExecutor.schemas().resolveTableInfo(invalidFqn, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());
     }
 
     @Test
@@ -182,7 +182,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         SessionContext sessionContext = sqlExecutor.getSessionContext();
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'missing_table' unknown");
-        sqlExecutor.schemas().resolveTableInfo(table, Operation.READ, sessionContext.user(), sessionContext.searchPath());
+        sqlExecutor.schemas().resolveTableInfo(table, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName tableQn = QualifiedName.of("t");
         SessionContext sessionContext = sqlExecutor.getSessionContext();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(tableQn, Operation.READ, sessionContext.user(), sessionContext.searchPath());
+            .resolveTableInfo(tableQn, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));

--- a/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
@@ -75,7 +75,7 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
 
         execute(e.plan("SET SESSION AUTHORIZATION " + user.name()));
 
-        assertThat(sessionContext.user(), is(user));
+        assertThat(sessionContext.sessionUser(), is(user));
     }
 
     @Test
@@ -83,14 +83,14 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
         var sessionContext = e.getSessionContext();
         sessionContext.setSessionUser(User.of("test"));
         assertThat(
-            sessionContext.user(),
+            sessionContext.sessionUser(),
             is(not(sessionContext.authenticatedUser()))
         );
 
         execute(e.plan("SET SESSION AUTHORIZATION DEFAULT"));
 
         assertThat(
-            sessionContext.user(),
+            sessionContext.sessionUser(),
             is(sessionContext.authenticatedUser())
         );
     }

--- a/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.statement;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.auth.user.AccessControl;
+import io.crate.auth.user.User;
+import io.crate.auth.user.UserManager;
+import io.crate.data.Row;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.NoopPlan;
+import io.crate.planner.Plan;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.TestingRowConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private UserManager userManager;
+
+    @Before
+    public void beforeEach() {
+        userManager = mock(UserManager.class);
+        when(userManager.getAccessControl(any(SessionContext.class)))
+            .thenReturn(AccessControl.DISABLED);
+        e = SQLExecutor.builder(clusterService).setUserManager(userManager).build();
+    }
+
+    @Test
+    public void test_set_local_session_auth_results_in_noop() {
+        assertThat(
+            e.plan("SET LOCAL SESSION AUTHORIZATION DEFAULT"),
+            instanceOf(NoopPlan.class)
+        );
+    }
+
+    @Test
+    public void test_set_session_auth_modifies_the_session_user() throws Exception {
+        var sessionContext = e.getSessionContext();
+        sessionContext.setSessionUser(User.CRATE_USER);
+        var user = User.of("test");
+        when(userManager.findUser(eq(user.name()))).thenReturn(user);
+
+        execute(e.plan("SET SESSION AUTHORIZATION " + user.name()));
+
+        assertThat(sessionContext.user(), is(user));
+    }
+
+    @Test
+    public void test_set_session_auth_to_default_sets_session_user_to_authenticated_user() throws Exception {
+        var sessionContext = e.getSessionContext();
+        sessionContext.setSessionUser(User.of("test"));
+        assertThat(
+            sessionContext.user(),
+            is(not(sessionContext.authenticatedUser()))
+        );
+
+        execute(e.plan("SET SESSION AUTHORIZATION DEFAULT"));
+
+        assertThat(
+            sessionContext.user(),
+            is(sessionContext.authenticatedUser())
+        );
+    }
+
+    @Test
+    public void test_set_session_auth_to_unknown_user_results_in_exception() throws Exception {
+        when(userManager.findUser(eq("unknown_user"))).thenReturn(null);
+        Plan plan = e.plan("SET SESSION AUTHORIZATION 'unknown_user'");
+
+        expectedException.expectMessage("User 'unknown_user' does not exist.");
+        expectedException.expect(IllegalArgumentException.class);
+        execute(plan);
+    }
+
+    private void execute(Plan plan) throws Exception {
+        var consumer = new TestingRowConsumer();
+        plan.execute(
+            mock(DependencyCarrier.class),
+            e.getPlannerContext(clusterService.state()),
+            consumer,
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
+        consumer.getResult();
+    }
+}

--- a/server/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLExecutor.java
@@ -791,6 +791,6 @@ public class SQLExecutor {
     public <T extends TableInfo> T resolveTableInfo(String tableName) {
         IndexParts indexParts = new IndexParts(tableName);
         QualifiedName qualifiedName = QualifiedName.of(indexParts.getSchema(), indexParts.getTable());
-        return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionContext.user(), sessionContext.searchPath());
+        return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds support for `SET AND RESET SESSION AUTHORIZATION` statements.
See commits.

An example the statements usage:
```
> psql -h localhost -U crate doc
psql (12.3, server 10.5)

=> create user test;
CREATE 1
kov=> set session authorization test;
SET 0
=> create user another_test;
ERROR:  Missing 'AL' privilege for user 'test'
=> set session authorization unknown_user;
ERROR:  User "test" is not authorized to execute the statement. Superuser permissions are required or you can set the session authorization back to the authenticated user.
=> set session authorization default;
SET 0
=> create user another_test;
CREATE 1
=> set session authorization another_test;
SET 0
=> create user another_test;
ERROR:  Missing 'AL' privilege for user 'another_test'
=> reset session authorization;
RESET 0
```
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
