### PR TITLE
Bump JNA

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -41,7 +41,7 @@ jts=1.15.0
 log4j=1.2.7
 log4j2=2.11.1
 slf4j=1.6.2
-jna=4.2.2
+jna=5.6.0
 
 # ES test
 randomizedrunner=2.7.7


### PR DESCRIPTION
Closes #10737.

## Summary of the changes / Why this improves CrateDB
This improves running on Windows (Win10) by supplying the machinery with more recent JNA libraries.

It will fix warnings like the following:

    [WARN ][o.e.b.Natives            ] unable to load JNA native support library, native methods will be disabled.
    java.lang.UnsatisfiedLinkError: C:\Users\IEUser\AppData\Local\Temp\jna--2138670329\jna7720128946891364185.dll: Can't find dependent libraries

## Details
- https://github.com/qzind/tray/pull/427 fixed things on their end by bumping from jna 4.2.2 to 4.5.2 on Mar 1, 2019.
- This PR uses the most recent jna 5.6.0, released on Jul 14, 2020. Currently, I have no clue about any implications. Maybe we should be more conservative here? However, after manually replacing `jna-4.2.2.jar` by `jna-5.6.0.jar` within CrateDB's `lib` folder, ~~everything still works~~ CrateDB still boots up successfully without any of the warnings outlined at #10737.
- For your quick reference, the changelog of JNA can be found at https://github.com/java-native-access/jna/blob/master/CHANGES.md.
