### PR TITLE
Fix flaky testFloatSummationWithoutLosingPrecision

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -45,7 +45,8 @@ public class ArrayAggTest extends AggregationTest {
                 new Object[]{null},
                 new Object[]{42},
                 new Object[]{24}
-            }
+            },
+            true
         );
         assertThat((List<Object>) result, Matchers.contains(20, null, 42, 24));
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -44,7 +44,8 @@ public class CountAggregationTest extends AggregationTest {
             CountAggregation.SIGNATURE,
             List.of(argumentType),
             DataTypes.LONG,
-            data
+            data,
+            true
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -28,6 +28,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+
 import org.junit.Test;
 
 import java.util.List;
@@ -103,9 +104,20 @@ public class SumAggregationTest extends AggregationTest {
 
     @Test
     public void testFloatSummationWithoutLosingPrecision() throws Exception {
-        Object result = executeAggregation(DataTypes.FLOAT, DataTypes.FLOAT, new Object[][]{{0.8f}, {0.4f}, {0.2f}});
-
-        assertEquals(1.4f, result);
+        Object[][] rows = new Object[][] { { 0.8f }, { 0.4f }, { 0.2f } };
+        Signature signature = Signature.aggregate(
+            SumAggregation.NAME,
+            DataTypes.FLOAT.getTypeSignature(),
+            DataTypes.FLOAT.getTypeSignature()
+        );
+        Object result = executeAggregation(
+            signature,
+            signature.getArgumentDataTypes(),
+            signature.getReturnType().createType(),
+            rows,
+            false
+        );
+        assertThat(result, is(1.4f));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adding random reduce steps changes the result because the `error` value
is not preserved across reduce steps.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)