### PR TITLE
Allow super users to drop corrupted tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,9 @@ Changes
 Fixes
 =====
 
+- Changed the ``DROP TABLE`` logic to allow super users to drop tables with a
+  corrupted schema.
+
 - Fixed an issue that could lead to a ``IndexShardClosedException`` when
   querying the ``sys.shards`` table.
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.metadata.RelationName;
 import io.crate.metadata.table.TableInfo;
 
 import javax.annotation.Nullable;
@@ -32,9 +33,15 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
     @Nullable
     private final T tableInfo;
 
-    AnalyzedDropTable(@Nullable T tableInfo, boolean dropIfExists) {
+    private final RelationName tableName;
+
+    private final boolean maybeCorrupt;
+
+    AnalyzedDropTable(@Nullable T tableInfo, boolean dropIfExists, RelationName tableName, boolean maybeCorrupt) {
         this.tableInfo = tableInfo;
         this.dropIfExists = dropIfExists;
+        this.tableName = tableName;
+        this.maybeCorrupt = maybeCorrupt;
     }
 
     @Nullable
@@ -44,6 +51,14 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
 
     public boolean dropIfExists() {
         return dropIfExists;
+    }
+
+    public RelationName tableName() {
+        return tableName;
+    }
+
+    public boolean maybeCorrupt() {
+        return maybeCorrupt;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -86,7 +86,6 @@ import io.crate.license.LicenseService;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
-import io.crate.metadata.table.TableInfo;
 import io.crate.planner.consumer.UpdatePlanner;
 import io.crate.planner.node.dcl.GenericDCLPlan;
 import io.crate.planner.node.ddl.AlterBlobTablePlan;
@@ -351,11 +350,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitDropTable(AnalyzedDropTable<?> dropTable, PlannerContext context) {
-        TableInfo table = dropTable.table();
-        if (table == null) {
-            return NoopPlan.INSTANCE;
-        }
-        return new DropTablePlan(table, dropTable.dropIfExists());
+        return new DropTablePlan(dropTable);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -44,6 +44,14 @@ public class CreateTableIntegrationTest extends SQLTransportIntegrationTest {
                                    "with (number_of_replicas = 0)");
     }
 
+    @Test
+    public void test_allow_drop_of_corrupted_table() throws Exception {
+        execute("create table tbl (\"created\" timestamp without time zone generated always as 'timestamp without time zone')");
+        execute("drop table tbl");
+        execute("select count(*) from information_schema.tables where table_name = 'tbl'");
+        assertThat(response.rows()[0][0], is(0L));
+    }
+
     private void executeCreateTableThreaded(final String statement) throws Throwable {
         ExecutorService executorService = Executors.newFixedThreadPool(20);
         final AtomicReference<Throwable> lastThrowable = new AtomicReference<>();

--- a/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -25,6 +25,8 @@ package io.crate.planner;
 import io.crate.planner.node.ddl.DropTablePlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,8 +55,9 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropTableIfExistsWithUnknownSchema() throws Exception {
-        Plan plan = e.plan("drop table if exists unknown_schema.unknwon_table");
-        assertThat(plan, instanceOf(NoopPlan.class));
+        DropTablePlan plan = e.plan("drop table if exists unknown_schema.unknwon_table");
+        assertThat(plan.tableInfo(), Matchers.nullValue());
+        assertThat(plan.dropTable().maybeCorrupt(), is(false));
     }
 
     @Test
@@ -64,9 +67,10 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testDropTableIfExistsNonExistentTableCreatesNoop() throws Exception {
-        Plan plan = e.plan("drop table if exists groups");
-        assertThat(plan, instanceOf(NoopPlan.class));
+    public void testDropTableIfExistsNonExistentTableCreatesPlanWithoutTableInfo() throws Exception {
+        DropTablePlan plan = e.plan("drop table if exists groups");
+        assertThat(plan.tableInfo(), Matchers.nullValue());
+        assertThat(plan.dropTable().maybeCorrupt(), is(false));
     }
 
 
@@ -83,8 +87,9 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testDropNonExistentBlobTableCreatesNoop() throws Exception {
-        Plan plan = e.plan("drop blob table if exists unknown");
-        assertThat(plan, instanceOf(NoopPlan.class));
+    public void testDropNonExistentBlobTableCreatesPlanWithoutTableInfo() throws Exception {
+        DropTablePlan plan = e.plan("drop blob table if exists unknown");
+        assertThat(plan.tableInfo(), Matchers.nullValue());
+        assertThat(plan.dropTable().maybeCorrupt(), is(false));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Due to bugs in other places it may be possible to have tables in the 
cluster that contain a schema which cannot be parsed anymore.

That currently causes a lot of queries to fail. For example
`information_schema.tables` cannot be queried anymore because it attempts
to load all the tables.

This adds an escape hatch for super users to that tables which are bad can
be deleted.


## Follow up actions

- [ ] Tighten the CREATE and ALTER table logic to prevent tables from becoming
  invalid. For example by attempting to parse the new metadata into a
  `DocTableInfo` before the cluster state update is finished.

- [ ] Allow to query `information_schema.tables` & others if a table cannot be parsed? 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)