### PR TITLE
Fix null handling in SubscriptObjectFunction

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2 that could cause subscript expressions
+  to fail with a ``Base argument to subscript must be an object, not null``
+  error.
+
 - Fixed an issue causing a node crash due to OOM when running the ``analyze``
   on large tables.
 

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -132,6 +132,9 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
         assert args.length >= 2 : NAME + " takes 2 or more arguments, got " + args.length;
         Object mapValue = args[0].value();
         for (var i = 1; i < args.length; i++) {
+            if (mapValue == null) {
+                return null;
+            }
             mapValue = SubscriptFunction.lookupByName(mapValue, args[i].value());
         }
         return mapValue;

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -69,4 +69,14 @@ public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
     public void testSubscriptOnObjectWithPath() {
         assertEvaluate("subscript_obj({x={y=10}}, 'x', 'y')", 10);
     }
+
+    @Test
+    public void test_subscript_obj_with_null_argument() throws Exception {
+        assertEvaluate("subscript_obj(null, 'x', 'y')", null);
+    }
+
+    @Test
+    public void test_subscript_obj_with_null_child() throws Exception {
+        assertEvaluate("subscript_obj({x=null}, 'x', 'y')", null);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`SubscriptFunction.lookupByName` does not allow nullable arguments.

`SubscriptFunction.evaluate` handles that correctly, but
`SubscriptObjectFunction` did not.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)