### PR TITLE
Allow double infinity to float infinity implicit casts

### DIFF
--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -66,8 +66,9 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         } else if (value instanceof String) {
             return Float.parseFloat((String) value);
         } else if (value instanceof Number) {
-            float val = ((Number) value).floatValue();
-            if (Float.isInfinite(val)) {
+            Number number = (Number) value;
+            float val = number.floatValue();
+            if (Float.isInfinite(val) && !Double.isInfinite(number.doubleValue())) {
                 throw new IllegalArgumentException("float value out of range: " + value);
             }
             return val;

--- a/server/src/test/java/io/crate/types/FloatTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatTypeTest.java
@@ -47,6 +47,18 @@ public class FloatTypeTest extends ESTestCase {
     }
 
     @Test
+    public void test_infinite_float_can_be_casted_to_infinite_float() throws Exception {
+        assertThat(FloatType.INSTANCE.implicitCast(Float.POSITIVE_INFINITY), is(Float.POSITIVE_INFINITY));
+        assertThat(FloatType.INSTANCE.implicitCast(Float.NEGATIVE_INFINITY), is(Float.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    public void test_infinite_double_can_be_casted_to_infinite_float() throws Exception {
+        assertThat(FloatType.INSTANCE.implicitCast(Double.POSITIVE_INFINITY), is(Float.POSITIVE_INFINITY));
+        assertThat(FloatType.INSTANCE.implicitCast(Double.NEGATIVE_INFINITY), is(Float.NEGATIVE_INFINITY));
+    }
+
+    @Test
     public void test_negative_max_float_value_can_be_casted_to_float() throws Exception {
         assertThat(FloatType.INSTANCE.implicitCast(-3.4028235e38d), is(- Float.MAX_VALUE));
         assertThat(FloatType.INSTANCE.implicitCast(-3.4028235e38f), is(- Float.MAX_VALUE));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/10623

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)