### PR TITLE
Using Kahan summation algorithm for doubles and floats in SUM operation

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDouble.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDouble.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+public class KahanSummationForDouble {
+
+    private double error;
+
+    public double sum(double sum, double value) {
+        var correctedValue = value - error;
+        var newSum = sum + correctedValue;
+        error = (newSum - sum) - correctedValue;
+        return newSum;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloat.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloat.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+public class KahanSummationForFloat {
+
+    private float error;
+
+    public float sum(float sum, float value) {
+        var correctedValue = value - error;
+        var newSum = sum + correctedValue;
+        error = (newSum - sum) - correctedValue;
+        return newSum;
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import io.crate.operation.aggregation.AggregationTest;
+import org.junit.Test;
+
+public class KahanSummationForDoubleTest extends AggregationTest {
+
+    @Test
+    public void shouldSumTwoValues() {
+        var kahanSummation = new KahanSummationForDouble();
+        assertEquals(kahanSummation.sum(1.0d, 2.0d), 3.0d, 0.0d);
+    }
+
+    @Test
+    public void shouldSumListOfValuesWithBetterPrecision() {
+        var kahanSummation = new KahanSummationForDouble();
+        double total = 0;
+        for (int i = 0; i < 10; i++) {
+            total = kahanSummation.sum(total, 0.2);
+        }
+
+        // The same operations using '+' returns 1.9999999999999998
+        assertEquals(total, 2.0d, 0.0d);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import io.crate.operation.aggregation.AggregationTest;
+import org.junit.Test;
+
+public class KahanSummationForFloatTest extends AggregationTest {
+
+    @Test
+    public void shouldSumTwoValues() {
+        var kahanSummation = new KahanSummationForFloat();
+        assertEquals(kahanSummation.sum(1.0f, 2.0f), 3.0f, 0.0f);
+    }
+
+    @Test
+    public void shouldSumListOfValuesWithBetterPrecision() {
+        var kahanSummation = new KahanSummationForFloat();
+        float total = 0;
+        for (int i = 0; i < 10; i++) {
+            total = kahanSummation.sum(total, 0.2f);
+        }
+
+        // The same operations using '+' returns 2.0000002
+        assertEquals(total, 2.0f, 0.0f);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -88,10 +88,24 @@ public class SumAggregationTest extends AggregationTest {
     }
 
     @Test
+    public void testDoubleSummationWithoutLosingPrecision() throws Exception {
+        Object result = executeAggregation(DataTypes.DOUBLE, DataTypes.DOUBLE, new Object[][]{{0.1d}, {0.3d}, {0.2d}});
+
+        assertEquals(0.6d, result);
+    }
+
+    @Test
     public void testFloat() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}});
 
         assertEquals(1.0f, result);
+    }
+
+    @Test
+    public void testFloatSummationWithoutLosingPrecision() throws Exception {
+        Object result = executeAggregation(DataTypes.FLOAT, DataTypes.FLOAT, new Object[][]{{0.8f}, {0.4f}, {0.2f}});
+
+        assertEquals(1.4f, result);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
In this PR i have implemented Kahan summation algorithm for SUM aggregation for floats and doubles.
Issue : https://github.com/crate/crate/issues/10543.

I wasn't sure about how I should structure my code. SumAggregation class was already pretty big, so I have moved KahanSummationFor[Double/Float] to separate classes, is it ok?

Also I have created separate classes for Doubles and Floats because it allows us to use primitive double and float types, generic implementation would have been cleaner but we will have to use "big" Floats and Doubles and allocate that values which will generate GC pressure. 

I did not add any new test to SumAggregation class, because there are already tests checking double and float summations.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
