### PR TITLE
Fix a type inference error when using eclipse jdt

### DIFF
--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -129,6 +129,7 @@ public final class TransportAnalyzeAction {
         );
     }
 
+    @SuppressWarnings("unchecked")
     public CompletableFuture<AcknowledgedResponse> fetchSamplesThenGenerateAndPublishStats() {
         ArrayList<CompletableFuture<Map.Entry<RelationName, Stats>>> futures = new ArrayList<>();
         for (SchemaInfo schema : schemas) {
@@ -149,8 +150,7 @@ public final class TransportAnalyzeAction {
             }
         }
         return CompletableFutures.allAsList(futures)
-            .thenApply(entries -> Map.ofEntries(entries.toArray(new Map.Entry[0])))
-            .thenCompose(entries -> publishTableStats((Map<RelationName, Stats>)(Map) entries));
+            .thenCompose(entries -> publishTableStats(Map.ofEntries(entries.toArray(new Map.Entry[0]))));
     }
 
     private CompletableFuture<AcknowledgedResponse> publishTableStats(Map<RelationName, Stats> newTableStats) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `thenApply` is unnecessary and caused a error message about not being able to infer the generic type when using
eclipse.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)