### PR TITLE
Fix functions resolution for text types with different limit lengths.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,13 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would prevent function resolution for arguments that
+  contain both text types with and without length limit. For example,
+  statements as following would fail with the unknown function exception::
+
+    CREATE TABLE tbl (str VARCHAR(3))
+    SELECT * FROM tbl WHERE str = 'x'
+
 - Improved the validation logic for ``CREATE TABLE`` and ``ALTER TABLE``
   statements to prevent users from creating tables that cannot be used due to
   an invalid schema definition.

--- a/server/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/server/src/main/java/io/crate/types/TypeCompatibility.java
@@ -94,8 +94,20 @@ public final class TypeCompatibility {
         if (fromTypeParameters.size() != toTypeParameters.size()) {
             if (fromType.id() == ObjectType.ID && toType.id() == ObjectType.ID) {
                 return fromTypeParameters.size() > toTypeParameters.size() ? fromType : toType;
+            } else if (fromType.id() == StringType.ID && toType.id() == StringType.ID) {
+                if (((StringType) fromType).unbound() || ((StringType) toType).unbound()) {
+                    return StringType.INSTANCE;
+                }
             }
             return null;
+        } else {
+            if (fromType.id() == StringType.ID && toType.id() == StringType.ID) {
+                if (((StringType) fromType).lengthLimit() > ((StringType) toType).lengthLimit()) {
+                    return fromType;
+                } else {
+                    return toType;
+                }
+            }
         }
 
         for (int i = 0; i < fromTypeParameters.size(); i++) {

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.metadata.functions;
 
+import io.crate.types.StringType;
 import org.elasticsearch.test.ESTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -278,7 +279,20 @@ public class SignatureBinderTest extends ESTestCase {
             .boundTo("bigint")
             .withCoercion()
             .fails();
+    }
 
+    @Test
+    public void test_bind_type_text_types_with_limit_length_binds_type_with_highest_length() {
+        var signature = functionSignature()
+            .argumentTypes(parseTypeSignature("E"), parseTypeSignature("E"))
+            .returnType(DataTypes.BOOLEAN.getTypeSignature())
+            .typeVariableConstraints(List.of(typeVariable("E")))
+            .build();
+
+        assertThat(signature)
+            .boundTo(StringType.of(1), StringType.of(2))
+            .produces(new BoundVariables(
+                Map.of("E", type(StringType.of(2).getTypeSignature().toString()))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
+++ b/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+class TypeCompatibilityTest {
+
+    @Test
+    void test_get_common_type_for_text_type_return_text_unbound_if_one_of_types_is_unbound() {
+        var commonType = TypeCompatibility.getCommonType(StringType.INSTANCE, StringType.of(1));
+        assertThat(commonType, is(StringType.INSTANCE));
+    }
+
+    @Test
+    void test_get_common_type_for_text_with_len_limit_return_text_with_highest_length() {
+        var commonType = TypeCompatibility.getCommonType(StringType.of(2), StringType.of(1));
+        assertThat(commonType, is(StringType.of(2)));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The function with signatures like `func(E, E)` would fail to
bind arguments of type text if they have different limit lengths.
This change fixes the inference of the common text type for provided
text arguments by following two rules:

1. If both text types use length limit, then the common type
will be the text type with the highest length limit.
2. If either of text types is unbound, then the common type
will be the unbound text type.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
