### PR TITLE
Fix sys.cluster usage in joins

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused queries involving a JOIN operation on system
+  tables like ``sys.cluster`` to fail.
+
 - Changed the memory reservation and circuit breaker behavior for ``INSERT FROM
   QUERY`` operations to allow for more concurrent operations. After the change
   introduced in 4.2.5, individual operations could reserve too much memory,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -22,8 +22,8 @@
 package io.crate.execution.engine.collect.sources;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserLookup;
 import io.crate.auth.user.UserManager;
@@ -59,6 +59,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
 
 /**
  * this collect service can be used to retrieve a collector for system tables (which don't contain shards)
@@ -107,7 +109,11 @@ public class SystemCollectSource implements CollectSource {
                                                   boolean requiresRepeat,
                                                   Iterable<?> data) {
         if (requiresRepeat) {
-            data = ImmutableList.copyOf(data);
+            var copy = new ArrayList<Object>();
+            for (var record : data) {
+                copy.add(record);
+            }
+            data = copy;
         }
         return RowsTransformer.toRowsIterable(
             txnCtx,

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1108,4 +1108,14 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute(stmt);
         assertThat(response.rowCount(), is(0L));
     }
+
+    @Test
+    public void test_group_by_on_cross_join_on_system_tables() throws Exception {
+        String stmt = "SELECT c.name as name, max(h.severity) as severity " +
+            "FROM sys.health h, sys.cluster c " +
+            "GROUP BY 1";
+        assertThat(printedTable(execute(stmt).rows()), is(
+            ""
+        ));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The records for `sys.cluster` (and maybe other tables) is defined as a
list of one item, where the single item is a `null`.

This is because all the columns and their values are provided
independently of the record and the record only acts as a dummy value to
provide a single row.

The `ImmutableList.copyOf` call failed on that, because `ImmutableList`
doesn't like null items.

Fixes https://github.com/crate/crate/issues/10590


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)