### PR TITLE
Backport of ES auto expanding changes 

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -362,6 +362,7 @@ should be crossed out as well.
 - [x] 0260c6f55c4 ThreadPool and ThreadContext are not closeable (#43249)
 - [x] 5aa5d7b54b9 Ignore Lucene index in peer recovery if translog corrupted (#49114)
 - [s] 0f6ffc20a53 Refactor percolator's QueryAnalyzer to use QueryVisitors (#49238)
+- [x] 508b74bb90b Auto-expand indices according to allocation filtering rules (#48974)
 - [x] c1c7fa5d9c8 Remove type field from internal PutMappingRequest (#48793)
 - [x] 66f49d8ea5d Always use primary term from primary to index docs on replica (#47583)
 - [x] fbaf8c428d7 Fix Transport Stopped Exception (#48930)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -323,6 +323,7 @@ should be crossed out as well.
 - [ ] f4989c54c45 Revert "serialize initial_connect_timeout as xcontent correctly"
 - [ ] ae64eaabdae serialize initial_connect_timeout as xcontent correctly
 - [ ] fa1a7c57b8e Add remote info to the HLRC (#49657)
+- [x] 6f81d6de161 Only auto-expand replicas with allocation filtering when all nodes upgraded (#50361)
 - [ ] cec6678587e Use peer recovery retention leases for indices without soft-deletes (#50351)
 - [ ] 3b8f5d9ea18 Modify proxy mode to support a single address (#50391)
 - [ ] 342a2920a96 Rename the remote connection mode simple to proxy (#50291)

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -84,6 +85,14 @@ public abstract class AllocationDecider {
      * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
      */
     public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    /**
+     * Returns a {@link Decision} whether shards of the given index should be auto-expanded to this node at this state of the
+     * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
+     */
+    public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
         return Decision.ALWAYS;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -137,6 +138,26 @@ public class AllocationDeciders extends AllocationDecider {
                 }
             } else if (decision != Decision.ALWAYS
                         && (allocation.getDebugMode() != EXCLUDE_YES_DECISIONS || decision.type() != Decision.Type.YES)) {
+                ret.add(decision);
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public Decision shouldAutoExpandToNode(IndexMetadata indexMetaData, DiscoveryNode node, RoutingAllocation allocation) {
+        Decision.Multi ret = new Decision.Multi();
+        for (AllocationDecider allocationDecider : allocations) {
+            Decision decision = allocationDecider.shouldAutoExpandToNode(indexMetaData, node, allocation);
+            // short track if a NO is returned.
+            if (decision == Decision.NO) {
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
+            } else if (decision != Decision.ALWAYS
+                && (allocation.getDebugMode() != EXCLUDE_YES_DECISIONS || decision.type() != Decision.Type.YES)) {
                 ret.add(decision);
             }
         }

--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.allocation;
+
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ClusterScope(scope= Scope.TEST, numDataNodes=0)
+public class FilteringAllocationIT extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(InternalSettingsPlugin.class);
+        return plugins;
+    }
+
+    public void testDecommissionNodeNoReplicas() throws Exception {
+        logger.info("--> starting 2 nodes");
+        List<String> nodesIds = internalCluster().startNodes(2);
+        final String node_0 = nodesIds.get(0);
+        final String node_1 = nodesIds.get(1);
+        assertThat(cluster().size(), equalTo(2));
+
+        logger.info("--> creating an index with no replicas");
+        execute("create table test(x int, value text) clustered into ? shards with (number_of_replicas='0')",
+                new Object[]{numberOfShards()});
+
+        String tableName = getFqn("test");
+
+        for (int i = 0; i < 100; i++) {
+            execute("insert into test(x, value) values(?,?)", new Object[]{i, Integer.toString(i)});
+        }
+
+        execute("refresh table test");
+        execute("select count(*) from test");
+        assertThat(100L, is(response.rows()[0][0]));
+
+        final boolean closed = randomBoolean();
+        if (closed) {
+            execute("alter table test close");
+            ensureGreen(tableName);
+        }
+
+        logger.info("--> decommission the second node");
+        execute(" set global \"cluster.routing.allocation.exclude._name\" = ?", new Object[]{node_1});
+
+        ensureGreen(tableName);
+
+        logger.info("--> verify all are allocated on node1 now");
+        assertBusy(()-> {
+            ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+            for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+                for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                    for (ShardRouting shardRouting : indexShardRoutingTable) {
+                        assertThat(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_0));
+                    }
+                }
+            }
+        }, 20, TimeUnit.SECONDS);
+
+        if (closed) {
+            execute("alter table test open");
+            ensureGreen(tableName);
+        }
+
+        execute("select count(*) from test");
+        assertThat(100L, is(response.rows()[0][0]));
+    }
+
+    public void testAutoExpandReplicasToFilteredNodes() throws Exception {
+        logger.info("--> starting 2 nodes");
+        List<String> nodesIds = internalCluster().startNodes(2);
+        final String node_0 = nodesIds.get(0);
+        final String node_1 = nodesIds.get(1);
+        assertThat(cluster().size(), equalTo(2));
+
+        logger.info("--> creating an index with auto-expand replicas");
+        execute("create table test(x int, value text) clustered into ? shards with (number_of_replicas='0-all')",
+                new Object[]{numberOfShards()});
+
+        String tableName = getFqn("test");
+
+        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertThat(clusterState.metadata().index(tableName).getNumberOfReplicas(), equalTo(1));
+        ensureGreen(tableName);
+
+        logger.info("--> filter out the second node");
+        if (randomBoolean()) {
+            execute(" set global \"cluster.routing.allocation.exclude._name\" = ?", new Object[]{node_1});
+        } else {
+            execute(" alter table test set( \"routing.allocation.exclude._name\" = ?)", new Object[]{node_1});
+        }
+        ensureGreen(tableName);
+
+        logger.info("--> verify all are allocated on node1 now");
+        assertBusy(() -> {
+            final var cs = client().admin().cluster().prepareState().execute().actionGet().getState();
+            assertThat(cs.metadata().index(tableName).getNumberOfReplicas(), equalTo(0));
+            for (IndexRoutingTable indexRoutingTable : cs.routingTable()) {
+                for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                    for (ShardRouting shardRouting : indexShardRoutingTable) {
+                        assertThat(cs.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_0));
+                    }
+                }
+            }
+        }, 20, TimeUnit.SECONDS);
+    }
+
+    public void testDisablingAllocationFiltering() throws Exception {
+        logger.info("--> starting 2 nodes");
+        List<String> nodesIds = internalCluster().startNodes(2);
+        final String node_0 = nodesIds.get(0);
+        final String node_1 = nodesIds.get(1);
+        assertThat(cluster().size(), equalTo(2));
+
+        logger.info("--> creating an index with no replicas");
+
+        execute("create table test(x int, value text) clustered into ? shards with (number_of_replicas='0')",
+                new Object[]{numberOfShards()});
+
+        String tableName = getFqn("test");
+        ensureGreen(tableName);
+
+        logger.info("--> index some data");
+        for (int i = 0; i < 100; i++) {
+            execute("insert into test(x, value) values(?,?)", new Object[]{i, Integer.toString(i)});
+        }
+
+        execute("refresh table test");
+        execute("select count(*) from test");
+        assertThat(100L, is(response.rows()[0][0]));
+
+        final boolean closed = randomBoolean();
+        if (closed) {
+            execute("alter table test close");
+            ensureGreen(tableName);
+        }
+
+        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(tableName);
+        int numShardsOnNode1 = 0;
+        for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+            for (ShardRouting shardRouting : indexShardRoutingTable) {
+                if ("node1".equals(clusterState.nodes().get(shardRouting.currentNodeId()).getName())) {
+                    numShardsOnNode1++;
+                }
+            }
+        }
+
+        if (numShardsOnNode1 > ThrottlingAllocationDecider.DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES) {
+            execute(" set global \"cluster.routing.allocation.node_concurrent_recoveries\" = ?", new Object[]{node_1});
+            // make sure we can recover all the nodes at once otherwise we might run into a state where
+            // one of the shards has not yet started relocating but we already fired up the request to wait for 0 relocating shards.
+        }
+        logger.info("--> remove index from the first node");
+
+        if (closed) {
+            execute("alter table test open");
+        }
+        execute(" alter table test set( \"routing.allocation.exclude._name\" = ?)", new Object[]{node_0});
+        ensureGreen(tableName);
+
+        logger.info("--> verify all shards are allocated on node_1 now");
+        assertBusy(() -> {
+            final var state = client().admin().cluster().prepareState().execute().actionGet().getState();
+            for (IndexShardRoutingTable indexShardRoutingTable : state.routingTable().index(tableName)) {
+                for (ShardRouting shardRouting : indexShardRoutingTable) {
+                    assertThat(state.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_1));
+                }
+            }
+        }, 20, TimeUnit.SECONDS);
+
+        logger.info("--> disable allocation filtering ");
+        execute(" alter table test reset( \"routing.allocation.exclude._name\")");
+
+        ensureGreen(tableName);
+
+        logger.info("--> verify that there are shards allocated on both nodes now");
+        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertThat(clusterState.routingTable().index(tableName).numberOfNodesShardsAreAllocatedOn(), equalTo(2));
+    }
+
+    public void testInvalidIPFilterClusterSettings() {
+        String ipKey = randomFrom("_ip", "_host_ip", "_publish_ip");
+        Setting<String> filterSetting = randomFrom(FilterAllocationDecider.CLUSTER_ROUTING_REQUIRE_GROUP_SETTING,
+                                                   FilterAllocationDecider.CLUSTER_ROUTING_INCLUDE_GROUP_SETTING, FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP_SETTING);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> client().admin().cluster().prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put(filterSetting.getKey() + ipKey, "192.168.1.1."))
+            .execute().actionGet());
+        assertEquals("invalid IP address [192.168.1.1.] for [" + filterSetting.getKey() + ipKey + "]", e.getMessage());
+    }
+
+    public void testTransientSettingsStillApplied() {
+        List<String> nodes = internalCluster().startNodes(6);
+        Set<String> excludeNodes = new HashSet<>(nodes.subList(0, 3));
+        Set<String> includeNodes = new HashSet<>(nodes.subList(3, 6));
+        String excludeNodeIdsAsString = Strings.collectionToCommaDelimitedString(excludeNodes);
+        logger.info("--> exclude: [{}], include: [{}]",
+                    excludeNodeIdsAsString,
+                    Strings.collectionToCommaDelimitedString(includeNodes));
+        ensureStableCluster(6);
+
+        execute("create table test(x int, value text) clustered into ? shards with (number_of_replicas='0')",
+                new Object[]{numberOfShards()});
+
+        String tableName = getFqn("test");
+        ensureGreen(tableName);
+
+
+        if (randomBoolean()) {
+            execute("alter table test close");
+        }
+
+        logger.info("--> updating settings");
+        execute(" set global transient \"cluster.routing.allocation.exclude._name\" = ?",
+                new Object[]{excludeNodeIdsAsString});
+
+        logger.info("--> waiting for relocation");
+        waitForRelocation(ClusterHealthStatus.GREEN);
+
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+
+        for (ShardRouting shard : state.getRoutingTable().shardsWithState(ShardRoutingState.STARTED)) {
+            String node = state.getRoutingNodes().node(shard.currentNodeId()).node().getName();
+            logger.info("--> shard on {} - {}", node, shard);
+            assertTrue("shard on " + node + " but should only be on the include node list: " +
+                       Strings.collectionToCommaDelimitedString(includeNodes),
+                       includeNodes.contains(node));
+        }
+
+        logger.info("--> updating settings with random persistent setting");
+        execute(" set global persistent \"memory.allocation.type\" = 'off-heap'");
+        execute(" set global transient \"cluster.routing.allocation.exclude._name\" = ?",
+                new Object[]{excludeNodeIdsAsString});
+
+        logger.info("--> waiting for relocation");
+        waitForRelocation(ClusterHealthStatus.GREEN);
+
+        state = client().admin().cluster().prepareState().get().getState();
+
+        // The transient settings still exist in the state
+        assertThat(state.metadata().transientSettings(),
+                   equalTo(Settings.builder().put("cluster.routing.allocation.exclude._name",
+                                                  excludeNodeIdsAsString).build()));
+
+        for (ShardRouting shard : state.getRoutingTable().shardsWithState(ShardRoutingState.STARTED)) {
+            String node = state.getRoutingNodes().node(shard.currentNodeId()).node().getName();
+            logger.info("--> shard on {} - {}", node, shard);
+            assertTrue("shard on " + node + " but should only be on the include node list: " +
+                       Strings.collectionToCommaDelimitedString(includeNodes),
+                       includeNodes.contains(node));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See individual commits.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
