### PR TITLE
Use follow-tags in create_tag script

### DIFF
--- a/devs/tools/create_tag.sh
+++ b/devs/tools/create_tag.sh
@@ -95,5 +95,5 @@ fi
 
 echo "Creating tag $VERSION..."
 git tag -a "$VERSION" -m "Tag release for revision $VERSION"
-git push --tags
+git push --follow-tags
 echo "Done."


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should help prevent pushing tags that shouldn't be pushed. From the man
page:

    --follow-tags
        Push all the refs that would be pushed without this option, and also push annotated tags in
        refs/tags that are missing from the remote but are pointing at commit-ish that are reachable
        from the refs being pushed. This can also be specified with configuration variable
        push.followTags. For more information, see push.followTags in git-config(1).


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
