### PR TITLE
Avoid wrapping AssertionError in RuntimeExceptions in test layer

### DIFF
--- a/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -188,6 +188,17 @@ public class SQLTransportExecutor {
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
             throw e;
+        } catch (RuntimeException e) {
+            var cause = e.getCause();
+            // ActionListener.onFailure takes `Exception` as argument instead of `Throwable`.
+            // That requires us to wrap Throwable; That Throwable may be an AssertionError.
+            //
+            // Wrapping the exception can hide parts of the stacktrace that are interesting
+            // to figure out the root cause of an error, so we prefer the cause here
+            if (e.getClass() == RuntimeException.class && cause != null) {
+                Exceptions.rethrowUnchecked(cause);
+            }
+            throw e;
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To get better stacktraces. If it is wrapped in a RuntimeException parts
of the stacktrace that are interesting can get truncated.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)