### PR TITLE
Try to fix flaky testShrinkShardsOfPartition

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
@@ -105,14 +105,12 @@ public class ResizeShardsITest extends SQLTransportIntegrationTest {
     public void testShrinkShardsOfPartition() {
         execute("create table quotes (id integer, quote string, date timestamp with time zone) " +
                 "partitioned by(date) clustered into 3 shards");
-        ensureYellow();
-
         execute("insert into quotes (id, quote, date) values (?, ?, ?), (?, ?, ?)",
             new Object[]{
                 1, "Don't panic", 1395874800000L,
                 2, "Now panic", 1395961200000L}
         );
-
+        ensureYellow();
         execute("refresh table quotes");
 
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The partitions are created after the insert, so the `ensureYellow`
should happen after the insert, not after the create table.

Not sure if this solves the flakyness. I ran this for over an hour on
repeat and only had a single failure before the fix.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)