### PR TITLE
Prevent dropping of a UDF used inside a generated col expression

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -156,4 +156,7 @@ Error handling improvements
 Fixes
 =====
 
+- Prevent dropping of a UDF if it is still used inside inside any
+  ``generated column`` expressions, throw an error instead.
+
 None

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -59,6 +59,12 @@ public class Functions {
     private final Map<FunctionName, List<FunctionProvider>> udfFunctionImplementations = new ConcurrentHashMap<>();
     private final Map<FunctionName, List<FunctionProvider>> functionImplementations;
 
+    public Functions copyOf() {
+        var functions = new Functions(Map.copyOf(functionImplementations));
+        functions.udfFunctionImplementations.putAll(udfFunctionImplementations);
+        return functions;
+    }
+
     @Inject
     public Functions(Map<FunctionName, List<FunctionProvider>> functionImplementationsBySignature) {
         this.functionImplementations = functionImplementationsBySignature;

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -123,7 +123,7 @@ public class DocSchemaInfo implements SchemaInfo {
 
     private final ConcurrentHashMap<String, DocTableInfo> docTableByName = new ConcurrentHashMap<>();
 
-    private static final Predicate<String> NO_BLOB_NOR_DANGLING =
+    public static final Predicate<String> NO_BLOB_NOR_DANGLING =
         index -> ! (BlobIndex.isBlobIndex(index) || IndexParts.isDangling(index));
 
     private final String schemaName;

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -48,7 +48,7 @@ import java.util.Locale;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 
-class DocTableInfoBuilder {
+public class DocTableInfoBuilder {
 
     private final RelationName ident;
     private final ClusterState state;
@@ -59,10 +59,10 @@ class DocTableInfoBuilder {
     private String[] concreteOpenIndices;
     private static final Logger LOGGER = LogManager.getLogger(DocTableInfoBuilder.class);
 
-    DocTableInfoBuilder(NodeContext nodeCtx,
-                        RelationName ident,
-                        ClusterState state,
-                        IndexNameExpressionResolver indexNameExpressionResolver) {
+    public DocTableInfoBuilder(NodeContext nodeCtx,
+                               RelationName ident,
+                               ClusterState state,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
         this.nodeCtx = nodeCtx;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.ident = ident;

--- a/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -28,17 +28,23 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Before;
 
 import javax.annotation.Nullable;
 import javax.script.ScriptException;
 
 import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.mockito.Mockito.mock;
 
 public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
-    UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class), createNodeContext());
+    UserDefinedFunctionService udfService;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        udfService = new UserDefinedFunctionService(clusterService, createNodeContext());
+    }
 
     static final UDFLanguage DUMMY_LANG = new UDFLanguage() {
         @Override

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetadataTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetadataTest.java
@@ -21,9 +21,7 @@
 
 package io.crate.expression.udf;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.analyze.FunctionArgumentDefinition;
-import org.elasticsearch.test.ESTestCase;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -35,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -47,7 +46,7 @@ import static org.hamcrest.core.Is.is;
 public class UserDefinedFunctionsMetadataTest extends ESTestCase {
 
     private static String definition = "function(a, b) {return a - b;}";
-    private static List<FunctionArgumentDefinition> args = ImmutableList.of(
+    private static List<FunctionArgumentDefinition> args = List.of(
         FunctionArgumentDefinition.of(DataTypes.DOUBLE_ARRAY),
         FunctionArgumentDefinition.of("my_named_arg", DataTypes.DOUBLE)
     );
@@ -135,13 +134,13 @@ public class UserDefinedFunctionsMetadataTest extends ESTestCase {
         assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", argumentTypesFrom(args)), is(true));
         assertThat(FUNCTION_METADATA.sameSignature("different_schema", "my_add", argumentTypesFrom(args)), is(false));
         assertThat(FUNCTION_METADATA.sameSignature("my_schema", "different_name", argumentTypesFrom(args)), is(false));
-        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", ImmutableList.of()), is(false));
+        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", List.of()), is(false));
     }
 
     @Test
     public void testSpecificName() throws Exception {
-        assertThat(specificName("my_func", ImmutableList.of()), is("my_func()"));
-        assertThat(specificName("my_func", ImmutableList.of(DataTypes.BOOLEAN, new ArrayType(DataTypes.BOOLEAN))),
+        assertThat(specificName("my_func", List.of()), is("my_func()"));
+        assertThat(specificName("my_func", List.of(DataTypes.BOOLEAN, new ArrayType<>(DataTypes.BOOLEAN))),
             is("my_func(boolean, boolean_array)"));
     }
 }

--- a/server/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLExecutor.java
@@ -52,6 +52,8 @@ import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.udf.UDFLanguage;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.license.CeLicenseService;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -143,6 +145,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static io.crate.analyze.TableDefinitions.DEEPLY_NESTED_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.NESTED_PK_TABLE_DEFINITION;
@@ -185,6 +188,7 @@ public class SQLExecutor {
     private final Random random;
     private final Schemas schemas;
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
+    private final UserDefinedFunctionService udfService;
 
     /**
      * Shortcut for {@link #getPlannerContext(ClusterState, Random)}
@@ -217,6 +221,7 @@ public class SQLExecutor {
         private final AllocationService allocationService;
         private final Random random;
         private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
+        private final UserDefinedFunctionService udfService;
         private String[] searchPath = new String[]{Schemas.DOC_SCHEMA_NAME};
         private User user = User.CRATE_USER;
         private UserManager userManager = new StubUserManager();
@@ -239,7 +244,7 @@ public class SQLExecutor {
             this.clusterService = clusterService;
             addNodesToClusterState(numNodes);
             nodeCtx = createNodeContext(additionalModules);
-            UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, nodeCtx);
+            udfService = new UserDefinedFunctionService(clusterService, nodeCtx);
             Map<String, SchemaInfo> schemaInfoByName = new HashMap<>();
             CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
             schemaInfoByName.put("sys", new SysSchemaInfo(clusterService, crateSettings, new CeLicenseService()));
@@ -420,7 +425,8 @@ public class SQLExecutor {
                 new SessionContext(user, searchPath),
                 schemas,
                 random,
-                fulltextAnalyzerResolver
+                fulltextAnalyzerResolver,
+                udfService
             );
         }
 
@@ -615,6 +621,16 @@ public class SQLExecutor {
             this.userManager = userManager;
             return this;
         }
+
+        public Builder addUDFLanguage(UDFLanguage language) {
+            udfService.registerLanguage(language);
+            return this;
+        }
+
+        public Builder addUDF(UserDefinedFunctionMetadata udf) {
+            udfService.updateImplementations(udf.schema(), Stream.of(udf));
+            return this;
+        }
     }
 
     public static Builder builder(ClusterService clusterService, AbstractModule... additionalModules) {
@@ -669,7 +685,8 @@ public class SQLExecutor {
                         SessionContext sessionContext,
                         Schemas schemas,
                         Random random,
-                        FulltextAnalyzerResolver fulltextAnalyzerResolver) {
+                        FulltextAnalyzerResolver fulltextAnalyzerResolver,
+                        UserDefinedFunctionService udfService) {
         this.analyzer = analyzer;
         this.planner = planner;
         this.relAnalyzer = relAnalyzer;
@@ -679,10 +696,15 @@ public class SQLExecutor {
         this.schemas = schemas;
         this.random = random;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
+        this.udfService = udfService;
     }
 
     public FulltextAnalyzerResolver fulltextAnalyzerResolver() {
         return fulltextAnalyzerResolver;
+    }
+
+    public UserDefinedFunctionService udfService() {
+        return udfService;
     }
 
     public <T extends AnalyzedStatement> T analyze(String stmt, ParamTypeHints typeHints) {


### PR DESCRIPTION
UDFs which are used inside any generated column expression must not be able to be dropped, otherwise the table info fails on resolving, making the table unusable.