### PR TITLE
Add the `sys.snapshot_restore` table.

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1980,6 +1980,55 @@ partition. The mapping follows the following pattern:
     cr> DROP REPOSITORY "my_repo";
     DROP OK, 1 row affected (... sec)
 
+
+.. _sys-snapshot-restore:
+
+Snapshot Restore
+================
+
+The ``sys.snapshot_restore`` table contains information about the current
+state of snapshot restore operations.
+
+.. list-table:: pg_stats schema
+    :header-rows: 1
+
+    * - Name
+      - Description
+      - Type
+    * - ``id``
+      - The ``UUID`` of the restore snapshot operation.
+      - ``TEXT``
+    * - ``repository``
+      - The name of the repository that contains the snapshot.
+      - ``TEXT``
+    * - ``snapshot``
+      - The name of the snapshot.
+      - ``TEXT``
+    * - ``state``
+      - The current state of the snapshot restore operations. Possible states
+        are: ``INIT``, ``STARTED``, ``SUCCESS``, and ``FAILURE``.
+      - ``TEXT``
+    * - ``shards['table_schema']``
+      - The schema name of the table of the shard.
+      - ``TEXT``
+    * - ``shards['table_name']``
+      - The table name of the shard.
+      - ``TEXT``
+    * - ``shards['partition_ident']``
+      - The identifier of the partition of the shard. ``NULL`` if the is not
+        partitioned.
+      - ``TEXT``
+    * - ``shards['shard_id']``
+      - The ID of the shard.
+      - ``INTEGER``
+    * - ``shards['state']``
+      - The restore state of the shard. Possible states are: ``INIT``,
+        ``STARTED``, ``SUCCESS``, and ``FAILURE``.
+      - ``TEXT``
+
+To get more information about the restoring snapshots and shards one can join
+the ``sys.snapshot_restore`` with ``sys.shards`` or ``sys.snapshots`` table.
+
 .. _sys-summits:
 
 Summits

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added the :ref:`sys.snapshot_restore <sys-snapshot-restore>` table to track the
+  progress of the :ref:`snapshot restore <snapshot-restore>` operations.
+
 - Added support for using the optimized primary key lookup plan if additional
   filters are combined via ``AND`` operators.
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -111,11 +111,12 @@ number of replicas.
     | sys                | repositories            | BASE TABLE |             NULL | NULL               |
     | sys                | segments                | BASE TABLE |             NULL | NULL               |
     | sys                | shards                  | BASE TABLE |             NULL | NULL               |
