### PR TITLE
Expose IndexSearcher instead of Engine.Searcher in SharedShardContext

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -30,8 +30,8 @@ import javax.annotation.Nonnull;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.Version;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.breaker.BlockBasedRamAccounting;
@@ -59,7 +59,7 @@ public class CollectTask extends AbstractTask {
     private final Function<RamAccounting, MemoryManager> memoryManagerFactory;
     private final SharedShardContexts sharedShardContexts;
 
-    private final IntObjectHashMap<RefCountedItem<Engine.Searcher>> searchers = new IntObjectHashMap<>();
+    private final IntObjectHashMap<RefCountedItem<IndexSearcher>> searchers = new IntObjectHashMap<>();
     private final Object subContextLock = new Object();
     private final RowConsumer consumer;
     private final int ramAccountingBlockSizeInBytes;
@@ -91,7 +91,7 @@ public class CollectTask extends AbstractTask {
         this.minNodeVersion = minNodeVersion;
     }
 
-    public void addSearcher(int searcherId, RefCountedItem<Engine.Searcher> searcher) {
+    public void addSearcher(int searcherId, RefCountedItem<IndexSearcher> searcher) {
         if (isClosed()) {
             // if this is closed and addContext is called this means the context got killed.
             searcher.close();

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -40,12 +40,12 @@ import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
 
 import io.crate.common.collections.BorrowedItem;
@@ -63,7 +63,7 @@ import io.crate.metadata.doc.DocTableInfo;
 
 public class FetchTask implements Task {
 
-    private final IntObjectHashMap<RefCountedItem<Engine.Searcher>> searchers = new IntObjectHashMap<>();
+    private final IntObjectHashMap<RefCountedItem<IndexSearcher>> searchers = new IntObjectHashMap<>();
     private final IntObjectHashMap<SharedShardContext> shardContexts = new IntObjectHashMap<>();
     private final FetchPhase phase;
     private final String localNodeId;
@@ -141,7 +141,7 @@ public class FetchTask implements Task {
     }
 
     @Nonnull
-    public BorrowedItem<Engine.Searcher> searcher(int readerId) {
+    public BorrowedItem<IndexSearcher> searcher(int readerId) {
         synchronized (jobId) {
             if (killed != null) {
                 throw Exceptions.toRuntimeException(killed);

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
@@ -26,6 +26,7 @@ import java.util.function.UnaryOperator;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
@@ -43,7 +44,7 @@ public class SharedShardContext {
     private final UnaryOperator<Engine.Searcher> wrapSearcher;
     private final IndexShard indexShard;
 
-    private RefCountedItem<Engine.Searcher> searcher;
+    private RefCountedItem<IndexSearcher> searcher;
 
     SharedShardContext(IndexService indexService,
                        ShardId shardId,
@@ -55,7 +56,7 @@ public class SharedShardContext {
         this.wrapSearcher = wrapSearcher;
     }
 
-    public synchronized RefCountedItem<Engine.Searcher> acquireSearcher(String source) throws IndexNotFoundException {
+    public synchronized RefCountedItem<IndexSearcher> acquireSearcher(String source) throws IndexNotFoundException {
         if (searcher == null) {
             var engineSearcher = wrapSearcher.apply(indexShard().acquireSearcher(source));
             searcher = new RefCountedItem<>(engineSearcher, engineSearcher::close);

--- a/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -34,6 +34,8 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.testing.TestingRowConsumer;
+
+import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -83,8 +85,8 @@ public class CollectTaskTest extends RandomizedTest {
 
     @Test
     public void testAddingSameContextTwice() throws Exception {
-        RefCountedItem<Engine.Searcher> mock1 = mock(RefCountedItem.class);
-        RefCountedItem<Engine.Searcher> mock2 = mock(RefCountedItem.class);
+        RefCountedItem<IndexSearcher> mock1 = mock(RefCountedItem.class);
+        RefCountedItem<IndexSearcher> mock2 = mock(RefCountedItem.class);
         try {
             collectTask.addSearcher(1, mock1);
             collectTask.addSearcher(1, mock2);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To ensure that the Engine.Searcher is not closed directly, but always
via the RefCountedItem.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)