### PR TITLE
Prevent a IndexShardClosedException on sys.shards queries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``IndexShardClosedException`` when
+  querying the ``sys.shards`` table.
+
 - Fixed an issue that led to a spike in the snapshot threadpool queue when
   taking snapshots.
 

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.seqno.RetentionLease;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreStats;
 
@@ -357,7 +358,7 @@ public class ShardRowContext {
     public Long retentionLeasesPrimaryTerm() {
         try {
             return indexShard.getRetentionLeaseStats().leases().primaryTerm();
-        } catch (AlreadyClosedException e) {
+        } catch (AlreadyClosedException | IndexShardClosedException e) {
             return null;
         }
     }
@@ -365,7 +366,7 @@ public class ShardRowContext {
     public Long retentionLeasesVersion() {
         try {
             return indexShard.getRetentionLeaseStats().leases().version();
-        } catch (AlreadyClosedException e) {
+        } catch (AlreadyClosedException | IndexShardClosedException e) {
             return null;
         }
     }
@@ -373,7 +374,7 @@ public class ShardRowContext {
     public Collection<RetentionLease> retentionLeases() {
         try {
             return indexShard.getRetentionLeaseStats().leases().leases();
-        } catch (AlreadyClosedException e) {
+        } catch (AlreadyClosedException | IndexShardClosedException e) {
             return List.of();
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Found via test failure:

    ./gradlew :server:test -Dtests.seed=A49E69D848B0D9F4 -Dtests.class=io.crate.execution.engine.collect.ShardCollectorProviderTest -Dtests.method="testQuerySysShardsWhileDropTable" -Dtests.locale=nb -Dtests.timezone=Europe/Guernsey

    ShardCollectorProviderTest > testQuerySysShardsWhileDropTable FAILED
        org.elasticsearch.index.shard.IndexShardClosedException at [A49E69D848B0D9F4:95662C3C28B2B2C6]:0
    [fdowuay.t2/-8iXdajeQ2iZUAjk4Ti5UA][[fdowuay.t2][0]] org.elasticsearch.index.shard.IndexShardClosedException: CurrentState[CLOSED] operation only allowed when not closed
    	at __randomizedtesting.SeedInfo.seed([A49E69D848B0D9F4:95662C3C28B2B2C6]:0)
    	at org.elasticsearch.index.shard.IndexShard.verifyNotClosed(IndexShard.java:1634)
    	at org.elasticsearch.index.shard.IndexShard.verifyNotClosed(IndexShard.java:1628)
    	at org.elasticsearch.index.shard.IndexShard.getRetentionLeaseStats(IndexShard.java:1976)
    	at io.crate.expression.reference.sys.shard.ShardRowContext.retentionLeasesPrimaryTerm(ShardRowContext.java:359)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)