### PR TITLE
Don't pass DistributingConsumer logger around unnecessarily

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -28,6 +28,8 @@ import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
+
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
@@ -52,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DistributingConsumer implements RowConsumer {
 
-    private final Logger logger;
+    private static final Logger LOGGER = LogManager.getLogger(DistributingConsumer.class);
     private final Executor responseExecutor;
     private final UUID jobId;
     private final int targetPhaseId;
@@ -70,8 +72,7 @@ public class DistributingConsumer implements RowConsumer {
 
     private volatile Throwable failure;
 
-    public DistributingConsumer(Logger logger,
-                                Executor responseExecutor,
+    public DistributingConsumer(Executor responseExecutor,
                                 UUID jobId,
                                 MultiBucketBuilder multiBucketBuilder,
                                 int targetPhaseId,
@@ -80,8 +81,7 @@ public class DistributingConsumer implements RowConsumer {
                                 Collection<String> downstreamNodeIds,
                                 TransportDistributedResultAction distributedResultAction,
                                 int pageSize) {
-        this.traceEnabled = logger.isTraceEnabled();
-        this.logger = logger;
+        this.traceEnabled = LOGGER.isTraceEnabled();
         this.responseExecutor = responseExecutor;
         this.jobId = jobId;
         this.multiBucketBuilder = multiBucketBuilder;
@@ -148,7 +148,7 @@ public class DistributingConsumer implements RowConsumer {
                 countdownAndMaybeCloseIt(numActiveRequests, it);
             } else {
                 if (traceEnabled) {
-                    logger.trace("forwardFailure targetNode={} jobId={} targetPhase={}/{} bucket={} failure={}",
+                    LOGGER.trace("forwardFailure targetNode={} jobId={} targetPhase={}/{} bucket={} failure={}",
                         downstream.nodeId, jobId, targetPhaseId, inputId, bucketIdx, failure);
                 }
                 distributedResultAction.pushResult(downstream.nodeId, request, new ActionListener<>() {
@@ -161,7 +161,7 @@ public class DistributingConsumer implements RowConsumer {
                     @Override
                     public void onFailure(Exception e) {
                         if (traceEnabled) {
-                            logger.trace(
+                            LOGGER.trace(
                                 "Error sending failure to downstream={} jobId={} targetPhase={}/{} bucket={} failure={}",
                                 downstream.nodeId,
                                 jobId,
@@ -198,7 +198,7 @@ public class DistributingConsumer implements RowConsumer {
                 continue;
             }
             if (traceEnabled) {
-                logger.trace("forwardResults targetNode={} jobId={} targetPhase={}/{} bucket={} isLast={}",
+                LOGGER.trace("forwardResults targetNode={} jobId={} targetPhase={}/{} bucket={} isLast={}",
                     downstream.nodeId, jobId, targetPhaseId, inputId, bucketIdx, isLast);
             }
             distributedResultAction.pushResult(

--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
@@ -22,6 +22,16 @@
 
 package io.crate.execution.engine.distribution;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.threadpool.ThreadPool;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.RowConsumer;
@@ -30,17 +40,6 @@ import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.StreamerVisitor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.Executor;
 
 @Singleton
 public class DistributingConsumerFactory {
@@ -50,7 +49,6 @@ public class DistributingConsumerFactory {
     private final ClusterService clusterService;
     private final Executor responseExecutor;
     private final TransportDistributedResultAction transportDistributedResultAction;
-    private final Logger distributingDownstreamLogger;
 
     @Inject
     public DistributingConsumerFactory(ClusterService clusterService,
@@ -59,7 +57,6 @@ public class DistributingConsumerFactory {
         this.clusterService = clusterService;
         this.responseExecutor = threadPool.executor(RESPONSE_EXECUTOR_NAME);
         this.transportDistributedResultAction = transportDistributedResultAction;
-        distributingDownstreamLogger = LogManager.getLogger(DistributingConsumer.class);
     }
 
     public RowConsumer create(NodeOperation nodeOperation,
@@ -105,7 +102,6 @@ public class DistributingConsumerFactory {
         }
 
         return new DistributingConsumer(
-            distributingDownstreamLogger,
             responseExecutor,
             jobId,
             multiBucketBuilder,

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -66,7 +66,6 @@ import static org.mockito.Mockito.verify;
 
 public class DistributingConsumerTest extends ESTestCase {
 
-    private Logger logger = LogManager.getLogger(DistributingConsumer.class);
     private ExecutorService executorService;
 
     @Before
@@ -168,7 +167,6 @@ public class DistributingConsumerTest extends ESTestCase {
 
     private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers, TransportDistributedResultAction distributedResultAction) {
         return new DistributingConsumer(
-            logger,
             executorService,
             UUID.randomUUID(),
             new ModuloBucketBuilder(streamers, 1, 0, RamAccounting.NO_ACCOUNTING),


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)