### PR TITLE
Ensure TableInfo can be created for new indices

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,10 @@ Changes
 Fixes
 =====
 
+- Improved the validation logic for ``CREATE TABLE`` statements to prevent
+  users from creating tables that cannot be used due to an invalid schema
+  definition.
+
 - Changed the ``DROP TABLE`` logic to allow super users to drop tables with a
   corrupted schema.
 

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -152,7 +152,7 @@ public class Analyzer {
                     SessionSettingRegistry sessionSettingRegistry
     ) {
         this.relationAnalyzer = relationAnalyzer;
-        this.dropTableAnalyzer = new DropTableAnalyzer(schemas);
+        this.dropTableAnalyzer = new DropTableAnalyzer(clusterService, schemas);
         this.dropCheckConstraintAnalyzer = new DropCheckConstraintAnalyzer(schemas);
         this.userManager = userManager;
         this.createTableStatementAnalyzer = new CreateTableStatementAnalyzer(nodeCtx);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -19,6 +19,38 @@
 
 package org.elasticsearch.node;
 
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.cluster.node.DiscoveryNode.getRolesFromSettings;
+import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
+
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SNIHostName;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.BooleanQuery;
@@ -28,8 +60,8 @@ import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionModule;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.client.Client;
@@ -54,7 +86,6 @@ import org.elasticsearch.cluster.routing.LazilyInitializedRerouteService;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdMonitor;
 import org.elasticsearch.cluster.service.ClusterService;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.component.Lifecycle;
@@ -77,13 +108,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
-import io.crate.common.unit.TimeValue;
-import io.crate.netty.EventLoopGroups;
-
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import io.crate.common.io.IOUtils;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
@@ -131,35 +158,14 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
-import javax.net.ssl.SNIHostName;
-import java.io.BufferedWriter;
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.cluster.node.DiscoveryNode.getRolesFromSettings;
-import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
+import io.crate.common.io.IOUtils;
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
+import io.crate.execution.engine.window.WindowFunctionModule;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.tablefunctions.TableFunctionModule;
+import io.crate.metadata.settings.session.SessionSettingModule;
+import io.crate.netty.EventLoopGroups;
 
 /**
  * A node represent a node within a cluster ({@code cluster.name}). The {@link #client()} can be used
@@ -322,6 +328,11 @@ public class Node implements Closeable {
             for (Module pluginModule : pluginsService.createGuiceModules()) {
                 modules.add(pluginModule);
             }
+            modules.add(new SessionSettingModule());
+            modules.add(new AggregationImplModule());
+            modules.add(new ScalarFunctionModule());
+            modules.add(new TableFunctionModule());
+            modules.add(new WindowFunctionModule());
             final MonitorService monitorService = new MonitorService(settings,
                                                                      nodeEnvironment,
                                                                      threadPool,
@@ -408,7 +419,8 @@ public class Node implements Closeable {
                 settingsModule.getIndexScopedSettings(),
                 threadPool,
                 xContentRegistry,
-                forbidPrivateIndexSettings);
+                forbidPrivateIndexSettings
+            );
 
             final Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class).stream()
                 .flatMap(p -> p.createComponents(client, clusterService, threadPool,

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -1087,13 +1087,6 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testOrphanedPartition() throws Exception {
-        prepareCreate(".partitioned.foo.04138").execute().get();
-        execute("select table_name from information_schema.tables where table_schema='doc'");
-        assertThat(response.rowCount(), is(0L));
-    }
-
-    @Test
     public void testSelectGeneratedColumnFromInformationSchemaColumns() {
         execute("create table t (lastname string, firstname string, name as (lastname || '_' || firstname)) " +
                 "with (number_of_replicas = 0)");

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1760,13 +1760,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertEquals("t| 04132\n", printedTable(response.rows()));
     }
 
-    @Test
-    public void testStartPartitionWithMissingTable() throws Exception {
-        // ensureYellow must succeed
-        String partition = ".partitioned.parted.04130";
-        client().admin().indices().prepareCreate(partition).execute().actionGet();
-        ensureYellow();
-    }
 
     @Test
     public void testCreateTableWithIllegalCustomSchemaCheckedByES() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds additional validation to the create-index action to ensure that new
indices can be parsed into a TableInfo

Should prevent bugs where users were able to create broken tables.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)