+    | sys                | snapshot_restore        | BASE TABLE |             NULL | NULL               |
     | sys                | snapshots               | BASE TABLE |             NULL | NULL               |
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 48 rows in set (... sec)
+    SELECT 49 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshotRestoreInProgress.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshotRestoreInProgress.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.sys.snapshot;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import io.crate.metadata.IndexParts;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class SysSnapshotRestoreInProgress {
+
+    private final String id;
+    private final String name;
+    private final String repository;
+    private final String state;
+    private final List<ShardRestoreInfo> shards;
+
+    public static SysSnapshotRestoreInProgress of(RestoreInProgress.Entry entry) {
+        return new SysSnapshotRestoreInProgress(
+            entry.uuid(),
+            entry.snapshot().getSnapshotId().getName(),
+            entry.snapshot().getRepository(),
+            entry.state().name(),
+            ShardRestoreInfo.of(entry.shards())
+        );
+    }
+
+    private SysSnapshotRestoreInProgress(String id,
+                                         String name,
+                                         String repository,
+                                         String state,
+                                         List<ShardRestoreInfo> shards) {
+        this.id = id;
+        this.name = name;
+        this.repository = repository;
+        this.state = state;
+        this.shards = shards;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String repository() {
+        return repository;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String state() {
+        return state;
+    }
+
+    public List<ShardRestoreInfo> shards() {
+        return shards;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SysSnapshotRestoreInProgress that = (SysSnapshotRestoreInProgress) o;
+        return Objects.equals(id, that.id) &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(repository, that.repository) &&
+               Objects.equals(state, that.state) &&
+               Objects.equals(shards, that.shards);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, repository, state, shards);
+    }
+
+    public static class ShardRestoreInfo {
+
+        public static List<ShardRestoreInfo> of(ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards) {
+            var shardsRestoreInfo = new ArrayList<ShardRestoreInfo>(shards.size());
+            for (ObjectObjectCursor<ShardId, RestoreInProgress.ShardRestoreStatus> shardEntry : shards) {
+                ShardId shardId = shardEntry.key;
+                RestoreInProgress.ShardRestoreStatus status = shardEntry.value;
+                shardsRestoreInfo.add(
+                    new ShardRestoreInfo(
+                        shardId.getId(),
+                        new IndexParts(shardId.getIndexName()),
+                        status.state())
+                );
+            }
+            return shardsRestoreInfo;
+        }
+
+        private final int id;
+        private final IndexParts indexParts;
+        private final RestoreInProgress.State state;
+
+        public ShardRestoreInfo(int id, IndexParts indexParts, RestoreInProgress.State state) {
+            this.id = id;
+            this.indexParts = indexParts;
+            this.state = state;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public IndexParts indexParts() {
+            return indexParts;
+        }
+
+        public RestoreInProgress.State state() {
+            return state;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ShardRestoreInfo that = (ShardRestoreInfo) o;
+            return id == that.id &&
+                   Objects.equals(indexParts.getTable(), that.indexParts.getTable()) &&
+                   Objects.equals(indexParts.getSchema(), that.indexParts.getSchema()) &&
+                   Objects.equals(indexParts.getPartitionIdent(), that.indexParts.getPartitionIdent()) &&
+                   state == that.state;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, indexParts, state);
+        }
+    }
+
+}

--- a/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -58,6 +58,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysNodeChecksTableInfo.IDENT.name(), SysNodeChecksTableInfo.create());
         tableInfos.put(SysRepositoriesTableInfo.IDENT.name(), SysRepositoriesTableInfo.create(clusterService.getClusterSettings().maskedSettings()));
         tableInfos.put(SysSnapshotsTableInfo.IDENT.name(), SysSnapshotsTableInfo.create());
+        tableInfos.put(SysSnapshotRestoreTableInfo.IDENT.name(), SysSnapshotRestoreTableInfo.create());
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.create());
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), SysAllocationsTableInfo.create());
         tableInfos.put(SysHealth.IDENT.name(), SysHealth.create());

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to CRATE.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import io.crate.expression.reference.sys.snapshot.SysSnapshotRestoreInProgress;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import org.elasticsearch.cluster.RestoreInProgress;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.stream.StreamSupport;
+
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+
+public class SysSnapshotRestoreTableInfo {
+
+    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "snapshot_restore");
+
+    static SystemTable<SysSnapshotRestoreInProgress> create() {
+        return SystemTable.<SysSnapshotRestoreInProgress>builder(IDENT)
+            .add("id", STRING, SysSnapshotRestoreInProgress::id)
+            .add("name", STRING, SysSnapshotRestoreInProgress::name)
+            .add("repository", STRING, SysSnapshotRestoreInProgress::repository)
+            .startObjectArray("shards", SysSnapshotRestoreInProgress::shards)
+                .add("table_schema", STRING, s -> s.indexParts().getSchema())
+                .add("table_name", STRING, s -> s.indexParts().getTable())
+                .add("partition_ident", STRING, s -> s.indexParts().getPartitionIdent())
+                .add("shard_id", INTEGER, SysSnapshotRestoreInProgress.ShardRestoreInfo::id)
+                .add("state", STRING, s -> s.state().name())
+            .endObjectArray()
+            .add("state", STRING, SysSnapshotRestoreInProgress::state)
+            .setPrimaryKeys(
+                new ColumnIdent("id"),
+                new ColumnIdent("name"),
+                new ColumnIdent("repository"))
+            .withRouting((state, routingProvider, sessionContext) ->
+                             routingProvider.forRandomMasterOrDataNode(IDENT, state.getNodes()))
+            .build();
+    }
+
+    public static Iterable<SysSnapshotRestoreInProgress> snapshotsRestoreInProgress(
+        @Nullable RestoreInProgress restoreInProgress) {
+        if (restoreInProgress != null) {
+            return () -> StreamSupport.stream(restoreInProgress.spliterator(), false)
+                .map(SysSnapshotRestoreInProgress::of)
+                .iterator();
+        } else {
+            return Collections::emptyIterator;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -34,6 +34,7 @@ import io.crate.expression.reference.sys.shard.SysAllocations;
 import io.crate.expression.reference.sys.snapshot.SysSnapshots;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
+import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -108,6 +109,12 @@ public class SysTableDefinitions {
         tableDefinitions.put(SysSnapshotsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(sysSnapshots.currentSnapshots()),
             SysSnapshotsTableInfo.create().expressions(),
+            true));
+        tableDefinitions.put(SysSnapshotRestoreTableInfo.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(SysSnapshotRestoreTableInfo.snapshotsRestoreInProgress(
+                    clusterService.state().custom(RestoreInProgress.TYPE))
+            ),
+            SysSnapshotRestoreTableInfo.create().expressions(),
             true));
 
         tableDefinitions.put(SysAllocationsTableInfo.IDENT, new StaticTableDefinition<>(

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(42L, response.rowCount());
+        assertEquals(43L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -104,6 +104,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| repositories| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| segments| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| shards| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| snapshot_restore| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| snapshots| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| summits| sys| BASE TABLE| NULL\n")
         );
@@ -186,13 +187,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(42L, response.rowCount());
+        assertEquals(43L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(43L, response.rowCount());
+        assertEquals(44L, response.rowCount());
     }
 
     @Test
@@ -397,6 +398,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "nodes_pk| PRIMARY KEY| nodes| sys\n" +
                 "repositories_pk| PRIMARY KEY| repositories| sys\n" +
                 "shards_pk| PRIMARY KEY| shards| sys\n" +
+                "snapshot_restore_pk| PRIMARY KEY| snapshot_restore| sys\n" +
                 "snapshots_pk| PRIMARY KEY| snapshots| sys\n" +
                 "summits_pk| PRIMARY KEY| summits| sys\n"
             ));
@@ -521,7 +523,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(818, response.rowCount());
+        assertEquals(828, response.rowCount());
     }
 
     @Test
