### PR TITLE
Broken link to `rolling_upgrade#step-2-graceful-stop` - #10447

### DIFF
--- a/docs/sql/statements/alter-cluster.rst
+++ b/docs/sql/statements/alter-cluster.rst
@@ -115,4 +115,4 @@ The ``ALTER CLUSTER GC DANGLING ARTIFACTS`` command can be used to remove all
 artifacts created by such operations.
 
 
-.. _Graceful stop: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html#step-2-graceful-stop
+.. _Graceful stop: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html#step-2-graceful-stop


### PR DESCRIPTION
Fixing link as per issue comment

## Summary of the changes / Why this improves CrateDB

Fix documentation

## Checklist

 - [N/A] Added an entry in `CHANGES.txt` for user facing changes
 - [N/A] Updated documentation & `sql_features` table for user facing changes
 - [N/A] Touched code is covered by tests
 - [Y] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [Y] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
