### PR TITLE
Remove guava from test code of the server module.

### DIFF
--- a/server/src/test/java/io/crate/analyze/ResetAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ResetAnalyzerTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -56,6 +55,6 @@ public class ResetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testResetLoggingSetting() {
         AnalyzedResetStatement analysis = executor.analyze("RESET GLOBAL \"logger.action\"");
-        assertThat(analysis.settingsToRemove(), Matchers.<Set<Symbol>>is(ImmutableSet.of(Literal.of("logger.action"))));
+        assertThat(analysis.settingsToRemove(), Matchers.<Set<Symbol>>is(Set.of(Literal.of("logger.action"))));
     }
 }

--- a/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
@@ -284,7 +283,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         BoundRestoreSnapshot statement =
             analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot TABLE custom.restoreme");
         assertThat(statement.restoreTables().size(), is(1));
-        var table = getOnlyElement(statement.restoreTables());
+        var table = statement.restoreTables().iterator().next();
         assertThat(table.tableIdent(), is(new RelationName("custom", "restoreme")));
         assertThat(table.partitionName(), is(nullValue()));
     }
@@ -311,7 +310,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         PartitionName partition = new PartitionName(
             new RelationName("doc", "parted"), List.of("123"));
         assertThat(statement.restoreTables().size(), is(1));
-        var table = getOnlyElement(statement.restoreTables());
+        var table = statement.restoreTables().iterator().next();
         assertThat(table.partitionName(), is(partition));
         assertThat(table.tableIdent(), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "parted")));
     }
@@ -324,7 +323,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         PartitionName partitionName = new PartitionName(
             new RelationName("doc", "unknown_parted"), List.of("123"));
         assertThat(statement.restoreTables().size(), is(1));
-        var table = getOnlyElement(statement.restoreTables());
+        var table = statement.restoreTables().iterator().next();
         assertThat(table.partitionName(), is(partitionName));
         assertThat(table.tableIdent(), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "unknown_parted")));
     }

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.analyze.relations;
 
-import com.google.common.collect.Sets;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -59,8 +58,8 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol symbol = asSymbol("t1.a = '10' and (t2.b = '30' or t2.b = '20') and t1.x = 1");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
-        assertThat(split.get(Sets.newHashSet(tr1)), isSQL("((doc.t1.a = '10') AND (doc.t1.x = 1))"));
-        assertThat(split.get(Sets.newHashSet(tr2)), isSQL("((doc.t2.b = '30') OR (doc.t2.b = '20'))"));
+        assertThat(split.get(Set.of(tr1)), isSQL("((doc.t1.a = '10') AND (doc.t1.x = 1))"));
+        assertThat(split.get(Set.of(tr2)), isSQL("((doc.t2.b = '30') OR (doc.t2.b = '20'))"));
     }
 
     @Test
@@ -78,8 +77,8 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol symbol = asSymbol("t1.a = '10' and (t2.b = '30' or t2.b = '20')");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
-        assertThat(split.get(Sets.newHashSet(tr1)), isSQL("(doc.t1.a = '10')"));
-        assertThat(split.get(Sets.newHashSet(tr2)), isSQL("((doc.t2.b = '30') OR (doc.t2.b = '20'))"));
+        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = '10')"));
+        assertThat(split.get(Set.of(tr2)), isSQL("((doc.t2.b = '30') OR (doc.t2.b = '20'))"));
     }
 
     @Test
@@ -87,8 +86,8 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol symbol = asSymbol("t1.a = '10' and (t2.b = t3.c)");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split.size(), is(2));
-        assertThat(split.get(Sets.newHashSet(tr1)), isSQL("(doc.t1.a = '10')"));
-        assertThat(split.get(Sets.newHashSet(tr2, tr3)), isSQL("(doc.t2.b = doc.t3.c)"));
+        assertThat(split.get(Set.of(tr1)), isSQL("(doc.t1.a = '10')"));
+        assertThat(split.get(Set.of(tr2, tr3)), isSQL("(doc.t2.b = doc.t3.c)"));
     }
 
     @Test
@@ -101,11 +100,11 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol t1t2 = asSymbol("t1.a = t2.b");
         Symbol t2t3 = asSymbol("t2.b = t3.c");
 
-        Set<RelationName> tr1AndTr2 = Sets.newHashSet(tr1, tr2);
+        Set<RelationName> tr1AndTr2 = Set.of(tr1, tr2);
         assertThat(split.containsKey(tr1AndTr2), is(true));
         assertThat(split.get(tr1AndTr2), is(t1t2));
 
-        Set<RelationName> tr2AndTr3 = Sets.newHashSet(tr2, tr3);
+        Set<RelationName> tr2AndTr3 = Set.of(tr2, tr3);
         assertThat(split.containsKey(tr2AndTr3), is(true));
         assertThat(split.get(tr2AndTr3), is(t2t3));
     }
@@ -119,11 +118,11 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol t1t2 = asSymbol("t1.a = t2.b");
         Symbol t1t2t3 = asSymbol("t2.b = t3.c || t1.a");
 
-        Set<RelationName> tr1AndTr2 = Sets.newHashSet(tr1, tr2);
+        Set<RelationName> tr1AndTr2 = Set.of(tr1, tr2);
         assertThat(split.containsKey(tr1AndTr2), is(true));
         assertThat(split.get(tr1AndTr2), is(t1t2));
 
-        Set<RelationName> tr1AndTr2AndTr3 = Sets.newHashSet(tr1, tr2, tr3);
+        Set<RelationName> tr1AndTr2AndTr3 = Set.of(tr1, tr2, tr3);
         assertThat(split.containsKey(tr1AndTr2AndTr3), is(true));
         assertThat(split.get(tr1AndTr2AndTr3), is(t1t2t3));
     }

--- a/server/src/test/java/io/crate/exceptions/MultiExceptionTest.java
+++ b/server/src/test/java/io/crate/exceptions/MultiExceptionTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.exceptions;
 