@@ -765,7 +767,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(45L, response.rows()[0][0]);
+        assertEquals(46L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -84,7 +84,7 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
     @Test
     public void testPgIndexTable() {
         execute("select count(*) from pg_catalog.pg_index");
-        assertThat(printedTable(response.rows()), is("20\n"));
+        assertThat(printedTable(response.rows()), is("21\n"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(42L, response.rowCount());
+        assertEquals(43L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());

--- a/server/src/test/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfoTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import io.crate.expression.reference.sys.snapshot.SysSnapshotRestoreInProgress;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SysSnapshotRestoreTableInfoTest {
+
+    @Test
+    public void test_convert_restore_in_progress_to_sys_restore_snapshot_info() {
+        ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder
+            = ImmutableOpenMap.builder();
+        shardsBuilder.put(
+            new ShardId("index", "_uuid", 0),
+            new RestoreInProgress.ShardRestoreStatus("nodeId", RestoreInProgress.State.STARTED)
+        );
+        RestoreInProgress.Entry entry = new RestoreInProgress.Entry(
+            "_uuid",
+            new Snapshot(
+                "repository",
+                new SnapshotId("snapshot", UUID.randomUUID().toString())),
+            RestoreInProgress.State.SUCCESS,
+            List.of("index"),
+            shardsBuilder.build()
+        );
+
+        var restoreInProgressIt = SysSnapshotRestoreTableInfo
+            .snapshotsRestoreInProgress(new RestoreInProgress.Builder().add(entry).build())
+            .iterator();
+
+        assertThat(restoreInProgressIt.hasNext(), is(true));
+        assertThat(restoreInProgressIt.next(), is(SysSnapshotRestoreInProgress.of(entry)));
+        assertThat(restoreInProgressIt.hasNext(), is(false));
+    }
+
+    @Test
+    public void test_convert_null_restore_in_progress_returns_empty_iterator() {
+        var restoreInProgressIt = SysSnapshotRestoreTableInfo.snapshotsRestoreInProgress(null).iterator();
+        assertThat(restoreInProgressIt.hasNext(), is(false));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A user can check the progress of the `RESTORE SNAPSHOT` statement
by querying the `sys.snapshot_restore`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
