### PR TITLE
Remove two ignored planner tests

### DIFF
--- a/server/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
@@ -80,20 +80,6 @@ public class GlobalAggregatePlannerTest extends CrateDummyClusterServiceUnitTest
     }
 
     @Test
-    @Ignore("TODO: figure out if early output stripping is necessary")
-    public void testJoinConditionFieldsAreNotPartOfNLOutputOnAggOnJoin() throws Exception {
-        Join nl = e.plan("select sum(u1.ints) from users u1 " +
-                         "    inner join users u2 on u1.id = u2.id ");
-        List<Projection> projections = nl.joinPhase().projections();
-        assertThat(projections, contains(
-            instanceOf(EvalProjection.class),
-            instanceOf(AggregationProjection.class)
-        ));
-        // Only u1.ints is in the outputs of the NL (pre projections)
-        assertThat(projections.get(0).outputs(), contains(isInputColumn(1)));
-    }
-
-    @Test
     public void test_aggregation_is_correctly_build_with_parameterized_expression() {
         Collect plan = e.plan("select sum(x + ?) from t1", UUID.randomUUID(), 0, new Row1(1));
         var projections = plan.collectPhase().projections();

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -710,24 +710,4 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(orderBy, instanceOf(InputColumn.class));
         assertThat(orderBy.valueType(), is(DataTypes.TIMESTAMPZ));
     }
-
-    @Test
-    @Ignore("Need to figure out a way to test this - the projection no longer matches the loop output")
-    public void testJoinConditionFieldsAreNotPartOfNLOutputInGroupByOnJoin() throws Exception {
-        var e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
-            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .build();
-        Join nl = e.plan("select count(*), u1.name " +
-                         "from users u1 " +
-                         "  inner join users u2 on u1.id = u2.id " +
-                         "group by u1.name");
-        List<Projection> projections = nl.joinPhase().projections();
-        assertThat(projections, contains(
-            instanceOf(EvalProjection.class),
-            instanceOf(GroupProjection.class),
-            instanceOf(EvalProjection.class)
-        ));
-        // Only u1.name is in the outputs of the NL (pre projections)
-        assertThat(projections.get(0).outputs(), contains(isInputColumn(0)));
-    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Due to how the operators work these test cases don't make sense anymore.
A Join operator will always have all the outputs and they're stripped
away by a later operator. In the test cases this would be the
aggregation or group projections.

That the aggregations or group projections don't have extra outputs is
implicitly tested by various logical planner test cases.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)