### PR TITLE
Fix PgArray#encodeAsUTF8Text for escaped double quotes.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,4 +58,7 @@ None
 Fixes
 =====
 
-None
+- Fixed an issue that caused an error when a client using the PostgreSQL
+  wire protocol is used to retrieve array values containing a escaped
+  double quotes. For example, the JDBC client failed with ``Can't extract
+  array data from JDBC array``.

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -189,7 +189,8 @@ public class PGArray extends PGType<List<Object>> {
                     if (isJson) {
                         for (byte aByte : bytes) {
                             // Escape double quotes with backslash for json
-                            if ((char) aByte == '"') {
+                            var ch = (char) aByte;
+                            if (ch == '"' || ch == '\\') {
                                 encodedValues.add((byte) '\\');
                             }
                             encodedValues.add(aByte);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The issue occurred only when the pg wire protocol.
The querying of string arrays that contain values with
escaped double quotes would fail. For example, the following
select query fails because the string representation of the
pg array is not convertible to internal array string type
due to the wrong encoding::

    CREATE TABLE t (obj OBJECT(DYNAMIC));
    INSERT INTO t VALUES('{"k":[{"k":" foo\" "}]}');
    SELECT obj['k'] FROM t;


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
