### PR TITLE
Remove duplicated registerRequestHandler overloads

### DIFF
--- a/server/src/main/java/io/crate/blob/transfer/BlobHeadRequestHandler.java
+++ b/server/src/main/java/io/crate/blob/transfer/BlobHeadRequestHandler.java
@@ -62,9 +62,24 @@ public class BlobHeadRequestHandler {
     }
 
     public void registerHandler() {
-        transportService.registerRequestHandler(Actions.GET_BLOB_HEAD, GetBlobHeadRequest::new, ThreadPool.Names.GENERIC, new GetBlobHeadHandler());
-        transportService.registerRequestHandler(Actions.GET_TRANSFER_INFO, BlobInfoRequest::new, ThreadPool.Names.GENERIC, new GetTransferInfoHandler());
-        transportService.registerRequestHandler(Actions.PUT_BLOB_HEAD_CHUNK, PutBlobHeadChunkRequest::new, ThreadPool.Names.GENERIC, new PutBlobHeadChunkHandler());
+        transportService.registerRequestHandler(
+            Actions.GET_BLOB_HEAD,
+            ThreadPool.Names.GENERIC,
+            GetBlobHeadRequest::new,
+            new GetBlobHeadHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.GET_TRANSFER_INFO,
+            ThreadPool.Names.GENERIC,
+            BlobInfoRequest::new,
+            new GetTransferInfoHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.PUT_BLOB_HEAD_CHUNK,
+            ThreadPool.Names.GENERIC,
+            PutBlobHeadChunkRequest::new,
+            new PutBlobHeadChunkHandler()
+        );
     }
 
     private class GetBlobHeadHandler implements TransportRequestHandler<GetBlobHeadRequest> {

--- a/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
+++ b/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
@@ -53,8 +53,8 @@ public class TransportDecommissionNodeAction implements NodeAction<DecommissionN
         this.transports = transports;
         transportService.registerRequestHandler(
             ACTION_NAME,
-            DecommissionNodeRequest::new,
             EXECUTOR,
+            DecommissionNodeRequest::new,
             new NodeActionRequestHandler<>(this)
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
@@ -53,9 +53,10 @@ public class TransportNodeStatsAction implements NodeAction<NodeStatsRequest, No
                                     Transports transports) {
         this.nodeContextFieldsResolver = nodeContextFieldsResolver;
         this.transports = transports;
-        transportService.registerRequestHandler(ACTION_NAME,
-            NodeStatsRequest::new,
+        transportService.registerRequestHandler(
+            ACTION_NAME,
             EXECUTOR,
+            NodeStatsRequest::new,
             new NodeActionRequestHandler<>(this)
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -102,9 +102,10 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
         this.killJobsAction = killJobsAction;
         this.backoffPolicy = backoffPolicy;
 
-        transportService.registerRequestHandler(DISTRIBUTED_RESULT_ACTION,
-            DistributedResultRequest::new,
+        transportService.registerRequestHandler(
+            DISTRIBUTED_RESULT_ACTION,
             ThreadPool.Names.SAME, // <- we will dispatch later at the nodeOperation on non failures
+            DistributedResultRequest::new,
             new NodeActionRequestHandler<>(this));
     }
 

--- a/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
@@ -75,7 +75,6 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
 
         transportService.registerRequestHandler(
             TRANSPORT_ACTION,
-            NodeFetchRequest::new,
             EXECUTOR_NAME,
             // force execution because this handler might receive empty close requests which
             // need to be processed to not leak the FetchTask.
@@ -83,6 +82,7 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
             // If the threadPool is overloaded the query phase would fail first.
             true,
             false,
+            NodeFetchRequest::new,
             new NodeActionRequestHandler<>(this)
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/profile/TransportCollectProfileNodeAction.java
+++ b/server/src/main/java/io/crate/execution/engine/profile/TransportCollectProfileNodeAction.java
@@ -68,10 +68,10 @@ public class TransportCollectProfileNodeAction implements NodeAction<NodeCollect
 
         transportService.registerRequestHandler(
             TRANSPORT_ACTION,
-            NodeCollectProfileRequest::new,
             EXECUTOR,
             true,
             false,
+            NodeCollectProfileRequest::new,
             new NodeActionRequestHandler<>(this)
         );
     }

--- a/server/src/main/java/io/crate/execution/jobs/kill/TransportKillNodeAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/kill/TransportKillNodeAction.java
@@ -65,8 +65,8 @@ abstract class TransportKillNodeAction<Request extends TransportRequest> impleme
         this.name = name;
         transportService.registerRequestHandler(
             name,
-            reader,
             ThreadPool.Names.GENERIC,
+            reader,
             new NodeActionRequestHandler<>(this));
     }
 

--- a/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -71,8 +71,8 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
         this.jobSetup = jobSetup;
         transportService.registerRequestHandler(
             ACTION_NAME,
-            JobRequest::new,
             EXECUTOR,
+            JobRequest::new,
             new NodeActionRequestHandler<>(this));
     }
 

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -98,8 +98,8 @@ public final class TransportAnalyzeAction {
         this.clusterService = clusterService;
         transportService.registerRequestHandler(
             INVOKE_ANALYZE,
-            AnalyzeRequest::new,
             ThreadPool.Names.SAME, // goes async right away
+            AnalyzeRequest::new,
             // Explicit generic is required for eclipse JDT, otherwise it won't compile
             new NodeActionRequestHandler<AnalyzeRequest, AcknowledgedResponse>(
                 req -> fetchSamplesThenGenerateAndPublishStats()
@@ -107,8 +107,8 @@ public final class TransportAnalyzeAction {
         );
         transportService.registerRequestHandler(
             FETCH_SAMPLES,
-            FetchSampleRequest::new,
             ThreadPool.Names.SEARCH,
+            FetchSampleRequest::new,
             // Explicit generic is required for eclipse JDT, otherwise it won't compile
             new NodeActionRequestHandler<FetchSampleRequest, FetchSampleResponse>(
                 req -> completedFuture(new FetchSampleResponse(
@@ -117,8 +117,8 @@ public final class TransportAnalyzeAction {
         );
         transportService.registerRequestHandler(
             RECEIVE_TABLE_STATS,
-            PublishTableStatsRequest::new,
             ThreadPool.Names.SAME, // cheap operation
+            PublishTableStatsRequest::new,
             // Explicit generic is required for eclipse JDT, otherwise it won't compile
             new NodeActionRequestHandler<PublishTableStatsRequest, AcknowledgedResponse>(
                 req -> {

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -97,8 +97,14 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
         transportNodeBroadcastAction = actionName + "[n]";
 
-        transportService.registerRequestHandler(transportNodeBroadcastAction, NodeRequest::new, executor, false, canTripCircuitBreaker,
-            new BroadcastByNodeTransportRequestHandler());
+        transportService.registerRequestHandler(
+            transportNodeBroadcastAction,
+            executor,
+            false,
+            canTripCircuitBreaker,
+            NodeRequest::new,
+            new BroadcastByNodeTransportRequestHandler()
+        );
     }
 
     private Response newResponse(

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -75,7 +75,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
         this.transportNodeAction = actionName + "[n]";
 
         transportService.registerRequestHandler(
-            transportNodeAction, nodeRequestReader, nodeExecutor, new NodeTransportHandler());
+            transportNodeAction, nodeExecutor, nodeRequestReader, new NodeTransportHandler());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -153,23 +153,23 @@ public abstract class TransportReplicationAction<
         this.transportPrimaryAction = actionName + "[p]";
         this.transportReplicaAction = actionName + "[r]";
 
-        transportService.registerRequestHandler(actionName, reader, ThreadPool.Names.SAME, new OperationTransportHandler());
+        transportService.registerRequestHandler(actionName, ThreadPool.Names.SAME, reader, new OperationTransportHandler());
         transportService.registerRequestHandler(
             transportPrimaryAction,
-            in -> new ConcreteShardRequest<>(in, reader),
             executor,
             forceExecutionOnPrimary,
             true,
+            in -> new ConcreteShardRequest<>(in, reader),
             new PrimaryOperationTransportHandler()
         );
 
         // we must never reject on because of thread pool capacity on replicas
         transportService.registerRequestHandler(
             transportReplicaAction,
-            in -> new ConcreteReplicaRequest<>(in, replicaReader),
             executor,
             true,
             true,
+            in -> new ConcreteReplicaRequest<>(in, replicaReader),
             new ReplicaOperationTransportHandler()
         );
         this.transportOptions = transportOptions();

--- a/server/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -52,7 +52,7 @@ public class NodeMappingRefreshAction {
     public NodeMappingRefreshAction(TransportService transportService, MetadataMappingService metadataMappingService) {
         this.transportService = transportService;
         this.metadataMappingService = metadataMappingService;
-        transportService.registerRequestHandler(ACTION_NAME, NodeMappingRefreshRequest::new, ThreadPool.Names.SAME, new NodeMappingRefreshTransportHandler());
+        transportService.registerRequestHandler(ACTION_NAME, ThreadPool.Names.SAME, NodeMappingRefreshRequest::new, new NodeMappingRefreshTransportHandler());
     }
 
     public void nodeMappingRefresh(final DiscoveryNode masterNode, final NodeMappingRefreshRequest request) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -133,8 +133,8 @@ public class JoinHelper {
 
         transportService.registerRequestHandler(
             VALIDATE_JOIN_ACTION_NAME,
-            ValidateJoinRequest::new,
             ThreadPool.Names.GENERIC,
+            ValidateJoinRequest::new,
             (request, channel, task) -> {
                 final ClusterState localState = currentStateSupplier.get();
                 if (localState.metadata().clusterUUIDCommitted() &&

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -89,10 +89,10 @@ public class PublicationTransportHandler {
 
         transportService.registerRequestHandler(
             PUBLISH_STATE_ACTION_NAME,
-            BytesTransportRequest::new,
             ThreadPool.Names.GENERIC,
             false,
             false,
+            BytesTransportRequest::new,
             (request, channel, task) -> channel.sendResponse(handleIncomingPublishRequest(request))
         );
 

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -74,9 +74,10 @@ public class LocalAllocateDangledIndices {
         this.metadataIndexUpgradeService = metadataIndexUpgradeService;
         transportService.registerRequestHandler(
             ACTION_NAME,
-            AllocateDangledRequest::new,
             ThreadPool.Names.SAME,
-            new AllocateDangledRequestHandler());
+            AllocateDangledRequest::new,
+            new AllocateDangledRequestHandler()
+        );
     }
 
     public void allocateDangled(Collection<IndexMetadata> indices, final ActionListener<AllocateDangledResponse> listener) {

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -86,14 +86,32 @@ public class SyncedFlushService implements IndexEventListener {
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Inject
-    public SyncedFlushService(IndicesService indicesService, ClusterService clusterService, TransportService transportService, IndexNameExpressionResolver indexNameExpressionResolver) {
+    public SyncedFlushService(IndicesService indicesService,
+                              ClusterService clusterService,
+                              TransportService transportService,
+                              IndexNameExpressionResolver indexNameExpressionResolver) {
         this.indicesService = indicesService;
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
-        transportService.registerRequestHandler(PRE_SYNCED_FLUSH_ACTION_NAME, PreShardSyncedFlushRequest::new, ThreadPool.Names.FLUSH, new PreSyncedFlushTransportHandler());
-        transportService.registerRequestHandler(SYNCED_FLUSH_ACTION_NAME, ShardSyncedFlushRequest::new, ThreadPool.Names.FLUSH, new SyncedFlushTransportHandler());
-        transportService.registerRequestHandler(IN_FLIGHT_OPS_ACTION_NAME, InFlightOpsRequest::new, ThreadPool.Names.SAME, new InFlightOpCountTransportHandler());
+        transportService.registerRequestHandler(
+            PRE_SYNCED_FLUSH_ACTION_NAME,
+            ThreadPool.Names.FLUSH,
+            PreShardSyncedFlushRequest::new,
+            new PreSyncedFlushTransportHandler()
+        );
+        transportService.registerRequestHandler(
+            SYNCED_FLUSH_ACTION_NAME,
+            ThreadPool.Names.FLUSH,
+            ShardSyncedFlushRequest::new,
+            new SyncedFlushTransportHandler()
+        );
+        transportService.registerRequestHandler(
+            IN_FLIGHT_OPS_ACTION_NAME,
+            ThreadPool.Names.SAME,
+            InFlightOpsRequest::new,
+            new InFlightOpCountTransportHandler()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/BlobRecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/BlobRecoveryTarget.java
@@ -97,12 +97,42 @@ public class BlobRecoveryTarget {
         this.blobIndicesService = blobIndicesService;
         this.peerRecoveryTargetService = peerRecoveryTargetService;
 
-        transportService.registerRequestHandler(Actions.START_RECOVERY, BlobStartRecoveryRequest::new, ThreadPool.Names.GENERIC, new StartRecoveryRequestHandler());
-        transportService.registerRequestHandler(Actions.START_PREFIX, BlobStartPrefixSyncRequest::new, ThreadPool.Names.GENERIC, new StartPrefixSyncRequestHandler());
-        transportService.registerRequestHandler(Actions.TRANSFER_CHUNK, BlobRecoveryChunkRequest::new, ThreadPool.Names.GENERIC, new TransferChunkRequestHandler());
-        transportService.registerRequestHandler(Actions.START_TRANSFER, BlobRecoveryStartTransferRequest::new, ThreadPool.Names.GENERIC, new StartTransferRequestHandler());
-        transportService.registerRequestHandler(Actions.DELETE_FILE, BlobRecoveryDeleteRequest::new, ThreadPool.Names.GENERIC, new DeleteFileRequestHandler());
-        transportService.registerRequestHandler(Actions.FINALIZE_RECOVERY, BlobFinalizeRecoveryRequest::new, ThreadPool.Names.GENERIC, new FinalizeRecoveryRequestHandler());
+        transportService.registerRequestHandler(
+            Actions.START_RECOVERY,
+            ThreadPool.Names.GENERIC,
+            BlobStartRecoveryRequest::new,
+            new StartRecoveryRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.START_PREFIX,
+            ThreadPool.Names.GENERIC,
+            BlobStartPrefixSyncRequest::new,
+            new StartPrefixSyncRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.TRANSFER_CHUNK,
+            ThreadPool.Names.GENERIC,
+            BlobRecoveryChunkRequest::new,
+            new TransferChunkRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.START_TRANSFER,
+            ThreadPool.Names.GENERIC,
+            BlobRecoveryStartTransferRequest::new,
+            new StartTransferRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.DELETE_FILE,
+            ThreadPool.Names.GENERIC,
+            BlobRecoveryDeleteRequest::new,
+            new DeleteFileRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.FINALIZE_RECOVERY,
+            ThreadPool.Names.GENERIC,
+            BlobFinalizeRecoveryRequest::new,
+            new FinalizeRecoveryRequestHandler()
+        );
     }
 
     class StartRecoveryRequestHandler implements TransportRequestHandler<BlobStartRecoveryRequest> {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -78,7 +78,12 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         this.transportService = transportService;
         this.indicesService = indicesService;
         this.recoverySettings = recoverySettings;
-        transportService.registerRequestHandler(Actions.START_RECOVERY, StartRecoveryRequest::new, ThreadPool.Names.GENERIC, new StartRecoveryTransportRequestHandler());
+        transportService.registerRequestHandler(
+            Actions.START_RECOVERY,
+            ThreadPool.Names.GENERIC,
+            StartRecoveryRequest::new,
+            new StartRecoveryTransportRequestHandler()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -108,23 +108,48 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         this.clusterService = clusterService;
         this.onGoingRecoveries = new RecoveriesCollection(LOGGER, threadPool);
 
-        transportService.registerRequestHandler(Actions.FILES_INFO, RecoveryFilesInfoRequest::new, ThreadPool.Names.GENERIC, new
-                FilesInfoRequestHandler());
-        transportService.registerRequestHandler(Actions.FILE_CHUNK, RecoveryFileChunkRequest::new, ThreadPool.Names.GENERIC, new
-                FileChunkTransportRequestHandler());
-        transportService.registerRequestHandler(Actions.CLEAN_FILES, RecoveryCleanFilesRequest::new, ThreadPool.Names.GENERIC, new
-                CleanFilesRequestHandler());
-        transportService.registerRequestHandler(Actions.PREPARE_TRANSLOG, ThreadPool.Names.GENERIC,
-            RecoveryPrepareForTranslogOperationsRequest::new, new PrepareForTranslogOperationsRequestHandler());
-        transportService.registerRequestHandler(Actions.TRANSLOG_OPS, RecoveryTranslogOperationsRequest::new, ThreadPool.Names.GENERIC,
-                new TranslogOperationsRequestHandler());
-        transportService.registerRequestHandler(Actions.FINALIZE, RecoveryFinalizeRecoveryRequest::new, ThreadPool.Names.GENERIC, new
-                FinalizeRecoveryRequestHandler());
         transportService.registerRequestHandler(
-                Actions.HANDOFF_PRIMARY_CONTEXT,
-                RecoveryHandoffPrimaryContextRequest::new,
-                ThreadPool.Names.GENERIC,
-                new HandoffPrimaryContextRequestHandler());
+            Actions.FILES_INFO,
+            ThreadPool.Names.GENERIC,
+            RecoveryFilesInfoRequest::new,
+            new FilesInfoRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.FILE_CHUNK,
+            ThreadPool.Names.GENERIC,
+            RecoveryFileChunkRequest::new,
+            new FileChunkTransportRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.CLEAN_FILES,
+            ThreadPool.Names.GENERIC,
+            RecoveryCleanFilesRequest::new,
+            new CleanFilesRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.PREPARE_TRANSLOG,
+            ThreadPool.Names.GENERIC,
+            RecoveryPrepareForTranslogOperationsRequest::new,
+            new PrepareForTranslogOperationsRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.TRANSLOG_OPS,
+            ThreadPool.Names.GENERIC,
+            RecoveryTranslogOperationsRequest::new,
+            new TranslogOperationsRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.FINALIZE,
+            ThreadPool.Names.GENERIC,
+            RecoveryFinalizeRecoveryRequest::new,
+            new FinalizeRecoveryRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.HANDOFF_PRIMARY_CONTEXT,
+            ThreadPool.Names.GENERIC,
+            RecoveryHandoffPrimaryContextRequest::new,
+            new HandoffPrimaryContextRequestHandler()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -100,7 +100,12 @@ public class IndicesStore implements ClusterStateListener, Closeable {
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.threadPool = threadPool;
-        transportService.registerRequestHandler(ACTION_SHARD_EXISTS, ShardActiveRequest::new, ThreadPool.Names.SAME, new ShardActiveRequestHandler());
+        transportService.registerRequestHandler(
+            ACTION_SHARD_EXISTS,
+            ThreadPool.Names.SAME,
+            ShardActiveRequest::new,
+            new ShardActiveRequestHandler()
+        );
         this.deleteShardTimeout = INDICES_STORE_DELETE_SHARD_TIMEOUT.get(settings);
         // Doesn't make sense to delete shards on non-data nodes
         if (DiscoveryNode.isDataNode(settings)) {

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -64,7 +64,7 @@ public class VerifyNodeRepositoryAction {
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.repositoriesService = repositoriesService;
-        transportService.registerRequestHandler(ACTION_NAME, VerifyNodeRepositoryRequest::new, ThreadPool.Names.SNAPSHOT, new VerifyNodeRepositoryRequestHandler());
+        transportService.registerRequestHandler(ACTION_NAME, ThreadPool.Names.SNAPSHOT, VerifyNodeRepositoryRequest::new, new VerifyNodeRepositoryRequestHandler());
     }
 
     public void verify(String repository, boolean readOnly, String verificationToken, final ActionListener<VerifyResponse> listener) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -185,9 +185,10 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         }
         registerRequestHandler(
             HANDSHAKE_ACTION_NAME,
-            HandshakeRequest::new,
             ThreadPool.Names.SAME,
-            false, false,
+            false,
+            false,
+            HandshakeRequest::new,
             (request, channel, task) -> channel.sendResponse(
                 new HandshakeResponse(localNode, clusterName, localNode.getVersion())));
     }
@@ -827,59 +828,18 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
      * Registers a new request handler
      *
      * @param action         The action the request handler is associated with
-     * @param reader a callable to be used construct new instances for streaming
-     * @param executor       The executor the request handling will be executed on
-     * @param handler        The handler itself that implements the request handling
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(String action,
-                                                                          Writeable.Reader<Request> reader,
-                                                                          String executor,
-                                                                          TransportRequestHandler<Request> handler) {
-        validateActionName(action);
-        handler = interceptor.interceptHandler(action, executor, false, handler);
-        RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
-            action, reader, taskManager, handler, executor, false, true);
-        transport.registerRequestHandler(reg);
-    }
-
-    /**
-     * Registers a new request handler
-     *
-     * @param action         The action the request handler is associated with
      * @param requestReader  a callable to be used construct new instances for streaming
      * @param executor       The executor the request handling will be executed on
      * @param handler        The handler itself that implements the request handling
      */
-    public <Request extends TransportRequest> void registerRequestHandler(String action, String executor,
+    public <Request extends TransportRequest> void registerRequestHandler(String action,
+                                                                          String executor,
                                                                           Writeable.Reader<Request> requestReader,
                                                                           TransportRequestHandler<Request> handler) {
         validateActionName(action);
         handler = interceptor.interceptHandler(action, executor, false, handler);
         RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
             action, requestReader, taskManager, handler, executor, false, true);
-        transport.registerRequestHandler(reg);
-    }
-
-    /**
-     * Registers a new request handler
-     *
-     * @param action                The action the request handler is associated with
-     * @param reader               The request class that will be used to construct new instances for streaming
-     * @param executor              The executor the request handling will be executed on
-     * @param forceExecution        Force execution on the executor queue and never reject it
-     * @param canTripCircuitBreaker Check the request size and raise an exception in case the limit is breached.
-     * @param handler               The handler itself that implements the request handling
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(String action,
-                                                                          Writeable.Reader<Request> reader,
-                                                                          String executor,
-                                                                          boolean forceExecution,
-                                                                          boolean canTripCircuitBreaker,
-                                                                          TransportRequestHandler<Request> handler) {
-        validateActionName(action);
-        handler = interceptor.interceptHandler(action, executor, forceExecution, handler);
-        RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
-            action, reader, taskManager, handler, executor, forceExecution, canTripCircuitBreaker);
         transport.registerRequestHandler(reg);
     }
 
@@ -894,7 +854,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
      * @param handler               The handler itself that implements the request handling
      */
     public <Request extends TransportRequest> void registerRequestHandler(String action,
-                                                                          String executor, boolean forceExecution,
+                                                                          String executor,
+                                                                          boolean forceExecution,
                                                                           boolean canTripCircuitBreaker,
                                                                           Writeable.Reader<Request> requestReader,
                                                                           TransportRequestHandler<Request> handler) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The same overloads already exists, except that some arguments were
shuffled around differently.

(The same overloads were also already removed in ES on the same patch
level we are at)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)