### PR TITLE
Use ProxyObject to represent map based data types in UDF.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented an access to the properties of object type
+  arguments in JavaScript user defined functions.
+
 - Fixed a regression introduced in 4.2 that could cause subscript expressions
   to fail with a ``Base argument to subscript must be an object, not null``
   error.

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -18,6 +18,7 @@
 
 package io.crate.operation.language;
 
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
@@ -25,6 +26,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
 
@@ -64,7 +66,10 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
     public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
             var function = resolvePolyglotFunctionValue(signature.getName().name(), script);
-            var polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(args);
+            Object[] polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(
+                args,
+                Lists2.map(signature.getArgumentTypes(), TypeSignature::createType)
+            );
             return PolyglotValuesConverter.toCrateObject(
                 function.execute(polyglotValueArgs),
                 signature.getReturnType().createType());
@@ -98,7 +103,10 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
 
         @Override
         public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
-            var polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(args);
+            Object[] polyglotValueArgs = PolyglotValuesConverter.toPolyglotValues(
+                args,
+                Lists2.map(signature.getArgumentTypes(), TypeSignature::createType)
+            );
             try {
                 return toCrateObject(
                     function.execute(polyglotValueArgs),

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/PolyglotValuesConverter.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/PolyglotValuesConverter.java
@@ -27,14 +27,18 @@ import io.crate.types.GeoShapeType;
 import io.crate.types.ObjectType;
 import org.graalvm.polyglot.TypeLiteral;
 import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyObject;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 class PolyglotValuesConverter {
 
-    private static final TypeLiteral<Number> NUMBER_TYPE_LITERAL = new TypeLiteral<>() {};
-    private static final TypeLiteral<Map> MAP_TYPE_LITERAL = new TypeLiteral<>() {};
+    private static final TypeLiteral<Number> NUMBER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Map> MAP_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     static Object toCrateObject(Value value, DataType<?> type) {
         if (value == null) {
@@ -77,10 +81,15 @@ class PolyglotValuesConverter {
         }
     }
 
-    static Object[] toPolyglotValues(Input<Object>[] inputs) {
+    static Object[] toPolyglotValues(Input<Object>[] inputs, List<DataType<?>> dataTypes) {
         Object[] args = new Object[inputs.length];
         for (int i = 0; i < inputs.length; i++) {
-            args[i] = Value.asValue(inputs[i].value());
+            switch (dataTypes.get(i).id()) {
+                case ObjectType.ID, GeoShapeType.ID ->
+                    //noinspection unchecked
+                    args[i] = ProxyObject.fromMap((Map<String, Object>) inputs[i].value());
+                default -> args[i] = Value.asValue(inputs[i].value());
+            }
         }
         return args;
     }

--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -55,7 +55,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
 
     private static final String JS = JavaScriptLanguage.NAME;
 
-    private Map<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
+    private final Map<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
     private UserDefinedFunctionService udfService;
 
     @Override
@@ -349,5 +349,32 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
             "function f(a) { return Array.prototype.join.call(a, '.'); }");
         assertEvaluate("f(['a', 'b'])", is("a.b"));
         assertEvaluate("f(['a', 'b'])", is("a.b"), Literal.of(List.of("a", "b"), DataTypes.STRING_ARRAY));
+    }
+
+    @Test
+    public void test_access_object_type_argument_properties_in_function_body() throws Exception {
+        registerUserDefinedFunction(
+            "f_dot",
+            DataTypes.INTEGER,
+            List.of(DataTypes.UNTYPED_OBJECT),
+            "function f_dot(a) { return a.y; }");
+        assertEvaluate("f_dot('{\"x\":1,\"y\":2}')", is(2));
+
+        registerUserDefinedFunction(
+            "f_brackets",
+            DataTypes.INTEGER,
+            List.of(DataTypes.UNTYPED_OBJECT),
+            "function f_brackets(a) { return a[\"x\"]; }");
+        assertEvaluate("f_brackets('{\"x\":1,\"y\":2}')", is(1));
+    }
+
+    @Test
+    public void test_access_geo_shape_type_argument_properties_in_function_body() throws Exception {
+        registerUserDefinedFunction(
+            "f",
+            DataTypes.STRING,
+            List.of(DataTypes.GEO_SHAPE),
+            "function f(a) { return a.type; }");
+        assertEvaluate("f('POINT(1 2)')", is("Point"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change fixes the object property access in the UDF guest
languages (JavaScript) by utilizing the GraalVM polyglot `Proxy`
interface, namely, its ProxyObject implementation for the Map
based CrateDB internal data types. e.g. the object data type.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
