### PR TITLE
Fix the partitions deletion from the subquery expressions.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -120,6 +120,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in 4.2 which prevented ``DELETE FROM ...``
+  statements with the subquery expression in the where clause from complete
+  deletion of the matching partitions in partitioned tables.
+
 - Fixed an issue that prevented casts from ``DOUBLE PRECISION`` to ``REAL`` for
   the minimal supported ``REAL`` number ``-3.4028235e38``.
 

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -41,6 +41,7 @@ import io.crate.execution.engine.pipeline.TopN;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
@@ -133,7 +134,8 @@ public final class DeletePlanner {
                 subQueryResults,
                 plannerContext.transactionContext(),
                 executor.nodeContext());
-            if (!where.partitions().isEmpty() && !where.hasQuery()) {
+            if (!where.partitions().isEmpty()
+                && (!where.hasQuery() || Literal.BOOLEAN_TRUE.equals(where.query()))) {
                 DeleteIndexRequest request = new DeleteIndexRequest(where.partitions().toArray(new String[0]));
                 request.indicesOptions(IndicesOptions.lenientExpandOpen());
                 executor.transportActionProvider().transportDeleteIndexAction()


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change fixes the regression introduced by #9707 in the `WhereClause`.
The `WhereClause#hasQuery` before the removal of the `QuerySpec`
retuned the false if the normalized query was a symbol of the value type
represented by `Literal.BOOLEAN_TRUE`. That resulted in the wrong plan that
would leave empty orphaned partitions after the deletion.

This change address this issue in the DeletePlanner by adding an additional
where clause query = `Literal.BOOLEAN_TRUE` check to decide which delete
plan to execute.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
