### PR TITLE
Add more context to source of acquireSearcher calls

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -99,7 +99,7 @@ public class DocValuesAggregates {
         }
         ShardId shardId = indexShard.shardId();
         SharedShardContext shardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Searcher searcher = shardContext.acquireSearcher(LuceneShardCollectorProvider.formatSource(phase));
+        Searcher searcher = shardContext.acquireSearcher("doc-value-aggregates: " + LuceneShardCollectorProvider.formatSource(phase));
         collectTask.addSearcher(shardContext.readerId(), searcher);
         QueryShardContext queryShardContext = shardContext.indexService().newQueryShardContext();
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -131,7 +131,7 @@ final class DocValuesGroupByOptimizedIterator {
 
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher("group-by-doc-value-aggregates: " + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -147,7 +147,7 @@ final class GroupByOptimizedIterator {
 
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher("group-by-ordinals:" + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
         final QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -129,7 +129,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                                                       CollectTask collectTask) {
         ShardId shardId = indexShard.shardId();
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(collectPhase));
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher("unordered-iterator: " + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexShard indexShard = sharedShardContext.indexShard();
         QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext();
@@ -206,7 +206,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
 
         CollectorContext collectorContext;
         InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx;
-        Engine.Searcher searcher = sharedShardContext.acquireSearcher(formatSource(phase));
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher("ordered-collector: " + formatSource(phase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexService indexService = sharedShardContext.indexService();
         QueryShardContext queryShardContext = indexService.newQueryShardContext();

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -231,7 +231,7 @@ public class FetchTask implements Task {
                 tablesWithFetchRefs.add(reference.ident().tableIdent());
             }
 
-            String source = jobId.toString() + '-' + phase.phaseId() + '-' + phase.name();
+            String source = "fetch-task: " + jobId.toString() + '-' + phase.phaseId() + '-' + phase.name();
             for (Routing routing : routingIterable) {
                 Map<String, Map<String, IntIndexedContainer>> locations = routing.locations();
                 Map<String, IntIndexedContainer> indexShards = locations.get(localNodeId);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should help debug issues where a searcher is not closed or closed twice.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)