### PR TITLE
Limit workers used for snapshot operation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that led to a spike in the snapshot threadpool queue when
+  taking snapshots.
+
 - Fixed an issue that caused an error when a client using the PostgreSQL
   wire protocol is used to retrieve array values containing a escaped
   double quotes. For example, the JDBC client failed with ``Can't extract

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -111,6 +111,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1236,8 +1237,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
             final Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
             // Start as many workers as fit into the snapshot pool at once at the most
-            //TODO find a better solution heres
-            final int workers = indexIncrementalFileCount;
+            final int maxPoolSize = executor instanceof ThreadPoolExecutor
+                ? ((ThreadPoolExecutor) executor).getMaximumPoolSize()
+                : 1;
+            final int workers = Math.min(maxPoolSize, indexIncrementalFileCount);
             final ActionListener<Void> filesListener = ActionListener.delegateResponse(
                 new GroupedActionListener<>(allFilesUploadedListener, workers), (l, e) -> {
                     filesToSnapshot.clear(); // Stop uploading the remaining files if we run into any exception


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The ES patch wasn't applied correctly.

See https://github.com/elastic/elasticsearch/blob/04200361f4fb2e17203612020ef4e379a53aef70/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java#L2081

This could lead spawning a lot more operations in the snapshot threadpool than
there are threads available.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)