### PR TITLE
Always close searchers via CollectTask

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -100,8 +100,8 @@ public class DocValuesAggregates {
         ShardId shardId = indexShard.shardId();
         SharedShardContext shardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Searcher searcher = shardContext.acquireSearcher(LuceneShardCollectorProvider.formatSource(phase));
-        QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
         collectTask.addSearcher(shardContext.readerId(), searcher);
+        QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             phase.where(),
             collectTask.txnCtx(),

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -132,8 +132,8 @@ final class DocValuesGroupByOptimizedIterator {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
-        QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+        QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
 
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
             = docInputFactory.getCtx(collectTask.txnCtx());

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -148,9 +148,9 @@ final class GroupByOptimizedIterator {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
         final QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
-        collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
         docCtx.add(collectPhase.toCollect().stream()::iterator);

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -130,35 +130,30 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexShard indexShard = sharedShardContext.indexShard();
-        try {
-            QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
-            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-                collectPhase.where(),
-                collectTask.txnCtx(),
-                indexShard.mapperService(),
-                indexShard.shardId().getIndexName(),
-                queryShardContext,
-                table,
-                sharedShardContext.indexService().cache()
-            );
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
-            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx =
-                docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
+        QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
+        LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+            collectPhase.where(),
+            collectTask.txnCtx(),
+            indexShard.mapperService(),
+            indexShard.shardId().getIndexName(),
+            queryShardContext,
+            table,
+            sharedShardContext.indexService().cache()
+        );
+        InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx =
+            docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
 
-            return new LuceneBatchIterator(
-                searcher,
-                queryContext.query(),
-                queryContext.minScore(),
-                Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
-                new CollectorContext(sharedShardContext.readerId()),
-                docCtx.topLevelInputs(),
-                docCtx.expressions()
-            );
-        } catch (Throwable t) {
-            searcher.close();
-            throw t;
-        }
+        return new LuceneBatchIterator(
+            searcher,
+            queryContext.query(),
+            queryContext.minScore(),
+            Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
+            new CollectorContext(sharedShardContext.readerId()),
+            docCtx.topLevelInputs(),
+            docCtx.expressions()
+        );
     }
 
     @Nullable
@@ -211,30 +206,21 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
 
         CollectorContext collectorContext;
         InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx;
-        Engine.Searcher searcher = null;
-        LuceneQueryBuilder.Context queryContext;
-        try {
-            searcher = sharedShardContext.acquireSearcher(formatSource(phase));
-            IndexService indexService = sharedShardContext.indexService();
-            QueryShardContext queryShardContext = indexService.newQueryShardContext();
-            queryContext = luceneQueryBuilder.convert(
-                collectPhase.where(),
-                collectTask.txnCtx(),
-                indexService.mapperService(),
-                indexShard.shardId().getIndexName(),
-                queryShardContext,
-                table,
-                indexService.cache()
-            );
-            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
-            ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
-            collectorContext = new CollectorContext(sharedShardContext.readerId());
-        } catch (Throwable t) {
-            if (searcher != null) {
-                searcher.close();
-            }
-            throw t;
-        }
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(phase));
+        collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+        IndexService indexService = sharedShardContext.indexService();
+        QueryShardContext queryShardContext = indexService.newQueryShardContext();
+        final var queryContext = luceneQueryBuilder.convert(
+            collectPhase.where(),
+            collectTask.txnCtx(),
+            indexService.mapperService(),
+            indexShard.shardId().getIndexName(),
+            queryShardContext,
+            table,
+            indexService.cache()
+        );
+        ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
+        collectorContext = new CollectorContext(sharedShardContext.readerId());
         int batchSize = collectPhase.shardQueueSize(localNodeId.get());
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("[{}][{}] creating LuceneOrderedDocCollector. Expected number of rows to be collected: {}",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Once a searcher is registered with the collectTask, the collectTask
ensures that the searcher will be closed.

This removes some try/catch blocks which took care of closing the
searcher in case of errors - they're not necessary if the searcher is
registered with the collectTask right after acquiring it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)