### PR TITLE
Add optimizer rule for count(*) on aliased table

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -34,7 +34,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import io.crate.metadata.NodeContext;
 import org.elasticsearch.Version;
 
 import io.crate.analyze.AnalyzedInsertStatement;
@@ -69,6 +68,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.DependencyCarrier;
@@ -79,6 +79,7 @@ import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
+import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
@@ -122,6 +123,7 @@ public class LogicalPlanner {
             List.of(
                 new RemoveRedundantFetchOrEval(),
                 new MergeAggregateAndCollectToCount(),
+                new MergeAggregateRenameAndCollectToCount(),
                 new MergeFilters(),
                 new MoveFilterBeneathRename(),
                 new MoveFilterBeneathFetchOrEval(),

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -22,7 +22,13 @@
 
 package io.crate.planner.optimizer;
 
+import java.util.List;
+import java.util.Locale;
+
 import com.google.common.base.CaseFormat;
+
+import org.elasticsearch.common.inject.Singleton;
+
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.metadata.settings.session.SessionSetting;
@@ -30,6 +36,7 @@ import io.crate.metadata.settings.session.SessionSettingProvider;
 import io.crate.planner.operators.RewriteInsertFromSubQueryToInsertFromValues;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
+import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
@@ -51,10 +58,6 @@ import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToTopNDistinct;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.inject.Singleton;
-
-import java.util.List;
-import java.util.Locale;
 
 @Singleton
 public class LoadedRules implements SessionSettingProvider {
@@ -64,6 +67,7 @@ public class LoadedRules implements SessionSettingProvider {
     private final List<Class<? extends Rule<?>>> rules = List.of(
         RemoveRedundantFetchOrEval.class,
         MergeAggregateAndCollectToCount.class,
+        MergeAggregateRenameAndCollectToCount.class,
         MergeFilters.class,
         MoveFilterBeneathRename.class,
         MoveFilterBeneathFetchOrEval.class,

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import io.crate.common.collections.Lists2;
+import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate> {
+
+    private final Capture<Collect> collectCapture;
+    private final Pattern<HashAggregate> pattern;
+
+    public MergeAggregateRenameAndCollectToCount() {
+        this.collectCapture = new Capture<>();
+        this.pattern = typeOf(HashAggregate.class)
+            .with(
+                source(),
+                typeOf(Rename.class)
+                .with(
+                    source(),
+                    typeOf(Collect.class)
+                        .capturedAs(collectCapture)
+                        .with(collect -> collect.relation().tableInfo() instanceof DocTableInfo)
+                )
+            )
+            .with(aggregate ->
+                aggregate.aggregates().size() == 1
+                && aggregate.aggregates().get(0).signature().equals(CountAggregation.COUNT_STAR_SIGNATURE));
+    }
+
+    @Override
+    public Pattern<HashAggregate> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(HashAggregate aggregate,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx) {
+        Collect collect = captures.get(collectCapture);
+        var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
+        if (countAggregate.filter() != null) {
+            return new Count(
+                countAggregate,
+                collect.relation(),
+                collect.where().add(countAggregate.filter()));
+        } else {
+            return new Count(countAggregate, collect.relation(), collect.where());
+        }
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -21,15 +21,13 @@
 
 package io.crate.integrationtests;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.Test;
-
-import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.core.Is.is;
+
+import org.junit.Test;
 
 public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
 
@@ -99,7 +97,7 @@ public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
         execute("select count(*) from auto_id where _id=''");
         assertThat((Long) response.rows()[0][0], is(0L)); // FOUND NONE
 
-        execute("select count(*) from auto_id where name=','");
+        execute("select count(*) from auto_id AS a where name=','");
         assertThat((Long) response.rows()[0][0], is(1L)); // FOUND ONE
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -111,6 +111,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL\n" +
+            "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL\n" +
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL\n" +
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL\n" +
             "optimizer_move_filter_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveFilterBeneathFetchOrEval is activated.| NULL| NULL\n" +

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -402,6 +402,7 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
             "max_index_keys| 32| Shows the maximum number of index keys.\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.\n" +
+            "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.\n" +
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.\n" +
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.\n" +
             "optimizer_move_filter_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveFilterBeneathFetchOrEval is activated.\n" +

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -66,7 +66,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private LogicalPlan plan(String statement) {
-        return assertMaxBytesAllocated(ByteSizeUnit.MB.toBytes(25), () -> sqlExecutor.logicalPlan(statement));
+        return assertMaxBytesAllocated(ByteSizeUnit.MB.toBytes(28), () -> sqlExecutor.logicalPlan(statement));
     }
 
     @Test
@@ -193,6 +193,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testSelectCountStarIsOptimized() throws Exception {
         LogicalPlan plan = plan("select count(*) from t1 where x > 10");
         assertThat(plan, isPlan("Count[doc.t1 | (x > 10)]"));
+    }
+
+    @Test
+    public void test_select_count_star_on_aliased_table_is_optimized() throws Exception {
+        LogicalPlan plan = plan("select count(*) from t1 as t");
+        assertThat(plan, isPlan("Count[doc.t1 | true]"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    select count(*) from tbl as t

should be as fast as

    select count(*) from tbl

Results (server side duration in ms)

    V1: 4.3.0-6da37b37f27e2075e83b1339b0344139d998d809
    V2: 4.3.0-0bda4aecf8bec0a309bdbe4e33d37c6c5239f94d

    Q: select count(*) from uservisits AS u
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      180.914 ±   21.002 |    149.203 |    181.490 |    185.159 |    421.064 |
    |   V2    |        2.789 ±    7.765 |      1.140 |      1.999 |      2.618 |    111.405 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 193.93%                           - 195.64%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 193.93%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |    0     0.00     0.00 |    0     0.00     0.00 |     2147        0 |     1.27         45
     V2 |    0     0.00     0.00 |    0     0.00     0.00 |     2147        0 |    53.02         37

    V1 top allocation frames
      DirectMethodHandle.allocateInstance(Object):13311056
      Weight.scorerSupplier(...):9435136
      DocIdSetIterator.all(int):1572864
      MatchAllDocsQuery$1.scorer(...):1524529
      Unsafe.allocateUninitializedArray(Class, int):1087376
    V2 top allocation frames
      DirectMethodHandle.allocateInstance(Object):6834176
      Arrays.copyOf(...):4704257
      Collectors.summingLong(...):1572864
      DefaultHttpHeaders.<init>(...):1570816
      ArrayList.iterator():1095680

Closes https://github.com/crate/crate/issues/10586

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)