### PR TITLE
Fix flaky FilteringAllocationIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -218,8 +218,10 @@ public class FilteringAllocationIT extends SQLTransportIntegrationTest {
         ensureGreen(tableName);
 
         logger.info("--> verify that there are shards allocated on both nodes now");
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
-        assertThat(clusterState.routingTable().index(tableName).numberOfNodesShardsAreAllocatedOn(), equalTo(2));
+        assertBusy(() -> {
+            final var state = client().admin().cluster().prepareState().execute().actionGet().getState();
+            assertThat(state.routingTable().index(tableName).numberOfNodesShardsAreAllocatedOn(), equalTo(2));
+        }, 20, TimeUnit.SECONDS);
     }
 
     public void testInvalidIPFilterClusterSettings() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`FilteringAllocationIT` seems still flaky, therefore lets wrap the failing assert in an assert busy. 

https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/12110/console

```
FilteringAllocationIT > testDisablingAllocationFiltering FAILED
    java.lang.AssertionError at FilteringAllocationIT.java:222
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
