### PR TITLE
Ensure TableInfo can be created for altered tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,9 +60,9 @@ Changes
 Fixes
 =====
 
-- Improved the validation logic for ``CREATE TABLE`` statements to prevent
-  users from creating tables that cannot be used due to an invalid schema
-  definition.
+- Improved the validation logic for ``CREATE TABLE`` and ``ALTER TABLE``
+  statements to prevent users from creating tables that cannot be used due to
+  an invalid schema definition.
 
 - Changed the ``DROP TABLE`` logic to allow super users to drop tables with a
   corrupted schema.

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
@@ -23,6 +23,7 @@
 package io.crate.execution.ddl.tables;
 
 import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.cluster.AlterTableClusterStateExecutor;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -59,7 +60,8 @@ public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterT
                                      AllocationService allocationService,
                                      IndexScopedSettings indexScopedSettings,
                                      MetadataCreateIndexService metadataCreateIndexService,
-                                     ShardLimitValidator shardLimitValidator) {
+                                     ShardLimitValidator shardLimitValidator,
+                                     NodeContext nodeContext) {
         super(ACTION_NAME,
               transportService,
               clusterService,
@@ -76,7 +78,8 @@ public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterT
             indexScopedSettings,
             indexNameExpressionResolver,
             metadataCreateIndexService,
-            shardLimitValidator
+            shardLimitValidator,
+            nodeContext
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -26,9 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.junit.Test;
 
-import io.crate.exceptions.RelationUnknown;
 
-import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)