### PR TITLE
Fix BWC issue with aggregation func resolving

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,9 @@ Changes
 Fixes
 =====
 
+- Fixed a BWC issue with aggregation function resolving in a mixed version
+  cluster where at least one node is on version < 4.2.
+
 - Improved the throttling behavior of ``INSERT INTO .. <query>``, it is now
   more aggressive to reduce the amount of memory used by a ``INSERT INTO``
   operation.

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -38,6 +38,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
@@ -141,10 +142,17 @@ public class ProjectionBuilder {
             assert aggregationFunction != null :
                 "Aggregation function implementation not found using full qualified lookup: " + function;
 
+            var valueType = mode.returnType(aggregationFunction);
+            var functionInfo = FunctionInfo.of(
+                aggregationFunction.signature(),
+                aggregationFunction.boundSignature().getArgumentDataTypes(),
+                valueType
+            );
             Aggregation aggregation = new Aggregation(
                 aggregationFunction.signature(),
+                functionInfo,
                 aggregationFunction.boundSignature().getReturnType().createType(),
-                mode.returnType(aggregationFunction),
+                valueType,
                 Lists2.map(aggregationInputs, subQueryAndParamBinder),
                 subQueryAndParamBinder.apply(filterInput)
             );

--- a/server/src/main/java/io/crate/expression/symbol/Aggregation.java
+++ b/server/src/main/java/io/crate/expression/symbol/Aggregation.java
@@ -48,10 +48,17 @@ public class Aggregation extends Symbol {
     private final Symbol filter;
 
     public Aggregation(Signature signature, DataType<?> valueType, List<Symbol> inputs) {
-        this(signature, valueType, valueType, inputs, Literal.BOOLEAN_TRUE);
+        this(signature,
+            FunctionInfo.of(signature, Symbols.typeView(inputs), valueType),
+            valueType,
+            valueType,
+            inputs,
+            Literal.BOOLEAN_TRUE
+        );
     }
 
     public Aggregation(Signature signature,
+                       FunctionInfo functionInfo,
                        DataType<?> boundSignatureReturnType,
                        DataType<?> valueType,
                        List<Symbol> inputs,
@@ -60,7 +67,7 @@ public class Aggregation extends Symbol {
         requireNonNull(filter, "filter must not be null");
 
         this.valueType = valueType;
-        this.functionInfo = FunctionInfo.of(signature, Symbols.typeView(inputs), valueType);
+        this.functionInfo = functionInfo;
         this.signature = signature;
         this.boundSignatureReturnType = boundSignatureReturnType;
         this.inputs = inputs;

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -107,6 +107,16 @@ public class Functions {
     }
 
     /**
+     * See {@link #get(String, String, List, List, SearchPath)}
+     */
+    public FunctionImplementation get(@Nullable String suppliedSchema,
+                                      String functionName,
+                                      List<Symbol> arguments,
+                                      SearchPath searchPath) {
+        return get(suppliedSchema, functionName, Symbols.typeView(arguments), arguments, searchPath);
+    }
+
+    /**
      * Return a function that matches the name/arguments.
      *
      * <pre>
@@ -119,13 +129,15 @@ public class Functions {
      *
      * @throws UnsupportedOperationException if the function wasn't found
      */
-    public FunctionImplementation get(@Nullable String suppliedSchema,
-                                      String functionName,
-                                      List<Symbol> arguments,
-                                      SearchPath searchPath) {
+    private FunctionImplementation get(@Nullable String suppliedSchema,
+                                       String functionName,
+                                       List<DataType<?>> argumentTypes,
+                                       List<Symbol> arguments,
+                                       SearchPath searchPath) {
         FunctionName fqnName = new FunctionName(suppliedSchema, functionName);
         FunctionImplementation func = resolveFunctionBySignature(
             fqnName,
+            argumentTypes,
             arguments,
             searchPath,
             functionImplementations
@@ -133,6 +145,7 @@ public class Functions {
         if (func == null) {
             func = resolveFunctionBySignature(
                 fqnName,
+                argumentTypes,
                 arguments,
                 searchPath,
                 udfFunctionImplementations
@@ -168,6 +181,7 @@ public class Functions {
 
     @Nullable
     private static FunctionImplementation resolveFunctionBySignature(FunctionName name,
+                                                                     List<DataType<?>> argumentTypes,
                                                                      List<Symbol> arguments,
                                                                      SearchPath searchPath,
                                                                      Map<FunctionName, List<FunctionProvider>> candidatesByName) {
@@ -190,7 +204,7 @@ public class Functions {
             var exactCandidates = candidates.stream()
                 .filter(function -> function.getSignature().getBindingInfo().getTypeVariableConstraints().isEmpty())
                 .collect(Collectors.toList());
-            var match = matchFunctionCandidates(exactCandidates, arguments, SignatureBinder.CoercionType.NONE);
+            var match = matchFunctionCandidates(exactCandidates, argumentTypes, SignatureBinder.CoercionType.NONE);
             if (match != null) {
                 return match;
             }
@@ -200,7 +214,7 @@ public class Functions {
             var genericCandidates = candidates.stream()
                 .filter(function -> !function.getSignature().getBindingInfo().getTypeVariableConstraints().isEmpty())
                 .collect(Collectors.toList());
-            match = matchFunctionCandidates(genericCandidates, arguments, SignatureBinder.CoercionType.NONE);
+            match = matchFunctionCandidates(genericCandidates, argumentTypes, SignatureBinder.CoercionType.NONE);
             if (match != null) {
                 return match;
             }
@@ -212,7 +226,7 @@ public class Functions {
                 .collect(Collectors.toList());
             match = matchFunctionCandidates(
                 candidatesAllowingCoercion,
-                arguments,
+                argumentTypes,
                 SignatureBinder.CoercionType.PRECEDENCE_ONLY
             );
             if (match != null) {
@@ -220,7 +234,7 @@ public class Functions {
             }
 
             // Last, try all candidates which allow coercion with full coercion.
-            match = matchFunctionCandidates(candidatesAllowingCoercion, arguments, SignatureBinder.CoercionType.FULL);
+            match = matchFunctionCandidates(candidatesAllowingCoercion, argumentTypes, SignatureBinder.CoercionType.FULL);
 
             if (match == null) {
                 raiseUnknownFunction(name.schema(), name.name(), arguments, candidates);
@@ -232,12 +246,12 @@ public class Functions {
 
     @Nullable
     private static FunctionImplementation matchFunctionCandidates(List<FunctionProvider> candidates,
-                                                                  List<Symbol> arguments,
+                                                                  List<DataType<?>> arguments,
                                                                   SignatureBinder.CoercionType coercionType) {
         List<ApplicableFunction> applicableFunctions = new ArrayList<>();
         for (FunctionProvider candidate : candidates) {
             Signature boundSignature = new SignatureBinder(candidate.getSignature(), coercionType)
-                .bind(Lists2.map(arguments, s -> s.valueType().getTypeSignature()));
+                .bind(Lists2.map(arguments, DataType::getTypeSignature));
             if (boundSignature != null) {
                 applicableFunctions.add(
                     new ApplicableFunction(
@@ -279,6 +293,7 @@ public class Functions {
         return get(
             function.info().ident().fqnName().schema(),
             function.info().ident().fqnName().name(),
+            function.info().ident().argumentTypes(),
             function.arguments(),
             searchPath
             );
@@ -295,6 +310,7 @@ public class Functions {
         return get(
             function.functionIdent().fqnName().schema(),
             function.functionIdent().fqnName().name(),
+            function.functionIdent().argumentTypes(),
             function.inputs(),
             searchPath
             );
@@ -361,13 +377,13 @@ public class Functions {
     }
 
     private static List<ApplicableFunction> selectMostSpecificFunctions(List<ApplicableFunction> applicableFunctions,
-                                                                        List<Symbol> arguments) {
+                                                                        List<DataType<?>> arguments) {
         if (applicableFunctions.isEmpty()) {
             return applicableFunctions;
         }
 
         // Find most specific by number of exact argument type matches
-        List<TypeSignature> argumentTypeSignatures = Lists2.map(arguments, s -> s.valueType().getTypeSignature());
+        List<TypeSignature> argumentTypeSignatures = Lists2.map(arguments, DataType::getTypeSignature);
         List<ApplicableFunction> mostSpecificFunctions = selectMostSpecificFunctions(
             applicableFunctions,
             (l, r) -> hasMoreExactTypeMatches(l, r, argumentTypeSignatures));
@@ -395,7 +411,7 @@ public class Functions {
         //     `concat(array(E), array(E)):array(E)`
         //
         if (returnTypeIsTheSame(mostSpecificFunctions)
-            || arguments.stream().allMatch(s -> s.valueType().id() == DataTypes.UNDEFINED.id())) {
+            || arguments.stream().allMatch(s -> s.id() == DataTypes.UNDEFINED.id())) {
             ApplicableFunction selectedFunction = mostSpecificFunctions.stream()
                 .sorted(Comparator.comparing(Objects::toString))
                 .iterator().next();

--- a/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
@@ -23,6 +23,7 @@
 package io.crate.expression.symbol;
 
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.metadata.FunctionInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -37,8 +38,14 @@ public class AggregationTest extends ESTestCase {
 
     @Test
     public void test_serialization_with_filter() throws Exception {
+        var functionInfo = FunctionInfo.of(
+            CountAggregation.COUNT_STAR_SIGNATURE,
+            List.of(),
+            CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType()
+        );
         Aggregation actual = new Aggregation(
             CountAggregation.COUNT_STAR_SIGNATURE,
+            functionInfo,
             CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
             CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType(),
             List.of(),


### PR DESCRIPTION
Aggregation functions have partial intermediate states which cannot be used for aggregation full qualified resolving when a `Signature` is not available when the function is streamed by nodes < 4.2.
Thus the registered argument types of the deprecated `FunctionInfo` must be used for this fallback full qualified resolving and not the actual input types.

Relates #10415.