### PR TITLE
Add scalar function translate

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -84,6 +84,8 @@ Performance improvements
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------
 
+- Added scalar function :ref:`translate(string, from, to) <scalar-translate>`.
+
 - Added support for :ref:`SET AND RESET SESSION AUTHORIZATION
   <ref-set-session-authorization>` SQL statements.
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -343,6 +343,41 @@ Replaces all occurrences of ``from`` in ``text`` with ``to``.
    +----------------+
    SELECT 1 row in set (... sec)
 
+.. _scalar-translate:
+
+``translate(string, from, to)``
+-------------------------------
+
+Performs several single-character, one-to-one translation in one operation.
+It translates ``string`` by replacing the characters in the ``from`` set, one-to-one
+positionally, with their counterparts in the ``to`` set. If ``from`` is longer than
+``to``, the function removes the occurrences of the extra characters in ``from``.
+If there are repeated characters in ``from``, only the first mapping is considered.
+
+Synopsis::
+
+    translate(string, from, to)
+
+Examples::
+
+   cr> select translate('Crate', 'Ct', 'Dk') as translation;
+    +-------------+
+    | translation |
+    +-------------+
+    | Drake       |
+    +-------------+
+    SELECT 1 row in set (... sec)
+
+::
+
+   cr> select translate('Crate', 'rCe', 'c') as translation;
+    +-------------+
+    | translation |
+    +-------------+
+    | cat         |
+    +-------------+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-trim:
 
 ``trim({LEADING | TRAILING | BOTH} 'str_arg_1' FROM 'str_arg_2')``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -68,6 +68,7 @@ import io.crate.expression.scalar.string.StringCaseFunction;
 import io.crate.expression.scalar.string.StringLeftRightFunction;
 import io.crate.expression.scalar.string.StringPaddingFunction;
 import io.crate.expression.scalar.string.StringRepeatFunction;
+import io.crate.expression.scalar.string.TranslateFunction;
 import io.crate.expression.scalar.string.TrimFunctions;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
@@ -145,6 +146,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         StringRepeatFunction.register(this);
         ChrFunction.register(this);
 
+        TranslateFunction.register(this);
         ConcatFunction.register(this);
 
         LengthFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TranslateFunction extends Scalar<String, String> {
+
+    private static final Character NULL = '\0';
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "translate",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()),
+            TranslateFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+    private final Map<Character, Character> tmap;
+
+    private TranslateFunction(Signature signature, Signature boundSignature) {
+        this(signature, boundSignature, null);
+    }
+
+    public TranslateFunction(Signature signature, Signature boundSignature, Map<Character, Character> tmap) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.tmap = tmap;
+    }
+
+    @Override
+    public Scalar<String, String> compile(List<Symbol> args) {
+        assert args.size() == 3 : "translate takes exactly three arguments";
+
+        Symbol from = args.get(1);
+        if (!Literal.isLiteral(from, DataTypes.STRING)) {
+            return this;
+        }
+        Symbol to = args.get(2);
+        if (!Literal.isLiteral(to, DataTypes.STRING)) {
+            return this;
+        }
+        String fromStr = ((Input<String>) from).value();
+        String toStr = ((Input<String>) to).value();
+        return new TranslateFunction(signature, boundSignature, computeMap(fromStr, toStr));
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
+        assert args.length == 3 : "translate takes exactly three arguments";
+        String source = args[0].value();
+        String from = args[1].value();
+        String to = args[2].value();
+        if (source == null || from == null || to == null) {
+            return null;
+        }
+        if (source.length() == 0 || from.length() == 0) {
+            return source;
+        }
+        return translate(this.tmap != null ? this.tmap : computeMap(from, to), source);
+    }
+
+    private static String translate(Map<Character, Character> tmap, String source) {
+        int sourceLen = source.length();
+        char[] result = new char[sourceLen];
+        int resultCount = 0;
+        for (int i = 0; i < sourceLen; i++) {
+            char c = source.charAt(i);
+            var mc = tmap.get(c);
+            if (mc == null) {
+                result[resultCount++] = c;
+            } else if (mc != NULL) {
+                result[resultCount++] = mc;
+            }
+        }
+        return String.valueOf(result, 0, resultCount);
+    }
+
+    private static Map<Character, Character> computeMap(String from, String to) {
+        Map<Character, Character> tmap = new HashMap<>();
+        for (int i = 0; i < from.length(); i++) {
+            char c = from.charAt(i);
+            tmap.putIfAbsent(c, i < to.length() ? to.charAt(i) : NULL);
+        }
+        return tmap;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.junit.Test;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class TranslateFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void testNormalizeTranslateFunc() throws Exception {
+        assertNormalize("translate('Crate', 'Ct', 'Dk')", isLiteral("Drake"));
+    }
+
+    @Test
+    public void testEvaluateTranslate() throws Exception {
+        assertEvaluate("translate(name, 'Ct', 'Dk')", "Drake", Literal.of(DataTypes.STRING, "Crate"));
+        assertEvaluate("translate('time', name, name)", "Zeit",
+                       Literal.of(DataTypes.STRING, "emit"), Literal.of(DataTypes.STRING, "tieZ"));
+    }
+
+    @Test
+    public void testWithEmptyTextField() throws Exception {
+        assertNormalize("translate('', 'Ct', 'Dk')", isLiteral(""));
+    }
+
+    @Test
+    public void testWithEmptyFromField() throws Exception {
+        // 'C' replaced with 'D', 't' replaced with 'k'
+        assertNormalize("translate('Crate', '', 'Dk')", isLiteral("Crate"));
+    }
+
+    @Test
+    public void testWithEmptyToField() throws Exception {
+        assertNormalize("translate('Crate', 're', '')", isLiteral("Cat"));
+    }
+
+    @Test
+    public void testWithFromFieldLargerThanToField() throws Exception {
+        // As from.length() > to.length(), unmatched chars in 'from' are removed
+        assertNormalize("translate('Crate', 'rCe', 'c')", isLiteral("cat"));
+    }
+
+    @Test
+    public void testWithToFieldLargerThanFromField() throws Exception {
+        // As to.length() > from.length(), unmatched chars in 'to' are ignored
+        assertNormalize("translate('Crate', 'C', 'Dk')", isLiteral("Drate"));
+    }
+
+    @Test
+    public void testWithDuplicateCharsInFromField() throws Exception {
+        assertNormalize("translate('Crate', 'CtC', 'Dk')", isLiteral("Drake"));
+    }
+
+    @Test
+    public void testWithNullArgument() {
+        assertEvaluate("translate(null, 'Ct', 'Dk')", null);
+        assertEvaluate("translate('Crate', null, 'Dk')", null);
+        assertEvaluate("translate('Crate', 'Ct', null)", null);
+    }
+}


### PR DESCRIPTION
Translate performs several single-character, one-to-one translation in one operation.

`translate('Crate', 'Ct', 'Dk') == 'Drake'`

This change increases compatibility with PostgreSQL, the function is described [here](https://www.postgresqltutorial.com/postgresql-translate/).

This PR supersedes https://github.com/crate/crate/pull/9616.
