### PR TITLE
Make memory reservation based on free bytes in insert-from-query

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,4 +120,7 @@ Changes
 Fixes
 =====
 
-None
+- Changed the memory reservation and circuit breaker behavior for ``INSERT FROM
+  QUERY`` operations to allow for more concurrent operations. After the change
+  introduced in 4.2.5, individual operations could reserve too much memory,
+  causing other operations to fail with a circuit breaker exception.

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -136,6 +137,13 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
 
     @Override
     public long addBytesRangeAndMaybeBreak(long minAcceptableBytes, long wantedBytes, String label) throws CircuitBreakingException {
+        if (wantedBytes < minAcceptableBytes) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "wantedBytes (%d) must be larger or equal to minAcceptableBytes (%d)",
+                wantedBytes,
+                minAcceptableBytes));
+        }
         if (minAcceptableBytes == wantedBytes) {
             addEstimateBytesAndMaybeBreak(wantedBytes, label);
             return wantedBytes;

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -120,4 +120,8 @@ public interface CircuitBreaker {
      * @return the name of the breaker
      */
     String getName();
+
+    default long getFree() {
+        return getLimit() - getUsed();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.breaker;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.indices.breaker.BreakerSettings;
@@ -61,6 +62,23 @@ public class ChildMemoryCircuitBreakerTest {
         Assertions.assertThrows(
             CircuitBreakingException.class,
             () -> breaker.addBytesRangeAndMaybeBreak(200L, 300L, "reserve another 300")
+        );
+    }
+
+    @Test
+    public void test_add_bytes_range_where_wanted_bytes_is_lower_than_min_acceptable_bytes_is_illegal() throws Exception {
+        var breaker = new ChildMemoryCircuitBreaker(
+            new BreakerSettings(
+                "dummy",
+                500L,
+                CircuitBreaker.Type.MEMORY
+            ),
+            LogManager.getLogger(ChildMemoryCircuitBreakerTest.class),
+            new NoneCircuitBreakerService()
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> breaker.addBytesRangeAndMaybeBreak(100L, 50L, "I need memory")
         );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

One of our nightly benchmarks failed because it's doing 15 concurrent
insert-from-unnest.

With the logic we had, each insert-from-query operation was allowed to
reserve memory anywhere from 5MB to 15% of the query circuit breaker's
limit.

The problem with that is that the first couple of insert-from-query
operations eagerly use up memory, and then there is nothing left for the
remainder.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)