### PR TITLE
Eagerly complete DistributingConsumer on failure

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -103,6 +103,7 @@ public class DistributingConsumer implements RowConsumer {
         if (failure == null) {
             consumeIt(iterator);
         } else {
+            completionFuture.completeExceptionally(failure);
             forwardFailure(null, failure);
         }
     }

--- a/server/src/main/java/io/crate/execution/support/Transports.java
+++ b/server/src/main/java/io/crate/execution/support/Transports.java
@@ -23,6 +23,8 @@
 package io.crate.execution.support;
 
 import io.crate.action.FutureActionListener;
+import io.crate.exceptions.Exceptions;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -86,7 +88,11 @@ public class Transports {
                 String.format(Locale.ENGLISH, "node \"%s\" not found in cluster state!", node)));
             return;
         }
-        transportService.sendRequest(discoveryNode, action, request, options, handler);
+        try {
+            transportService.sendRequest(discoveryNode, action, request, options, handler);
+        } catch (Throwable t) {
+            listener.onFailure(Exceptions.toRuntimeException(t));
+        }
     }
 
     public <TRequest extends TransportRequest, TResponse extends TransportResponse> void sendRequest(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)