### PR TITLE
Ensure searchers are always closed

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -59,4 +59,9 @@ public final class CapturingRowConsumer implements RowConsumer {
     public boolean requiresScroll() {
         return requiresScroll;
     }
+
+    @Override
+    public String toString() {
+        return "CapturingRowConsumer{captured=" + batchIterator.isDone() + '}';
+    }
 }

--- a/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -92,6 +92,7 @@ class InterceptingRowConsumer implements RowConsumer {
             assert iterator != null : "iterator must be present";
             ThreadPools.forceExecute(executor, () -> consumer.accept(iterator, null));
         } else {
+            consumer.accept(null, failure);
             KillJobsRequest killRequest = new KillJobsRequest(
                 List.of(jobId),
                 User.CRATE_USER.name(),
@@ -102,9 +103,8 @@ class InterceptingRowConsumer implements RowConsumer {
                     @Override
                     public void onResponse(Long numKilled) {
                         if (LOGGER.isTraceEnabled()) {
-                            LOGGER.trace("Killed {} contexts for jobId={} before forwarding the failure={}", numKilled, jobId, failure);
+                            LOGGER.trace("Killed {} contexts for jobId={} forwarding the failure={}", numKilled, jobId, failure);
                         }
-                        consumer.accept(null, failure);
                     }
 
                     @Override
@@ -112,7 +112,6 @@ class InterceptingRowConsumer implements RowConsumer {
                         if (LOGGER.isTraceEnabled()) {
                             LOGGER.trace("Failed to kill jobId={}, forwarding failure={} anyway", jobId, failure);
                         }
-                        consumer.accept(null, failure);
                     }
                 });
         }

--- a/server/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -338,6 +338,7 @@ public class RootTask implements CompletionListenable<Void> {
         }
 
         private void onFailure(@Nonnull Throwable t) {
+            t = SQLExceptions.unwrap(t);
             failure = t;
             jobsLogs.operationFinished(id, jobId, SQLExceptions.messageOf(t));
             if (finishIfNeeded()) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`kill/start` had race conditions due to the change of `createIterator` being async.
`addSearcher` could also be called after a kill in which case it might add searchers which are never released.

The changes in this PR should fix both these issues

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
