### PR TITLE
Mute testAutoExpandReplicasToFilteredNodes in FilteringAllocationIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -35,6 +35,8 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalSettingsPlugin;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -109,6 +111,8 @@ public class FilteringAllocationIT extends SQLTransportIntegrationTest {
         assertThat(100L, is(response.rows()[0][0]));
     }
 
+    @Test
+    @Ignore("https://github.com/crate/crate/issues/10755")
     public void testAutoExpandReplicasToFilteredNodes() throws Exception {
         logger.info("--> starting 2 nodes");
         List<String> nodesIds = internalCluster().startNodes(2);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
