### PR TITLE
Add the empty_string_as_null option for ``COPY FROM``.

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -1,6 +1,6 @@
 package io.crate.execution.engine.reader;
 
-import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
@@ -103,11 +103,12 @@ public class CsvReaderBenchmark {
             inputs,
             ctx.expressions(),
             null,
-            ImmutableMap.of(
+            Map.of(
                 LocalFsFileInputFactory.NAME, new LocalFsFileInputFactory()),
             false,
             1,
             0,
+            CopyFromParserProperties.DEFAULT,
             CSV);
 
         while (batchIterator.moveNext()) {

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -1,6 +1,6 @@
 package io.crate.execution.engine.reader;
 
-import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
@@ -102,11 +102,12 @@ public class JsonReaderBenchmark {
             inputs,
             ctx.expressions(),
             null,
-            ImmutableMap.of(
+            Map.of(
                 LocalFsFileInputFactory.NAME, new LocalFsFileInputFactory()),
             false,
             1,
             0,
+            CopyFromParserProperties.DEFAULT,
             JSON);
 
         while (batchIterator.moveNext()) {

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,10 @@ None
 Changes
 =======
 
+- Added the ``empty_string_as_null`` option for :ref:`copy_from` CSV files.
+  If the option is enabled, all column's values represented by an empty string,
+  including a quoted empty string, are set to ``NULL``.
+
 - Added the :ref:`sys.snapshot_restore <sys-snapshot-restore>` table to track the
   progress of the :ref:`snapshot restore <snapshot-restore>` operations.
 

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -323,6 +323,17 @@ Default: false
 ``COPY FROM`` by default won't overwrite rows if a document with the same
 primary key already exists. Set to true to overwrite duplicate rows.
 
+``empty_string_as_null``
+''''''''''''''''''''''''
+
+If set to ``true`` the ``empty_string_as_null`` option enables conversion
+of un-/quoted empty strings into ``NULL``. The default value is ``false``
+meaning that no action will be taken on empty strings during the COPY FROM
+execution.
+
+The option is only supported when using the ``CSV`` format,
+otherwise, it will be ignored.
+
 ``format``
 ''''''''''
 

--- a/server/src/main/java/io/crate/analyze/CopyFromParserProperties.java
+++ b/server/src/main/java/io/crate/analyze/CopyFromParserProperties.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.common.annotations.VisibleForTesting;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static io.crate.analyze.CopyStatementSettings.EMPTY_STRING_AS_NULL;
+
+
+public class CopyFromParserProperties implements Writeable {
+
+    public static final CopyFromParserProperties DEFAULT = CopyFromParserProperties.of(Settings.EMPTY);
+
+    private final boolean emptyStringAsNull;
+
+    public static CopyFromParserProperties of(Settings settings) {
+        return new CopyFromParserProperties(
+            settings.getAsBoolean(EMPTY_STRING_AS_NULL.getKey(), false)
+        );
+    }
+
+    @VisibleForTesting
+    public CopyFromParserProperties(boolean emptyStringAsNull) {
+        this.emptyStringAsNull = emptyStringAsNull;
+    }
+
+    public CopyFromParserProperties(StreamInput in) throws IOException {
+        emptyStringAsNull = in.readBoolean();
+    }
+
+    public boolean emptyStringAsNull() {
+        return emptyStringAsNull;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(emptyStringAsNull);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CopyFromParserProperties that = (CopyFromParserProperties) o;
+        return emptyStringAsNull == that.emptyStringAsNull;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(emptyStringAsNull);
+    }
+
+    @Override
+    public String toString() {
+        return "CopyFromParserProperties{" +
+               "emptyStringAsNull=" + emptyStringAsNull +
+               '}';
+    }
+}

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -50,6 +50,11 @@ public final class CopyStatementSettings {
         Validators.stringValidator("format", "json", "csv"),
         Setting.Property.Dynamic);
 
+    public static final Setting<Boolean> EMPTY_STRING_AS_NULL = Setting.boolSetting(
+        "empty_string_as_null",
+        false,
+        Setting.Property.Dynamic);
+
     public static final Map<String, Setting<?>> OUTPUT_SETTINGS = Map.of(
         COMPRESSION_SETTING.getKey(), COMPRESSION_SETTING,
         OUTPUT_FORMAT_SETTING.getKey(), OUTPUT_FORMAT_SETTING

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.files;
 
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.operation.collect.files.CSVLineParser;
 
@@ -31,18 +32,25 @@ import java.nio.charset.StandardCharsets;
 
 public class LineParser {
 
+    private final CopyFromParserProperties parserProperties;
     private CSVLineParser csvLineParser;
 
     private InputType inputType;
+
+    public LineParser(CopyFromParserProperties parserProperties) {
+        this.parserProperties = parserProperties;
+    }
 
     private enum InputType {
         CSV,
         JSON
     }
 
-    public void readFirstLine(URI currentUri, FileUriCollectPhase.InputFormat inputFormat, BufferedReader currentReader) throws IOException {
+    public void readFirstLine(URI currentUri,
+                              FileUriCollectPhase.InputFormat inputFormat,
+                              BufferedReader currentReader) throws IOException {
         if (isInputCsv(inputFormat, currentUri)) {
-            csvLineParser = new CSVLineParser();
+            csvLineParser = new CSVLineParser(parserProperties);
             csvLineParser.parseHeader(currentReader.readLine());
             inputType = InputType.CSV;
         } else {

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.files;
 
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat;
 import io.crate.expression.reference.file.LineContext;
 
@@ -31,7 +32,11 @@ import java.net.URI;
 public final class LineProcessor {
 
     private final LineContext lineContext = new LineContext();
-    private final LineParser lineParser = new LineParser();
+    private final LineParser lineParser;
+
+    public LineProcessor(CopyFromParserProperties parserProperties) {
+        lineParser = new LineParser(parserProperties);
+    }
 
     public void startCollect(Iterable<LineCollectorExpression<?>> collectorExpressions) {
         for (LineCollectorExpression<?> collectorExpression : collectorExpressions) {

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -86,6 +86,7 @@ public class FileCollectSource implements CollectSource {
             fileUriCollectPhase.sharedStorage(),
             fileUriCollectPhase.nodeIds().size(),
             getReaderNumber(fileUriCollectPhase.nodeIds(), clusterService.state().nodes().getLocalNodeId()),
+            fileUriCollectPhase.parserProperties(),
             fileUriCollectPhase.inputFormat()
         ));
     }

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -26,6 +26,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.AnalyzedCopyFromReturnSummary;
 import io.crate.analyze.BoundCopyFrom;
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.analyze.PartitionPropertiesAnalyzer;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.copy.NodeFilters;
@@ -292,14 +293,16 @@ public final class CopyFromPlan implements Plan {
             context.jobId(),
             context.nextExecutionPhaseId(),
             "copyFrom",
-            getExecutionNodes(allNodes, boundedCopyFrom
-                .settings()
-                .getAsInt("num_readers", allNodes.getSize()), boundedCopyFrom.nodePredicate()),
+            getExecutionNodes(
+                allNodes,
+                boundedCopyFrom.settings().getAsInt("num_readers", allNodes.getSize()),
+                boundedCopyFrom.nodePredicate()),
             boundedCopyFrom.uri(),
             toCollect,
             Collections.emptyList(),
             boundedCopyFrom.settings().get("compression", null),
             boundedCopyFrom.settings().getAsBoolean("shared", null),
+            CopyFromParserProperties.of(boundedCopyFrom.settings()),
             boundedCopyFrom.inputFormat()
         );
 

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -39,6 +39,7 @@ import io.crate.planner.statement.CopyFromPlan;
 import io.crate.planner.statement.CopyToPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -161,6 +162,19 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         BoundCopyFrom analysis = analyze(
             "COPY users FROM '/some/distant/file.ext' WITH (format='csv')");
         assertThat(analysis.inputFormat(), is(FileUriCollectPhase.InputFormat.CSV));
+    }
+
+    @Test
+    public void test_copy_from_supports_empty_string_as_null_setting_option() {
+        BoundCopyFrom analysis = analyze(
+            "COPY users FROM '/some/distant/file.ext' WITH (format='csv', empty_string_as_null=true)");
+        assertThat(
+            analysis.settings(),
+            is(Settings.builder()
+                   .put("empty_string_as_null", true)
+                   .put("format", "csv")
+                   .build())
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dsl.phases;
+
+
+import io.crate.analyze.CopyFromParserProperties;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static io.crate.testing.TestingHelpers.createReference;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class FileUriCollectPhaseTest {
+
+    @Test
+    public void test_streaming_of_file_uri_collect_phase_before_4_4_0() throws IOException {
+        var expected = new FileUriCollectPhase(
+            UUID.randomUUID(),
+            0,
+            "test",
+            Collections.singletonList("noop_id"),
+            Literal.of("uri"),
+            List.of(createReference("name", DataTypes.STRING)),
+            Collections.emptyList(),
+            null,
+            false,
+            new CopyFromParserProperties(true),
+            FileUriCollectPhase.InputFormat.CSV
+        );
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(Version.V_4_3_0);
+        expected.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        input.setVersion(Version.V_4_3_0);
+        var actual = new FileUriCollectPhase(input);
+
+        assertThat(expected.nodeIds(), is(actual.nodeIds()));
+        assertThat(expected.distributionInfo(), is(actual.distributionInfo()));
+        assertThat(expected.targetUri(), is(actual.targetUri()));
+        assertThat(expected.toCollect(), is(actual.toCollect()));
+
+        // parser properties option serialization implemented in crate >= 4.4.0
+        assertThat(expected.parserProperties().emptyStringAsNull(), is(true));
+        assertThat(actual.parserProperties().emptyStringAsNull(), is(false));
+        assertThat(expected.inputFormat(), is(actual.inputFormat()));
+        assertThat(expected.compression(), is(actual.compression()));
+        assertThat(expected.sharedStorage(), is(actual.sharedStorage()));
+    }
+
+    @Test
+    public void test_streaming_of_file_uri_collect_phase_after_or_on_4_4_0() throws IOException {
+        var expected = new FileUriCollectPhase(
+            UUID.randomUUID(),
+            0,
+            "test",
+            Collections.singletonList("noop_id"),
+            Literal.of("uri"),
+            List.of(createReference("name", DataTypes.STRING)),
+            Collections.emptyList(),
+            null,
+            false,
+            new CopyFromParserProperties(true),
+            FileUriCollectPhase.InputFormat.CSV
+        );
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(Version.V_4_4_0);
+        expected.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        input.setVersion(Version.V_4_4_0);
+        var actual = new FileUriCollectPhase(input);
+
+        assertThat(expected.parserProperties().emptyStringAsNull(), is(true));
+        assertThat(expected, is(actual));
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect;
 
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
@@ -32,6 +33,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -81,6 +83,7 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
             Collections.emptyList(),
             null,
             false,
+            CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON
         );
         TestingRowConsumer consumer = new TestingRowConsumer();

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
 import io.crate.data.Input;
@@ -313,6 +314,7 @@ public class FileReadingCollectorTest extends ESTestCase {
             false,
             1,
             0,
+            CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.collect.files;
 
+import io.crate.analyze.CopyFromParserProperties;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -175,6 +176,7 @@ public class FileReadingIteratorTest extends ESTestCase {
             false,
             1,
             0,
+            CopyFromParserProperties.DEFAULT,
             format);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -1,5 +1,6 @@
 package io.crate.execution.engine.collect.files;
 
+import io.crate.analyze.CopyFromParserProperties;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,9 +13,9 @@ import java.net.URISyntaxException;
 
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.CSV;
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
 
 public class LineProcessorTest {
 
@@ -24,7 +25,7 @@ public class LineProcessorTest {
 
     @Before
     public void setup() {
-        subjectUnderTest  = new LineProcessor();
+        subjectUnderTest  = new LineProcessor(CopyFromParserProperties.DEFAULT);
     }
 
     @Test
@@ -35,7 +36,7 @@ public class LineProcessorTest {
 
         subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
 
-        assertThat(bufferedReader.readLine(), is(nullValue()));;
+        assertThat(bufferedReader.readLine(), is(nullValue()));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class LineProcessorTest {
 
         subjectUnderTest.readFirstLine(uri, CSV, bufferedReader);
 
-        assertThat(bufferedReader.readLine(), is(nullValue()));;
+        assertThat(bufferedReader.readLine(), is(nullValue()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -1,11 +1,10 @@
 package io.crate.operation.collect.files;
 
+import io.crate.analyze.CopyFromParserProperties;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -17,8 +16,8 @@ public class CSVLineParserTest {
     private byte[] result;
 
     @Before
-    public void setup(){
-        csvParser = new CSVLineParser();
+    public void setup() {
+        csvParser = new CSVLineParser(CopyFromParserProperties.DEFAULT);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -92,6 +91,19 @@ public class CSVLineParserTest {
         result = csvParser.parse("GER,Germany\n");
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Coun, try\":\"Germany\"}"));
+    }
+
+    @Test
+    public void test_quoted_and_unquoted_empty_string_converted_to_null_empty_string_as_null_is_set() throws IOException {
+        String header = "Code,Country,City\n";
+        csvParser = new CSVLineParser(new CopyFromParserProperties(true));
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,,\"\"\n");
+
+        assertThat(
+            new String(result, StandardCharsets.UTF_8),
+            is("{\"Code\":\"GER\",\"Country\":null,\"City\":null}")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If ``empty_string_as_null`` is ``true``, then all column's values
represented by an empty string, including a quoted empty string,
are set to``NULL``.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
