### PR TITLE
Fix integer overflow at the reservoir sampling

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue causing a node crash due to OOM when running the ``analyze``
+  on large tables.
+
 - Fixed an issue that caused queries involving a JOIN operation on system
   tables like ``sys.cluster`` to fail.
 

--- a/server/src/main/java/io/crate/statistics/Reservoir.java
+++ b/server/src/main/java/io/crate/statistics/Reservoir.java
@@ -45,6 +45,9 @@ public final class Reservoir<T> {
     }
 
     public void update(T item) {
+        if (itemsSeen == Integer.MAX_VALUE) {
+            return;
+        }
         itemsSeen++;
         if (itemsSeen <= maxSamples) {
             samples.add(item);

--- a/server/src/main/java/io/crate/statistics/Reservoir.java
+++ b/server/src/main/java/io/crate/statistics/Reservoir.java
@@ -44,9 +44,9 @@ public final class Reservoir<T> {
         this.random = random;
     }
 
-    public void update(T item) {
+    public boolean update(T item) {
         if (itemsSeen == Integer.MAX_VALUE) {
-            return;
+            return false;
         }
         itemsSeen++;
         if (itemsSeen <= maxSamples) {
@@ -54,6 +54,7 @@ public final class Reservoir<T> {
         } else if (random.nextInt(itemsSeen) < maxSamples) {
             samples.set(random.nextInt(maxSamples), item);
         }
+        return true;
     }
 
     public List<T> samples() {

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -22,19 +22,32 @@
 
 package io.crate.statistics;
 
-import static io.crate.breaker.BlockBasedRamAccounting.MAX_BLOCK_SIZE_IN_BYTES;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.function.Function;
-
+import io.crate.Streamer;
+import io.crate.breaker.BlockBasedRamAccounting;
+import io.crate.breaker.RamAccounting;
+import io.crate.breaker.RowCellsAccountingWithEstimators;
+import io.crate.common.collections.Lists2;
+import io.crate.data.Input;
+import io.crate.data.RowN;
+import io.crate.exceptions.RelationUnknown;
+import io.crate.execution.engine.collect.DocInputFactory;
+import io.crate.execution.engine.fetch.FetchId;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.symbol.Symbols;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.types.DataTypes;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -53,28 +66,15 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 
-import io.crate.Streamer;
-import io.crate.breaker.BlockBasedRamAccounting;
-import io.crate.breaker.RamAccounting;
-import io.crate.breaker.RowCellsAccountingWithEstimators;
-import io.crate.common.collections.Lists2;
-import io.crate.data.Input;
-import io.crate.data.RowN;
-import io.crate.exceptions.RelationUnknown;
-import io.crate.execution.engine.collect.DocInputFactory;
-import io.crate.execution.engine.fetch.FetchId;
-import io.crate.expression.reference.doc.lucene.CollectorContext;
-import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
-import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
-import io.crate.expression.symbol.Symbols;
-import io.crate.lucene.FieldTypeLookup;
-import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Reference;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.TableInfo;
-import io.crate.types.DataTypes;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+
+import static io.crate.breaker.BlockBasedRamAccounting.MAX_BLOCK_SIZE_IN_BYTES;
 
 public final class ReservoirSampler {
 
@@ -292,7 +292,10 @@ public final class ReservoirSampler {
 
         @Override
         public void collect(int doc) {
-            reservoir.update(FetchId.encode(readerIdx, doc + context.docBase));
+            var shouldContinue = reservoir.update(FetchId.encode(readerIdx, doc + context.docBase));
+            if (shouldContinue == false) {
+                throw new CollectionTerminatedException();
+            }
         }
     }
 }


### PR DESCRIPTION
As the Reservoir sampling implementation is shared across shards and partitions, it may process more documents than an integer value can hold.
It must be protected against integer overflows to not add more that the defined maximum samples to the list (this limit is also in the integer range and such supporting sample sizes > integer is not needed).

The integer overflow results in bypassing the maximum samples boundary and can lead to node crashes due to OutOfMemory exceptions.
