### PR TITLE
Fix nested table function handling

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,4 +60,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that led to an error if a user nested multiple table
+  functions.

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -47,6 +47,8 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
         private final ArrayList<WindowFunction> windowFunctions = new ArrayList<>();
         private boolean insideAggregate = false;
 
+        private int tableFunctionLevel = 0;
+
         boolean foundAggregateOrTableFunction = false;
 
         Context() {
@@ -141,9 +143,13 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
                     throw new UnsupportedOperationException("Cannot use table functions inside aggregates");
                 }
                 context.foundAggregateOrTableFunction = true;
-                context.allocateTableFunction(function);
-                return super.visitFunction(function, context);
-
+                if (context.tableFunctionLevel == 0) {
+                    context.allocateTableFunction(function);
+                }
+                context.tableFunctionLevel++;
+                super.visitFunction(function, context);
+                context.tableFunctionLevel--;
+                return null;
             default:
                 throw new UnsupportedOperationException("Invalid function type: " + type);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We need to create one ProjectSet operator per level of table function
for the execution to work correctly.

This fixes errors like the following:

    class io.crate.expression.tablefunctions.MatchesFunction$$Lambda$3842/0x0000000801701e18 cannot be cast to class java.util.List (io.crate.expression.tablefunctions.MatchesFunction$$Lambda$3842/0x0000000801701e18


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)