### PR TITLE
Backport of IndexServiceTest

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -473,6 +473,7 @@ should be crossed out as well.
 - [x] 302d29c8705 Trim local translog in peer recovery (#44756)
 - [x] 6215f98fa68 Remove fileBasedRecovery flag (#45131)
 - [x] 01287eacb2f Use index for peer recovery instead of translog (#45136)
+- [x] 3c352a85963 Make setting index.translog.sync_interval be dynamic (#37382))
 - [x] c4b831645cb MINOR: Remove some deadcode in NodeEnv and Related (#34133)
 
 Below lists deferred patches. In-between patches that we applied or skipped

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -159,7 +159,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.trimTranslogTask = new AsyncTrimTranslogTask(this);
         this.globalCheckpointTask = new AsyncGlobalCheckpointTask(this);
         this.retentionLeaseSyncTask = new AsyncRetentionLeaseSyncTask(this);
-        rescheduleFsyncTask(indexSettings.getTranslogDurability());
+        updateFsyncTaskIfNecessary();
     }
 
     public enum IndexCreationContext {
@@ -513,8 +513,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
     @Override
     public synchronized void updateMetadata(final IndexMetadata currentIndexMetadata, final IndexMetadata newIndexMetadata) {
-        final Translog.Durability oldTranslogDurability = indexSettings.getTranslogDurability();
-
         final boolean updateIndexMetadata = indexSettings.updateIndexMetadata(newIndexMetadata);
 
         if (Assertions.ENABLED
@@ -566,20 +564,23 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 });
                 rescheduleRefreshTasks();
             }
-            final Translog.Durability durability = indexSettings.getTranslogDurability();
-            if (durability != oldTranslogDurability) {
-                rescheduleFsyncTask(durability);
-            }
+            updateFsyncTaskIfNecessary();
         }
     }
 
-    private void rescheduleFsyncTask(Translog.Durability durability) {
-        try {
-            if (fsyncTask != null) {
-                fsyncTask.close();
+    private void updateFsyncTaskIfNecessary() {
+        if (indexSettings.getTranslogDurability() == Translog.Durability.REQUEST) {
+            try {
+                if (fsyncTask != null) {
+                    fsyncTask.close();
+                }
+            } finally {
+                fsyncTask = null;
             }
-        } finally {
-            fsyncTask = durability == Translog.Durability.REQUEST ? null : new AsyncTranslogFSync(this);
+        } else if (fsyncTask == null) {
+            fsyncTask = new AsyncTranslogFSync(this);
+        } else {
+            fsyncTask.updateIfNeeded();
         }
     }
 
@@ -736,6 +737,13 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         @Override
         protected void runInternal() {
             indexService.maybeFSyncTranslogs();
+        }
+
+        void updateIfNeeded() {
+            final TimeValue newInterval = indexService.getIndexSettings().getTranslogSyncInterval();
+            if (newInterval.equals(getInterval()) == false) {
+                setInterval(newInterval);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -104,7 +104,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private volatile AsyncRetentionLeaseSyncTask retentionLeaseSyncTask;
 
     // don't convert to Setting<> and register... we only set this in tests and register via a plugin
-    private final String INDEX_TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING = "index.translog.retention.check_interval";
+    public static final String INDEX_TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING = "index.translog.retention.check_interval";
 
     private final AsyncTrimTranslogTask trimTranslogTask;
     private final ThreadPool threadPool;

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -66,7 +66,7 @@ public final class IndexSettings {
         Setting.boolSetting("index.query.parse.allow_unmapped_fields", true, Property.IndexScope);
     public static final Setting<TimeValue> INDEX_TRANSLOG_SYNC_INTERVAL_SETTING =
         Setting.timeSetting("index.translog.sync_interval", TimeValue.timeValueSeconds(5), TimeValue.timeValueMillis(100),
-            Property.IndexScope);
+            Property.Dynamic, Property.IndexScope);
     public static final Setting<TimeValue> INDEX_SEARCH_IDLE_AFTER =
         Setting.timeSetting("index.search.idle.after", TimeValue.timeValueSeconds(30),
             TimeValue.timeValueMinutes(0), Property.IndexScope, Property.Dynamic);
@@ -256,7 +256,7 @@ public final class IndexSettings {
     private volatile List<String> defaultFields;
     private final boolean defaultAllowUnmappedFields;
     private volatile Translog.Durability durability;
-    private final TimeValue syncInterval;
+    private volatile TimeValue syncInterval;
     private volatile TimeValue refreshInterval;
     private volatile ByteSizeValue flushThresholdSize;
     private volatile TimeValue translogRetentionAge;
@@ -388,6 +388,7 @@ public final class IndexSettings {
             mergeSchedulerConfig::setMaxThreadAndMergeCount);
         scopedSettings.addSettingsUpdateConsumer(MergeSchedulerConfig.AUTO_THROTTLE_SETTING, mergeSchedulerConfig::setAutoThrottle);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_DURABILITY_SETTING, this::setTranslogDurability);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_SYNC_INTERVAL_SETTING, this::setTranslogSyncInterval);
         scopedSettings.addSettingsUpdateConsumer(MAX_NGRAM_DIFF_SETTING, this::setMaxNgramDiff);
         scopedSettings.addSettingsUpdateConsumer(MAX_SHINGLE_DIFF_SETTING, this::setMaxShingleDiff);
         scopedSettings.addSettingsUpdateConsumer(INDEX_WARMER_ENABLED_SETTING, this::setEnableWarmer);
@@ -596,6 +597,10 @@ public final class IndexSettings {
      */
     public TimeValue getTranslogSyncInterval() {
         return syncInterval;
+    }
+
+    public void setTranslogSyncInterval(TimeValue translogSyncInterval) {
+        this.syncInterval = translogSyncInterval;
     }
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -88,8 +88,8 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testSetNonDynamicTableSetting() {
-        assertThrows(() -> execute("alter table settings_table set (\"translog.sync_interval\"='10s')"),
-                     isSQLError(containsString("Can't update non dynamic settings [[index.translog.sync_interval]] for open indices"),
+        assertThrows(() -> execute("alter table settings_table set (\"soft_deletes.enabled\"='true')"),
+                     isSQLError(containsString("Can't update non dynamic settings [[index.soft_deletes.enabled]] for open indices"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
                                 4000));

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineTestCase;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.threadpool.ThreadPool;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.SQLErrorMatcher.isSQLError;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.elasticsearch.index.shard.IndexShardTestCase.flushShard;
+import static org.elasticsearch.index.shard.IndexShardTestCase.getEngine;
+import static org.elasticsearch.test.InternalSettingsPlugin.TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false)
+public class IndexServiceTests extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(InternalSettingsPlugin.class);
+        return plugins;
+    }
+
+    public void testBaseAsyncTask() throws Exception {
+        execute("create table test (x int) clustered into 1 shards");
+        IndexService indexService = getIndexService("test");
+
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
+        AtomicReference<CountDownLatch> latch2 = new AtomicReference<>(new CountDownLatch(1));
+        final AtomicInteger count = new AtomicInteger();
+        IndexService.BaseAsyncTask task = new IndexService.BaseAsyncTask(indexService, TimeValue.timeValueMillis(1)) {
+            @Override
+            protected void runInternal() {
+                final CountDownLatch l1 = latch.get();
+                final CountDownLatch l2 = latch2.get();
+                count.incrementAndGet();
+                assertTrue("generic threadpool is configured", Thread.currentThread().getName().contains("[generic]"));
+                l1.countDown();
+                try {
+                    l2.await();
+                } catch (InterruptedException e) {
+                    fail("interrupted");
+                }
+                if (randomBoolean()) { // task can throw exceptions!!
+                    if (randomBoolean()) {
+                        throw new RuntimeException("foo");
+                    } else {
+                        throw new RuntimeException("bar");
+                    }
+                }
+            }
+
+            @Override
+            protected String getThreadPool() {
+                return ThreadPool.Names.GENERIC;
+            }
+        };
+
+        latch.get().await();
+        latch.set(new CountDownLatch(1));
+        assertEquals(1, count.get());
+        // here we need to swap first before we let it go otherwise threads might be very fast and run that task twice due to
+        // random exception and the schedule interval is 1ms
+        latch2.getAndSet(new CountDownLatch(1)).countDown();
+        latch.get().await();
+        assertEquals(2, count.get());
+        task.close();
+        latch2.get().countDown();
+        assertEquals(2, count.get());
+
+        task = new IndexService.BaseAsyncTask(indexService, TimeValue.timeValueMillis(1000000)) {
+            @Override
+            protected void runInternal() {
+
+            }
+        };
+        assertTrue(task.mustReschedule());
+
+        // now close the index
+        execute("alter table test close");
+        final Index index = indexService.index();
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+        final IndexService closedIndexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(indexService, closedIndexService);
+        assertFalse(task.mustReschedule());
+        assertFalse(task.isClosed());
+        assertEquals(1000000, task.getInterval().millis());
+
+        assertNotSame(indexService, closedIndexService);
+        assertFalse(task.mustReschedule());
+        assertFalse(task.isClosed());
+        assertEquals(1000000, task.getInterval().millis());
+
+        // now reopen the index
+        execute("alter table test open");
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+        indexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(closedIndexService, indexService);
+
+        task = new IndexService.BaseAsyncTask(indexService, TimeValue.timeValueMillis(100000)) {
+            @Override
+            protected void runInternal() {
+
+            }
+        };
+        assertTrue(task.mustReschedule());
+        assertFalse(task.isClosed());
+        assertTrue(task.isScheduled());
+
+        indexService.close("simon says", false);
+        assertFalse("no shards left", task.mustReschedule());
+        assertTrue(task.isScheduled());
+        task.close();
+        assertFalse(task.isScheduled());
+    }
+
+    public void testRefreshTaskIsUpdated() throws Exception {
+        execute("create table test (x int) clustered into 1 shards");
+        IndexService indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+        IndexService.AsyncRefreshTask refreshTask = indexService.getRefreshTask();
+        assertEquals(1000, refreshTask.getInterval().millis());
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+
+        // now disable
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)).get();
+        assertNotSame(refreshTask, indexService.getRefreshTask());
+        assertTrue(refreshTask.isClosed());
+        assertFalse(refreshTask.isScheduled());
+
+        // set it to 100ms
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(),  "100ms")).get();
+        assertNotSame(refreshTask, indexService.getRefreshTask());
+        assertTrue(refreshTask.isClosed());
+
+        refreshTask = indexService.getRefreshTask();
+        assertTrue(refreshTask.mustReschedule());
+        assertTrue(refreshTask.isScheduled());
+        assertEquals(100, refreshTask.getInterval().millis());
+
+        // set it to 200ms
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "200ms")).get();
+        assertNotSame(refreshTask, indexService.getRefreshTask());
+        assertTrue(refreshTask.isClosed());
+
+        refreshTask = indexService.getRefreshTask();
+        assertTrue(refreshTask.mustReschedule());
+        assertTrue(refreshTask.isScheduled());
+        assertEquals(200, refreshTask.getInterval().millis());
+
+        // set it to 200ms again
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "200ms")).get();
+        assertSame(refreshTask, indexService.getRefreshTask());
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+        assertTrue(refreshTask.isScheduled());
+        assertFalse(refreshTask.isClosed());
+        assertEquals(200, refreshTask.getInterval().millis());
+
+        // now close the index
+        execute("alter table test close");
+        final Index index = indexService.index();
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+
+        final IndexService closedIndexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(indexService, closedIndexService);
+        assertNotSame(refreshTask, closedIndexService.getRefreshTask());
+        assertFalse(closedIndexService.getRefreshTask().mustReschedule());
+        assertFalse(closedIndexService.getRefreshTask().isClosed());
+        assertEquals(200, closedIndexService.getRefreshTask().getInterval().millis());
+
+        // now reopen the index
+        execute("alter table test open");
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+        indexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(closedIndexService, indexService);
+        refreshTask = indexService.getRefreshTask();
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+        assertTrue(refreshTask.isScheduled());
+        assertFalse(refreshTask.isClosed());
+
+        indexService.close("simon says", false);
+        assertFalse(refreshTask.isScheduled());
+        assertTrue(refreshTask.isClosed());
+    }
+
+    public void testFsyncTaskIsRunning() throws Exception {
+        execute("create table test(x int) clustered into 1 shards with (\"translog.durability\" = 'ASYNC')");
+        IndexService indexService = getIndexService("test");
+        IndexService.AsyncTranslogFSync fsyncTask = indexService.getFsyncTask();
+        assertNotNull(fsyncTask);
+        assertEquals(5000, fsyncTask.getInterval().millis());
+        assertTrue(fsyncTask.mustReschedule());
+        assertTrue(fsyncTask.isScheduled());
+
+        // now close the index
+        execute("alter table test close");
+        final Index index = indexService.index();
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+
+        final IndexService closedIndexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(indexService, closedIndexService);
+        assertNotSame(fsyncTask, closedIndexService.getFsyncTask());
+        assertFalse(closedIndexService.getFsyncTask().mustReschedule());
+        assertFalse(closedIndexService.getFsyncTask().isClosed());
+        assertEquals(5000, closedIndexService.getFsyncTask().getInterval().millis());
+
+        // now reopen the index
+        execute("alter table test open");
+        assertBusy(() -> assertTrue("Index not found: " + index.getName(), getIndicesService().hasIndex(index)));
+        indexService = getIndicesService().indexServiceSafe(index);
+        assertNotSame(closedIndexService, indexService);
+        fsyncTask = indexService.getFsyncTask();
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+        assertTrue(fsyncTask.isScheduled());
+        assertFalse(fsyncTask.isClosed());
+
+        indexService.close("simon says", false);
+        assertFalse(fsyncTask.isScheduled());
+        assertTrue(fsyncTask.isClosed());
+
+        execute("create table test1 (x int, data text)");
+        indexService = getIndexService("test1");
+        assertNull(indexService.getFsyncTask());
+    }
+
+    public void testRefreshActuallyWorks() throws Exception {
+        execute("create table test (x int, data text) clustered into 1 shards");
+        var indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+        ensureGreen(indexName);
+        IndexService.AsyncRefreshTask refreshTask = indexService.getRefreshTask();
+        assertEquals(1000, refreshTask.getInterval().millis());
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+        IndexShard shard = indexService.getShard(0);
+        execute("insert into test (x, data) values (1, 'foo')");
+        // now disable the refresh
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)).get();
+        // when we update we reschedule the existing task AND fire off an async refresh to make sure we make everything visible
+        // before that this is why we need to wait for the refresh task to be unscheduled and the first doc to be visible
+        assertTrue(refreshTask.isClosed());
+        refreshTask = indexService.getRefreshTask();
+        assertBusy(() -> {
+            // this one either becomes visible due to a concurrently running scheduled refresh OR due to the force refresh
+            // we are running on updateMetadata if the interval changes
+            try (Engine.Searcher searcher = shard.acquireSearcher(indexName)) {
+                TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
+                assertEquals(1, search.totalHits.value);
+            }
+        });
+        assertFalse(refreshTask.isClosed());
+        // refresh every millisecond
+        execute("insert into test (x, data) values (2, 'foo')");
+        client().admin().indices().prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1ms")).get();
+        assertTrue(refreshTask.isClosed());
+
+        assertBusy(() -> {
+            // this one becomes visible due to the force refresh we are running on updateMetadata if the interval changes
+            try (Engine.Searcher searcher = shard.acquireSearcher(indexName)) {
+                TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
+                assertEquals(2, search.totalHits.value);
+            }
+        });
+        execute("insert into test (x, data) values (3, 'foo')");
+
+        assertBusy(() -> {
+            // this one becomes visible due to the scheduled refresh
+            try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
+                TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
+                assertEquals(3, search.totalHits.value);
+            }
+        });
+    }
+
+    public void testAsyncFsyncActuallyWorks() throws Exception {
+        execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '100ms', " +
+                "\"translog.durability\" = 'ASYNC')");
+        IndexService indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+        ensureGreen(indexName);
+        assertTrue(indexService.getRefreshTask().mustReschedule());
+        execute("insert into test (x, data) values (1, 'foo')");
+        IndexShard shard = indexService.getShard(0);
+        assertBusy(() -> assertFalse(shard.isSyncNeeded()));
+    }
+
+    public void testRescheduleAsyncFsync() throws Exception {
+        execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '100ms', \"translog.durability\" = 'REQUEST')");
+        IndexService indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+
+        ensureGreen(indexName);
+        assertNull(indexService.getFsyncTask());
+
+        execute("alter table test set (\"translog.durability\" = 'ASYNC')");
+
+        assertNotNull(indexService.getFsyncTask());
+        assertTrue(indexService.getFsyncTask().mustReschedule());
+        execute("insert into test (x, data) values (1, 'foo')");
+        assertNotNull(indexService.getFsyncTask());
+        final IndexShard shard = indexService.getShard(0);
+        assertBusy(() -> assertFalse(shard.isSyncNeeded()));
+
+        execute("alter table test set (\"translog.durability\" = 'REQUEST')");
+        assertNull(indexService.getFsyncTask());
+
+        execute("alter table test set (\"translog.durability\" = 'ASYNC')");
+        assertNotNull(indexService.getFsyncTask());
+    }
+
+    public void testAsyncTranslogTrimActuallyWorks() throws Exception {
+        execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '100ms')");
+        IndexService indexService = getIndexService("test");
+
+        ensureGreen(indexService.index().getName());
+        assertTrue(indexService.getTrimTranslogTask().mustReschedule());
+        execute("insert into test (x, data) values (1, 'foo')");
+        IndexShard shard = indexService.getShard(0);
+        flushShard(shard, true);
+        assertBusy(() -> assertThat(EngineTestCase.getTranslog(getEngine(shard)).totalOperations(), equalTo(0)));
+    }
+
+    public void testAsyncTranslogTrimTaskOnClosedIndex() throws Exception {
+        execute ("create table test(x int) clustered into 1 shards");
+        var indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+
+        client()
+            .admin()
+            .indices()
+            .prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING.getKey(), "100ms"))
+            .get();
+
+        Translog translog = EngineTestCase.getTranslog(getEngine(indexService.getShard(0)));
+        final Path translogPath = translog.getConfig().getTranslogPath();
+        final String translogUuid = translog.getTranslogUUID();
+
+        int translogOps = 0;
+        final int numDocs = scaledRandomIntBetween(10, 100);
+        for (int i = 0; i < numDocs; i++) {
+            execute("insert into test (x) values (?)", new Object[]{i});
+            translogOps++;
+            if(randomBoolean()) {
+                for (IndexShard indexShard : indexService) {
+                    flushShard(indexShard, true);
+                }
+                if (indexService.getIndexSettings().isSoftDeleteEnabled()) {
+                    translogOps = 0;
+                }
+            }
+        }
+        assertThat(translog.totalOperations(), equalTo(translogOps));
+        assertThat(translog.stats().estimatedNumberOfOperations(), equalTo(translogOps));
+
+        execute("alter table test close");
+
+        indexService =  getIndicesService().indexServiceSafe(indexService.index());
+        assertTrue(indexService.getTrimTranslogTask().mustReschedule());
+
+        final long lastCommitedTranslogGeneration;
+        try (Engine.IndexCommitRef indexCommitRef = getEngine(indexService.getShard(0)).acquireLastIndexCommit(false)) {
+            Map<String, String> lastCommittedUserData = indexCommitRef.getIndexCommit().getUserData();
+            lastCommitedTranslogGeneration = Long.parseLong(lastCommittedUserData.get(Translog.TRANSLOG_GENERATION_KEY));
+        }
+        assertBusy(() -> {
+            long minTranslogGen = Translog.readMinTranslogGeneration(translogPath, translogUuid);
+            assertThat(minTranslogGen, equalTo(lastCommitedTranslogGeneration));
+        });
+
+        execute("alter table test open");
+        ensureGreen(indexName);
+
+        indexService = getIndexService("test");
+        translog = IndexShardTestCase.getTranslog(indexService.getShard(0));
+        assertThat(translog.totalOperations(), equalTo(0));
+        assertThat(translog.stats().estimatedNumberOfOperations(), equalTo(0));
+    }
+
+    public void testIllegalFsyncInterval() {
+        assertThrows(() -> execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '0ms')"),
+                     isSQLError(is("failed to parse value [0ms] for setting [index.translog.sync_interval], must be >= [100ms]"),
+                                INTERNAL_ERROR,
+                                BAD_REQUEST,
+                                4000));
+    }
+
+    public void testUpdateSyncIntervalDynamically() {
+        execute("create table test(x int) clustered into 1 shards with(\"translog.sync_interval\" = '10s')");
+        IndexService indexService = getIndexService("test");
+        var indexName = indexService.index().getName();
+
+        ensureGreen(indexName);
+        assertNull(indexService.getFsyncTask());
+
+        Settings.Builder builder = Settings.builder().put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "5s")
+            .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC.name());
+
+        client()
+            .admin()
+            .indices()
+            .prepareUpdateSettings(indexName)
+            .setSettings(builder)
+            .get();
+
+        assertNotNull(indexService.getFsyncTask());
+        assertTrue(indexService.getFsyncTask().mustReschedule());
+
+        IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index(indexName);
+        assertEquals("5s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
+
+        execute("alter table test close");
+        client()
+            .admin()
+            .indices()
+            .prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "20s"))
+            .get();
+        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index(indexName);
+        assertEquals("20s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
+    }
+
+    private IndexService getIndexService(String index) {
+        return getIndicesService().indexServiceSafe(resolveIndex(getFqn(index)));
+    }
+
+    private IndicesService getIndicesService() {
+        return internalCluster().getInstances(IndicesService.class).iterator().next();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -268,7 +268,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         flushShard(shard, false);
     }
 
-    protected void flushShard(IndexShard shard, boolean force) {
+    public static void flushShard(IndexShard shard, boolean force) {
         shard.flush(new FlushRequest(shard.shardId().getIndexName()).force(force));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Backport of IndexServiceTest and depending https://github.com/elastic/elasticsearch/commit/3c352a85963f47a8272025e1969982bbe64c6a87

See individual commits.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
