### PR TITLE
Fix implicit cast from double to float for the min-value

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented casts from ``DOUBLE PRECISION`` to ``REAL`` for
+  the minimal supported ``REAL`` number ``-3.4028235e38``.
+
 - Fixed an issue that prevented an access to the properties of object type
   arguments in JavaScript user defined functions.
 

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -66,12 +66,11 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         } else if (value instanceof String) {
             return Float.parseFloat((String) value);
         } else if (value instanceof Number) {
-            double doubleValue = ((Number) value).doubleValue();
-            if (!Double.isInfinite(doubleValue)
-                && (doubleValue < -Float.MAX_VALUE || Float.MAX_VALUE < doubleValue)) {
-                throw new IllegalArgumentException("float value out of range: " + doubleValue);
+            float val = ((Number) value).floatValue();
+            if (Float.isInfinite(val)) {
+                throw new IllegalArgumentException("float value out of range: " + value);
             }
-            return ((Number) value).floatValue();
+            return val;
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }

--- a/server/src/test/java/io/crate/types/FloatTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatTypeTest.java
@@ -47,6 +47,12 @@ public class FloatTypeTest extends ESTestCase {
     }
 
     @Test
+    public void test_negative_max_float_value_can_be_casted_to_float() throws Exception {
+        assertThat(FloatType.INSTANCE.implicitCast(-3.4028235e38d), is(- Float.MAX_VALUE));
+        assertThat(FloatType.INSTANCE.implicitCast(-3.4028235e38f), is(- Float.MAX_VALUE));
+    }
+
+    @Test
     public void test_cast_double_to_real_out_of_positive_range_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("float value out of range: 1.7976931348623157E308");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The range check didn't work:

    jshell> -3.4028235e38f < -Float.MAX_VALUE
    $10 ==> false

    jshell> -3.4028235e38d < -Float.MAX_VALUE
    $11 ==> true

Closes https://github.com/crate/crate/issues/10618


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)