### PR TITLE
Release memory for sharded requests to avoid circuit breaker errors

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause ``COPY`` or ``INSERT FROM QUERY`` operations
+  to fail with a circuit breaking exception, even if more memory would've been
+  available.
+
 - Fixed an issue that would prevent function resolution for arguments that
   contain both text types with and without length limit. For example,
   statements as following would fail with the unknown function exception::


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `RamAccounting` instance is only closed *after* a full COPY or
INSERT FROM QUERY operation. During the operation each new
`ShardedRequests` instance kept accounting the used memory per row, but
never released it. This would eventually cause a circuit breaker
exception even if there is memory available.

Fixes https://github.com/crate/crate/issues/10701


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)