### PR TITLE
Avoid wrapping exceptions in RuntimeException

### DIFF
--- a/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
@@ -40,6 +40,14 @@ public final class Exceptions {
         throw toRuntimeException(t);
     }
 
+    public static Exception toException(Throwable t) {
+        if (t instanceof Exception) {
+            return (Exception) t;
+        } else {
+            return new RuntimeException(t);
+        }
+    }
+
     public static RuntimeException toRuntimeException(Throwable t) {
         if (t instanceof RuntimeException) {
             return (RuntimeException) t;

--- a/server/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
@@ -29,6 +29,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.data.RowN;
+import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.support.MultiActionListener;
 import io.crate.execution.support.OneRowActionListener;
@@ -242,7 +243,7 @@ public class ShardRequestExecutor<Req> {
         if (exception != null) {
             Throwable t = SQLExceptions.unwrap(exception, e -> e instanceof RuntimeException);
             if (!(t instanceof DocumentMissingException) && !(t instanceof VersionConflictEngineException)) {
-                throw new RuntimeException(t);
+                throw Exceptions.toRuntimeException(t);
             }
         }
         for (int i = 0; i < response.itemIndices().size(); i++) {

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -24,6 +24,7 @@ package io.crate.execution.dml.upsert;
 
 import io.crate.Constants;
 import io.crate.common.annotations.VisibleForTesting;
+import io.crate.exceptions.Exceptions;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
@@ -177,10 +178,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 }
             } catch (Exception e) {
                 if (retryPrimaryException(e)) {
-                    if (e instanceof RuntimeException) {
-                        throw (RuntimeException) e;
-                    }
-                    throw new RuntimeException(e);
+                    throw Exceptions.toRuntimeException(e);
                 }
                 if (logger.isDebugEnabled()) {
                     logger.debug("Failed to execute upsert shardId={} id={} error={}", request.shardId(), item.id(), e);

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -446,8 +446,6 @@ public class ShardCollectSource implements CollectSource {
                         throw e;
                     }
                     iterators.add(remoteCollectorFactory.createCollector(shardId, collectPhase, collectTask, shardCollectorProviderFactory));
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
                 } catch (IndexNotFoundException e) {
                     // Prevent wrapping this to not break retry-detection
                     throw e;

--- a/server/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -133,11 +133,7 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
             }
         } else {
             killed = ex;
-            if (ex instanceof RuntimeException) {
-                throw ((RuntimeException) ex);
-            } else {
-                throw new RuntimeException(ex);
-            }
+            throw Exceptions.toRuntimeException(ex);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -22,6 +22,7 @@
 package io.crate.execution.jobs;
 
 import io.crate.breaker.RamAccounting;
+import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -59,10 +60,8 @@ public class DistResultRXTask implements Task, DownstreamRXTask {
             }
             if (ex == null) {
                 return null;
-            } else if (ex instanceof RuntimeException) {
-                throw (RuntimeException) ex;
             } else {
-                throw new RuntimeException(ex);
+                throw Exceptions.toRuntimeException(ex);
             }
         });
     }

--- a/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -667,7 +667,7 @@ public class SQLTransportExecutor {
 
         @Override
         public void fail(@Nonnull Throwable t) {
-            listener.onFailure(Exceptions.toRuntimeException(t));
+            listener.onFailure(Exceptions.toException(t));
             super.fail(t);
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Changes a few places where we did the RuntimeException dance manually to
re-use `Exceptions.toRuntimeException` and others where we didn't to use
it, to avoid wrapping if not necessary.

Motivated by a flaky `testKillInsertFromSubQuery` that sometimes failed because
of a wrapped `InterruptedException` into a `RuntimeException`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)