### PR TITLE
Share a single event loop group across netty servers

### DIFF
--- a/server/src/main/java/io/crate/netty/EventLoopGroups.java
+++ b/server/src/main/java/io/crate/netty/EventLoopGroups.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.netty;
+
+import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadFactory;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.netty4.Netty4Transport;
+
+import io.crate.common.collections.BorrowedItem;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.Future;
+
+@Singleton
+public class EventLoopGroups {
+
+    public static final String WORKER_THREAD_PREFIX = "netty-worker";
+    private static final Logger LOGGER = LogManager.getLogger(EventLoopGroups.class);
+
+    private int refs = 0;
+    private EventLoopGroup worker;
+
+    public synchronized BorrowedItem<EventLoopGroup> getEventLoopGroup(Settings settings) {
+        if (worker == null) {
+            ThreadFactory workerThreads = daemonThreadFactory(settings, WORKER_THREAD_PREFIX);
+            int workerCount = Netty4Transport.WORKER_COUNT.get(settings);
+            if (Epoll.isAvailable()) {
+                worker = new EpollEventLoopGroup(workerCount, workerThreads);
+            } else {
+                worker = new NioEventLoopGroup(workerCount, workerThreads);
+            }
+        }
+        refs++;
+        return new BorrowedItem<>(worker, () -> {
+            synchronized (EventLoopGroups.this) {
+                refs--;
+                if (refs == 0) {
+                    Future<?> shutdownGracefully = worker.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+                    shutdownGracefully.awaitUninterruptibly();
+                    if (shutdownGracefully.isSuccess() == false) {
+                        LOGGER.warn("Error closing netty event loop group", shutdownGracefully.cause());
+                    }
+                    worker = null;
+                }
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -27,6 +27,8 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import io.crate.common.CheckedFunction;
+import io.crate.netty.EventLoopGroups;
+
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -101,6 +103,7 @@ public final class NetworkModule {
                          NamedWriteableRegistry namedWriteableRegistry,
                          NamedXContentRegistry xContentRegistry,
                          NetworkService networkService,
+                         EventLoopGroups eventLoopGroups,
                          NodeClient nodeClient) {
         this.settings = settings;
         for (NetworkPlugin plugin : plugins) {
@@ -112,13 +115,22 @@ public final class NetworkModule {
                 namedWriteableRegistry,
                 xContentRegistry,
                 networkService,
+                eventLoopGroups,
                 nodeClient
             );
             for (Map.Entry<String, Supplier<HttpServerTransport>> entry : httpTransportFactory.entrySet()) {
                 registerHttpTransport(entry.getKey(), entry.getValue());
             }
-            Map<String, Supplier<Transport>> transportFactory = plugin.getTransports(settings, threadPool, bigArrays, pageCacheRecycler,
-                circuitBreakerService, namedWriteableRegistry, networkService);
+            Map<String, Supplier<Transport>> transportFactory = plugin.getTransports(
+                settings,
+                threadPool,
+                bigArrays,
+                pageCacheRecycler,
+                circuitBreakerService,
+                namedWriteableRegistry,
+                networkService,
+                eventLoopGroups
+            );
             for (Map.Entry<String, Supplier<Transport>> entry : transportFactory.entrySet()) {
                 registerTransport(entry.getKey(), entry.getValue());
             }

--- a/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
@@ -24,8 +24,6 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 
 public interface HttpServerTransport extends LifecycleComponent {
 
-    String HTTP_SERVER_WORKER_THREAD_NAME_PREFIX = "http_server_worker";
-
     BoundTransportAddress boundAddress();
 
     HttpInfo info();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -76,6 +76,8 @@ import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import io.crate.common.unit.TimeValue;
+import io.crate.netty.EventLoopGroups;
+
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -414,6 +416,7 @@ public class Node implements Closeable {
                 pluginsService.filterPlugins(ActionPlugin.class));
             modules.add(actionModule);
 
+            final EventLoopGroups eventLoopGroups = new EventLoopGroups();
             final NetworkModule networkModule = new NetworkModule(
                 settings,
                 pluginsService.filterPlugins(NetworkPlugin.class),
@@ -424,6 +427,7 @@ public class Node implements Closeable {
                 namedWriteableRegistry,
                 xContentRegistry,
                 networkService,
+                eventLoopGroups,
                 client);
             Collection<UnaryOperator<Map<String, Metadata.Custom>>> customMetadataUpgraders =
                 pluginsService.filterPlugins(Plugin.class).stream()
@@ -525,6 +529,7 @@ public class Node implements Closeable {
                     }
                     b.bind(HttpServerTransport.class).toInstance(httpServerTransport);
                     b.bind(ShardLimitValidator.class).toInstance(shardLimitValidator);
+                    b.bind(EventLoopGroups.class).toInstance(eventLoopGroups);
                     pluginComponents.stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));
                 }
             );

--- a/server/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
@@ -35,6 +35,8 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 
+import io.crate.netty.EventLoopGroups;
+
 /**
  * Plugin for extending network and transport related classes
  */
@@ -45,11 +47,14 @@ public interface NetworkPlugin {
      * Returns a map of {@link Transport} suppliers.
      * See {@link org.elasticsearch.common.network.NetworkModule#TRANSPORT_TYPE_KEY} to configure a specific implementation.
      */
-    default Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+    default Map<String, Supplier<Transport>> getTransports(Settings settings,
+                                                           ThreadPool threadPool,
+                                                           BigArrays bigArrays,
                                                            PageCacheRecycler pageCacheRecycler,
                                                            CircuitBreakerService circuitBreakerService,
                                                            NamedWriteableRegistry namedWriteableRegistry,
-                                                           NetworkService networkService) {
+                                                           NetworkService networkService,
+                                                           EventLoopGroups eventLoopGroups) {
         return Collections.emptyMap();
     }
 
@@ -64,6 +69,7 @@ public interface NetworkPlugin {
                                                                          NamedWriteableRegistry namedWriteableRegistry,
                                                                          NamedXContentRegistry xContentRegistry,
                                                                          NetworkService networkService,
+                                                                         EventLoopGroups eventLoopGroups,
                                                                          NodeClient nodeClient) {
         return Collections.emptyMap();
     }

--- a/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -50,6 +50,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
+import io.crate.netty.EventLoopGroups;
 import io.crate.plugin.PipelineRegistry;
 
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
@@ -111,7 +112,8 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
                                                           PageCacheRecycler pageCacheRecycler,
                                                           CircuitBreakerService circuitBreakerService,
                                                           NamedWriteableRegistry namedWriteableRegistry,
-                                                          NetworkService networkService) {
+                                                          NetworkService networkService,
+                                                          EventLoopGroups eventLoopGroups) {
         return Collections.singletonMap(
             NETTY_TRANSPORT_NAME,
             () -> new Netty4Transport(
@@ -121,17 +123,21 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
                 networkService,
                 bigArrays,
                 namedWriteableRegistry,
-                circuitBreakerService
+                circuitBreakerService,
+                eventLoopGroups
             )
         );
     }
 
     @Override
-    public Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+    public Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings,
+                                                                        ThreadPool threadPool,
+                                                                        BigArrays bigArrays,
                                                                         CircuitBreakerService circuitBreakerService,
                                                                         NamedWriteableRegistry namedWriteableRegistry,
                                                                         NamedXContentRegistry xContentRegistry,
                                                                         NetworkService networkService,
+                                                                        EventLoopGroups eventLoopGroups,
                                                                         NodeClient nodeClient) {
         return Collections.singletonMap(
             NETTY_HTTP_TRANSPORT_NAME,
@@ -142,6 +148,7 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
                 threadPool,
                 xContentRegistry,
                 pipelineRegistry,
+                eventLoopGroups,
                 nodeClient
             )
         );

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -96,8 +96,6 @@ import io.crate.common.unit.TimeValue;
 
 public abstract class TcpTransport extends AbstractLifecycleComponent implements Transport {
 
-    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = "transport_worker";
-
     // This is the number of bytes necessary to read the message size
     public static final int BYTES_NEEDED_FOR_MESSAGE_SIZE = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
     private static final long THIRTY_PER_HEAP_SIZE = (long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.3);

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.http.HttpServerTransport;
-
 import java.util.Arrays;
+
+import io.crate.netty.EventLoopGroups;
 
 public enum Transports {
     ;
@@ -37,8 +37,7 @@ public enum Transports {
     public static boolean isTransportThread(Thread t) {
         final String threadName = t.getName();
         for (String s : Arrays.asList(
-                HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
-                TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX,
+                EventLoopGroups.WORKER_THREAD_PREFIX,
                 TEST_MOCK_TRANSPORT_THREAD_PREFIX)) {
             if (threadName.contains(s)) {
                 return true;

--- a/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -173,7 +173,6 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(SETTING_HTTP_COMPRESSION.getKey(), false)
-            .put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1)
             .put(PSQL_PORT_SETTING.getKey(), 0);
         if (randomBoolean()) {
             builder.put("memory.allocation.type", "off-heap");

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
@@ -24,6 +24,7 @@ package io.crate.protocols.postgres;
 
 import io.crate.action.sql.SQLOperations;
 import io.crate.auth.AlwaysOKNullAuthentication;
+import io.crate.netty.EventLoopGroups;
 import io.crate.protocols.ssl.SslContextProvider;
 import org.elasticsearch.test.ESTestCase;
 import io.crate.user.StubUserManager;
@@ -83,6 +84,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             new StubUserManager(),
             networkService,
             new AlwaysOKNullAuthentication(),
+            new EventLoopGroups(),
             mock(SslContextProvider.class));
         try {
             psql.doStart();
@@ -102,6 +104,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             new StubUserManager(),
             networkService,
             new AlwaysOKNullAuthentication(),
+            new EventLoopGroups(),
             mock(SslContextProvider.class));
         try {
             psql.doStart();
@@ -111,6 +114,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             assertThat(e.getCause(), instanceOf(UnknownHostException.class));
         } finally {
             psql.doStop();
+            psql.close();
         }
     }
 
@@ -125,6 +129,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             new StubUserManager(),
             networkService,
             new AlwaysOKNullAuthentication(),
+            new EventLoopGroups(),
             mock(SslContextProvider.class));
         try {
             psql.doStart();
@@ -134,6 +139,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             assertThat(e.getCause(), instanceOf(UnknownHostException.class));
         } finally {
             psql.doStop();
+            psql.close();
         }
     }
 
@@ -148,6 +154,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             new StubUserManager(),
             networkService,
             new AlwaysOKNullAuthentication(),
+            new EventLoopGroups(),
             mock(SslContextProvider.class));
         try {
             psql.doStart();
@@ -157,6 +164,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             assertThat(e.getCause(), instanceOf(UnknownHostException.class));
         } finally {
             psql.doStop();
+            psql.close();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
+++ b/server/src/test/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
@@ -28,6 +28,8 @@ import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import io.crate.netty.EventLoopGroups;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -37,11 +39,14 @@ public class MockTcpTransportPlugin extends Plugin implements NetworkPlugin {
     public static final String MOCK_TCP_TRANSPORT_NAME = "mock-socket-network";
 
     @Override
-    public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+    public Map<String, Supplier<Transport>> getTransports(Settings settings,
+                                                          ThreadPool threadPool,
+                                                          BigArrays bigArrays,
                                                           PageCacheRecycler pageCacheRecycler,
                                                           CircuitBreakerService circuitBreakerService,
                                                           NamedWriteableRegistry namedWriteableRegistry,
-                                                          NetworkService networkService) {
+                                                          NetworkService networkService,
+                                                          EventLoopGroups eventLoopGroups) {
         return Collections.singletonMap(MOCK_TCP_TRANSPORT_NAME,
             () -> new MockTcpTransport(settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We usually have at least 3 netty servers running:

- PostgreSQL
- HTTP
- Internal Transport

Each had its own event loop group with dedicated worker threads.
With the exception of blob uploads, all operations on the netty threads
are non-blocking, so we can reduce the amount of threads we create by
sharing the workers across netty servers.

This should reduce the footprint of CrateDB a bit without affecting the
performance in a negative way.

This also marks the http worker_count setting as deprecated internally.
We didn't expose it in the documentation so there is no change log
entry. But to avoid breaking upgrades in case some users used it anyway
it is kept internally for the time being.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
