### PR TITLE
Fix flaky ThreadPoolsExhaustedIntegrationTest

### DIFF
--- a/server/src/main/java/io/crate/common/collections/RefCountedItem.java
+++ b/server/src/main/java/io/crate/common/collections/RefCountedItem.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.common.collections;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RefCountedItem<T> implements AutoCloseable {
+
+    private final T item;
+    private final Runnable onClose;
+    private final AtomicInteger refs = new AtomicInteger(1);
+
+    public RefCountedItem(T item, Runnable onClose) {
+        this.item = item;
+        this.onClose = onClose;
+    }
+
+    public void inc() {
+        refs.incrementAndGet();
+    }
+
+    public T item() {
+        return item;
+    }
+
+    @Override
+    public void close() {
+        int remainingRefs = refs.decrementAndGet();
+        assert remainingRefs >= 0 : "refcount must not get negative: " + remainingRefs;
+        if (remainingRefs == 0) {
+            onClose.run();
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -147,7 +147,7 @@ final class GroupByOptimizedIterator {
 
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher("group-by-ordinals:" + formatSource(collectPhase));
+        var searcher = sharedShardContext.acquireSearcher("group-by-ordinals:" + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
         final QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
@@ -179,7 +179,7 @@ final class GroupByOptimizedIterator {
 
         return getIterator(
             bigArrays,
-            searcher,
+            searcher.item(),
             keyRef.column().fqn(),
             aggregations,
             expressions,
@@ -364,7 +364,7 @@ final class GroupByOptimizedIterator {
     static boolean hasHighCardinalityRatio(Supplier<Engine.Searcher> acquireSearcher, String fieldName) {
         // acquire separate searcher:
         // Can't use sharedShardContexts() yet, if we bail out the "getOrCreateContext" causes issues later on in the fallback logic
-        try (Engine.Searcher searcher = acquireSearcher.get()) {
+        try (var searcher = acquireSearcher.get()) {
             for (LeafReaderContext leaf : searcher.getIndexReader().leaves()) {
                 Terms terms = leaf.reader().terms(fieldName);
                 if (terms == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -129,7 +128,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                                                       CollectTask collectTask) {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher("unordered-iterator: " + formatSource(collectPhase));
+        var searcher = sharedShardContext.acquireSearcher("unordered-iterator: " + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexShard indexShard = sharedShardContext.indexShard();
         QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
@@ -146,7 +145,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
 
         return new LuceneBatchIterator(
-            searcher,
+            searcher.item(),
             queryContext.query(),
             queryContext.minScore(),
             Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
@@ -206,7 +205,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
 
         CollectorContext collectorContext;
         InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx;
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher("ordered-collector: " + formatSource(phase));
+        var searcher = sharedShardContext.acquireSearcher("ordered-collector: " + formatSource(phase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexService indexService = sharedShardContext.indexService();
         QueryShardContext queryShardContext = indexService.newQueryShardContext();
@@ -235,7 +234,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         );
         return new LuceneOrderedDocCollector(
             indexShard.shardId(),
-            searcher,
+            searcher.item(),
             queryContext.query(),
             queryContext.minScore(),
             Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),

--- a/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.collect;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.breaker.RamAccounting;
+import io.crate.common.collections.RefCountedItem;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.exceptions.JobKilledException;
@@ -82,8 +83,8 @@ public class CollectTaskTest extends RandomizedTest {
 
     @Test
     public void testAddingSameContextTwice() throws Exception {
-        Engine.Searcher mock1 = mock(Engine.Searcher.class);
-        Engine.Searcher mock2 = mock(Engine.Searcher.class);
+        RefCountedItem<Engine.Searcher> mock1 = mock(RefCountedItem.class);
+        RefCountedItem<Engine.Searcher> mock2 = mock(RefCountedItem.class);
         try {
             collectTask.addSearcher(1, mock1);
             collectTask.addSearcher(1, mock2);
@@ -97,8 +98,8 @@ public class CollectTaskTest extends RandomizedTest {
 
     @Test
     public void testInnerCloseClosesSearchContexts() throws Exception {
-        Engine.Searcher mock1 = mock(Engine.Searcher.class);
-        Engine.Searcher mock2 = mock(Engine.Searcher.class);
+        RefCountedItem mock1 = mock(RefCountedItem.class);
+        RefCountedItem mock2 = mock(RefCountedItem.class);
 
         collectTask.addSearcher(1, mock1);
         collectTask.addSearcher(2, mock2);
@@ -111,7 +112,7 @@ public class CollectTaskTest extends RandomizedTest {
 
     @Test
     public void testKillOnJobCollectContextPropagatesToCrateCollectors() throws Exception {
-        Engine.Searcher mock1 = mock(Engine.Searcher.class);
+        RefCountedItem mock1 = mock(RefCountedItem.class);
         MapSideDataCollectOperation collectOperationMock = mock(MapSideDataCollectOperation.class);
 
         var ramAccounting = mock(RamAccounting.class);

--- a/server/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
@@ -21,22 +21,22 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.SQLResponse;
-import io.crate.testing.SQLTransportExecutor;
-import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.is;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.crate.testing.SQLResponse;
+import io.crate.testing.SQLTransportExecutor;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, maxNumDataNodes = 2)
 public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegrationTest {
@@ -51,7 +51,6 @@ public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegration
     }
 
     @Test
-    @Ignore("https://github.com/crate/crate/issues/10326")
     public void testRegularSelectWithFewAvailableThreadsShouldNeverGetStuck() throws Exception {
         execute("create table t (x int) with (number_of_replicas = 0)");
         ensureYellow();
@@ -61,7 +60,6 @@ public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegration
     }
 
     @Test
-    @Ignore("https://github.com/crate/crate/issues/10326")
     public void testDistributedPushSelectWithFewAvailableThreadsShouldNeverGetStuck() throws Exception {
         execute("create table t (x int) with (number_of_replicas = 0)");
         ensureYellow();
@@ -86,7 +84,8 @@ public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegration
             } catch (Exception e) {
                 assertThat(e.getMessage(), anyOf(
                     Matchers.containsString("rejected execution"),
-                    Matchers.containsString("job killed")));
+                    Matchers.containsString("job killed")
+                ));
             }
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This makes again sure that collect & search share the very same searcher
instance.

We changed that in https://github.com/crate/crate/commit/e7695886044540030b1a50f82f33a52d99c9b1be and since then the ThreadPoolsExhaustedIntegrationTest has been flaky.

Due to the nature of the test, the assumption was that the errors were
related to the kill handling, but logging indicates that the error is
unrelated to the kill handling.

Closes https://github.com/crate/crate/issues/10326


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)