### PR TITLE
Run linkcheck in GHA instead of Jenkins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,22 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
+
+  linkcheck:
+    name: Sphinx linkcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r blackbox/requirements.txt
+
+      - name: Run linkcheck
+        run: |
+          sphinx-build -n -W -c docs/ -b linkcheck -E docs/ docs/out/html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
           agent { label 'medium' }
           steps {
             sh 'cd ./blackbox/ && ./bootstrap.sh'
-            sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b linkcheck -E docs/ docs/out/html'
             sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b html -E docs/ docs/out/html'
             sh 'find ./blackbox/*/src/ -type f -name "*.py" | xargs ./blackbox/.venv/bin/pycodestyle'
           }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There are currently sporadic 403.
Running the check with separate GHA job will allow us to see failures
but won't block a merge.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)