### PR TITLE
Make completionFuture mandatory in CapturingRowConsumer

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -28,12 +28,12 @@ import java.util.concurrent.CompletableFuture;
 public final class CapturingRowConsumer implements RowConsumer {
 
     private final CompletableFuture<BatchIterator<Row>> batchIterator;
-    private CompletableFuture<?> completionFuture;
+    private final CompletableFuture<?> completionFuture;
     private final boolean requiresScroll;
 
-    public CapturingRowConsumer(boolean requiresScroll, @Nullable CompletableFuture<?> completionFuture) {
+    public CapturingRowConsumer(boolean requiresScroll, CompletableFuture<?> completionFuture) {
         this.batchIterator = new CompletableFuture<>();
-        this.completionFuture = completionFuture == null ? batchIterator : completionFuture;
+        this.completionFuture = completionFuture;
         this.requiresScroll = requiresScroll;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There are no call-sites which pass in a `null` value, so we can make it
mandatory.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)