### PR TITLE
Improve "is still locked" errors in test layer

### DIFF
--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2233,7 +2233,7 @@ public final class InternalTestCluster extends TestCluster {
                 try {
                     env.shardLock(id, "InternalTestCluster assert after test", TimeUnit.SECONDS.toMillis(5)).close();
                 } catch (ShardLockObtainFailedException ex) {
-                    fail("Shard " + id + " is still locked after 5 sec waiting");
+                    throw new AssertionError("Shard " + id + " is still locked after 5 sec waiting", ex);
                 }
             }
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Changes the assertion error to also include the original
`ShardLockObtainedFailedException` to have its information available as
well.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)