### PR TITLE
Configure retries for linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,3 +7,4 @@ extensions = ['crate.sphinx.csv', 'sphinx_sitemap']
 linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*'  # Breaks accessibility via JS ¯\_(ツ)_/¯
 ]
+linkcheck_retries = 3


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We get sporadic 403 erros on some resources. Hopefully enabling retries
helps preventing unnecessary CI failures.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)