### PR TITLE
Fix subscript resolving inside views/aliases

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -125,7 +125,7 @@ Fixes
 
 - Fixed a regression introduced in 4.2 that could cause subscript expressions
   to fail with a ``Base argument to subscript must be an object, not null``
-  error.
+  or ``Can't handle Symbol`` error.
 
 - Fixed an issue causing a node crash due to OOM when running the ``analyze``
   on large tables.

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -50,6 +50,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
     private final RelationName alias;
     private final Map<ColumnIdent, ColumnIdent> aliasToColumnMapping;
     private final ArrayList<Symbol> outputs;
+    private final ArrayList<ScopedSymbol> scopedSymbols;
 
     public AliasedAnalyzedRelation(AnalyzedRelation relation, RelationName alias) {
         this(relation, alias, List.of());
@@ -60,17 +61,18 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         this.alias = alias;
         aliasToColumnMapping = new HashMap<>(columnAliases.size());
         this.outputs = new ArrayList<>(relation.outputs().size());
+        this.scopedSymbols = new ArrayList<>(relation.outputs().size());
         for (int i = 0; i < relation.outputs().size(); i++) {
             Symbol childOutput = relation.outputs().get(i);
             ColumnIdent childColumn = Symbols.pathFromSymbol(childOutput);
+            ColumnIdent columnAlias = childColumn;
             if (i < columnAliases.size()) {
-                ColumnIdent columnAlias = new ColumnIdent(columnAliases.get(i));
-                aliasToColumnMapping.put(columnAlias, childColumn);
-                outputs.add(new ScopedSymbol(this.alias, columnAlias, childOutput.valueType()));
-            } else {
-                aliasToColumnMapping.put(childColumn, childColumn);
-                outputs.add(new ScopedSymbol(alias, childColumn, childOutput.valueType()));
+                columnAlias = new ColumnIdent(columnAliases.get(i));
             }
+            aliasToColumnMapping.put(columnAlias, childColumn);
+            var scopedSymbol = new ScopedSymbol(alias, columnAlias, childOutput.valueType());
+            outputs.add(scopedSymbol);
+            scopedSymbols.add(scopedSymbol);
         }
     }
 
@@ -104,11 +106,15 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             return null;
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
-        // If the scopedSymbol exists in `outputs`, return that instance so that IdentityHashMaps work
-        int i = outputs.indexOf(scopedSymbol);
+
+        // If the scopedSymbol exists already, return that instance.
+        // Otherwise (e.g. lazy-loaded subscript expression) it must be stored to comply with
+        // IdentityHashMap constraints.
+        int i = scopedSymbols.indexOf(scopedSymbol);
         if (i >= 0) {
-            return outputs.get(i);
+            return scopedSymbols.get(i);
         }
+        scopedSymbols.add(scopedSymbol);
         return scopedSymbol;
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -119,4 +119,12 @@ public final class Filter extends ForwardingLogicalPlan {
             .text("]")
             .nest(source::print);
     }
+
+    @Override
+    public String toString() {
+        return "Filter{" +
+            "src=" + source +
+            ", query=" + query +
+            '}';
+    }
 }

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -22,20 +22,6 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.Limit.limitAndOffset;
-import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -62,6 +48,19 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.statistics.TableStats;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.crate.planner.operators.Limit.limitAndOffset;
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 public class NestedLoopJoin implements LogicalPlan {
 
@@ -408,5 +407,17 @@ public class NestedLoopJoin implements LogicalPlan {
         printContext
             .text("]")
             .nest(Lists2.map(sources(), x -> x::print));
+    }
+
+    @Override
+    public String toString() {
+        return "NestedLoopJoin{" +
+            "joinCondition=" + joinCondition +
+            ", joinType=" + joinType +
+            ", isFiltered=" + isFiltered +
+            ", lhs=" + lhs +
+            ", rhs=" + rhs +
+            ", outputs=" + outputs +
+            '}';
     }
 }

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+import io.crate.metadata.RelationName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+
+public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_view_of_join_condition_containing_subscript_expressions() throws IOException {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table doc.t1 (id int, o object as (i int))")
+            .addView(new RelationName("doc", "v1"),
+                "select b.id, b.o['i']" +
+                    " from t1 g1" +
+                    " left join t1 b on b.o['i'] = g1.o['i']")
+            .build();
+
+        var logicalPlan = e.logicalPlan("SELECT id FROM v1");
+        var expectedPlan =
+            "Eval[id]\n" +
+            "  └ Rename[id, o['i']] AS doc.v1\n" +
+            "    └ Eval[id, o['i']]\n" +
+            "      └ NestedLoopJoin[LEFT | (o['i'] = o['i'])]\n" +
+            "        ├ Rename[o['i']] AS g1\n" +
+            "        │  └ Collect[doc.t1 | [o['i']] | true]\n" +
+            "        └ Rename[id, o['i']] AS b\n" +
+            "          └ Collect[doc.t1 | [id, o['i']] | true]";
+        assertThat(logicalPlan, isPlan(expectedPlan));
+    }
+}


### PR DESCRIPTION
Scoped symbols of lazy-loaded subscript columns must be stored inside
aliased relations. Otherwise repeated field resolving breaks
the IdentityHashMap constraint of the `Rename` plan operator.