-import com.google.common.collect.Lists;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -37,10 +37,14 @@ public class MultiExceptionTest extends ESTestCase {
 
     @Test
     public void testGetMessageReturnsCombinedMessages() throws Exception {
-        MultiException multiException = new MultiException(Lists.newArrayList(
-            new Exception("first one"), new Exception("second one")));
-        assertThat(multiException.getMessage(), is("first one\n" +
-                                                   "second one"));
+        MultiException multiException = new MultiException(
+            List.of(
+                new Exception("first one"),
+                new Exception("second one"))
+        );
+        assertThat(
+            multiException.getMessage(),
+            is("first one\nsecond one"));
     }
 
     @Test
@@ -56,7 +60,7 @@ public class MultiExceptionTest extends ESTestCase {
 
     @Test
     public void testMultiExceptionsAreFlattened() throws Exception {
-        MultiException e1 = new MultiException(Lists.newArrayList(new Exception("exception 1"), new Exception("exception 2")));
+        MultiException e1 = new MultiException(List.of(new Exception("exception 1"), new Exception("exception 2")));
         Exception e2 = new Exception("exception 3");
 
         MultiException multiException = MultiException.of(e1, e2);

--- a/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.ddl;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -48,6 +47,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,10 +62,13 @@ public class RepositoryServiceTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expect(RepositoryException.class);
         expectedException.expectMessage("[foo] failed: [foo] missing location");
 
-        throw RepositoryService.convertRepositoryException(new RepositoryException("foo", "failed", new CreationException(ImmutableList.of(
-            new Message(Collections.singletonList(10),
-                "creation error", new RepositoryException("foo", "missing location"))
-        ))));
+        throw RepositoryService.convertRepositoryException(
+            new RepositoryException("foo", "failed", new CreationException(
+                List.of(new Message(
+                    Collections.singletonList(10),
+                    "creation error",
+                    new RepositoryException("foo", "missing location"))
+                ))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/GroupProjectionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.dsl.projection;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
@@ -43,11 +42,11 @@ public class GroupProjectionTest extends ESTestCase {
 
     @Test
     public void testStreaming() throws Exception {
-        ImmutableList<Symbol> keys = ImmutableList.of(
+        List<Symbol> keys = List.of(
             new InputColumn(0, DataTypes.STRING),
             new InputColumn(1, DataTypes.SHORT)
         );
-        ImmutableList<Aggregation> aggregations = ImmutableList.of();
+        List<Aggregation> aggregations = List.of();
         GroupProjection p = new GroupProjection(keys, aggregations, AggregateMode.ITER_FINAL, RowGranularity.CLUSTER);
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -85,11 +84,11 @@ public class GroupProjectionTest extends ESTestCase {
 
     @Test
     public void testStreamingGranularity() throws Exception {
-        ImmutableList<Symbol> keys = ImmutableList.of(
+        List<Symbol> keys = List.of(
             new InputColumn(0, DataTypes.STRING),
             new InputColumn(1, DataTypes.SHORT)
         );
-        ImmutableList<Aggregation> aggregations = ImmutableList.of();
+        List<Aggregation> aggregations = List.of();
         GroupProjection p = new GroupProjection(keys, aggregations, AggregateMode.ITER_FINAL, RowGranularity.SHARD);
         BytesStreamOutput out = new BytesStreamOutput();
         Projection.toStream(p, out);

--- a/server/src/test/java/io/crate/execution/dsl/projection/WriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WriterProjectionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.dsl.projection;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -32,17 +31,19 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.List;
+
 public class WriterProjectionTest extends ESTestCase {
 
     @Test
     public void testStreaming() throws Exception {
         WriterProjection p = new WriterProjection(
-            ImmutableList.<Symbol>of(new InputColumn(1)),
+            List.of(new InputColumn(1)),
             Literal.of("/foo.json"),
             WriterProjection.CompressionType.GZIP,
             MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
                 new ColumnIdent("partitionColumn"), Literal.of(1)).map(),
-            ImmutableList.of("foo"),
+            List.of("foo"),
             WriterProjection.OutputFormat.JSON_OBJECT
         );
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
@@ -64,7 +63,7 @@ public class AverageAggregationTest extends AggregationTest {
 
     private FunctionImplementation getFunction(String name) {
         return nodeCtx.functions().get(
-            null, name, ImmutableList.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
+            null, name, List.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
@@ -58,7 +57,7 @@ public class CollectSetAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         FunctionImplementation collectSet = nodeCtx.functions().get(
-            null, "collect_set", ImmutableList.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
+            null, "collect_set", List.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
         assertEquals(new ArrayType<>(DataTypes.INTEGER), collectSet.info().returnType());
     }
 
@@ -72,7 +71,7 @@ public class CollectSetAggregationTest extends AggregationTest {
     @Test
     public void testLongSerialization() throws Exception {
         AggregationFunction impl = (AggregationFunction) nodeCtx.functions().get(
-                null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+                null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
 
         Object state = impl.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
 
@@ -86,7 +85,7 @@ public class CollectSetAggregationTest extends AggregationTest {
     @Test
     public void test_value_adding_and_removal() {
         AggregationFunction impl = (AggregationFunction) nodeCtx.functions().get(
-            null, "collect_set", ImmutableList.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+            null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
         AggregationFunction aggregationFunction = impl.optimizeForExecutionAsWindowFunction();
 
         Object state = aggregationFunction.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);

--- a/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -22,8 +22,6 @@
 
 package io.crate.execution.engine.collect;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.crate.analyze.WhereClause;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
@@ -47,8 +45,10 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.is;
 
@@ -78,23 +78,24 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
             "collect",
             new Routing(Map.of()),
             RowGranularity.SHARD,
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
 
         // No read Isolation
         Iterable<Row> iterable = getBlobRows(collectPhase, false);
-        assertThat(Iterables.size(iterable), is(2));
+        assertThat(StreamSupport.stream(iterable.spliterator(), false).count(), is(2L));
         upload("b1", "newEntry1");
-        assertThat(Iterables.size(iterable), is(3));
+
+        assertThat(StreamSupport.stream(iterable.spliterator(), false).count(), is(3L));
 
         // Read isolation
         iterable = getBlobRows(collectPhase, true);
-        assertThat(Iterables.size(iterable), is(3));
+        assertThat(StreamSupport.stream(iterable.spliterator(), false).count(), is(3L));
         upload("b1", "newEntry2");
-        assertThat(Iterables.size(iterable), is(3));
+        assertThat(StreamSupport.stream(iterable.spliterator(), false).count(), is(3L));
     }
 
     private final class Initializer implements CheckedRunnable<Exception> {

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.engine.collect;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
-import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.data.Bucket;
@@ -194,7 +193,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             routing,
             RowGranularity.DOC,
             toCollect,
-            ImmutableList.of(),
+            List.of(),
             whereClause.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
@@ -241,7 +240,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
         List<CompletableFuture<StreamBucket>> results = jobSetup.prepareOnRemote(
             DUMMY_SESSION_INFO,
-            ImmutableList.of(nodeOperation),
+            List.of(nodeOperation),
             builder,
             sharedShardContexts
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.collect;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.data.BatchIterator;
@@ -30,7 +29,6 @@ import io.crate.data.Buckets;
 import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -99,7 +97,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
             routing,
             rowGranularity,
             toCollect,
-            ImmutableList.<Projection>of(),
+            List.of(),
             whereClause.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
@@ -124,7 +122,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
             null,
             null
         );
-        RoutedCollectPhase collectNode = collectNode(routing, Arrays.<Symbol>asList(clusterNameRef), RowGranularity.CLUSTER);
+        RoutedCollectPhase collectNode = collectNode(routing, List.of(clusterNameRef), RowGranularity.CLUSTER);
         Bucket result = collect(collectNode);
         assertThat(result.size(), is(1));
         assertThat(((String) result.iterator().next().get(0)), Matchers.startsWith("SUITE-"));

--- a/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.collect;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.expression.symbol.InputColumn;
@@ -56,11 +55,10 @@ public class RowShardResolverTest extends ESTestCase {
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private NodeContext nodeCtx = createNodeContext();
 
-
     @Test
     public void testNoPrimaryKeyNoRouting() {
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), null, null);
+            new RowShardResolver(txnCtx, nodeCtx, List.of(), List.of(), null, null);
         rowShardResolver.setNextRow(row());
 
         // auto-generated id, no special routing
@@ -71,7 +69,7 @@ public class RowShardResolverTest extends ESTestCase {
     @Test
     public void testNoPrimaryKeyButRouting() {
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), ID_IDENT, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, List.of(), List.of(), ID_IDENT, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // auto-generated id, special routing
@@ -81,9 +79,9 @@ public class RowShardResolverTest extends ESTestCase {
 
     @Test
     public void testPrimaryKeyNoRouting() {
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, null);
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ci("id"), ci("foo")), primaryKeySymbols, null, null);
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, no special routing
@@ -93,9 +91,9 @@ public class RowShardResolverTest extends ESTestCase {
 
     @Test
     public void testPrimaryKeyAndRouting() {
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, special routing
@@ -105,9 +103,9 @@ public class RowShardResolverTest extends ESTestCase {
 
     @Test
     public void testMultipleRows() {
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(0), new InputColumn(1));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ci("id"), ci("foo")), primaryKeySymbols, ci("foo"), new InputColumn(1));
 
         rowShardResolver.setNextRow(row(1, "hoschi"));
         assertThat(rowShardResolver.id(), is("AgZob3NjaGkBMQ=="));
@@ -120,9 +118,9 @@ public class RowShardResolverTest extends ESTestCase {
 
     @Test
     public void testIdPrimaryKeyNull() {
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(2));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(2));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ID_IDENT), primaryKeySymbols, null, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ID_IDENT), primaryKeySymbols, null, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, "hoschi", null));
 
         // generated _id, special routing
@@ -135,9 +133,9 @@ public class RowShardResolverTest extends ESTestCase {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("A primary key value must not be NULL");
 
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(0));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id")), primaryKeySymbols, null, null);
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ci("id")), primaryKeySymbols, null, null);
         rowShardResolver.setNextRow(row(new Object[]{null}));
     }
 
@@ -146,9 +144,9 @@ public class RowShardResolverTest extends ESTestCase {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("A primary key value must not be NULL");
 
-        List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(1), new InputColumn(0));
+        List<Symbol> primaryKeySymbols = List.of(new InputColumn(1), new InputColumn(0));
         RowShardResolver rowShardResolver =
-            new RowShardResolver(txnCtx, nodeCtx, ImmutableList.of(ci("id"), ci("foo")), primaryKeySymbols, null, new InputColumn(1));
+            new RowShardResolver(txnCtx, nodeCtx, List.of(ci("id"), ci("foo")), primaryKeySymbols, null, new InputColumn(1));
         rowShardResolver.setNextRow(row(1, null));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.collect;
 
-import com.google.common.collect.Lists;
 import io.crate.execution.engine.collect.sources.ShardCollectSource;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import org.elasticsearch.index.shard.ShardId;
@@ -31,6 +30,8 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.is;
 
@@ -39,7 +40,9 @@ public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
     public void assertNoShardEntriesLeftInShardCollectSource() throws Exception {
         final Field shards = ShardCollectSource.class.getDeclaredField("shards");
         shards.setAccessible(true);
-        final List<ShardCollectSource> shardCollectSources = Lists.newArrayList((internalCluster().getInstances(ShardCollectSource.class)));
+        final List<ShardCollectSource> shardCollectSources = StreamSupport.stream(
+            internalCluster().getInstances(ShardCollectSource.class).spliterator(), false)
+            .collect(Collectors.toList());
         for (ShardCollectSource shardCollectSource : shardCollectSources) {
             try {
                 //noinspection unchecked

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -23,8 +23,6 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Row;
@@ -78,6 +76,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -140,7 +139,8 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
     }
 
     private Long[] nextPageQuery(IndexReader reader, FieldDoc lastCollected, boolean reverseFlag, boolean nullFirst) throws IOException {
-        OrderBy orderBy = new OrderBy(ImmutableList.of(REFERENCE),
+        OrderBy orderBy = new OrderBy(
+            List.of(REFERENCE),
             new boolean[]{reverseFlag},
             new boolean[]{nullFirst});
 
@@ -263,7 +263,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
                     DocSysColumns.SCORE), RowGranularity.DOC, DataTypes.FLOAT, null, null
             );
 
-        OrderBy orderBy = new OrderBy(ImmutableList.of(sysColReference, REFERENCE),
+        OrderBy orderBy = new OrderBy(List.of(sysColReference, REFERENCE),
             new boolean[]{false, false},
             new boolean[]{false, false});
 
@@ -298,8 +298,8 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         // without minScore filter we get 2 and 2 docs - this is not necessary for the test but is here
         // to make sure the "FuzzyQuery" matches the right documents
         collector = collector(searcher, columnReferences, query, null, true);
-        assertThat(Iterables.size(collector.collect()), is(2));
-        assertThat(Iterables.size(collector.collect()), is(2));
+        assertThat(StreamSupport.stream(collector.collect().spliterator(), false).count(), is(2L));
+        assertThat(StreamSupport.stream(collector.collect().spliterator(), false).count(), is(2L));
 
         collector = collector(searcher, columnReferences, query, 0.15f, true);
         int count = 0;
@@ -338,7 +338,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         LuceneOrderedDocCollector collector = collector(searcher, columnReferences, query, null, false);
         KeyIterable<ShardId, Row> result = collector.collect();
 
-        assertThat(Iterables.size(result), is(2));
+        assertThat(StreamSupport.stream(result.spliterator(), false).count(), is(2L));
 
         Iterator<Row> values = result.iterator();
 
@@ -365,7 +365,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         LuceneOrderedDocCollector collector = collector(searcher, columnReferences, query, null, true);
         KeyIterable<ShardId, Row> result = collector.collect();
 
-        assertThat(Iterables.size(result), is(2));
+        assertThat(StreamSupport.stream(result.spliterator(), false).count(), is(2L));
 
         Iterator<Row> values = result.iterator();
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -23,7 +23,6 @@
 package io.crate.execution.engine.collect.collectors;
 
 
-import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccounting;
@@ -132,7 +131,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
                     Arrays.asList(collector1, collector2),
                     OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
                     ROW_ACCOUNTING,
-                    MoreExecutors.directExecutor(),
+                    Runnable::run,
                     () -> 1,
                     true
                 );
@@ -152,7 +151,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
             Arrays.asList(createOrderedCollector(searcher1, 1)),
             OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
             rowAccounting,
-            MoreExecutors.directExecutor(),
+            Runnable::run,
             () -> 2,
             true
         );
@@ -172,7 +171,8 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
         BatchIterator<Row> rowBatchIterator = OrderedLuceneBatchIteratorFactory.newInstance(
             Arrays.asList(collector1, collector2),
             OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
-            rowAccounting, MoreExecutors.directExecutor(),
+            rowAccounting,
+            Runnable::run,
             () -> 1,
             true
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -23,7 +23,6 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccounting;
 import io.crate.exceptions.JobKilledException;
@@ -114,7 +113,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
             "remoteNode",
             transportJobAction,
             transportKillJobsNodeAction,
-            MoreExecutors.directExecutor(),
+            Runnable::run,
             tasksService,
             RamAccounting.NO_ACCOUNTING,
             consumer,

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FilesIterablesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FilesIterablesTest.java
@@ -22,14 +22,12 @@
 
 package io.crate.execution.engine.collect.files;
 
-import com.google.common.collect.Iterators;
 import org.junit.Test;
 
-import java.util.Iterator;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -38,7 +36,9 @@ public class FilesIterablesTest {
 
     @Test
     public void testSqlFeatureIterable() throws Exception {
-        Iterator<SqlFeatureContext> iterator = SqlFeatures.loadFeatures().iterator();
+        Iterable<SqlFeatureContext> sqlFeatureContextIterable = SqlFeatures.loadFeatures();
+
+        var iterator = sqlFeatureContextIterable.iterator();
         assertTrue(iterator.hasNext());
         SqlFeatureContext context = iterator.next();
         assertEquals("B011", context.featureId);
@@ -48,16 +48,19 @@ public class FilesIterablesTest {
         assertEquals(false, context.isSupported);
         assertNull(context.isVerifiedBy);
         assertNull(context.comments);
-        assertEquals(671L, Iterators.size(iterator));
-        assertFalse(iterator.hasNext());
+
+        assertThat(
+            StreamSupport.stream(sqlFeatureContextIterable.spliterator(), false).count(),
+            is(672L)
+        );
     }
 
     @Test
     public void testSummitsIterable() throws Exception {
         SummitsIterable summitsIterable = new SummitsIterable();
-        var iterator = summitsIterable.iterator();
-        assertTrue(iterator.hasNext());
-        assertThat(Iterators.size(iterator), is(1605));
-        assertFalse(iterator.hasNext());
+        assertThat(
+            StreamSupport.stream(summitsIterable.spliterator(), false).count(),
+            is(1605L)
+        );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.collect.sources;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.reference.information.ColumnContext;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -44,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static io.crate.testing.T3.T1;
 import static io.crate.testing.T3.T1_DEFINITION;
@@ -51,7 +51,6 @@ import static io.crate.testing.T3.T4;
 import static io.crate.testing.T3.T4_DEFINITION;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
 
@@ -67,7 +66,8 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testColumnsIteratorCanBeMaterializedToList() {
         InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(t1Info);
-        ImmutableList<ColumnContext> contexts = ImmutableList.copyOf(columns);
+        List<ColumnContext> contexts = StreamSupport.stream(columns.spliterator(), false)
+            .collect(Collectors.toList());
 
         assertThat(
             contexts.stream().map(c -> c.info.column().name()).collect(Collectors.toList()),
@@ -90,7 +90,8 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testOrdinalIsNotNullOnSubColumns() throws Exception {
         InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(t4Info);
-        ImmutableList<ColumnContext> contexts = ImmutableList.copyOf(columns);
+        List<ColumnContext> contexts = StreamSupport.stream(columns.spliterator(), false)
+            .collect(Collectors.toList());
 
         // sub columns must have NON-NULL ordinal value
         assertThat(contexts.get(1).ordinal, is(2));

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -22,8 +22,6 @@
 
 package io.crate.execution.engine.collect.sources;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.data.Row;
@@ -50,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -76,7 +75,7 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
             new Routing(Map.of()),
             RowGranularity.SHARD,
             Collections.singletonList(shardId),
-            ImmutableList.of(),
+            List.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
@@ -110,8 +109,8 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
             "collect",
             new Routing(Map.of()),
             RowGranularity.SHARD,
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST);
 
@@ -124,10 +123,10 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
         Iterable<? extends Row> rows = systemCollectSource.toRowsIterableTransformation(
             collectPhase, txnCtx, unassignedShardRefResolver(), false)
             .apply(noReadIsolationIterable);
-        assertThat(Iterables.size(rows), is(2));
+        assertThat(StreamSupport.stream(rows.spliterator(), false).count(), is(2L));
 
         noReadIsolationIterable.add("c");
-        assertThat(Iterables.size(rows), is(3));
+        assertThat(StreamSupport.stream(rows.spliterator(), false).count(), is(3L));
 
         // Read isolation
         List<String> readIsolationIterable = new ArrayList<>();
@@ -136,9 +135,9 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
 
         rows = systemCollectSource.toRowsIterableTransformation(collectPhase, txnCtx, unassignedShardRefResolver(), true)
             .apply(readIsolationIterable);
-        assertThat(Iterables.size(rows), is(2));
+        assertThat(StreamSupport.stream(rows.spliterator(), false).count(), is(2L));
 
         readIsolationIterable.add("c");
-        assertThat(Iterables.size(rows), is(2));
+        assertThat(StreamSupport.stream(rows.spliterator(), false).count(), is(2L));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
@@ -23,7 +23,6 @@
 package io.crate.execution.engine.distribution;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.google.common.collect.ImmutableSet;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Paging;
@@ -94,14 +93,14 @@ public class DistributingConsumerFactoryTest extends CrateDummyClusterServiceUni
 
     @Test
     public void testCreateDownstreamOneNode() throws Exception {
-        RowConsumer downstream = createDownstream(ImmutableSet.of("downstream_node"));
+        RowConsumer downstream = createDownstream(Set.of("downstream_node"));
         assertThat(downstream, instanceOf(DistributingConsumer.class));
         assertThat(((DistributingConsumer) downstream).multiBucketBuilder, instanceOf(BroadcastingBucketBuilder.class));
     }
 
     @Test
     public void testCreateDownstreamMultipleNode() throws Exception {
-        RowConsumer downstream = createDownstream(ImmutableSet.of("downstream_node1", "downstream_node2"));
+        RowConsumer downstream = createDownstream(Set.of("downstream_node1", "downstream_node2"));
         assertThat(((DistributingConsumer) downstream).multiBucketBuilder, instanceOf(ModuloBucketBuilder.class));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/PassThroughPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/PassThroughPagingIteratorTest.java
@@ -21,20 +21,20 @@
 
 package io.crate.execution.engine.distribution.merge;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 
 public class PassThroughPagingIteratorTest extends ESTestCase {
 
     private static <T> PassThroughPagingIterator<Integer, T> iter() {
-        return randomBoolean() ? PassThroughPagingIterator.<Integer, T>repeatable() : PassThroughPagingIterator.<Integer, T>oneShot();
+        return randomBoolean() ? PassThroughPagingIterator.repeatable() : PassThroughPagingIterator.oneShot();
     }
 
     @Test
@@ -51,8 +51,9 @@ public class PassThroughPagingIteratorTest extends ESTestCase {
             new KeyIterable<>(1, Arrays.asList("d", "e"))));
 
         iterator.finish();
-        String[] objects = Iterators.toArray(iterator, String.class);
-        assertThat(objects, Matchers.arrayContaining("a", "b", "c", "d", "e"));
+        ArrayList<String> objects = new ArrayList<>();
+        iterator.forEachRemaining(objects::add);
+        assertThat(objects, contains("a", "b", "c", "d", "e"));
     }
 
     @Test
@@ -64,7 +65,8 @@ public class PassThroughPagingIteratorTest extends ESTestCase {
         iterator.merge(Collections.singletonList(
             new KeyIterable<>(1, Arrays.asList("f", "g"))));
         iterator.finish();
-        String[] objects = Iterators.toArray(iterator, String.class);
-        assertThat(objects, Matchers.arrayContaining("a", "b", "c", "d", "e", "f", "g"));
+        ArrayList<String> objects = new ArrayList<>();
+        iterator.forEachRemaining(objects::add);
+        assertThat(objects, contains("a", "b", "c", "d", "e", "f", "g"));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.execution.engine.distribution.merge;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RamAccounting;
@@ -42,8 +40,10 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -109,7 +109,7 @@ public class RamAccountingPageIteratorTest extends ESTestCase {
             2,
             true,
             null,
-            () -> new RowAccountingWithEstimators(ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
+            () -> new RowAccountingWithEstimators(List.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
                                                   RamAccounting.NO_ACCOUNTING));
         assertThat(pagingIterator, instanceOf(RamAccountingPageIterator.class));
         assertThat(((RamAccountingPageIterator) pagingIterator).delegatePagingIterator,
@@ -120,9 +120,10 @@ public class RamAccountingPageIteratorTest extends ESTestCase {
             new KeyIterable<>(1, Collections.singletonList(TEST_ROWS[1]))));
         pagingIterator.finish();
 
-        Row[] rows = Iterators.toArray(pagingIterator, Row.class);
-        assertThat(rows[0], TestingHelpers.isRow("a", "b", "c"));
-        assertThat(rows[1], TestingHelpers.isRow("d", "e", "f"));
+        var rows = new ArrayList<Row>();
+        pagingIterator.forEachRemaining(rows::add);
+        assertThat(rows.get(0), TestingHelpers.isRow("a", "b", "c"));
+        assertThat(rows.get(1), TestingHelpers.isRow("d", "e", "f"));
     }
 
     @Test
@@ -132,7 +133,7 @@ public class RamAccountingPageIteratorTest extends ESTestCase {
             true,
             null,
             () -> new RowAccountingWithEstimators(
-                ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
+                List.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
                 ConcurrentRamAccounting.forCircuitBreaker(
                     "test",
                     new MemoryCircuitBreaker(

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.execution.engine.distribution.merge;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
+import io.crate.common.collections.Lists2;
 import io.crate.data.ArrayBucket;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
@@ -32,9 +31,7 @@ import org.elasticsearch.test.ESTestCase;
 import io.crate.testing.TestingHelpers;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -49,7 +46,7 @@ public class SortedPagingIteratorTest extends ESTestCase {
     public void testTwoBucketsAndTwoPagesAreSortedCorrectly() throws Exception {
         SortedPagingIterator<Void, Row> pagingIterator = new SortedPagingIterator<>(ORDERING, randomBoolean());
 
-        pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
+        pagingIterator.merge(numberedBuckets(List.of(
             new ArrayBucket(new Object[][]{
                 new Object[]{"a"},
                 new Object[]{"b"},
@@ -67,7 +64,7 @@ public class SortedPagingIteratorTest extends ESTestCase {
         assertThat(rows.size(), is(3));
         assertThat(TestingHelpers.printRows(rows), is("a\nb\nc\n"));
 
-        pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
+        pagingIterator.merge(numberedBuckets(List.of(
             new ArrayBucket(new Object[][]{
                 new Object[]{"d"},
                 new Object[]{"e"},
@@ -103,7 +100,7 @@ public class SortedPagingIteratorTest extends ESTestCase {
     @Test
     public void testReplayReplaysCorrectly() throws Exception {
         SortedPagingIterator<Void, Row> pagingIterator = new SortedPagingIterator<>(ORDERING, true);
-        pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
+        pagingIterator.merge(numberedBuckets(List.of(
             new ArrayBucket(new Object[][]{
                 new Object[]{"a"},
                 new Object[]{"b"},
@@ -121,7 +118,7 @@ public class SortedPagingIteratorTest extends ESTestCase {
         List<Object> rows = new ArrayList<>();
         consumeSingleColumnRows(pagingIterator, rows);
 
-        pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
+        pagingIterator.merge(numberedBuckets(List.of(
             new ArrayBucket(new Object[][]{
                 new Object[]{"d"},
                 new Object[]{"e"},
@@ -140,13 +137,6 @@ public class SortedPagingIteratorTest extends ESTestCase {
     }
 
     private Iterable<? extends KeyIterable<Void, Row>> numberedBuckets(List<Bucket> buckets) {
-        return Iterables.transform(buckets, new Function<Bucket, KeyIterable<Void, Row>>() {
-
-            @Nullable
-            @Override
-            public KeyIterable<Void, Row> apply(Bucket input) {
-                return new KeyIterable<>(null, input);
-            }
-        });
+        return Lists2.mapLazy(buckets, bucket -> new KeyIterable<>(null, bucket));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.export;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.exceptions.UnhandledServerException;
@@ -39,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
@@ -64,7 +64,7 @@ public class FileWriterProjectorTest extends ESTestCase {
         Path file = createTempFile("out", "json");
 
         FileWriterProjector fileWriterProjector = new FileWriterProjector(executorService, file.toUri().toString(),
-            null, null, ImmutableSet.of(), new HashMap<>(),
+            null, null, Set.of(), new HashMap<>(),
             null, WriterProjection.OutputFormat.JSON_OBJECT);
 
         new TestingRowConsumer().accept(fileWriterProjector.apply(sourceSupplier.get()), null);
@@ -83,10 +83,10 @@ public class FileWriterProjectorTest extends ESTestCase {
 
         Path directory = createTempDir();
 
-        FileWriterProjector fileWriterProjector = new FileWriterProjector(executorService, directory.toUri().toString(),
-            null, null, ImmutableSet.of(), new HashMap<>(),
+        FileWriterProjector fileWriterProjector = new FileWriterProjector(
+            executorService, directory.toUri().toString(),
+            null, null, Set.of(), new HashMap<>(),
             null, WriterProjection.OutputFormat.JSON_OBJECT);
-
         new TestingRowConsumer().accept(fileWriterProjector.apply(sourceSupplier.get()), null);
     }
 
@@ -98,7 +98,7 @@ public class FileWriterProjectorTest extends ESTestCase {
         String uri = Paths.get(folder.newFile().toURI()).resolve("out.json").toUri().toString();
 
         FileWriterProjector fileWriterProjector = new FileWriterProjector(executorService, uri,
-            null, null, ImmutableSet.of(), new HashMap<>(),
+            null, null, Set.of(), new HashMap<>(),
             null, WriterProjection.OutputFormat.JSON_OBJECT);
 
         new TestingRowConsumer().accept(fileWriterProjector.apply(sourceSupplier.get()), null);

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.engine.fetch;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import io.crate.execution.dsl.phases.FetchPhase;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.metadata.ColumnIdent;
@@ -42,6 +41,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -65,7 +65,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 null,
                 new TreeMap<>(),
                 HashMultimap.create(),
-                ImmutableList.of()),
+                List.of()),
             "dummy",
             new SharedShardContexts(mock(IndicesService.class), UnaryOperator.identity()),
             clusterService.state().getMetadata(),
@@ -101,12 +101,12 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 null,
                 ibb.build(),
                 tableIndices,
-                ImmutableList.of(createReference("i1", new ColumnIdent("x"), DataTypes.STRING))),
+                List.of(createReference("i1", new ColumnIdent("x"), DataTypes.STRING))),
             "dummy",
             new SharedShardContexts(mock(IndicesService.class, RETURNS_MOCKS), UnaryOperator.identity()),
             metadata,
             relationName -> null,
-            ImmutableList.of(routing));
+            List.of(routing));
 
         context.start();
 

--- a/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchOperationTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.fetch;
 
-import com.google.common.collect.Iterables;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.jobs.TasksService;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -33,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.core.Is.is;
 
@@ -52,7 +52,9 @@ public class NodeFetchOperationTest extends CrateDummyClusterServiceUnitTest {
 
             fetchOperation.fetch(UUID.randomUUID(), 1, null, true).get(5, TimeUnit.SECONDS);
 
-            assertThat(Iterables.size(jobsLogs.activeOperations()), is(0));
+            assertThat(
+                StreamSupport.stream(jobsLogs.activeOperations().spliterator(), false).count(),
+                is(0L));
         } finally {
             threadPoolExecutor.shutdown();
             threadPoolExecutor.awaitTermination(2, TimeUnit.SECONDS);

--- a/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
@@ -26,11 +26,9 @@ import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
-import com.google.common.collect.Iterables;
 import io.crate.Streamer;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RamAccounting;
-import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.distribution.StreamBucket;
 import org.elasticsearch.test.ESTestCase;
@@ -46,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.TestingHelpers.isRow;
+import static org.hamcrest.CoreMatchers.is;
 
 public class NodeFetchResponseTest extends ESTestCase {
 
@@ -78,7 +77,8 @@ public class NodeFetchResponseTest extends ESTestCase {
         // receiving side is required to set the streamers
         NodeFetchResponse streamed = new NodeFetchResponse(in, streamers, RamAccounting.NO_ACCOUNTING);
 
-        assertThat((Row) Iterables.getOnlyElement(streamed.fetched().get(1)), isRow(true));
+        assertThat(streamed.fetched().get(1).size(), is(1));
+        assertThat(streamed.fetched().get(1).iterator().next(), isRow(true));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/join/JoinOperationsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/JoinOperationsTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.join;
 
-import com.google.common.collect.Sets;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPair;
 import io.crate.expression.symbol.Symbol;
@@ -75,7 +74,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         List<JoinPair> joinPairs = new ArrayList<>();
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b")));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2, T3.T3), asSymbol("t1.x = t2.y + t3.z"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2, T3.T3), asSymbol("t1.x = t2.y + t3.z"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 
@@ -91,7 +90,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         List<JoinPair> joinPairs = new ArrayList<>();
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b")));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 
@@ -107,7 +106,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         List<JoinPair> joinPairs = new ArrayList<>();
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.CROSS, null));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 
@@ -121,7 +120,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testImplicitToExplicit_JoinPairDoesNotExist() {
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(Collections.emptyList(), remainingQueries);
 
@@ -137,7 +136,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         List<JoinPair> joinPairs = new ArrayList<>();
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.LEFT, asSymbol("t1.a = t2.b")));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 
@@ -153,7 +152,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         List<JoinPair> joinPairs = new ArrayList<>();
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.SEMI, asSymbol("t1.a = t2.b")));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
+        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
 
         List<JoinPair> newJoinPairs = JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 
@@ -170,7 +169,7 @@ public class JoinOperationsTest extends CrateDummyClusterServiceUnitTest {
         joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b")));
         joinPairs.add(JoinPair.of(T3.T2, T3.T3, JoinType.INNER, asSymbol("t2.y = t3.z")));
         Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Sets.newHashSet(T3.T2, T3.T3), asSymbol("t2.b = t3.c"));
+        remainingQueries.put(Set.of(T3.T2, T3.T3), asSymbol("t2.b = t3.c"));
         List<JoinPair> newJoinPairs =
             JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
 

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.pipeline;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
@@ -220,7 +219,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
             new InputColumn(0, DataTypes.STRING), new InputColumn(1, DataTypes.STRING),
             new InputColumn(2, DataTypes.DOUBLE), new InputColumn(3, DataTypes.LONG));
         OrderedTopNProjection topNProjection = new OrderedTopNProjection(10, 0, outputs,
-            ImmutableList.of(new InputColumn(2, DataTypes.DOUBLE)),
+            List.of(new InputColumn(2, DataTypes.DOUBLE)),
             new boolean[]{false},
             new boolean[]{false});
         Projector topNProjector = visitor.create(

--- a/server/src/test/java/io/crate/execution/engine/pipeline/SimpleTopNProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/SimpleTopNProjectorTest.java
@@ -22,23 +22,17 @@
 
 package io.crate.execution.engine.pipeline;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
 import io.crate.data.InMemoryBatchIterator;
-import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
-import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
 import org.elasticsearch.test.ESTestCase;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.stream.StreamSupport;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -46,11 +40,7 @@ import static org.hamcrest.Matchers.is;
 
 public class SimpleTopNProjectorTest extends ESTestCase {
 
-    private static final InputCollectExpression input = new InputCollectExpression(0);
-    private static final ImmutableList<Input<?>> INPUTS = ImmutableList.of(input);
-    private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = Collections.singletonList(input);
-
-    private TestingRowConsumer consumer = new TestingRowConsumer();
+    private final TestingRowConsumer consumer = new TestingRowConsumer();
 
     private SimpleTopNProjector prepareProjector(int limit, int offset) {
         return new SimpleTopNProjector(limit, offset);
@@ -66,8 +56,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(10));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(10));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(10L));
     }
 
     @Test
@@ -79,8 +69,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(5));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(5));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(5L));
     }
 
     @Test
@@ -91,8 +81,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(10));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(10));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(10L));
 
     }
 
@@ -104,8 +94,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected, emptyIterable());
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(0));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(0L));
     }
 
     @Test
@@ -117,8 +107,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(1));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(1));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(1L));
     }
 
     @Test
@@ -130,8 +120,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(90));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(90));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(90L));
     }
 
     @Test
@@ -156,8 +146,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(10));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(10));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(10L));
     }
 
     @Test
@@ -168,8 +158,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(5));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(5));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(5L));
     }
 
 
@@ -189,8 +179,8 @@ public class SimpleTopNProjectorTest extends ESTestCase {
         Bucket projected = consumer.getBucket();
         assertThat(projected.size(), is(90));
 
-        int iterateLength = Iterables.size(consumer.getBucket());
-        assertThat(iterateLength, is(90));
+        long iterateLength = StreamSupport.stream(consumer.getBucket().spliterator(), false).count();
+        assertThat(iterateLength, is(90L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.sort;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RowAccounting;
 import io.crate.breaker.RowCellsAccountingWithEstimators;
@@ -57,8 +56,8 @@ public class SortingProjectorTest extends ESTestCase {
         InputCollectExpression input = new InputCollectExpression(0);
         return new SortingProjector(
             rowAccounting,
-            ImmutableList.of(input, Literal.of(true)),
-            ImmutableList.<CollectExpression<Row, ?>>of(input),
+            List.of(input, Literal.of(true)),
+            List.<CollectExpression<Row, ?>>of(input),
             numOutputs,
             OrderingByPosition.arrayOrdering(0, false, false),
             offset

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.sort;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RowAccounting;
 import io.crate.breaker.RowCellsAccountingWithEstimators;
@@ -55,8 +54,8 @@ public class SortingTopNProjectorTest extends ESTestCase {
 
     private static final InputCollectExpression INPUT = new InputCollectExpression(0);
     private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
-    private static final List<Input<?>> INPUT_LITERAL_LIST = ImmutableList.of(INPUT, TRUE_LITERAL);
-    private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = ImmutableList.<CollectExpression<Row, ?>>of(INPUT);
+    private static final List<Input<?>> INPUT_LITERAL_LIST = List.of(INPUT, TRUE_LITERAL);
+    private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = List.of(INPUT);
     private static final Comparator<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, false);
 
     private TestingRowConsumer consumer = new TestingRowConsumer();

--- a/server/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -22,10 +22,8 @@
 package io.crate.execution.jobs;
 
 import com.google.common.collect.ForwardingIterator;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.ArrayBucket;
@@ -41,6 +39,7 @@ import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -67,7 +66,7 @@ public class DistResultRXTaskTest extends ESTestCase {
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
             "n1",
             1,
-            MoreExecutors.directExecutor(),
+            Runnable::run,
             new Streamer[1],
             batchConsumer,
             pagingIterator,
@@ -288,7 +287,7 @@ public class DistResultRXTaskTest extends ESTestCase {
     private static class FailOnMergePagingIterator<TKey, TRow> extends ForwardingIterator<TRow> implements PagingIterator<TKey, TRow> {
 
         private Iterator<TRow> iterator = Collections.emptyIterator();
-        private final ImmutableList.Builder<KeyIterable<TKey, TRow>> iterables = ImmutableList.builder();
+        private final List<KeyIterable<TKey, TRow>> iterables = new ArrayList<>();
         private final int mergesCallCountUntilError;
         private int mergesCallCount = 0;
 

--- a/server/src/test/java/io/crate/execution/jobs/NodeOperationCtxTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/NodeOperationCtxTest.java
@@ -30,7 +30,8 @@ import org.elasticsearch.test.ESTestCase;
 import io.crate.testing.StubPhases;
 import org.junit.Test;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.List;
+
 import static io.crate.execution.jobs.JobSetup.NodeOperationCtx;
 import static io.crate.planner.distribution.DistributionInfo.DEFAULT_BROADCAST;
 import static io.crate.testing.StubPhases.newPhase;
@@ -46,8 +47,11 @@ public class NodeOperationCtxTest extends ESTestCase {
         ExecutionPhase p2 = newPhase(1, "n1", "n2");
         ExecutionPhase p3 = newPhase(2, "n2");
 
-        NodeOperationCtx opCtx = new NodeOperationCtx("n1",
-            newArrayList(NodeOperation.withDownstream(p1, p2, (byte) 0), NodeOperation.withDownstream(p2, p3, (byte) 0))
+        NodeOperationCtx opCtx = new NodeOperationCtx(
+            "n1",
+            List.of(
+                NodeOperation.withDownstream(p1, p2, (byte) 0),
+                NodeOperation.withDownstream(p2, p3, (byte) 0))
         );
 
         assertThat(opCtx.findLeafs(), is(IntArrayList.from(2)));
@@ -88,7 +92,7 @@ public class NodeOperationCtxTest extends ESTestCase {
         ExecutionPhase p3 = newPhase(3, "n2");
 
         NodeOperationCtx opCtx = new NodeOperationCtx("n1",
-            newArrayList(NodeOperation.withDownstream(p1, p3, (byte) 0), NodeOperation.withDownstream(p2, p3, (byte) 0)));
+            List.of(NodeOperation.withDownstream(p1, p3, (byte) 0), NodeOperation.withDownstream(p2, p3, (byte) 0)));
 
         assertThat(opCtx.upstreamsAreOnSameNode(3), is(true));
     }

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -36,8 +36,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import com.google.common.util.concurrent.MoreExecutors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
@@ -142,7 +140,7 @@ public class RootTaskTest extends ESTestCase {
         PageBucketReceiver pageBucketReceiver = new CumulativePageBucketReceiver(
             "n1",
             2,
-            MoreExecutors.directExecutor(),
+            Runnable::run,
             new Streamer[]{IntegerType.INSTANCE.streamer()},
             batchConsumer,
             PassThroughPagingIterator.oneShot(),

--- a/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.execution.jobs;
 
-import com.google.common.collect.ImmutableList;
-
 import io.crate.auth.user.User;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -214,7 +212,7 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testKillSingleJob() throws Exception {
-        ImmutableList<UUID> jobsToKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        List<UUID> jobsToKill = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
         RootTask.Builder builder = tasksService.newBuilder(jobsToKill.get(0));
         builder.addTask(new DummyTask());
         tasksService.createTask(builder);

--- a/server/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/KillJobsRequestTest.java
@@ -22,12 +22,12 @@
 package io.crate.execution.jobs.kill;
 
 
-import com.google.common.collect.ImmutableList;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -37,7 +37,7 @@ public class KillJobsRequestTest extends ESTestCase {
 
     @Test
     public void testStreaming() throws Exception {
-        ImmutableList<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
+        List<UUID> toKill = List.of(UUID.randomUUID(), UUID.randomUUID());
         KillJobsRequest r = new KillJobsRequest(toKill, "dummy-user", "just because");
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.jobs.kill;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.execution.jobs.TasksService;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
@@ -50,7 +49,7 @@ public class TransportKillJobsNodeActionTest extends CrateDummyClusterServiceUni
                 Settings.EMPTY, Version.CURRENT, THREAD_POOL, clusterService.getClusterSettings())
         );
 
-        List<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
+        List<UUID> toKill = List.of(UUID.randomUUID(), UUID.randomUUID());
 
         transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill, "dummy-user", null)).get(5, TimeUnit.SECONDS);
         verify(tasksService, times(1)).killJobs(toKill, "dummy-user", null);

--- a/server/src/test/java/io/crate/executor/transport/ExecutionPhasesRootTaskTest.java
+++ b/server/src/test/java/io/crate/executor/transport/ExecutionPhasesRootTaskTest.java
@@ -23,8 +23,6 @@ package io.crate.executor.transport;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import io.crate.analyze.WhereClause;
 import io.crate.execution.dsl.phases.ExecutionPhase;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -38,7 +36,9 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 
@@ -62,8 +62,8 @@ public class ExecutionPhasesRootTaskTest {
             "c1",
             twoNodeRouting,
             RowGranularity.DOC,
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
@@ -74,9 +74,9 @@ public class ExecutionPhasesRootTaskTest {
             "merge1",
             2,
             1,
-            Sets.newHashSet("node3", "node4"),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            Set.of("node3", "node4"),
+            List.of(),
+            List.of(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );
@@ -87,9 +87,9 @@ public class ExecutionPhasesRootTaskTest {
             "merge2",
             2,
             1,
-            Sets.newHashSet("node1", "node3"),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            Set.of("node1", "node3"),
+            List.of(),
+            List.of(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );
@@ -98,7 +98,7 @@ public class ExecutionPhasesRootTaskTest {
         NodeOperation n2 = NodeOperation.withDownstream(m1, m2, (byte) 0);
         NodeOperation n3 = NodeOperation.withDownstream(m2, mock(ExecutionPhase.class), (byte) 0);
 
-        Map<String, Collection<NodeOperation>> groupByServer = NodeOperationGrouper.groupByServer(ImmutableList.of(n1, n2, n3));
+        Map<String, Collection<NodeOperation>> groupByServer = NodeOperationGrouper.groupByServer(List.of(n1, n2, n3));
 
         assertThat(groupByServer.containsKey("node1"), is(true));
         assertThat(groupByServer.get("node1"), Matchers.containsInAnyOrder(n1, n3));

--- a/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.executor.transport.task.elasticsearch;
 
-import com.google.common.collect.Lists;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.DocRefResolver;
@@ -59,7 +58,7 @@ public class DocRefResolverTest extends ESTestCase {
 
     @Test
     public void testSystemColumnsCollectExpressions() throws Exception {
-        List<Reference> references = Lists.newArrayList(
+        List<Reference> references = List.of(
             refInfo("t1._id", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.ID), RowGranularity.DOC),
             refInfo("t1._version", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.VERSION), RowGranularity.DOC),
             refInfo("t1._doc", DocSysColumns.COLUMN_IDENTS.get(DocSysColumns.DOC), RowGranularity.DOC),

--- a/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
+++ b/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.reference;
 
-import com.google.common.collect.Iterables;
 import io.crate.auth.user.User;
 import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.metadata.SearchPath;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.StreamSupport;
 
 import static io.crate.auth.user.User.CRATE_USER;
 import static java.util.Collections.emptyList;
@@ -61,10 +61,10 @@ public class StaticTableDefinitionTest {
             (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()), true);
 
         Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
-        assertThat(Iterables.size(expected), is(3));
+        assertThat(StreamSupport.stream(expected.spliterator(), false).count(), is(3L));
 
         expected = tableDef.retrieveRecords(dummyTxnCtx, dummyUser).get();
-        assertThat(Iterables.size(expected), is(1));
+        assertThat(StreamSupport.stream(expected.spliterator(), false).count(), is(1L));
     }
 
     @Test
@@ -76,6 +76,6 @@ public class StaticTableDefinitionTest {
             (user, ctx) -> user.isSuperUser() || ctx.username().equals(user.name()), true);
 
         Iterable<JobContext> expected = tableDef.retrieveRecords(dummyTxnCtx, CRATE_USER).get();
-        assertThat(Iterables.size(expected), is(0));
+        assertThat(StreamSupport.stream(expected.spliterator(), false).count(), is(0L));
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.reference.sys.node;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
@@ -43,6 +42,7 @@ import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.Set;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
 import static org.hamcrest.CoreMatchers.is;
@@ -87,7 +87,7 @@ public class NodeStatsContextFieldResolverTest {
 
     @Test
     public void testEmptyColumnIdents() {
-        NodeStatsContext context = resolver.forTopColumnIdents(ImmutableSet.of());
+        NodeStatsContext context = resolver.forTopColumnIdents(Set.of());
         assertDefaultDiscoveryContext(context);
     }
 
@@ -145,7 +145,7 @@ public class NodeStatsContextFieldResolverTest {
 
     @Test
     public void testColumnIdentsResolution() {
-        NodeStatsContext context = resolver.forTopColumnIdents(ImmutableSet.of(
+        NodeStatsContext context = resolver.forTopColumnIdents(Set.of(
             SysNodesTableInfo.Columns.ID,
             SysNodesTableInfo.Columns.NAME
         ));
@@ -157,13 +157,13 @@ public class NodeStatsContextFieldResolverTest {
 
     @Test
     public void testNoteStatsContextTimestampResolvedCorrectly() {
-        NodeStatsContext context = resolver.forTopColumnIdents(ImmutableSet.of(SysNodesTableInfo.Columns.OS));
+        NodeStatsContext context = resolver.forTopColumnIdents(Set.of(SysNodesTableInfo.Columns.OS));
         assertThat(context.timestamp(), greaterThan(0L));
     }
 
     @Test
     public void testPSQLPortResolution() throws IOException {
-        NodeStatsContext context = resolver.forTopColumnIdents(ImmutableSet.of(
+        NodeStatsContext context = resolver.forTopColumnIdents(Set.of(
             new ColumnIdent(SysNodesTableInfo.Columns.PORT.name())
         ));
         assertThat(context.isComplete(), is(true));
@@ -172,7 +172,7 @@ public class NodeStatsContextFieldResolverTest {
 
     @Test
     public void testClusterStateVersion() throws IOException {
-        NodeStatsContext context = resolver.forTopColumnIdents(ImmutableSet.of(
+        NodeStatsContext context = resolver.forTopColumnIdents(Set.of(
             new ColumnIdent(SysNodesTableInfo.Columns.CLUSTER_STATE_VERSION.name())
         ));
         assertThat(context.isComplete(), is(true));
@@ -182,7 +182,7 @@ public class NodeStatsContextFieldResolverTest {
     @Test
     public void testResolveForNonExistingColumnIdent() {
         assertThrows(IllegalArgumentException.class,
-                     () -> resolver.forTopColumnIdents(ImmutableSet.of(SysNodesTableInfo.Columns.ID, new ColumnIdent("dummy"))),
+                     () -> resolver.forTopColumnIdents(Set.of(SysNodesTableInfo.Columns.ID, new ColumnIdent("dummy"))),
                      "Cannot resolve NodeStatsContext field for \"dummy\" column ident.");
     }
 

--- a/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.reference.sys.snapshot;
 
-import com.google.common.collect.ImmutableList;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.UUIDs;
@@ -40,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,7 +65,8 @@ public class SysSnapshotsTest extends ESTestCase {
         when(r1.getSnapshotInfo(eq(s2))).thenReturn(new SnapshotInfo(s2, Collections.emptyList(), SnapshotState.SUCCESS));
 
         SysSnapshots sysSnapshots = new SysSnapshots(() -> Collections.singletonList(r1));
-        List<SysSnapshot> currentSnapshots = ImmutableList.copyOf(sysSnapshots.currentSnapshots());
+        List<SysSnapshot> currentSnapshots = StreamSupport.stream(sysSnapshots.currentSnapshots().spliterator(), false)
+            .collect(Collectors.toList());
         assertThat(
             currentSnapshots.stream().map(SysSnapshot::name).collect(Collectors.toList()),
             containsInAnyOrder("s1", "s2")

--- a/server/src/test/java/io/crate/expression/tablefunctions/EmptyRowTableFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/EmptyRowTableFunctionTest.java
@@ -22,11 +22,13 @@
 
 package io.crate.expression.tablefunctions;
 
-import com.google.common.collect.Iterables;
 import io.crate.data.Row;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.CoreMatchers.is;
+
 
 public class EmptyRowTableFunctionTest extends AbstractTableFunctionsTest {
 
@@ -38,6 +40,6 @@ public class EmptyRowTableFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void testEmptyRowReturnsOneRow() {
         Iterable<Row> result = execute("empty_row()");
-        assertThat(Iterables.size(result), is(1));
+        assertThat(StreamSupport.stream(result.spliterator(), false).count(), is(1L));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -44,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -21,14 +21,12 @@
 
 package io.crate.integrationtests;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.metadata.IndexMappings;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
@@ -153,10 +151,10 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         refresh();
         ensureYellow();
 
-        for (String id : ImmutableList.of("1", "2", "3")) {
+        for (String id : List.of("1", "2", "3")) {
             String partitionName = new PartitionName(
                 new RelationName(sqlExecutor.getCurrentSchema(), "quotes"),
-                ImmutableList.of(id)).asIndexName();
+                List.of(id)).asIndexName();
             assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metadata().indices().get(partitionName));
             assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
@@ -746,9 +744,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "order by partition_ident", new Object[]{defaultSchema});
         assertThat(response.rowCount(), is(2L));
         assertThat((String) response.rows()[0][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1388534400000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1388534400000")).ident()));
         assertThat((String) response.rows()[1][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1391212800000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1391212800000")).ident()));
 
         execute("delete from parted where date = '2014-03-01'");
         refresh();
@@ -768,9 +766,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "order by partition_ident", new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(response.rowCount(), is(2L));
         assertThat((String) response.rows()[0][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1388534400000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1388534400000")).ident()));
         assertThat((String) response.rows()[1][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1391212800000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1391212800000")).ident()));
 
         execute("delete from parted where o['dat'] = '2014-03-01'");
         refresh();
@@ -806,11 +804,11 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "order by partition_ident", new Object[]{defaultSchema});
         assertThat(response.rowCount(), is(3L));
         assertThat((String) response.rows()[0][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1395874800000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1395874800000")).ident()));
         assertThat((String) response.rows()[1][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1395961200000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1395961200000")).ident()));
         assertThat((String) response.rows()[2][0], is(new PartitionName(
-            new RelationName(defaultSchema, "parted"), ImmutableList.of("1396303200000")).ident()));
+            new RelationName(defaultSchema, "parted"), List.of("1396303200000")).ident()));
 
         execute("delete from quotes where quote = 'Don''t panic'");
         refresh();
@@ -1318,7 +1316,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         assertTrue(clusterService().state().metadata().hasAlias(getFqn("quotes")));
 
-        List<String> partitions = ImmutableList.of(
+        List<String> partitions = List.of(
             new PartitionName(
                 new RelationName(defaultSchema, "quotes"),
                 Collections.singletonList("1395874800000")).asIndexName(),

--- a/server/src/test/java/io/crate/integrationtests/Setup.java
+++ b/server/src/test/java/io/crate/integrationtests/Setup.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -165,12 +164,12 @@ public class Setup {
                                                              ")", numericType));
         transportExecutor.ensureYellowOrGreen();
 
-        Map<String, String> details = newHashMap();
+        Map<String, String> details = new HashMap<>();
         details.put("job", "Sandwitch Maker");
         transportExecutor.exec("insert into characters (race, gender, age, birthdate, name, details) values (?, ?, ?, ?, ?, ?)",
             new Object[]{"Human", "male", 34, "1975-10-01", "Arthur Dent", details});
 
-        details = newHashMap();
+        details = new HashMap<>();
         details.put("job", "Mathematician");
         transportExecutor.exec("insert into characters (race, gender, age, birthdate, name, details) values (?, ?, ?, ?, ?, ?)",
             new Object[]{"Human", "female", 32, "1978-10-11", "Trillian", details});

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -42,8 +42,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import com.google.common.base.Joiner;
-
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -123,7 +121,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     private void createSnapshot(String snapshotName, String... tables) {
-        execute("CREATE SNAPSHOT " + REPOSITORY_NAME + "." + snapshotName + " TABLE " + Joiner.on(", ").join(tables) +
+        execute("CREATE SNAPSHOT " + REPOSITORY_NAME + "." + snapshotName + " TABLE " + String.join(", ", tables) +
                 " WITH (wait_for_completion=true)");
         assertThat(response.rowCount(), is(1L));
     }

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -27,8 +27,6 @@ import static org.hamcrest.Matchers.is;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Splitter;
-
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.MemorySizeValue;
@@ -195,7 +193,7 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
 
     private void assertSettingsValue(String key, Object expectedValue) {
         Map<String, Object> settingMap = (Map<String, Object>) response.rows()[0][0];
-        List<String> settingPath = Splitter.on(".").splitToList(key);
+        List<String> settingPath = List.of(key.split("\\."));
         for (int i = 0; i < settingPath.size() - 1; i++) {
             settingMap = (Map<String, Object>) settingMap.get(settingPath.get(i));
         }

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
-import static com.google.common.collect.Maps.newHashMap;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThrows;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
@@ -355,8 +354,8 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testUpdateNestedObjectDeleteWithArgs() throws Exception {
         execute("create table test (a object as (x object as (y int, z int))) with (number_of_replicas=0)");
-        Map<String, Object> map = newHashMap();
-        Map<String, Object> nestedMap = newHashMap();
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> nestedMap = new HashMap<>();
         nestedMap.put("y", 2);
         nestedMap.put("z", 3);
         map.put("x", nestedMap);
@@ -380,8 +379,8 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testUpdateNestedObjectDeleteWithoutArgs() throws Exception {
         execute("create table test (a object as (x object as (y int, z int))) with (number_of_replicas=0)");
-        Map<String, Object> map = newHashMap();
-        Map<String, Object> nestedMap = newHashMap();
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> nestedMap = new HashMap<>();
         nestedMap.put("y", 2);
         nestedMap.put("z", 3);
         map.put("x", nestedMap);

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.ColumnPolicy;
@@ -36,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static io.crate.testing.T3.T1_DEFINITION;
 import static io.crate.testing.T3.T1;
@@ -70,7 +70,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
             formattedGeneratedExpression, false);
 
         generatedReferenceInfo.generatedExpression(expressions.normalize(executor.asSymbol(formattedGeneratedExpression)));
-        generatedReferenceInfo.referencedReferences(ImmutableList.of(t1Info.getReference(new ColumnIdent("a"))));
+        generatedReferenceInfo.referencedReferences(List.of(t1Info.getReference(new ColumnIdent("a"))));
 
         BytesStreamOutput out = new BytesStreamOutput();
         Reference.toStream(generatedReferenceInfo, out);

--- a/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.Constants;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
@@ -32,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -72,7 +72,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPartitionWithoutMapping() throws Exception {
         PartitionName partitionName = new PartitionName(
-            new RelationName("doc", "test1"), ImmutableList.of("foo"));
+            new RelationName("doc", "test1"), List.of("foo"));
         addIndexMetadataToClusterState(IndexMetadata.builder(partitionName.asIndexName())
             .settings(defaultSettings()).numberOfShards(10).numberOfReplicas(4));
         Iterable<PartitionInfo> partitioninfos = new PartitionInfos(clusterService);
@@ -82,7 +82,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPartitionWithMeta() throws Exception {
         PartitionName partitionName = new PartitionName(
-            new RelationName("doc", "test1"), ImmutableList.of("foo"));
+            new RelationName("doc", "test1"), List.of("foo"));
         IndexMetadata.Builder indexMetadata = IndexMetadata
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())
@@ -103,7 +103,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPartitionWithMetaMultiCol() throws Exception {
         PartitionName partitionName = new PartitionName(
-            new RelationName("doc", "test1"), ImmutableList.of("foo", "1"));
+            new RelationName("doc", "test1"), List.of("foo", "1"));
         IndexMetadata.Builder indexMetadata = IndexMetadata
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())

--- a/server/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
@@ -35,10 +35,10 @@ public class PartitionNameTest extends ESTestCase {
 
     @Test
     public void testSingleColumn() throws Exception {
-        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), ImmutableList.of("1"));
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), List.of("1"));
 
         assertThat(partitionName.values().size(), is(1));
-        assertEquals(ImmutableList.of("1"), partitionName.values());
+        assertEquals(List.of("1"), partitionName.values());
 
         PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
@@ -46,10 +46,10 @@ public class PartitionNameTest extends ESTestCase {
 
     @Test
     public void testSingleColumnSchema() throws Exception {
-        PartitionName partitionName = new PartitionName(new RelationName("schema", "test"), ImmutableList.of("1"));
+        PartitionName partitionName = new PartitionName(new RelationName("schema", "test"), List.of("1"));
 
         assertThat(partitionName.values().size(), is(1));
-        assertEquals(ImmutableList.of("1"), partitionName.values());
+        assertEquals(List.of("1"), partitionName.values());
 
         PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
@@ -57,11 +57,13 @@ public class PartitionNameTest extends ESTestCase {
 
     @Test
     public void testMultipleColumns() throws Exception {
-        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"),
-            ImmutableList.of("1", "foo"));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "test"),
+            List.of("1", "foo")
+        );
 
         assertThat(partitionName.values().size(), is(2));
-        assertEquals(ImmutableList.of("1", "foo"), partitionName.values());
+        assertEquals(List.of("1", "foo"), partitionName.values());
 
         PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
@@ -70,10 +72,10 @@ public class PartitionNameTest extends ESTestCase {
     @Test
     public void testMultipleColumnsSchema() throws Exception {
         PartitionName partitionName = new PartitionName(
-            new RelationName("schema", "test"), ImmutableList.of("1", "foo"));
+            new RelationName("schema", "test"), List.of("1", "foo"));
 
         assertThat(partitionName.values().size(), is(2));
-        assertEquals(ImmutableList.of("1", "foo"), partitionName.values());
+        assertEquals(List.of("1", "foo"), partitionName.values());
 
         PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
@@ -102,10 +104,10 @@ public class PartitionNameTest extends ESTestCase {
 
     @Test
     public void testEmptyStringValue() throws Exception {
-        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), ImmutableList.of(""));
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), List.of(""));
 
         assertThat(partitionName.values().size(), is(1));
-        assertEquals(ImmutableList.of(""), partitionName.values());
+        assertEquals(List.of(""), partitionName.values());
 
         PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());

--- a/server/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
-import io.crate.expression.reference.partitioned.PartitionExpression;
 import org.elasticsearch.test.ESTestCase;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -35,8 +35,7 @@ public class PartitionReferenceResolverTest extends ESTestCase {
     @Test
     public void testClusterExpressionsNotAllowed() throws Exception {
         Reference refInfo = TestingHelpers.refInfo("foo.bar", DataTypes.STRING, RowGranularity.CLUSTER);
-        PartitionReferenceResolver referenceResolver = new PartitionReferenceResolver(
-            ImmutableList.<PartitionExpression>of());
+        PartitionReferenceResolver referenceResolver = new PartitionReferenceResolver(List.of());
 
         if (assertionsEnabled()) {
             try {

--- a/server/src/test/java/io/crate/metadata/RelationNameTest.java
+++ b/server/src/test/java/io/crate/metadata/RelationNameTest.java
@@ -22,10 +22,11 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.blob.v2.BlobIndex;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 
@@ -44,10 +45,10 @@ public class RelationNameTest extends ESTestCase {
         assertThat(RelationName.fromIndexName("t"), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "t")));
         assertThat(RelationName.fromIndexName("s.t"), is(new RelationName("s", "t")));
 
-        PartitionName pn = new PartitionName(new RelationName("s", "t"), ImmutableList.of("v1"));
+        PartitionName pn = new PartitionName(new RelationName("s", "t"), List.of("v1"));
         assertThat(RelationName.fromIndexName(pn.asIndexName()), is(new RelationName("s", "t")));
 
-        pn = new PartitionName(new RelationName("doc", "t"), ImmutableList.of("v1"));
+        pn = new PartitionName(new RelationName("doc", "t"), List.of("v1"));
         assertThat(RelationName.fromIndexName(pn.asIndexName()), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "t")));
     }
 

--- a/server/src/test/java/io/crate/metadata/RoutingTest.java
+++ b/server/src/test/java/io/crate/metadata/RoutingTest.java
@@ -23,7 +23,6 @@ package io.crate.metadata;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
-import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -77,14 +76,14 @@ public class RoutingTest extends ESTestCase {
     @Test
     public void testRoutingForRandomMasterOrDataNode() throws IOException {
         Map<String, String> attr = Map.of();
-        Set<DiscoveryNode.Role> master_and_data = ImmutableSet.of(DiscoveryNode.Role.MASTER, DiscoveryNode.Role.DATA);
-        DiscoveryNode local = new DiscoveryNode("client_node_1", buildNewFakeTransportAddress(), attr, ImmutableSet.of(), null);
+        Set<DiscoveryNode.Role> master_and_data = Set.of(DiscoveryNode.Role.MASTER, DiscoveryNode.Role.DATA);
+        DiscoveryNode local = new DiscoveryNode("client_node_1", buildNewFakeTransportAddress(), attr, Set.of(), null);
         DiscoveryNodes nodes = new DiscoveryNodes.Builder()
             .add(new DiscoveryNode("data_master_node_1", buildNewFakeTransportAddress(), attr, master_and_data, null))
             .add(new DiscoveryNode("data_master_node_2", buildNewFakeTransportAddress(), attr, master_and_data, null))
             .add(local)
-            .add(new DiscoveryNode("client_node_2", buildNewFakeTransportAddress(), attr, ImmutableSet.of(), null))
-            .add(new DiscoveryNode("client_node_3", buildNewFakeTransportAddress(), attr, ImmutableSet.of(), null))
+            .add(new DiscoveryNode("client_node_2", buildNewFakeTransportAddress(), attr, Set.of(), null))
+            .add(new DiscoveryNode("client_node_3", buildNewFakeTransportAddress(), attr, Set.of(), null))
             .localNodeId(local.getId())
             .build();
 
@@ -99,7 +98,7 @@ public class RoutingTest extends ESTestCase {
 
     @Test
     public void testRoutingForRandomMasterOrDataNodePrefersLocal() throws Exception {
-        Set<DiscoveryNode.Role> data = ImmutableSet.of(DiscoveryNode.Role.DATA);
+        Set<DiscoveryNode.Role> data = Set.of(DiscoveryNode.Role.DATA);
         Map<String, String> attr = Map.of();
         DiscoveryNode local = new DiscoveryNode("local_data", buildNewFakeTransportAddress(), attr, data, null);
         DiscoveryNodes nodes = new DiscoveryNodes.Builder()

--- a/server/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasITest.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
-import com.google.common.collect.Sets;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.expression.symbol.Symbol;
@@ -127,7 +126,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
             clusterService.state(), routingProvider, null, null, SessionContext.systemSessionContext());
 
         Set<String> tables = new HashSet<>();
-        Set<String> expectedTables = Sets.newHashSet(getFqn("t2"), getFqn("t3"));
+        Set<String> expectedTables = Set.of(getFqn("t2"), getFqn("t3"));
         int numShards = 0;
         for (Map.Entry<String, Map<String, IntIndexedContainer>> nodeEntry : routing.locations().entrySet()) {
             for (Map.Entry<String, IntIndexedContainer> indexEntry : nodeEntry.getValue().entrySet()) {

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
@@ -46,6 +45,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
@@ -83,8 +83,8 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
             .putCustom(
                 UserDefinedFunctionsMetadata.TYPE,
                 UserDefinedFunctionsMetadata.of(
-                    new UserDefinedFunctionMetadata("new_schema", "my_function", ImmutableList.of(), DataTypes.STRING,
-                        "burlesque", "Hello, World!Q")
+                    new UserDefinedFunctionMetadata("new_schema", "my_function", List.of(), DataTypes.STRING,
+                                                    "burlesque", "Hello, World!Q")
                 )
             ).build();
         assertThat(Schemas.getNewCurrentSchemas(metadata), containsInAnyOrder("doc", "new_schema"));

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -1,6 +1,5 @@
 package io.crate.metadata.doc;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -19,6 +18,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class DocTableInfoTest extends ESTestCase {
@@ -29,23 +29,23 @@ public class DocTableInfoTest extends ESTestCase {
 
         DocTableInfo info = new DocTableInfo(
             relationName,
-            ImmutableList.of(
+            List.of(
                 new Reference(
-                    new ReferenceIdent(relationName, new ColumnIdent("o", ImmutableList.of())),
+                    new ReferenceIdent(relationName, new ColumnIdent("o", List.of())),
                     RowGranularity.DOC,
                     DataTypes.UNTYPED_OBJECT,
                     null,
                     null
                 )
             ),
-            ImmutableList.of(),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
+            List.of(),
             Map.of(),
             Map.of(),
             Map.of(),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             null,
             true,
             new String[0],
@@ -54,8 +54,8 @@ public class DocTableInfoTest extends ESTestCase {
             5,
             "0",
             Settings.EMPTY,
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             ColumnPolicy.DYNAMIC,
             Version.CURRENT,
             null,
@@ -63,11 +63,11 @@ public class DocTableInfoTest extends ESTestCase {
             Operation.ALL
         );
 
-        Reference foobar = info.getReference(new ColumnIdent("o", ImmutableList.of("foobar")));
+        Reference foobar = info.getReference(new ColumnIdent("o", List.of("foobar")));
         assertNull(foobar);
-        DynamicReference reference = info.getDynamic(new ColumnIdent("o", ImmutableList.of("foobar")), false);
+        DynamicReference reference = info.getDynamic(new ColumnIdent("o", List.of("foobar")), false);
         assertNull(reference);
-        reference = info.getDynamic(new ColumnIdent("o", ImmutableList.of("foobar")), true);
+        reference = info.getDynamic(new ColumnIdent("o", List.of("foobar")), true);
         assertNotNull(reference);
         assertSame(reference.valueType(), DataTypes.UNDEFINED);
     }
@@ -91,15 +91,15 @@ public class DocTableInfoTest extends ESTestCase {
 
         DocTableInfo info = new DocTableInfo(
             dummy,
-            ImmutableList.of(strictParent),
-            ImmutableList.of(),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(strictParent),
+            List.of(),
+            List.of(),
+            List.of(),
             Map.of(),
             references,
             Map.of(),
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             null,
             true,
             new String[0],
@@ -108,8 +108,8 @@ public class DocTableInfoTest extends ESTestCase {
             5,
             "0",
             Settings.EMPTY,
-            ImmutableList.of(),
-            ImmutableList.of(),
+            List.of(),
+            List.of(),
             ColumnPolicy.DYNAMIC,
             Version.CURRENT,
             null,

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner;
 
-import com.google.common.collect.Lists;
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.Row;
 import io.crate.exceptions.VersioninigValidationException;
@@ -44,6 +43,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static io.crate.testing.TestingHelpers.isDocKey;
 import static java.util.Collections.singletonList;
@@ -86,8 +86,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testMultiDeletePlan() throws Exception {
         DeleteById plan = e.plan("delete from users where id in (1, 2)");
         assertThat(plan.docKeys().size(), is(2));
-        List<String> docKeys = Lists.newArrayList(plan.docKeys())
-            .stream()
+        List<String> docKeys = StreamSupport.stream(plan.docKeys().spliterator(), false)
             .map(x -> x.getId(txnCtx, e.nodeCtx, Row.EMPTY, SubQueryResults.EMPTY))
             .collect(Collectors.toList());
 

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -44,7 +43,7 @@ import static org.hamcrest.Matchers.containsString;
 
 public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final List<String> EXPLAIN_TEST_STATEMENTS = ImmutableList.of(
+    private static final List<String> EXPLAIN_TEST_STATEMENTS = List.of(
         "select 1 as connected",
         "select id from sys.cluster",
         "select id from users order by id",

--- a/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -2,7 +2,6 @@ package io.crate.planner;
 
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.google.common.collect.Iterables;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.EvalProjection;
@@ -59,7 +58,7 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         MergePhase mergePhase = merge.mergePhase();
 
-        assertEquals(DataTypes.LONG, Iterables.get(mergePhase.inputTypes(), 0));
+        assertEquals(DataTypes.LONG, mergePhase.inputTypes().iterator().next());
         assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
     }
 
@@ -83,7 +82,7 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         MergePhase mergePhase = merge.mergePhase();
 
-        assertEquals(DataTypes.LONG, Iterables.get(mergePhase.inputTypes(), 0));
+        assertEquals(DataTypes.LONG, mergePhase.inputTypes().iterator().next());
         assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
     }
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.google.common.collect.Iterables;
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.RowN;
 import io.crate.exceptions.UnsupportedFeatureException;
@@ -224,7 +223,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         MergePhase mergePhase = globalAggregate.mergePhase();
 
-        assertEquals(CountAggregation.LongStateType.INSTANCE, Iterables.get(mergePhase.inputTypes(), 0));
+        assertEquals(CountAggregation.LongStateType.INSTANCE, mergePhase.inputTypes().iterator().next());
         assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
     }
 

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -23,7 +23,6 @@
 package io.crate.planner.consumer;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.google.common.collect.Iterables;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.phases.CollectPhase;
@@ -51,7 +50,6 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.node.dql.Collect;
-import io.crate.planner.node.dql.join.Join;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SymbolMatchers;
@@ -59,14 +57,12 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isAggregation;
-import static io.crate.testing.SymbolMatchers.isInputColumn;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static java.util.Collections.singletonList;
@@ -136,7 +132,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(localMerge.numUpstreams(), is(2));
         assertThat(localMerge.nodeIds().size(), is(1));
-        assertThat(Iterables.getOnlyElement(localMerge.nodeIds()), is(NODE_ID));
+        assertThat(localMerge.nodeIds().iterator().next(), is(NODE_ID));
         assertEquals(mergePhase.outputTypes(), localMerge.inputTypes());
 
         assertThat(localMerge.projections(), empty());

--- a/server/src/test/java/io/crate/planner/consumer/OrderByPositionVisitorTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/OrderByPositionVisitorTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.consumer;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -31,13 +30,15 @@ import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import java.util.List;
+
 public class OrderByPositionVisitorTest extends ESTestCase {
 
     @Test
     public void testOrderByPositionInputs() throws Exception {
         int[] orderByPositions = OrderByPositionVisitor.orderByPositions(
-            ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1), new InputColumn(0)),
-            ImmutableList.<Symbol>of(Literal.BOOLEAN_TRUE, Literal.of(1))
+            List.<Symbol>of(new InputColumn(0), new InputColumn(1), new InputColumn(0)),
+            List.<Symbol>of(Literal.BOOLEAN_TRUE, Literal.of(1))
         );
         assertArrayEquals(new int[]{0, 1, 0}, orderByPositions);
     }
@@ -46,8 +47,8 @@ public class OrderByPositionVisitorTest extends ESTestCase {
     public void testSymbols() throws Exception {
         Reference ref = TestingHelpers.createReference("column", DataTypes.STRING);
         int[] orderByPositions = OrderByPositionVisitor.orderByPositions(
-            ImmutableList.of(ref, new InputColumn(1), new InputColumn(0)),
-            ImmutableList.of(ref, Literal.of(1))
+            List.of(ref, new InputColumn(1), new InputColumn(0)),
+            List.of(ref, Literal.of(1))
         );
         assertArrayEquals(new int[]{0, 1, 0}, orderByPositions);
     }

--- a/server/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/server/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.node;
 
-import com.google.common.collect.Sets;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
@@ -43,6 +42,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.core.Is.is;
@@ -70,7 +70,7 @@ public class MergeNodeTest extends ESTestCase {
             "merge",
             2,
             1,
-            Sets.newHashSet("node1", "node2"),
+            Set.of("node1", "node2"),
             List.of(DataTypes.UNDEFINED, DataTypes.STRING),
             projections,
             DistributionInfo.DEFAULT_BROADCAST,

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.node.dql;
 
-import com.google.common.collect.Sets;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.NestedLoopPhase;
@@ -43,6 +42,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -102,7 +102,7 @@ public class JoinPhaseTest extends ESTestCase {
             mp2,
             2,
             3,
-            Sets.newHashSet("node1", "node2"),
+            Set.of("node1", "node2"),
             JoinType.FULL,
             joinCondition,
             List.of(DataTypes.LONG, DataTypes.STRING, new ArrayType<>(DataTypes.INTEGER)),
@@ -142,7 +142,7 @@ public class JoinPhaseTest extends ESTestCase {
             mp2,
             2,
             3,
-            Sets.newHashSet("node1", "node2"),
+            Set.of("node1", "node2"),
             joinCondition,
             List.of(Literal.of("testLeft"), Literal.of(10)),
             List.of(Literal.of("testRight"), Literal.of(20)),

--- a/server/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
@@ -23,8 +23,6 @@
 package io.crate.planner.node.fetch;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.crate.execution.dsl.phases.FetchPhase;
 import io.crate.metadata.Reference;
@@ -38,6 +36,8 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.hamcrest.Matchers.is;
@@ -50,7 +50,7 @@ public class FetchPhaseTest {
 
         RelationName t1 = new RelationName(Schemas.DOC_SCHEMA_NAME, "t1");
 
-        TreeMap<String, Integer> bases = new TreeMap<String, Integer>();
+        TreeMap<String, Integer> bases = new TreeMap<>();
         bases.put(t1.name(), 0);
         bases.put("i2", 1);
 
@@ -64,10 +64,10 @@ public class FetchPhaseTest {
 
         FetchPhase orig = new FetchPhase(
             1,
-            ImmutableSet.<String>of("node1", "node2"),
+            Set.of("node1", "node2"),
             bases,
             tableIndices,
-            ImmutableList.of(name)
+            List.of(name)
         );
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/server/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
-import com.google.common.collect.Sets;
 import io.crate.metadata.RelationName;
 import io.crate.testing.T3;
 import org.junit.Test;
@@ -31,6 +30,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -63,7 +63,7 @@ public class JoinOrderingTest {
         occurrences.put(T3.T2, 1);
         occurrences.put(T3.T3, 1);
         occurrences.put(T3.T4, 1);
-        Set<Set<RelationName>> sets = Sets.newLinkedHashSet();
+        Set<Set<RelationName>> sets = new LinkedHashSet<>();
         sets.add(Set.of(T3.T1, T3.T2));
         sets.add(Set.of(T3.T2, T3.T3));
         sets.add(Set.of(T3.T3, T3.T4));
@@ -74,8 +74,8 @@ public class JoinOrderingTest {
     public void testOptimizeJoinNoPresort() throws Exception {
         Collection<RelationName> qualifiedNames = JoinOrdering.orderByJoinConditions(
             Arrays.asList(T3.T1, T3.T2, T3.T3),
-            Set.of(Sets.newLinkedHashSet(List.of(T3.T1, T3.T2))),
-            Set.of(Sets.newLinkedHashSet(List.of(T3.T2, T3.T3)))
+            Set.of(new LinkedHashSet<>(List.of(T3.T1, T3.T2))),
+            Set.of(new LinkedHashSet<>(List.of(T3.T2, T3.T3)))
         );
         assertThat(qualifiedNames, contains(T3.T1, T3.T2, T3.T3));
     }

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
@@ -22,14 +22,13 @@
 
 package io.crate.protocols.postgres.types;
 
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeParseException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 
 public class TimestampTypeTest extends BasePGTypeTest<Long> {
@@ -55,15 +54,15 @@ public class TimestampTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testEncodeAsUTF8Text() {
-        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(1467072000000L), StandardCharsets.UTF_8),
+        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(1467072000000L), UTF_8),
             is("2016-06-28 00:00:00.000+00"));
-        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(-93661920000000L), StandardCharsets.UTF_8),
+        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(-93661920000000L), UTF_8),
             is("1000-12-22 00:00:00.000+00 BC"));
     }
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedNumberOfFractionDigits() {
         expectedException.expect(DateTimeParseException.class);
-        TimestampType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(Charsets.UTF_8));
+        TimestampType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
@@ -22,13 +22,11 @@
 
 package io.crate.protocols.postgres.types;
 
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 
 public class TimestampZTypeTest extends BasePGTypeTest<Long> {
@@ -54,9 +52,9 @@ public class TimestampZTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testEncodeAsUTF8Text() {
-        assertThat(new String(TimestampZType.INSTANCE.encodeAsUTF8Text(1467072000000L), StandardCharsets.UTF_8),
+        assertThat(new String(TimestampZType.INSTANCE.encodeAsUTF8Text(1467072000000L), UTF_8),
             is("2016-06-28 00:00:00.000+00"));
-        assertThat(new String(TimestampZType.INSTANCE.encodeAsUTF8Text(-93661920000000L), StandardCharsets.UTF_8),
+        assertThat(new String(TimestampZType.INSTANCE.encodeAsUTF8Text(-93661920000000L), UTF_8),
             is("1000-12-22 00:00:00.000+00 BC"));
     }
 
@@ -64,6 +62,6 @@ public class TimestampZTypeTest extends BasePGTypeTest<Long> {
     public void testDecodeUTF8TextWithUnexpectedNumberOfFractionDigits() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot parse more than 9 digits for fraction of a second");
-        TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(Charsets.UTF_8));
+        TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
     }
 }

--- a/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.rest.action;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.Row;
@@ -46,12 +45,12 @@ import java.util.List;
 
 public class RestActionReceiversTest extends ESTestCase {
 
-    private final ImmutableList<RowN> rows = ImmutableList.of(
+    private final List<RowN> rows = List.of(
         new RowN("foo", 1, true),
         new RowN("bar", 2, false),
         new RowN("foobar", 3, null)
     );
-    private final List<Symbol> fields = ImmutableList.of(
+    private final List<Symbol> fields = List.of(
         new ScopedSymbol(new RelationName("doc", "dummy"), ColumnIdent.fromPath("doc.col_a"), DataTypes.STRING),
         new ScopedSymbol(new RelationName("doc", "dummy"), ColumnIdent.fromPath("doc.col_b"), DataTypes.INTEGER),
         new ScopedSymbol(new RelationName("doc", "dummy"), ColumnIdent.fromPath("doc.col_c"), DataTypes.BOOLEAN)

--- a/server/src/test/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/test/java/io/crate/testing/DataTypeTesting.java
@@ -27,7 +27,6 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.BiasedNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import com.google.common.base.Joiner;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -147,7 +146,7 @@ public class DataTypeTesting {
         for (int i = 0; i < 8; i++) {
             parts[i] = Integer.toHexString(random.nextInt(2 ^ 16));
         }
-        return Joiner.on(":").join(parts);
+        return String.join(":", parts);
     }
 
     private static String randomIPv4Address(Random random) {

--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -66,7 +66,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Remove guava usage in the serve test code.
However, there are still guava usages left, but it would require removing it from the production code first.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
