### PR TITLE
Fix searcher double-release race condition

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -59,7 +59,7 @@ public class CollectTask extends AbstractTask {
     private final Function<RamAccounting, MemoryManager> memoryManagerFactory;
     private final SharedShardContexts sharedShardContexts;
 
-    private final IntObjectHashMap<RefCountedItem<IndexSearcher>> searchers = new IntObjectHashMap<>();
+    private final IntObjectHashMap<RefCountedItem<? extends IndexSearcher>> searchers = new IntObjectHashMap<>();
     private final Object subContextLock = new Object();
     private final RowConsumer consumer;
     private final int ramAccountingBlockSizeInBytes;
@@ -91,7 +91,7 @@ public class CollectTask extends AbstractTask {
         this.minNodeVersion = minNodeVersion;
     }
 
-    public void addSearcher(int searcherId, RefCountedItem<IndexSearcher> searcher) {
+    public void addSearcher(int searcherId, RefCountedItem<? extends IndexSearcher> searcher) {
         if (isClosed()) {
             // if this is closed and addContext is called this means the context got killed.
             searcher.close();

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -63,7 +63,7 @@ import io.crate.metadata.doc.DocTableInfo;
 
 public class FetchTask implements Task {
 
-    private final IntObjectHashMap<RefCountedItem<IndexSearcher>> searchers = new IntObjectHashMap<>();
+    private final IntObjectHashMap<RefCountedItem<? extends IndexSearcher>> searchers = new IntObjectHashMap<>();
     private final IntObjectHashMap<SharedShardContext> shardContexts = new IntObjectHashMap<>();
     private final FetchPhase phase;
     private final String localNodeId;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The incRef/release-on-zero pattern in the RefCountedItem didn't protect
sufficently against double releases, because an already closed
RefCountedItem could gain new refs and that would cause it to be closed
multiple times.

A scenario where that can happen is a union or a join where the same
table is used more than one time.

If the table is small or the operation is fast, the close on the first
use of table A can happen before the second use of table A.

This fix here makes sure that a release happens only once, by discarding
the item and re-acquiring it if the refs reach zero.

Note that this circumvents part of the motivation for the
SharedShardContext - that is to re-use the same searchers across
operations. We'd have to re-introduce a prepare/start split or similar
to guarantee that all reference increments happen before the first close
can happen to ensure that searchers are truly shared.

This fixes flaky tests. An example that failed occassionally is:

    ./gradlew :server:test -Dtests.seed=50DCF5AD232E645D -Dtests.class=io.crate.integrationtests.UnionIntegrationTest -Dtests.method="testUnionAllArrayAndObjectColumns" -Dtests.locale=brx-IN -Dtests.timezone=America/Argentina/Rio_Gallegos -Dtests.iters=20 --fail-fast

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)