### PR TITLE
Disallow creating self referencing views

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -156,7 +156,8 @@ Error handling improvements
 Fixes
 =====
 
+- Fixed an issue that allowed users to create a self-referencing view which
+  broke any further operations accessing table meta data.
+
 - Prevent dropping of a UDF if it is still used inside inside any
   ``generated column`` expressions, throw an error instead.
-
-None

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -25,6 +25,8 @@ package io.crate.integrationtests;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.view.ViewsMetadata;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
 import org.elasticsearch.cluster.service.ClusterService;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -195,5 +197,20 @@ public class ViewsITest extends SQLTransportIntegrationTest {
         execute("create table test (x timestamp, y int)");
         execute("create view v_test as select * from test");
         execute("select * from v_test where x > current_timestamp - 1000 * 60 * 60 * 24");
+    }
+
+
+    @Test
+    public void test_creating_a_self_referencing_view_is_not_allowed() throws Exception {
+        execute("create view v as select * from sys.cluster");
+        assertThrows(
+            () -> execute("create or replace view v as select * from v"),
+            isSQLError(
+                containsString("Creating a view that references itself is not allowed"),
+                INTERNAL_ERROR,
+                HttpResponseStatus.BAD_REQUEST,
+                4000
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We had a check in place that ensures that the updated view definition
can be parsed and analyzed again.

But that analyze step uses the `Schemas` instance from *before* the view
is changed.

This allowed users to do something like:

    create table tbl (x int);
    create view v as select * from tbl;
    create or replace view v as select * from v;

The analyze step passed, because at that point `v` resolves to `select *
from tbl`, but once the change is applied, it starts resolving to
itself, leading to an infinite recursion and StackOverflow.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)